### PR TITLE
chore: refind ob with hostnetwork and host path SC to restart in-place

### DIFF
--- a/addons/oceanbase-cluster/templates/_helpers.tpl
+++ b/addons/oceanbase-cluster/templates/_helpers.tpl
@@ -68,13 +68,14 @@ Create extra env
 {{- define "oceanbase-cluster.extra-envs" }}
 {
 {{- if .Values.tenant -}}
-"TENANT_NAME": "{{ .Values.tenant.name | default "tenant1" }}",
+"TENANT_NAME": "{{ .Values.tenant.name }}",
 "TENANT_CPU": "{{ min (sub .Values.cpu 1) .Values.tenant.max_cpu }}",
 "TENANT_MEMORY": "{{ print (min (sub .Values.memory  2) .Values.tenant.memory_size) "G" }}",
 "TENANT_DISK": "{{ print (.Values.tenant.log_disk_size | default 5) "G" }}",
 {{- end -}}
 "ZONE_COUNT": "{{ .Values.zoneCount | default "1" }}",
-"OB_CLUSTERS_COUNT": "{{ .Values.obClusters | default "1" }}"
+"OB_CLUSTERS_COUNT": "{{ .Values.obClusters | default "1" }}",
+"OB_DEBUG": "{{ .Values.debug | default "false" }}"
 }
 {{- end }}
 

--- a/addons/oceanbase-cluster/templates/cluster.yaml
+++ b/addons/oceanbase-cluster/templates/cluster.yaml
@@ -1,15 +1,15 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  name: {{ include "oceanbase.fullname" . }}
+  name: {{ include "kblib.clusterName" . }}
   labels:
     {{- include "oceanbase.labels" . | nindent 4 }}
   annotations:
     {{ include "oceanbase-cluster.annotations.extra-envs" . | nindent 4 }}
 spec:
-  clusterDefinitionRef: oceanbase
-  clusterVersionRef: oceanbase-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
-  terminationPolicy: {{ .Values.terminationPolicy }}
+  clusterDefinitionRef: {{- if .Values.hostNetwork }} oceanbase-host-network {{- else }} oceanbase {{- end }}
+  clusterVersionRef: {{- if .Values.hostNetwork }} oceanbase-host-network-{{ default .Chart.AppVersion .Values.clusterVersionOverrid }} {{- else }} oceanbase-{{ default .Chart.AppVersion .Values.clusterVersionOverrid }} {{- end }}
+  terminationPolicy: {{ .Values.extra.terminationPolicy }}
   {{- include "kblib.affinity" . | indent 2 }}
   componentSpecs:
   {{- range $i, $e := until (int .Values.obClusters) }}
@@ -19,13 +19,36 @@ spec:
       replicas: {{ max $.Values.zoneCount $.Values.replicas}}
       {{- include "kblib.componentResources" $ | indent 6 }}
       volumeClaimTemplates:
-        {{- range $key, $val := $.Values.storages }}
-        - name: {{ $key }}
+        - name: data-file
           spec:
+            storageClassName: {{ $.Values.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ $val | quote }}
-        {{- end }}
+                storage: {{ print $.Values.datafile "Gi" }}
+        - name: data-log
+          spec:
+            storageClassName: {{ $.Values.storageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ print $.Values.datalog "Gi" }}
+        - name: log
+          spec:
+            storageClassName: {{ $.Values.storageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ print $.Values.log "Gi" }}
+        - name: workdir
+          spec:
+            storageClassName: {{ $.Values.storageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: "100Mi"
   {{- end }}

--- a/addons/oceanbase-cluster/values.schema.json
+++ b/addons/oceanbase-cluster/values.schema.json
@@ -40,7 +40,7 @@
                 "string"
             ],
             "default": 8,
-            "minimum": 4,
+            "minimum": 2,
             "maximum": 128,
             "multipleOf": 0.5
         },
@@ -52,7 +52,7 @@
                 "string"
             ],
             "default": 16,
-            "minimum": 4,
+            "minimum": 2,
             "maximum": 1024
         },
         "tenant": {
@@ -62,7 +62,6 @@
                     "title": "Tenant Name",
                     "description": "Tenant Name.",
                     "type": "string",
-                    "minLength": 4,
                     "maxLength": 32
                 },
                 "max_cpu": {
@@ -107,56 +106,54 @@
                 "log_disk_size"
             ]
         },
-        "storage": {
-            "type": "object",
-            "properties": {
-                "data-file": {
-                    "title": "Data file Storage(Gi)",
-                    "description": "Data file Storage size, the unit is Gi.",
-                    "type": [
-                        "number",
-                        "string"
-                    ],
-                    "default": 50,
-                    "minimum": 20,
-                    "maximum": 10000
-                },
-                "data-log": {
-                    "title": "Data log Storage(Gi)",
-                    "description": "Data log Storage size, the unit is Gi.",
-                    "type": [
-                        "number",
-                        "string"
-                    ],
-                    "default": 50,
-                    "minimum": 20,
-                    "maximum": 10000
-                },
-                "log": {
-                    "title": "Log Storage(Gi)",
-                    "description": "Log Storage size, the unit is Gi.",
-                    "type": [
-                        "number",
-                        "string"
-                    ],
-                    "default": 20,
-                    "minimum": 10,
-                    "maximum": 100
-                }
-            },
-            "required": [
-                "data-file",
-                "data-log",
-                "log"
+
+        "datafile": {
+            "title": "Data file Storage(Gi)",
+            "description": "Data file Storage size, the unit is Gi.",
+            "type": [
+                "number",
+                "string"
+            ],
+            "default": 50,
+            "minimum": 20,
+            "maximum": 10000
+        },
+        "datalog": {
+            "title": "Data log Storage(Gi)",
+            "description": "Data log Storage size, the unit is Gi.",
+            "type": [
+                "number",
+                "string"
+            ],
+            "default": 50,
+            "minimum": 20,
+            "maximum": 10000
+        },
+        "log": {
+            "title": "Log Storage(Gi)",
+            "description": "Log Storage size, the unit is Gi.",
+            "type": [
+                "number",
+                "string"
+            ],
+            "default": 20,
+            "minimum": 10,
+            "maximum": 100
+        },
+        "hostNetwork": {
+            "title": "Host Network",
+            "description": "Host Network.",
+            "type": "boolean",
+            "default": true,
+            "enum": [
+                true,
+                false
             ]
         }
     },
     "required": [
         "obClusters",
         "zoneCount",
-        "replicas",
-        "cpu",
-        "memory",
-        "storages"
+        "replicas"
     ]
 }

--- a/addons/oceanbase-cluster/values.yaml
+++ b/addons/oceanbase-cluster/values.yaml
@@ -7,8 +7,6 @@ nameOverride: ""
 fullnameOverride: ""
 clusterVersionOverride: "4.2.0.0-100010032023083021"
 
-terminationPolicy: "Delete"
-
 # how many clusters to create with-in one ob cluster, set to 2 when creating a primary and secondary oceanbae cluster
 obClusters: 2
 # zone count
@@ -18,19 +16,24 @@ replicas: 1
 
 tenant:
   name: "alice"
-  max_cpu: 4
-  memory_size: 8
-  log_disk_size: 5
+  max_cpu: 2
+  memory_size: 4
+  log_disk_size: 10
 
 # resources
-cpu: 8
-memory: 16
-storages:
-  data-file: 50Gi
-  data-log: 50Gi
-  log: 20Gi
-storageClassName: "openebs-hostpath"
+cpu: 4
+memory: 8
+datafile: 50
+datalog: 50
+log: 20
+storageClassName: ""
+# storageClassName: "openebs-hostpath"
 
-## customized default values to override kblib chart's values
+# customized default values to override kblib chart's values
 extra:
   podAntiAffinity: Required
+  availabilityPolicy: node
+  tenancy: DedicatedNode
+
+debug: false
+hostNetwork: true

--- a/addons/oceanbase/templates/clusterdefinition.yaml
+++ b/addons/oceanbase/templates/clusterdefinition.yaml
@@ -36,6 +36,7 @@ spec:
           volumeName: scripts
           defaultMode: 0555
       podSpec:
+        terminationGracePeriodSeconds: 60
         containers:
           - name: observer-container
             command:
@@ -66,11 +67,13 @@ spec:
                 name: data-log
               - mountPath: /home/admin/log
                 name: log
+              - mountPath: /home/admin/workdir
+                name: workdir
               - name: scripts
                 mountPath: /scripts
               - name: oceanbase-config
                 mountPath: /kb-config
-            workingDir: /home/admin/oceanbase
+            workingDir: /home/admin/workdir
             env:
               - name: LD_LIBRARY_PATH
                 value: /home/admin/oceanbase/lib
@@ -85,14 +88,100 @@ spec:
                   secretKeyRef:
                     name: $(CONN_CREDENTIAL_SECRET_NAME)
                     key: password
-              - name: OB_CPU_LIMIT
+              - name: OB_HOME_DIR
+                value: "/home/admin/workdir"
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterDefinition
+metadata:
+  name: oceanbase-host-network
+  labels:
+    {{- include "oceanbase.labels" . | nindent 4 }}
+spec:
+  connectionCredential:
+    username: root
+    password: ""
+    endpoint: "$(SVC_FQDN):$(SVC_PORT_sql)"
+    host: "$(SVC_FQDN)"
+    port: "$(SVC_PORT_sql)"
+  componentDefs:
+    - name: ob-bundle
+      characterType: oceanbase
+      workloadType: Stateful
+      service:
+        ports:
+          - name: sql
+            port: 2881
+            targetPort: 2881
+          - name: rpc
+            port: 2882
+            targetPort: 2882
+      configSpecs:
+        - name: oceanbase-config
+          templateRef: oceanbase-configuration
+          volumeName: oceanbase-config
+          namespace: {{ .Release.Namespace }}
+          defaultMode: 0555
+      scriptSpecs:
+        - name: oceanbase-scripts
+          templateRef: oceanbase-scripts
+          namespace: {{ .Release.Namespace }}
+          volumeName: scripts
+          defaultMode: 0555
+      podSpec:
+        terminationGracePeriodSeconds: 60
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        containers:
+          - name: observer-container
+            command:
+              - bash
+              - -c
+              - |
+                /scripts/entrypoint.sh
+            ports:
+              - containerPort: 2881
+                name: sql
+                protocol: TCP
+              - containerPort: 2882
+                name: rpc
+                protocol: TCP
+            readinessProbe:
+              failureThreshold: 10
+              initialDelaySeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 5
+              exec:
+                command:
+                  - cat
+                  - /tmp/ready
+            volumeMounts:
+              - mountPath: /home/admin/data-file
+                name: data-file
+              - mountPath: /home/admin/data-log
+                name: data-log
+              - mountPath: /home/admin/log
+                name: log
+              - mountPath: /home/admin/workdir
+                name: workdir
+              - name: scripts
+                mountPath: /scripts
+              - name: oceanbase-config
+                mountPath: /kb-config
+            workingDir: /home/admin/workdir
+            env:
+              - name: LD_LIBRARY_PATH
+                value: /home/admin/oceanbase/lib
+              - name: CLUSTER_NAME
+                value: "$(KB_CLUSTER_COMP_NAME)"
+              - name: POD_IP
                 valueFrom:
-                  resourceFieldRef:
-                    containerName: observer-container
-                    resource: limits.cpu
-              - name: OB_MEM_LIMIT
+                  fieldRef:
+                    fieldPath: status.podIP
+              - name: DB_ROOT_PASSWORD
                 valueFrom:
-                  resourceFieldRef:
-                    containerName: observer-container
-                    resource: limits.memory
-                    divisor: 1Mi
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+              - name: OB_HOME_DIR
+                value: "/home/admin/workdir"

--- a/addons/oceanbase/templates/clusterversion.yaml
+++ b/addons/oceanbase/templates/clusterversion.yaml
@@ -13,3 +13,19 @@ spec:
       - name: observer-container
         image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.observer.repository }}:{{ .Values.images.observer.tag }}
         imagePullPolicy: {{ default .Values.images.pullPolicy "IfNotPresent" }}
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterVersion
+metadata:
+  name: oceanbase-host-network-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  labels:
+    {{- include "oceanbase.labels" . | nindent 4 }}
+spec:
+  clusterDefinitionRef: oceanbase-host-network
+  componentVersions:
+  - componentDefRef: ob-bundle
+    versionsContext:
+      containers:
+      - name: observer-container
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.observer.repository }}:{{ .Values.images.observer.tag }}
+        imagePullPolicy: {{ default .Values.images.pullPolicy "IfNotPresent" }}


### PR DESCRIPTION
```bash
helm install oceanbase ./addons/oceanbase
helm install myob ./addons/oceanbase-cluster  --set hostNetwork=true
```
will,  by default,  create an oceanbase cluster (with a primary cluster and a secondary cluster, each of which has EXACTLY ONE replcia, and has primary tenant and standy tenant created by default)

Fixed errors on running OB using HostNetwork, and on IN-PLACE restart.
- when use HostNetwork, set `podSpec.dnsPolicy: ClusterFirstWithHostNet`
- mount working dir to a PV to make 
- update some typos and errors in scritps.
- refine in-place recovering strategy.
- update `values.schema.json`

## To register oceanbase to our `kbcli`:
```bash
helm install oceanbase ./addons/oceanbase
helm package addons/oceanbase-cluster
kbcli cluster register oceanbase --source /path/to/your/ob-cluster-version.tgz
```
## create clusters of different topology:
then you can 
1. create primary-secondary (single replica) ob cluster by
```bash
kbcli cluster create oceanbase myob --cpu 4 --memory 4 --zone-count 1 --replicas 1 --ob-clusters 2 --tenant.name bobs 
 --tenant.max-cpu 2 --datafile 50 --host-network true
```

2. create a 3-zone distributed ob by
```bash
kbcli cluster create oceanbase myob --cpu 4 --memory 4  --zone-count 3 --replicas 3 --ob-clusters 1 --host-network true
```
or use default resource setting
```bash
kbcli cluster create oceanbase myob  --zone-count 3 --replicas 3 --ob-clusters 1 --host-network true
```

3. create a single-replica OB by
```bash
kbcli cluster create oceanbase myob  --zone-count 1 --replicas 1 --ob-clusters 1 --host-network true
```
## Check OBServer BootStrap Status:

Check pod log of the 0-th component
<img width="1103" alt="image" src="https://github.com/apecloud/kubeblocks-addons/assets/111829739/40f8b4d7-1bcf-4c2b-bc3b-68711b0ffd1c">
wait till it shows `bootstrap successfully`.


## Primary-Secondary Topology:
1. connect to primary as tenant
```bash
kbcli cluster connect -i myob-ob-bundle-0-0 --as-user root@bob
```
where `myob-ob-bundle-0-0` is the first component (default to PRIMARY), and `bob` is the tenant name

say, for example, the node  where our primary replica resides is restarted unexpected. when it is back ,pod is recoverd with log showing:
<img width="935" alt="image" src="https://github.com/apecloud/kubeblocks-addons/assets/111829739/41ced088-95ce-4494-be6d-3ec016cdea8d">

