### PR TITLE
fix: remove duplicate env in kafka

### DIFF
--- a/addons/kafka/templates/clusterdefinition.yaml
+++ b/addons/kafka/templates/clusterdefinition.yaml
@@ -530,6 +530,3 @@ spec:
               - name: scripts
                 mountPath: /scripts/setup.sh
                 subPath: kafka-exporter-setup.sh
-            env:
-              - name: SERVICE_PORT
-                value: "9308"


### PR DESCRIPTION
fix #18 