### PR TITLE
fix: fix apecloud-mysql parameter match path

### DIFF
--- a/addons/apecloud-mysql/scripts/set_config_variables.sh
+++ b/addons/apecloud-mysql/scripts/set_config_variables.sh
@@ -5,7 +5,7 @@ function set_config_variables(){
   config_content=$(sed -n '/\['$1'\]/,/\[/ { /\['$1'\]/d; /\[/q; p; }' $config_file)
   while read line
   do
-    if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*=[a-zA-Z0-9_.]*$ ]]; then
+    if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*=[a-zA-Z0-9_./-]*$ ]]; then
       echo $line
       eval "export $line"
     elif ! [[ -z $line  || $line =~ ^[[:space:]]*# ]]; then 


### PR DESCRIPTION
Fixed the problem that the vtgate setting environment variable script regular expression could not match '/', resulting in an unavailable path.