### PR TITLE
chore: fix foxlake access password is not correct

### DIFF
--- a/addons/foxlake/templates/_helpers.tpl
+++ b/addons/foxlake/templates/_helpers.tpl
@@ -79,7 +79,7 @@ FoxLake Configration Environment Variables
     secretKeyRef:
       name: $(CONN_CREDENTIAL_SECRET_NAME)
       key: password  
-- name: rootPasswd
+- name: rootUserPassword
   valueFrom:
     secretKeyRef:
       name: $(CONN_CREDENTIAL_SECRET_NAME)


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/6310

ref: https://github.com/apecloud/foxlake/commit/beea37bcee6ca76811944a9a3b85ecfea1e41407#diff-f95ae90ce86491673de77d607a5f2a5c5c68a7bba750edb2d66f69778e319ce9
