### PR TITLE
chore: add name and instance labels to kafka and pulsar

### DIFF
--- a/addons/kafka/templates/_helpers.tpl
+++ b/addons/kafka/templates/_helpers.tpl
@@ -35,8 +35,17 @@ Common labels
 */}}
 {{- define "kafka.labels" -}}
 helm.sh/chart: {{ include "kafka.chart" . }}
+{{ include "kafka.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kafka.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kafka.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/addons/pulsar/templates/_helpers.tpl
+++ b/addons/pulsar/templates/_helpers.tpl
@@ -35,10 +35,19 @@ Common labels
 */}}
 {{- define "pulsar.labels" -}}
 helm.sh/chart: {{ include "pulsar.chart" . }}
+{{ include "pulsar.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pulsar.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pulsar.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
label 'app.kubernetes.io/name' is used in Anywhere.