### PR TITLE
chore: Use 'unixSignalTrigger' to support parameter hot reload for wescale

### DIFF
--- a/addons/apecloud-mysql/Chart.yaml
+++ b/addons/apecloud-mysql/Chart.yaml
@@ -5,7 +5,7 @@ description: ApeCloud MySQL is a database that is compatible with MySQL syntax a
 
 type: application
 
-version: 0.8.0-beta.4
+version: 0.8.0-beta.5
 
 # This is the version number of the ApeCloud MySQL being deployed,
 # rather than the version number of ApeCloud MySQL-Scale itself.

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config-effect-scope.yaml
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config-effect-scope.yaml
@@ -16,6 +16,8 @@ staticParameters:
   - queryserver_config_strict_table_acl
   - table_acl_config_reload_interval
   - enforce_tableacl_config
+
+dynamicParameters:
   - queryserver_config_pool_size
   - queryserver_config_stream_pool_size
   - queryserver_config_transaction_cap

--- a/addons/apecloud-mysql/templates/configconstraint.yaml
+++ b/addons/apecloud-mysql/templates/configconstraint.yaml
@@ -67,30 +67,16 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
+  reloadOptions:
+    unixSignalTrigger:
+      processName: vtgate
+      signal: SIGHUP
+
   cfgSchemaTopLevelName: VtTabletParameter
 
   configurationSchema:
     cue: |-
       {{- .Files.Get "config/mysql-scale-vttablet-config-constraint.cue" | nindent 6 }}
-
-  # mysql-scale configuration file format
-  formatterConfig:
-    format: ini
-    iniConfig:
-      sectionName: vttablet
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: ConfigConstraint
-metadata:
-  name: {{ include "apecloud-mysql.configConstraintVtconsensusName" . }}
-  labels:
-    {{- include "apecloud-mysql.labels" . | nindent 4 }}
-spec:
-  cfgSchemaTopLevelName: VtConsensusParameter
-
-  configurationSchema:
-    cue: |-
-      {{- .Files.Get "config/mysql-scale-vtconsensus-config-constraint.cue" | nindent 6 }}
 
   ## define static parameter list
   {{- if hasKey $vttabletcc "staticParameters" }}
@@ -123,6 +109,24 @@ spec:
   formatterConfig:
     format: ini
     iniConfig:
+      sectionName: vttablet
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ConfigConstraint
+metadata:
+  name: {{ include "apecloud-mysql.configConstraintVtconsensusName" . }}
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+spec:
+  cfgSchemaTopLevelName: VtConsensusParameter
+
+  configurationSchema:
+    cue: |-
+      {{- .Files.Get "config/mysql-scale-vtconsensus-config-constraint.cue" | nindent 6 }}
+  # mysql-scale configuration file format
+  formatterConfig:
+    format: ini
+    iniConfig:
       sectionName: vtconsensus
 ---
 {{- $vtgatecc := .Files.Get "config/mysql-scale-vtgate-config-effect-scope.yaml" | fromYaml }}
@@ -133,6 +137,11 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
+  reloadOptions:
+    unixSignalTrigger:
+      processName: vtgate
+      signal: SIGHUP
+
   cfgSchemaTopLevelName: VtGateParameter
 
   configurationSchema:

--- a/addons/apecloud-mysql/templates/configconstraint.yaml
+++ b/addons/apecloud-mysql/templates/configconstraint.yaml
@@ -69,7 +69,7 @@ metadata:
 spec:
   reloadOptions:
     unixSignalTrigger:
-      processName: vtgate
+      processName: vttablet
       signal: SIGHUP
 
   cfgSchemaTopLevelName: VtTabletParameter

--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -118,7 +118,7 @@ wesqlscale:
     # if the value of wesqlscale.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
     repository: apecloud/apecloud-mysql-scale
-    tag: "0.2.2"
+    tag: "0.2.3"
     pullPolicy: IfNotPresent
 
 ## @param resourceNamePrefix Prefix for all resources name created by this chart, that can avoid name conflict


### PR DESCRIPTION
1. set `reloadOptions=unixSignalTrigger` for vttablet and vtgate
2. make pool size parameters in vttablet to be dynamic