### PR TITLE
chore: change zookeeper logConfig path

### DIFF
--- a/addons/zookeeper/values.yaml
+++ b/addons/zookeeper/values.yaml
@@ -22,5 +22,5 @@ containerPorts:
   http: 8080
 
 logConfigs:
-  info: /opt/zookeeper/logs/zookeeper-*-server-*.log
-  audit: /opt/zookeeper/logs/zookeeper_audit.log
+  info: /opt/bitnami/zookeeper/logs/zookeeper-*-server-*.log
+  audit: /opt/bitnami/zookeeper/logs/zookeeper_audit.log


### PR DESCRIPTION
fix: https://github.com/apecloud/kubeblocks-addons/issues/227
The logs path of the bitnami zookeeper image is `/opt/bitnami/zookeeper/logs/`
```
kuebclt exec -it zkeeper-pfkpxz-zookeeper-0 --  bash
I have no name!@zkeeper-pfkpxz-zookeeper-0:/$ ls /opt/bitnami/zookeeper/logs
zookeeper_audit.log
```