### PR TITLE
fix: apecloud-mysql componentDef

### DIFF
--- a/addons/apecloud-mysql-cluster/templates/cluster.yaml
+++ b/addons/apecloud-mysql-cluster/templates/cluster.yaml
@@ -16,7 +16,6 @@ spec:
   componentSpecs:
     - name: mysql
       componentDefRef: mysql # ref clusterdefinition componentDefs.name
-      componentDef: apecloud-mysql #
       {{- include "kblib.componentMonitor" . | indent 6 }}
       replicas: {{ include "apecloud-mysql-cluster.replicas" . }}
       enabledLogs:


### PR DESCRIPTION
apecloud-mysql's componentdefinition not ready, rollback to old API.