### PR TITLE
chore: fix oracle

### DIFF
--- a/addons/oracle/templates/clusterdefinition.yaml
+++ b/addons/oracle/templates/clusterdefinition.yaml
@@ -56,9 +56,7 @@ spec:
                     name: $(CONN_CREDENTIAL_SECRET_NAME)
                     key: password
               - name: AUTO_MEM_CALCULATION
-                value: "TRUE"
-              - name: INIT_CPU_COUNT
-              - name: INIT_PROCESSES
+                value: "false"
               - name: ORACLE_EDITION
                 value: "enterprise"
             readinessProbe:


### PR DESCRIPTION
- set `AUTO_MEM_CALCULATION=false`  to disable auto calculation of the DBCA total memory limit during the database creation 