### PR TITLE
chore: add params for some wescale features

### DIFF
--- a/addons/apecloud-mysql/Chart.yaml
+++ b/addons/apecloud-mysql/Chart.yaml
@@ -5,7 +5,7 @@ description: ApeCloud MySQL is a database that is compatible with MySQL syntax a
 
 type: application
 
-version: 0.8.0-beta.6
+version: 0.8.0-beta.7
 
 # This is the version number of the ApeCloud MySQL being deployed,
 # rather than the version number of ApeCloud MySQL-Scale itself.

--- a/addons/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
+++ b/addons/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
@@ -86,6 +86,12 @@
 	// Set default strategy for DDL statements. Override with @@ddl_strategy session variable
 	ddl_strategy: string & "direct" | "online" | "mysql"
 
+    // Enable or disable the feature of showing information about the vttablet node which executing the SQL. (default false)
+    enable_display_sql_execution_vttablets: bool
+
+    // Enable or disable the feature of read write splitting for read only txn (default false)
+    enable_read_write_split_for_read_only_txn: bool
+
 	...
 }
 

--- a/addons/apecloud-mysql/config/mysql-scale-vtgate-config-effect-scope.yaml
+++ b/addons/apecloud-mysql/config/mysql-scale-vtgate-config-effect-scope.yaml
@@ -32,3 +32,7 @@ dynamicParameters:
   - ddl_strategy
   - enable_display_sql_execution_vttablets
   - enable_read_write_split_for_read_only_txn
+  - mysql_server_ssl_key
+  - mysql_server_ssl_cert
+  - mysql_server_ssl_ca
+  - mysql_server_require_secure_transport

--- a/addons/apecloud-mysql/config/mysql-scale-vtgate-config-effect-scope.yaml
+++ b/addons/apecloud-mysql/config/mysql-scale-vtgate-config-effect-scope.yaml
@@ -30,3 +30,5 @@ dynamicParameters:
   - read_after_write_consistency
   - read_after_write_timeout
   - ddl_strategy
+  - enable_display_sql_execution_vttablets
+  - enable_read_write_split_for_read_only_txn

--- a/addons/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
+++ b/addons/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
@@ -28,3 +28,5 @@ enable_query_log=true
 {{- end }}
 {{ end }}
 ddl_strategy=direct
+enable_display_sql_execution_vttablets=false
+enable_read_write_split_for_read_only_txn=false

--- a/addons/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
+++ b/addons/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
@@ -30,3 +30,14 @@ enable_query_log=true
 ddl_strategy=direct
 enable_display_sql_execution_vttablets=false
 enable_read_write_split_for_read_only_txn=false
+
+{{- if $.component.tlsConfig }}
+{{- $ca_file := getCAFile }}
+{{- $cert_file := getCertFile }}
+{{- $key_file := getKeyFile }}
+# tls
+# mysql_server_require_secure_transport=ON
+mysql_server_ssl_ca={{ $ca_file }}
+mysql_server_ssl_cert={{ $cert_file }}
+mysql_server_ssl_key={{ $key_file }}
+{{- end }}

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -72,7 +72,7 @@
     non_transactional_dml_table_gc_interval: int & >=1
 
     // the interval of job scheduler running in seconds
-    non_transactional_dml_job_scheduler_running_interval: int & >=1
+    non_transactional_dml_job_manager_running_interval: int & >=1
 
     // the interval of throttle check in milliseconds
     non_transactional_dml_throttle_check_interval: int & >=1

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -59,6 +59,30 @@
 	// query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout)
 	queryserver_config_transaction_cap: int & >=0
 
+	// the size of database connection pool in non transaction dml
+    non_transactional_dml_database_pool_size: int & >=1
+
+    // the number of rows to be processed in one batch by default
+    non_transactional_dml_default_batch_size: int & >=1
+
+    // the interval of batch processing in milliseconds by default
+    non_transactional_dml_default_batch_interval: int & >=1
+
+    // the interval of table GC in hours
+    non_transactional_dml_table_gc_interval: int & >=1
+
+    // the interval of job scheduler running in seconds
+    non_transactional_dml_job_scheduler_running_interval: int & >=1
+
+    // the interval of throttle check in milliseconds
+    non_transactional_dml_throttle_check_interval: int & >=1
+
+    // the threshold of batch size
+    non_transactional_dml_batch_size_threshold: int & >=1 & <=1000000
+
+    // final threshold = ratio * non_transactional_dml_batch_size_threshold / table index numbers
+    non_transactional_dml_batch_size_threshold_ratio: float & >=0 & <=1
+
 	...
 }
 

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config-effect-scope.yaml
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config-effect-scope.yaml
@@ -21,3 +21,11 @@ dynamicParameters:
   - queryserver_config_pool_size
   - queryserver_config_stream_pool_size
   - queryserver_config_transaction_cap
+  - non_transactional_dml_database_pool_size
+  - non_transactional_dml_default_batch_size
+  - non_transactional_dml_default_batch_interval
+  - non_transactional_dml_table_gc_interval
+  - non_transactional_dml_job_scheduler_running_interval
+  - non_transactional_dml_throttle_check_interval
+  - non_transactional_dml_batch_size_threshold
+  - non_transactional_dml_batch_size_threshold_ratio

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config-effect-scope.yaml
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config-effect-scope.yaml
@@ -25,7 +25,7 @@ dynamicParameters:
   - non_transactional_dml_default_batch_size
   - non_transactional_dml_default_batch_interval
   - non_transactional_dml_table_gc_interval
-  - non_transactional_dml_job_scheduler_running_interval
+  - non_transactional_dml_job_manager_running_interval
   - non_transactional_dml_throttle_check_interval
   - non_transactional_dml_batch_size_threshold
   - non_transactional_dml_batch_size_threshold_ratio

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
@@ -24,14 +24,19 @@ enforce_tableacl_config=false
 # max_connections={{ div ( div $phy_memory 4 ) $single_thread_memory }}
 {{- end}}
 
-# OltpReadPool
-queryserver_config_pool_size=30
-
-# OlapReadPool
-queryserver_config_stream_pool_size=30
+{{- $max_connections := div ( div $phy_memory 4 ) $single_thread_memory }}
+# 10 percentage
+{{- $pool_k := max 1 ( div (sub $max_connections 35) 10 ) }}
 
 # TxPool
-queryserver_config_transaction_cap=50
+queryserver_config_transaction_cap={{ mul 5 $pool_k }}
+
+# OltpReadPool
+queryserver_config_pool_size={{ mul 4 $pool_k }}
+
+# OlapReadPool
+queryserver_config_stream_pool_size={{ mul $pool_k }}
+
 
 # the size of database connection pool in non transaction dml
 non_transactional_dml_database_pool_size=3

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
@@ -46,7 +46,7 @@ non_transactional_dml_default_batch_interval=1
 non_transactional_dml_table_gc_interval=24
 
 # the interval of job scheduler running in seconds
-non_transactional_dml_job_scheduler_running_interval=24
+non_transactional_dml_job_manager_running_interval=24
 
 # the interval of throttle check in milliseconds
 non_transactional_dml_throttle_check_interval=250

--- a/addons/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
+++ b/addons/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
@@ -32,3 +32,27 @@ queryserver_config_stream_pool_size=30
 
 # TxPool
 queryserver_config_transaction_cap=50
+
+# the size of database connection pool in non transaction dml
+non_transactional_dml_database_pool_size=3
+
+# the number of rows to be processed in one batch by default
+non_transactional_dml_default_batch_size=2000
+
+# the interval of batch processing in milliseconds by default
+non_transactional_dml_default_batch_interval=1
+
+# the interval of table GC in hours
+non_transactional_dml_table_gc_interval=24
+
+# the interval of job scheduler running in seconds
+non_transactional_dml_job_scheduler_running_interval=24
+
+# the interval of throttle check in milliseconds
+non_transactional_dml_throttle_check_interval=250
+
+# the threshold of batch size
+non_transactional_dml_batch_size_threshold=10000
+
+# final threshold = ratio * non_transactional_dml_batch_size_threshold / table index numbers
+non_transactional_dml_batch_size_threshold_ratio=0.5

--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -118,7 +118,7 @@ wesqlscale:
     # if the value of wesqlscale.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
     repository: apecloud/apecloud-mysql-scale
-    tag: "0.2.4"
+    tag: "0.2.5"
     pullPolicy: IfNotPresent
 
 ## @param resourceNamePrefix Prefix for all resources name created by this chart, that can avoid name conflict


### PR DESCRIPTION
Add some params for wescale VTGate and VTTablet. 


The functions involved include `non-transactional DML`, `routing of read-only transaction` and` vttablet info display when SQL executing`.