### PR TITLE
feat: support configure patroni parameters

### DIFF
--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ description: A PostgreSQL (with Patroni HA) cluster definition Helm chart for Ku
 
 type: application
 
-version: 0.8.0-alpha.5
+version: 0.8.0
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # and each PostgreSQL (with Patroni HA) version corresponds to a clusterVersion object.

--- a/addons/postgresql/config/patroni-parameter.yaml
+++ b/addons/postgresql/config/patroni-parameter.yaml
@@ -1,0 +1,4 @@
+- ttl
+- loop_wait
+- retry_timeouts
+- maximum_lag_on_failover

--- a/addons/postgresql/config/patroni-yaml.tpl
+++ b/addons/postgresql/config/patroni-yaml.tpl
@@ -1,0 +1,6 @@
+ttl: 30
+loop_wait: 10
+retry_timeout: 10
+maximum_lag_on_failover: 1048576
+max_timelines_history: 0
+check_timeline: true

--- a/addons/postgresql/scripts/generate_patroni_yaml.py
+++ b/addons/postgresql/scripts/generate_patroni_yaml.py
@@ -3,12 +3,16 @@
 import os
 import sys
 import yaml
+
+
 def write_file(config, filename, overwrite):
     if not overwrite and os.path.exists(filename):
         pass
     else:
         with open(filename, 'w') as f:
             f.write(config)
+
+
 def read_file_lines(file):
     ret = []
     for line in file.readlines():
@@ -16,6 +20,8 @@ def read_file_lines(file):
         if line and not line.startswith('#'):
             ret.append(line)
     return ret
+
+
 def postgresql_conf_to_dict(file_path):
     with open(file_path, 'r') as f:
         content = f.read()
@@ -29,33 +35,54 @@ def postgresql_conf_to_dict(file_path):
         key, value = line.split('=', 1)
         result[key.strip()] = value.strip().strip("'")
     return result
+
+
 def main(filename):
     restore_dir = os.environ.get('RESTORE_DATA_DIR', '')
     local_config = yaml.safe_load(
-        os.environ.get('SPILO_CONFIGURATION', os.environ.get('PATRONI_CONFIGURATION', ''))) or {}
-    if not 'postgresql' in local_config:
+        os.environ.get('SPILO_CONFIGURATION',
+                       os.environ.get('PATRONI_CONFIGURATION', ''))) or {}
+
+    # set postgresql parameters
+    if 'postgresql' not in local_config:
         local_config['postgresql'] = {}
     postgresql = local_config['postgresql']
     postgresql['config_dir'] = '/home/postgres/pgdata/conf'
     postgresql['custom_conf'] = '/home/postgres/conf/postgresql.conf'
+
     # add pg_hba.conf
     with open('/home/postgres/conf/pg_hba.conf', 'r') as f:
         lines = read_file_lines(f)
         if lines:
             postgresql['pg_hba'] = lines
-    if restore_dir and os.path.isfile(os.path.join(restore_dir, 'kb_restore.signal')):
-        if not 'bootstrap' in local_config:
+    if restore_dir and os.path.isfile(
+            os.path.join(restore_dir, 'kb_restore.signal')):
+        if 'bootstrap' not in local_config:
             local_config['bootstrap'] = {}
         with open('/home/postgres/conf/kb_restore.conf', 'r') as f:
             local_config['bootstrap'].update(yaml.safe_load(f))
+
     # point in time recovery(PITR)
-    data_dir = os.environ.get('PGDATA', '')
     if os.path.isfile("/home/postgres/pgdata/conf/recovery.conf"):
         with open('/home/postgres/conf/kb_pitr.conf', 'r') as f:
             pitr_config = yaml.safe_load(f)
             re_config = postgresql_conf_to_dict("/home/postgres/pgdata/conf/recovery.conf")
             pitr_config[pitr_config['method']]['recovery_conf'].update(re_config)
             local_config['bootstrap'].update(pitr_config)
-    write_file(yaml.dump(local_config, default_flow_style=False), filename, True)
+
+    # patroni parameters
+    if 'bootstrap' not in local_config:
+        local_config['bootstrap'] = {}
+    if 'dcs' not in local_config['bootstrap']:
+        local_config['bootstrap']['dcs'] = {}
+    if os.path.exists('/home/postgres/conf/patroni.yaml'):
+        with open('/home/postgres/conf/patroni.yaml', 'r') as f:
+            local_config['bootstrap']['dcs'].update(yaml.safe_load(f))
+    else:
+        print('patroni.yaml not found')
+    write_file(yaml.dump(local_config, default_flow_style=False), filename,
+               True)
+
+
 if __name__ == '__main__':
     main(sys.argv[1])

--- a/addons/postgresql/scripts/generate_patroni_yaml.py
+++ b/addons/postgresql/scripts/generate_patroni_yaml.py
@@ -80,8 +80,7 @@ def main(filename):
             local_config['bootstrap']['dcs'].update(yaml.safe_load(f))
     else:
         print('patroni.yaml not found')
-    write_file(yaml.dump(local_config, default_flow_style=False), filename,
-               True)
+    write_file(yaml.dump(local_config, default_flow_style=False), filename, True)
 
 
 if __name__ == '__main__':

--- a/addons/postgresql/templates/configmap-12.yaml
+++ b/addons/postgresql/templates/configmap-12.yaml
@@ -23,3 +23,5 @@ data:
       command: bash /home/postgres/pgdata/kb_restore/kb_restore.sh
       keep_existing_recovery_conf: false
       recovery_conf: {}
+  patroni.yaml: |-
+    {{- .Files.Get "config/patroni-yaml.tpl" | nindent 4 }}

--- a/addons/postgresql/templates/configmap-14.yaml
+++ b/addons/postgresql/templates/configmap-14.yaml
@@ -23,3 +23,5 @@ data:
       command: bash /home/postgres/pgdata/kb_restore/kb_restore.sh
       keep_existing_recovery_conf: false
       recovery_conf: {}
+  patroni.yaml: |-
+    {{- .Files.Get "config/patroni-yaml.tpl" | nindent 4 }}

--- a/addons/postgresql/templates/patroni-reload.yaml
+++ b/addons/postgresql/templates/patroni-reload.yaml
@@ -9,6 +9,8 @@ data:
     {{- .Files.Get "config/patroni-reload.tpl" | nindent 4 }}
   bootstrap.yaml: |-
     {{- .Files.Get "config/restart-parameter.yaml" | nindent 4 }}
+  patroni_parameter.yaml: |-
+    {{- .Files.Get "config/patroni-parameter.yaml" | nindent 4 }}
   reload.yaml: |-
     scripts: patroni_reload.tpl
     dataType: patroni


### PR DESCRIPTION
resolve https://github.com/apecloud/kubeblocks/issues/6486


* support configure patroni parameters:
  - ttl
  - loop_wait
  - retry_timeouts
  - maximum_lag_on_failover

https://patroni.readthedocs.io/en/latest/dynamic_configuration.html#dynamic-configuration


* set patroni parameters default value:
  - set maximum_lag_on_failover from 32MB to 1MB
  - set check_timeline to true
  
  ```
  ttl: 30
  loop_wait: 10
  retry_timeout: 10
  maximum_lag_on_failover: 1048576
  max_timelines_history: 0
  check_timeline: true
  ```

set `check_timeline` to true, avoid timeline conflict.
https://patroni.readthedocs.io/en/latest/replication_modes.html#asynchronous-mode-durability
Reference:

> By default, when running leader elections, Patroni does not take into account the current timeline of replicas, what in some cases could be undesirable behavior. You can prevent the node not having the same timeline as a former primary become the new leader by changing the value of check_timeline parameter to true.


Test:

```
root@mypg-postgresql-0:/home/postgres# curl -s http://localhost:8008/config | jq .
{
  "check_timeline": true,
  "loop_wait": 10,
  "max_timelines_history": 0,
  "maximum_lag_on_failover": "10000000",
  "postgresql": {
    "parameters": {
      "archive_command": "/bin/true",
      "archive_mode": "on",
      "archive_timeout": "1800s",
      "autovacuum_analyze_scale_factor": "0.1",
      "autovacuum_max_workers": "3",
      "autovacuum_vacuum_scale_factor": "0.05",
      "checkpoint_completion_target": "0.9",
      "hot_standby": "on",
      "log_autovacuum_min_duration": "10000",
      "log_checkpoints": "True",
      "log_connections": "False",
      "log_disconnections": "False",
      "log_line_prefix": "%t [%p]: [%l-1] %c %x %d %u %a %h ",
      "log_lock_waits": "on",
      "log_min_duration_statement": "1000",
      "log_statement": "ddl",
      "log_temp_files": "128kB",
      "max_connections": "56",
      "max_locks_per_transaction": "64",
      "max_prepared_transactions": "100",
      "max_replication_slots": "16",
      "max_wal_senders": "64",
      "max_worker_processes": "8",
      "tcp_keepalives_idle": "45s",
      "tcp_keepalives_interval": "10s",
      "track_commit_timestamp": "False",
      "track_functions": "pl",
      "wal_compression": "True",
      "wal_keep_size": "0",
      "wal_level": "replica",
      "wal_log_hints": "False"
    },
    "use_pg_rewind": true,
    "use_slots": true
  },
  "retry_timeout": 10,
  "ttl": 30
}

kbcli cluster configure mypg --config-spec postgresql-configuration --config-file postgresql.conf --set maximum_lag_on_failover=0       
Will updated configure file meta:
  ConfigSpec: postgresql-configuration    ConfigFile: postgresql.conf   ComponentName:  ClusterName: mypg       
OpsRequest mypg-reconfiguring-ztrjx created successfully, you can view the progress:
        kbcli cluster describe-ops mypg-reconfiguring-ztrjx -n default


root@mypg-postgresql-0:/home/postgres# curl -s http://localhost:8008/config | jq .maximum_lag_on_failover
"0"

```
