### PR TITLE
fix: mysql cannot be started in some Storage Classes 

### DIFF
--- a/addons/mysql/templates/clusterdefinition.yaml
+++ b/addons/mysql/templates/clusterdefinition.yaml
@@ -58,7 +58,7 @@ spec:
             command:
               - bash 
               - -c
-              - "docker-entrypoint.sh mysqld --server-id $(( ${KB_POD_NAME##*-} + 1))"
+              - "docker-entrypoint.sh mysqld --server-id $(( ${KB_POD_NAME##*-} + 1)) --ignore-db-dir=lost+found"
             volumeMounts:
               - mountPath: /var/lib/mysql
                 name: data


### PR DESCRIPTION
fix: mysql cannot be started in some Storage Classes due to the presence of the "lost+found" directory