### PR TITLE
chore: access Kafka brokers from outside the k8s cluster (#5811)

### DIFF
--- a/addons/kafka/configs/kafka-server-constraint.cue
+++ b/addons/kafka/configs/kafka-server-constraint.cue
@@ -665,3 +665,6 @@
 	// other parameters
 	...
 }
+
+configuration: #KafkaParameter & {
+}

--- a/addons/kafka/scripts/kafka-server-setup.sh.tpl
+++ b/addons/kafka/scripts/kafka-server-setup.sh.tpl
@@ -110,6 +110,17 @@ if [[ -n "$KB_KAFKA_BROKER_HEAP" ]]; then
   echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
 fi
 
+# for support access Kafka brokers from outside the k8s cluster
+if [[ -n "$KAFKA_CFG_K8S_NODEPORT" ]];then
+  if [[ "broker,controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] || [[ "broker" = "$KAFKA_CFG_PROCESS_ROLES" ]]; then
+    export KAFKA_CFG_ADVERTISED_LISTENERS="PLAINTEXT://${KB_HOST_IP}:${KAFKA_CFG_K8S_NODEPORT}"
+    echo "[cfg]KAFKA_CFG_ADVERTISED_LISTENERS=$KAFKA_CFG_ADVERTISED_LISTENERS"
+    echo "[cfg]KAFKA_CFG_LISTENERS=$KAFKA_CFG_LISTENERS"
+    echo "[cfg]KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP"
+    echo "[cfg]KAFKA_CFG_INTER_BROKER_LISTENER_NAME=$KAFKA_CFG_INTER_BROKER_LISTENER_NAME"
+  fi
+fi
+
 # cfg setting
 if [[ "broker,controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] || [[ "broker" = "$KAFKA_CFG_PROCESS_ROLES" ]]; then
     # deleting this information can reacquire the controller members when the broker restarts,

--- a/addons/kafka/templates/clusterdefinition.yaml
+++ b/addons/kafka/templates/clusterdefinition.yaml
@@ -42,7 +42,7 @@ spec:
           templateRef: {{ include "kafka.name" . }}-configuration-tpl
           volumeName: kafka-config
           namespace: {{ .Release.Namespace }}
-        - name: kafka-jmx-configuration-tpl
+        - name: {{ include "kafka.name" . }}-jmx-configuration-tpl
           templateRef: {{ include "kafka.name" . }}-jmx-configuration-tpl
           volumeName: jmx-config
           namespace: {{ .Release.Namespace }}

--- a/addons/kafka/values.yaml
+++ b/addons/kafka/values.yaml
@@ -31,6 +31,8 @@ images:
 ##
 debugEnabled: true
 
+commonAnnotations: {}
+
 kafkaBroker:
   minNodeId: 100
 


### PR DESCRIPTION
1. add new parameters: k8s.nodeport
2. render configuration on the pod

### reconfigure

![image](https://github.com/apecloud/kubeblocks-addons/assets/111836083/937619ab-2b4d-43eb-a471-5c1bc5f18e86)

### verification

```
$ k get svc kafka-broker-nodeport
NAME                    TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
kafka-broker-nodeport   NodePort   10.124.6.254   <none>        9092:30603/TCP   10h

# zhangtao @ zhangtaoworkingdeMacBook-Pro in ~ [10:07:12]
$ for i in `seq 3`;do kubectl exec -ti kafka-sparated-broker-$((i -1)) -c kafka -- sh -c "cat /opt/bitnami/kafka/config/kraft/server.properties |grep advertised.listeners" ;done
advertised.listeners=PLAINTEXT://10.128.0.26:30603
advertised.listeners=PLAINTEXT://10.128.0.81:30603
advertised.listeners=PLAINTEXT://10.128.0.33:30603
```