### PR TITLE
chore: fix redis cluster template error

### DIFF
--- a/addons/redis-cluster/templates/cluster.yaml
+++ b/addons/redis-cluster/templates/cluster.yaml
@@ -30,27 +30,27 @@
   shardingSpecs:
   {{- include "redis-cluster.shardingSpec" . | indent 6 }}
   {{- else }}
-    {{- if .Values.nodePortEnabled }}
-    {{- include "redis-cluster.clusterCommonWithNodePort" . }}
-    {{- else }}
-    {{- include "kblib.clusterCommon" . }}
+  {{- if .Values.nodePortEnabled }}
+  {{- include "redis-cluster.clusterCommonWithNodePort" . }}
+  {{- else }}
+  {{- include "kblib.clusterCommon" . }}
+  {{- end }}
+  clusterDefinitionRef: redis  # ref clusterDefinition.name
+  componentSpecs:
+    - name: redis
+      componentDef: redis
+      {{- include "kblib.componentMonitor" . | indent 6 }}
+      {{- include "redis-cluster.replicaCount" . | indent 6 }}
+      enabledLogs:
+        - running
+      serviceAccountName: {{ include "kblib.serviceAccountName" . }}
+      switchPolicy:
+        type: Noop
+      {{- include "kblib.componentResources" . | indent 6 }}
+      {{- include "kblib.componentStorages" . | indent 6 }}
+      {{- include "kblib.componentServices" . | indent 6 }}
+    {{- if and (eq .Values.mode "replication") .Values.sentinel.enabled }}
+    {{- include "redis-cluster.sentinelCompDef" . | indent 4 }}
     {{- end }}
-    clusterDefinitionRef: redis  # ref clusterDefinition.name
-    componentSpecs:
-      - name: redis
-        componentDef: redis
-        {{- include "kblib.componentMonitor" . | indent 6 }}
-        {{- include "redis-cluster.replicaCount" . | indent 6 }}
-        enabledLogs:
-          - running
-        serviceAccountName: {{ include "kblib.serviceAccountName" . }}
-        switchPolicy:
-          type: Noop
-        {{- include "kblib.componentResources" . | indent 6 }}
-        {{- include "kblib.componentStorages" . | indent 6 }}
-        {{- include "kblib.componentServices" . | indent 6 }}
-      {{- if and (eq .Values.mode "replication") .Values.sentinel.enabled }}
-      {{- include "redis-cluster.sentinelCompDef" . | indent 4 }}
-      {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
```
helm template test ./redis-cluster  --set nodePortEnabled=true                       
Error: YAML parse error on redis-cluster/templates/cluster.yaml: error converting YAML to JSON: yaml: line 24: did not find expected '-' indicator

```