### PR TITLE
fix: redis-cluster default config

### DIFF
--- a/addons/redis-cluster/templates/cluster.yaml
+++ b/addons/redis-cluster/templates/cluster.yaml
@@ -19,7 +19,7 @@
     {{- include "redis-cluster.twemproxy" . | indent 4 }}
     {{- end }}
 
-    {{- if eq .Values.mode "replication" }}
+    {{- if and (eq .Values.mode "replication") .Values.sentinel.enabled }}
     {{- include "redis-cluster.sentinel" . | indent 4 }}
     {{- end }}
 {{- else }}
@@ -37,7 +37,7 @@
           - name: redis-nodeport
             port: 6379
             targetPort: 6379
-  {{- if .Values.sentinel.enabled }}
+  {{- if and (eq .Values.mode "replication") .Values.sentinel.enabled }}
   {{- include "redis-cluster.sentinel-nodeport" . | indent 4 }}
   {{- end }}
   {{- end }}
@@ -54,7 +54,7 @@
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- include "kblib.componentStorages" . | indent 6 }}
       {{- include "kblib.componentServices" . | indent 6 }}
-    {{- if .Values.sentinel.enabled }}
+    {{- if and (eq .Values.mode "replication") .Values.sentinel.enabled }}
     {{- include "redis-cluster.sentinelCompDef" . | indent 4 }}
     {{- end }}
 {{- end }}

--- a/addons/redis-cluster/values.schema.json
+++ b/addons/redis-cluster/values.schema.json
@@ -18,7 +18,7 @@
       "title": "Mode",
       "description": "Cluster topology mode.",
       "type": "string",
-      "default": "standalone",
+      "default": "replication",
       "enum": [
         "standalone",
         "replication"

--- a/addons/redis-cluster/values.yaml
+++ b/addons/redis-cluster/values.yaml
@@ -11,7 +11,7 @@ version: redis-7.0.6
 
 ## @param mode redis cluster topology mode, standalone and replication
 ##
-mode: standalone
+mode: replication
 
 ## @param replicas specify cluster replicas
 ##


### PR DESCRIPTION
- adjust redis cluster default setting:
1. mode: replication
2. sentinel: enabled (need replication mode)
3. node port service: disabled 