### PR TITLE
chore: fix OceanBase values.schema.json

### DIFF
--- a/addons/oceanbase-cluster/values.schema.json
+++ b/addons/oceanbase-cluster/values.schema.json
@@ -55,58 +55,6 @@
             "minimum": 2,
             "maximum": 1024
         },
-        "tenant": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "title": "Tenant Name",
-                    "description": "Tenant Name.",
-                    "type": "string",
-                    "maxLength": 32
-                },
-                "max_cpu": {
-                    "title": "Tenant CPU",
-                    "description": "Tenant CPU cores.",
-                    "type": [
-                        "number",
-                        "string"
-                    ],
-                    "default": 2,
-                    "minimum": 2,
-                    "maximum": 64,
-                    "multipleOf": 0.5
-                },
-                "memory_size": {
-                    "title": "Tenant Max Memory(Gi)",
-                    "description": "Memory, the unit is Gi.",
-                    "type": [
-                        "number",
-                        "string"
-                    ],
-                    "default": 2,
-                    "minimum": 2,
-                    "maximum": 1024
-                },
-                "log_disk_size": {
-                    "title": "Tenant Log Disk Size(Gi)",
-                    "description": "Log Disk Size, the unit is Gi.",
-                    "type": [
-                        "number",
-                        "string"
-                    ],
-                    "default": 5,
-                    "minimum": 2,
-                    "maximum": 10000
-                }
-            },
-            "required": [
-                "name",
-                "max_cpu",
-                "memory_size",
-                "log_disk_size"
-            ]
-        },
-
         "datafile": {
             "title": "Data file Storage(Gi)",
             "description": "Data file Storage size, the unit is Gi.",


### PR DESCRIPTION
- to support `oceanbase`  embeded as `kbcli cluster create` subcommand