### PR TITLE
fix: convert integer env to string in kafka

### DIFF
--- a/addons/kafka/templates/clusterdefinition.yaml
+++ b/addons/kafka/templates/clusterdefinition.yaml
@@ -520,7 +520,7 @@ spec:
           - name: kafka-exporter
             env:
               - name: SERVICE_PORT
-                value: 9308
+                value: "9308"
             command:
               - /scripts/setup.sh
             ports:


### PR DESCRIPTION
fix #24 