### PR TITLE
feat: support wal-g to backup/restore pgsql

### DIFF
--- a/addons/oceanbase/dataprotection/backup.sh
+++ b/addons/oceanbase/dataprotection/backup.sh
@@ -201,6 +201,7 @@ done
 
 if [[ $tenantCount -eq 0 ]]; then
    echo "INFO: no normal tenants exists."
+   echo "{}" >"${DP_BACKUP_INFO_FILE}"
    exit 0
 fi
 

--- a/addons/postgresql/dataprotection/config-wal-g.sh
+++ b/addons/postgresql/dataprotection/config-wal-g.sh
@@ -1,0 +1,23 @@
+set -e
+
+if [[ ! -f /etc/datasafed/datasafed.conf ]]; then
+  echo "ERROR: backupRepo should use Tool accessMode"
+  exit 1
+fi
+
+function config_wal_g() {
+    walg_dir=${VOLUME_DATA_DIR}/wal-g
+    walg_env=${walg_dir}/env
+    mkdir -p ${walg_dir}/env
+    cp /etc/datasafed/datasafed.conf ${walg_dir}/datasafed.conf
+    cp /usr/bin/wal-g ${walg_dir}/wal-g
+    datasafed_base_path=${1:?missing datasafed_base_path}
+    # config wal-g env
+    # config WALG_PG_WAL_SIZE with wal_segment_size which fetched by psql
+    # echo "" > ${walg_env}/WALG_PG_WAL_SIZE
+    echo "${walg_dir}/datasafed.conf" > ${walg_env}/WALG_DATASAFED_CONFIG
+    echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH
+}
+
+config_wal_g "/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/archive"
+sync

--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -1,4 +1,4 @@
-backup_base_path="/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/wal-g"
+backup_base_path="$(dirname $DP_BACKUP_BASE_PATH)/wal-g"
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export WALG_COMPRESSION_METHOD=zstd
@@ -56,8 +56,7 @@ datasafed pull ${sentinel_file} backup_stop_sentinel.json
 result_json=$(cat backup_stop_sentinel.json)
 STOP_TIME=$(echo $result_json | jq -r ".FinishTime")
 START_TIME=$(echo $result_json | jq -r ".StartTime")
+TOTAL_SIZE=$(echo $result_json | jq -r ".CompressedSize")
 
 # 5. update backup status
-backupFilePath=/basebackups_005/${backupName}
-TOTAL_SIZE=$(datasafed stat ${backupFilePath} | grep TotalSize | awk '{print $2}')
 echo "{\"totalSize\":\"$TOTAL_SIZE\",\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"

--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -1,6 +1,7 @@
 backup_base_path="/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/wal-g"
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
+export WALG_COMPRESSION_METHOD=zstd
 export PGPASSWORD=${DP_DB_PASSWORD}
 export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 # 20Gi for bundle file

--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -1,0 +1,40 @@
+set -e
+export WALG_DATASAFED_CONFIG=""
+export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
+export PGPASSWORD=${DP_DB_PASSWORD}
+
+trap handle_exit EXIT
+
+# cleanup the expired wal logs, will be retained for one more day than full backup.
+function cleanup_archived_wal_logs() {
+  if [[ -z $DP_TTL_SECONDS ]]; then
+     return
+  fi
+  export DATASAFED_BACKEND_BASE_PATH="/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/archive"
+  local currentUnix=$(date +%s)
+  expiredUnix=$((${currentUnix}-${DP_TTL_SECONDS}-86400))
+  files=$(datasafed list -f --recursive --older-than ${expiredUnix} /wal_005)
+  for file in ${files[@]}
+  do
+      datasafed rm ${file}
+      echo "INFO: cleanup expired wal log ${file}"
+  done
+}
+cleanup_archived_wal_logs
+
+# do full backup
+export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
+START_TIME=`get_current_time`
+PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=5432 wal-g backup-push ${DATA_DIR}
+
+STOP_TIME=""
+for file in $(datasafed list /basebackups_005/  -f); do
+   if [[ $file == *"backup_stop_sentinel.json" ]]; then
+     datasafed pull $file backup_stop_sentinel.json
+     result_json=$(cat backup_stop_sentinel.json)
+     STOP_TIME=$(echo $result_json | jq -r ".FinishTime")
+     START_TIME=$(echo $result_json | jq -r ".StartTime")
+   fi
+done
+# stat and save the backup information
+stat_and_save_backup_info "$START_TIME" "$STOP_TIME"

--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -1,40 +1,52 @@
-set -e
+backup_base_path="/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/wal-g"
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export PGPASSWORD=${DP_DB_PASSWORD}
+export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
+# 20Gi for bundle file
+export WALG_TAR_SIZE_THRESHOLD=21474836480
+
+# if the script exits with a non-zero exit code, touch a file to indicate that the backup failed,
+# the sync progress container will check this file and exit if it exists
+function handle_exit() {
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    echo "failed with exit code $exit_code"
+    touch "${DP_BACKUP_INFO_FILE}.exit"
+    exit 1
+  fi
+}
+
+function get_backup_name() {
+  line=$(cat result.txt | tail -n 1)
+  if [[ $line == *"Wrote backup with name"* ]]; then
+     echo ${line##* }
+  fi
+}
 
 trap handle_exit EXIT
+set -e
+# 1. do full backup
+PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=5432 wal-g backup-push ${DATA_DIR} 2>&1 | tee result.txt
 
-# cleanup the expired wal logs, will be retained for one more day than full backup.
-function cleanup_archived_wal_logs() {
-  if [[ -z $DP_TTL_SECONDS ]]; then
-     return
-  fi
-  export DATASAFED_BACKEND_BASE_PATH="/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/archive"
-  local currentUnix=$(date +%s)
-  expiredUnix=$((${currentUnix}-${DP_TTL_SECONDS}-86400))
-  files=$(datasafed list -f --recursive --older-than ${expiredUnix} /wal_005)
-  for file in ${files[@]}
-  do
-      datasafed rm ${file}
-      echo "INFO: cleanup expired wal log ${file}"
-  done
-}
-cleanup_archived_wal_logs
+# 2. get backup name of the wal-g
+backupName=$(get_backup_name)
+if [[ -z ${backupName} ]] || [[ ${backupName} != "base_"* ]];then
+   echo "{\"path\":\"${backup_base_path}/basebackups_005\"}" >"${DP_BACKUP_INFO_FILE}"
+   echo "ERROR: backup failed, can not get the backup name"
+   exit 1
+fi
+# 3. add sentinel file for this backup CR
+echo "" | datasafed push - "/basebackups_005/${backupName}_dp_${DP_BACKUP_NAME}"
 
-# do full backup
-export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
-START_TIME=`get_current_time`
-PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=5432 wal-g backup-push ${DATA_DIR}
+# 4. stat startTime,stopTime,totalSize for this backup
+sentinel_file="/basebackups_005/${backupName}_backup_stop_sentinel.json"
+datasafed pull ${sentinel_file} backup_stop_sentinel.json
+result_json=$(cat backup_stop_sentinel.json)
+STOP_TIME=$(echo $result_json | jq -r ".FinishTime")
+START_TIME=$(echo $result_json | jq -r ".StartTime")
 
-STOP_TIME=""
-for file in $(datasafed list /basebackups_005/  -f); do
-   if [[ $file == *"backup_stop_sentinel.json" ]]; then
-     datasafed pull $file backup_stop_sentinel.json
-     result_json=$(cat backup_stop_sentinel.json)
-     STOP_TIME=$(echo $result_json | jq -r ".FinishTime")
-     START_TIME=$(echo $result_json | jq -r ".StartTime")
-   fi
-done
-# stat and save the backup information
-stat_and_save_backup_info "$START_TIME" "$STOP_TIME"
+# 5. update backup status
+backupFilePath=/basebackups_005/${backupName}
+TOTAL_SIZE=$(datasafed stat ${backupFilePath} | grep TotalSize | awk '{print $2}')
+echo "{\"path\":\"${backup_base_path}${backupFilePath}\",\"totalSize\":\"$TOTAL_SIZE\",\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"

--- a/addons/postgresql/dataprotection/wal-g-config.sh
+++ b/addons/postgresql/dataprotection/wal-g-config.sh
@@ -21,5 +21,5 @@ function config_wal_g() {
     echo "zstd" > ${walg_env}/WALG_COMPRESSION_METHOD
 }
 
-config_wal_g "/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/wal-g"
+config_wal_g "$(dirname $DP_BACKUP_BASE_PATH)/wal-g"
 sync

--- a/addons/postgresql/dataprotection/wal-g-config.sh
+++ b/addons/postgresql/dataprotection/wal-g-config.sh
@@ -17,6 +17,7 @@ function config_wal_g() {
     # echo "" > ${walg_env}/WALG_PG_WAL_SIZE
     echo "${walg_dir}/datasafed.conf" > ${walg_env}/WALG_DATASAFED_CONFIG
     echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH
+    echo "true" > ${walg_env}/PG_READY_RENAME
     echo "zstd" > ${walg_env}/WALG_COMPRESSION_METHOD
 }
 

--- a/addons/postgresql/dataprotection/wal-g-config.sh
+++ b/addons/postgresql/dataprotection/wal-g-config.sh
@@ -19,5 +19,5 @@ function config_wal_g() {
     echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH
 }
 
-config_wal_g "/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/archive"
+config_wal_g "/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/wal-g"
 sync

--- a/addons/postgresql/dataprotection/wal-g-config.sh
+++ b/addons/postgresql/dataprotection/wal-g-config.sh
@@ -17,6 +17,7 @@ function config_wal_g() {
     # echo "" > ${walg_env}/WALG_PG_WAL_SIZE
     echo "${walg_dir}/datasafed.conf" > ${walg_env}/WALG_DATASAFED_CONFIG
     echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH
+    echo "zstd" > ${walg_env}/WALG_COMPRESSION_METHOD
 }
 
 config_wal_g "/${KB_NAMESPACE}/${KB_CLUSTER_NAME}-${KB_CLUSTER_UID}/${KB_COMP_NAME}/wal-g"

--- a/addons/postgresql/dataprotection/wal-g-delete.sh
+++ b/addons/postgresql/dataprotection/wal-g-delete.sh
@@ -1,35 +1,49 @@
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
+export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
-if [[ ${DP_BACKUP_BASE_PATH} != *"basebackups_005"* ]]; then
-   echo "INFO: can not found the backup repository."
+function remote_file_exists() {
+    local out=$(datasafed list $1)
+    if [ "${out}" == "$1" ]; then
+        echo "true"
+        return
+    fi
+    echo "false"
+}
+
+# 1. get backup repo path of wal-g
+backupRepoPathFile="wal-g-backup-repo.path"
+if [[ $(remote_file_exists "${backupRepoPathFile}") == "false" ]]; then
+   echo "INFO: nothing to delete."
    exit 0
 fi
+datasafed pull "${backupRepoPathFile}" ${backupRepoPathFile}
+backupRepoPath=$(cat ${backupRepoPathFile})
 
-# 1. config backup base path
-backupName=$(basename ${DP_BACKUP_BASE_PATH})
-backupDir=$(dirname ${DP_BACKUP_BASE_PATH})
-
-# 2. delete unsuccessfully backup and outdated WAL archive if this backup CR of the wal-g is not completed
-if [[ $backupName == "basebackups_005" ]]; then
+# 2. get backup name of this backup
+backupNameFile="wal-g-backup-name"
+if [[ $(remote_file_exists "${backupNameFile}")  == "false" ]]; then
    echo "INFO: delete unsuccessfully backup files and outdated WAL archive."
-   export DATASAFED_BACKEND_BASE_PATH=${backupDir}
+   export DATASAFED_BACKEND_BASE_PATH=${backupRepoPath}
    wal-g delete garbage --confirm
    exit 0
 fi
 
-backupRepo=$(dirname ${backupDir})
-export DATASAFED_BACKEND_BASE_PATH=${backupRepo}
 
-# 3. cleanup outdated wal logs, only effective when existing at least one full backup
+# 3. config backup base path
+datasafed pull "${backupNameFile}" ${backupNameFile}
+backupName=$(cat ${backupNameFile})
+export DATASAFED_BACKEND_BASE_PATH=${backupRepoPath}
+
+# 4. cleanup outdated wal logs, only effective when existing at least one full backup
 wal-g delete garbage ARCHIVES
 
-# 4. delete wal-g
+# 5. delete wal-g
 dpBackupFilesCount=$(datasafed list --name "${backupName}_dp_*" /basebackups_005 | wc -l)
 if [[ ${dpBackupFilesCount} -le 1 ]]; then
   # if this base backup only belongs to a backup CR, delete it.
   echo "INFO: delete ${backupName}, backupRepo: ${backupRepo}"
-  wal-g delete target ${backupName} --confirm && wal-g delete garbage ARCHIVES --confirm
+  wal-g delete target ${backupName} --confirm  && wal-g delete garbage ARCHIVES --confirm
 fi
 datasafed rm "/basebackups_005/${backupName}_dp_${DP_BACKUP_NAME}"
 

--- a/addons/postgresql/dataprotection/wal-g-delete.sh
+++ b/addons/postgresql/dataprotection/wal-g-delete.sh
@@ -1,0 +1,36 @@
+export WALG_DATASAFED_CONFIG=""
+export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
+
+if [[ ${DP_BACKUP_BASE_PATH} != *"basebackups_005"* ]]; then
+   echo "INFO: can not found the backup repository."
+   exit 0
+fi
+
+# 1. config backup base path
+backupName=$(basename ${DP_BACKUP_BASE_PATH})
+backupDir=$(dirname ${DP_BACKUP_BASE_PATH})
+
+# 2. delete unsuccessfully backup and outdated WAL archive if this backup CR of the wal-g is not completed
+if [[ $backupName == "basebackups_005" ]]; then
+   echo "INFO: delete unsuccessfully backup files and outdated WAL archive."
+   export DATASAFED_BACKEND_BASE_PATH=${backupDir}
+   wal-g delete garbage --confirm
+   exit 0
+fi
+
+backupRepo=$(dirname ${backupDir})
+export DATASAFED_BACKEND_BASE_PATH=${backupRepo}
+
+# 3. cleanup outdated wal logs, only effective when existing at least one full backup
+wal-g delete garbage ARCHIVES
+
+# 4. delete wal-g
+dpBackupFilesCount=$(datasafed list --name "${backupName}_dp_*" /basebackups_005 | wc -l)
+if [[ ${dpBackupFilesCount} -le 1 ]]; then
+  # if this base backup only belongs to a backup CR, delete it.
+  echo "INFO: delete ${backupName}, backupRepo: ${backupRepo}"
+  wal-g delete target ${backupName} --confirm && wal-g delete garbage ARCHIVES --confirm
+fi
+datasafed rm "/basebackups_005/${backupName}_dp_${DP_BACKUP_NAME}"
+
+

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -1,12 +1,20 @@
 set -e
-dirPath=$(dirname ${DP_BACKUP_BASE_PATH})
-backupRepo=$(dirname ${dirPath})
 export WALG_DATASAFED_CONFIG=""
 export WALG_COMPRESSION_METHOD=zstd
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 # 20Gi for bundle file
 export WALG_TAR_SIZE_THRESHOLD=21474836480
-export DATASAFED_BACKEND_BASE_PATH="${backupRepo}"
+export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
+
+function getWalGSentinelInfo() {
+  local sentinelFile=${1}
+  local out=$(datasafed list ${sentinelFile})
+  if [ "${out}" == "${sentinelFile}" ]; then
+     datasafed pull "${sentinelFile}" ${sentinelFile}
+     echo "$(cat ${sentinelFile})"
+     return
+  fi
+}
 
 function config_wal_g_for_fetch_wal_log() {
     walg_dir=${VOLUME_DATA_DIR}/wal-g
@@ -23,11 +31,16 @@ function config_wal_g_for_fetch_wal_log() {
     echo "zstd" > ${walg_env}/WALG_COMPRESSION_METHOD
 }
 
-# 1. fetch base backup
-mkdir -p ${DATA_DIR};
-wal-g backup-fetch ${DATA_DIR} LATEST
+# 1. get restore info
+backupRepoPath=$(getWalGSentinelInfo "wal-g-backup-repo.path")
+backupName=$(getWalGSentinelInfo "wal-g-backup-name")
 
-# 2. config restore script
+# 2. fetch base backup
+export DATASAFED_BACKEND_BASE_PATH="${backupRepoPath}"
+mkdir -p ${DATA_DIR};
+wal-g backup-fetch ${DATA_DIR} ${backupName}
+
+# 3. config restore script
 touch ${DATA_DIR}/recovery.signal;
 mkdir -p ${RESTORE_SCRIPT_DIR};
 echo "#!/bin/bash" > ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
@@ -35,10 +48,10 @@ echo "[[ -d '${DATA_DIR}.old' ]] && mv -f ${DATA_DIR}.old/* ${DATA_DIR}/;" >> ${
 echo "sync;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 chmod +x ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 
-# 3. config wal-g to fetch wal logs
-config_wal_g_for_fetch_wal_log "${backupRepo}"
+# 4. config wal-g to fetch wal logs
+config_wal_g_for_fetch_wal_log "${backupRepoPath}"
 
-# 4. config restore command
+# 5. config restore command
 mkdir -p ${CONF_DIR} && chmod 777 -R ${CONF_DIR};
 echo "restore_command='envdir /home/postgres/pgdata/wal-g/restore-env /home/postgres/pgdata/wal-g/wal-g wal-fetch %f %p'" > ${CONF_DIR}/recovery.conf;
 if [[ ! -z ${DP_RESTORE_TIME} ]]; then

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -2,6 +2,7 @@ set -e
 dirPath=$(dirname ${DP_BACKUP_BASE_PATH})
 backupRepo=$(dirname ${dirPath})
 export WALG_DATASAFED_CONFIG=""
+export WALG_COMPRESSION_METHOD=zstd
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 # 20Gi for bundle file
 export WALG_TAR_SIZE_THRESHOLD=21474836480
@@ -19,6 +20,7 @@ function config_wal_g_for_fetch_wal_log() {
     # echo "" > ${walg_env}/WALG_PG_WAL_SIZE
     echo "${walg_dir}/datasafed.conf" > ${walg_env}/WALG_DATASAFED_CONFIG
     echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH
+    echo "zstd" > ${walg_env}/WALG_COMPRESSION_METHOD
 }
 
 # 1. fetch base backup

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -1,0 +1,48 @@
+set -e
+export WALG_DATASAFED_CONFIG=""
+export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
+export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
+# 20Gi for bundle file
+export WALG_TAR_SIZE_THRESHOLD=21474836480
+
+function config_wal_g_for_fetch_wal_log() {
+    walg_dir=${VOLUME_DATA_DIR}/wal-g
+    walg_env=${walg_dir}/restore-env
+    mkdir -p ${walg_dir}/restore-env
+    cp /etc/datasafed/datasafed.conf ${walg_dir}/datasafed.conf
+    cp /usr/bin/wal-g ${walg_dir}/wal-g
+    datasafed_base_path=${1:?missing datasafed_base_path}
+    # config wal-g env
+    # config WALG_PG_WAL_SIZE with wal_segment_size which fetched by psql
+    # echo "" > ${walg_env}/WALG_PG_WAL_SIZE
+    echo "${walg_dir}/datasafed.conf" > ${walg_env}/WALG_DATASAFED_CONFIG
+    echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH
+}
+
+# fetch base backup
+mkdir -p ${DATA_DIR};
+wal-g backup-fetch ${DATA_DIR} LATEST
+
+# config restore script
+touch ${DATA_DIR}/recovery.signal;
+mkdir -p ${RESTORE_SCRIPT_DIR};
+echo "#!/bin/bash" > ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
+echo "[[ -d '${DATA_DIR}.old' ]] && mv -f ${DATA_DIR}.old/* ${DATA_DIR}/;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
+echo "sync;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
+chmod +x ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
+
+# config wal-g to fetch wal logs
+dirPath=$(dirname ${DP_BACKUP_BASE_PATH})
+config_wal_g_for_fetch_wal_log ${dirPath}/archive
+
+# config restore command
+mkdir -p ${CONF_DIR} && chmod 777 -R ${CONF_DIR};
+echo "restore_command='envdir /home/postgres/pgdata/wal-g/restore-env /home/postgres/pgdata/wal-g/wal-g wal-fetch %f %p'" > ${CONF_DIR}/recovery.conf;
+if [[ ! -z ${DP_RESTORE_TIME} ]]; then
+   echo "recovery_target_time='${DP_RESTORE_TIME}'" >> ${CONF_DIR}/recovery.conf;
+   echo "recovery_target_action='promote'" >> ${CONF_DIR}/recovery.conf;
+   echo "recovery_target_timeline='latest'" >> ${CONF_DIR}/recovery.conf;
+fi
+# this step is necessary, data dir must be empty for patroni
+mv ${DATA_DIR} ${DATA_DIR}.old
+sync

--- a/addons/postgresql/templates/actionset-wal-g.yaml
+++ b/addons/postgresql/templates/actionset-wal-g.yaml
@@ -57,7 +57,7 @@ spec:
       syncProgress:
         enabled: true
         intervalSeconds: 5
-    deleteBackup:
+    preDelete:
       image: {{ .Values.image.registry | default "docker.io" }}/apecloud/wal-g:postgres-1.0
       command:
         - bash

--- a/addons/postgresql/templates/actionset-wal-g.yaml
+++ b/addons/postgresql/templates/actionset-wal-g.yaml
@@ -20,7 +20,7 @@ spec:
         - bash
         - -c
         - |
-          {{- .Files.Get "dataprotection/config-wal-g.sh" | nindent 10 }}
+          {{- .Files.Get "dataprotection/wal-g-config.sh" | nindent 10 }}
       syncProgress:
         enabled: false
         intervalSeconds: 5
@@ -53,11 +53,17 @@ spec:
         - bash
         - -c
         - |
-          {{- .Files.Get "dataprotection/backup-info-collector.sh" | nindent 10 }}
           {{- .Files.Get "dataprotection/wal-g-backup.sh" | nindent 10 }}
       syncProgress:
         enabled: true
         intervalSeconds: 5
+    deleteBackup:
+      image: {{ .Values.image.registry | default "docker.io" }}/apecloud/wal-g:postgres-1.0
+      command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/wal-g-delete.sh" | nindent 10 }}
   restore:
     prepareData:
       image: {{ .Values.image.registry | default "docker.io" }}/apecloud/wal-g:postgres-1.0

--- a/addons/postgresql/templates/actionset-wal-g.yaml
+++ b/addons/postgresql/templates/actionset-wal-g.yaml
@@ -1,0 +1,69 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: ActionSet
+metadata:
+  name: postgres-config-wal-g
+  labels:
+    clusterdefinition.kubeblocks.io/name: postgresql
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  backupType: Full
+  env:
+    - name: VOLUME_DATA_DIR
+      value: {{ .Values.dataMountPath }}
+  backup:
+    preBackup: []
+    postBackup: []
+    backupData:
+      image: {{ .Values.image.registry | default "docker.io" }}/apecloud/wal-g:postgres-1.0
+      runOnTargetPodNode: true
+      command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/config-wal-g.sh" | nindent 10 }}
+      syncProgress:
+        enabled: false
+        intervalSeconds: 5
+---
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: ActionSet
+metadata:
+  name: postgres-wal-g
+  labels:
+    clusterdefinition.kubeblocks.io/name: postgresql
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  backupType: Full
+  env:
+    - name: VOLUME_DATA_DIR
+      value: {{ .Values.dataMountPath }}
+    - name: RESTORE_SCRIPT_DIR
+      value: "$(VOLUME_DATA_DIR)/kb_restore"
+    - name: DATA_DIR
+      value: "$(VOLUME_DATA_DIR)/pgroot/data"
+    - name: CONF_DIR
+      value: "$(VOLUME_DATA_DIR)/conf"
+  backup:
+    preBackup: []
+    postBackup: []
+    backupData:
+      image: {{ .Values.image.registry | default "docker.io" }}/apecloud/wal-g:postgres-1.0
+      runOnTargetPodNode: true
+      command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/backup-info-collector.sh" | nindent 10 }}
+          {{- .Files.Get "dataprotection/wal-g-backup.sh" | nindent 10 }}
+      syncProgress:
+        enabled: true
+        intervalSeconds: 5
+  restore:
+    prepareData:
+      image: {{ .Values.image.registry | default "docker.io" }}/apecloud/wal-g:postgres-1.0
+      command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/wal-g-restore.sh" | nindent 10 }}
+    postReady: []

--- a/addons/postgresql/templates/backuppolicytemplate.yaml
+++ b/addons/postgresql/templates/backuppolicytemplate.yaml
@@ -32,12 +32,35 @@ spec:
       targetVolumes:
         volumes:
         - data
+    - name: config-wal-g
+      target:
+        role: ""
+        strategy: All
+      actionSetName: postgres-config-wal-g
+      snapshotVolumes: false
+      targetVolumes:
+        volumeMounts:
+          - name: data
+            mountPath: {{ .Values.dataMountPath }}
+    - name: wal-g
+      target:
+        role: secondary
+      actionSetName: postgres-wal-g
+      snapshotVolumes: false
+      targetVolumes:
+        volumeMounts:
+          - name: data
+            mountPath: {{ .Values.dataMountPath }}
     schedules: &backupschedules
     - backupMethod: pg-basebackup
       enabled: false
       cronExpression: "0 18 * * *"
       retentionPeriod: 7d
     - backupMethod: volume-snapshot
+      enabled: false
+      cronExpression: "0 18 * * *"
+      retentionPeriod: 7d
+    - backupMethod: wal-g
       enabled: false
       cronExpression: "0 18 * * *"
       retentionPeriod: 7d
@@ -66,4 +89,23 @@ spec:
         targetVolumes:
           volumes:
             - data
+      - name: config-wal-g
+        target:
+          role: ""
+          strategy: All
+        actionSetName: postgres-config-wal-g
+        snapshotVolumes: false
+        targetVolumes:
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.dataMountPath }}
+      - name: wal-g
+        target:
+          role: secondary
+        actionSetName: postgres-wal-g
+        snapshotVolumes: false
+        targetVolumes:
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.dataMountPath }}
     schedules: *backupschedules


### PR DESCRIPTION
how to use:
1. config wal-g tools
 `kbcli cluster backup <clusterName> --method config-wal-g`
wait this job to completed.
2.  enable archiving
```
apiVersion: apps.kubeblocks.io/v1alpha1
kind: OpsRequest
metadata:
  generateName: pg-cluster-reconfiguring-
spec:
  clusterRef: <clusterName>
  reconfigure:
    componentName: postgresql
    configurations:
      - keys:
          - key: postgresql.conf
            parameters:
              - key: archive_command
                value: "'envdir /home/postgres/pgdata/wal-g/env /home/postgres/pgdata/wal-g/wal-g wal-push %p'"
              - key: archive_timeout
                 value: "60s"
        name: postgresql-configuration
  type: Reconfiguring
```
3. backup 
`kbcli clutser backup <clusterName> --method wal-g`

4. how to cleanup the expired wal logs
 when deleting the full backup, it will cleanup the outedated wal logs with this backup. but if no any full backup exists, the wal logs will retain all time.
manually clean wal logs if necessary 