### PR TITLE
chore: improve redis cluster helm chart

### DIFF
--- a/addons/redis-cluster/templates/_helpers.tpl
+++ b/addons/redis-cluster/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Define redis cluster mode shardingSpec
 */}}
 {{- define "redis-cluster.shardingSpec" }}
 - name: shard
-  shards: {{ .Values.redisCluster.shardCount }}
+  {{- include "redis-cluster.shardCount" . | nindent 2 }}
   template:
     name: redis
     componentDef: redis-cluster
@@ -141,6 +141,17 @@ replicas: {{ max .Values.replicas 2 }}
 {{/*
 Define redis cluster sharding count.
 */}}
-{{- define "redis-cluster.shards" }}
-shards: {{ max .Values.redisCluster.shardCount 3 }}
+{{- define "redis-cluster.shardCount" -}}
+shards: {{ max .Values.shards 3 }}
+{{- end }}
+
+{{/*
+Define use legacy API or not
+*/}}
+{{- define "redis-cluster.useLegacyAPI" }}
+{{- if or .Values.nodePortEnabled .Values.mode "cluster" -}}
+false
+{{- else }}
+{{ .Values.useLegacyCompDef }}
+{{- end }}
 {{- end }}

--- a/addons/redis-cluster/templates/cluster.yaml
+++ b/addons/redis-cluster/templates/cluster.yaml
@@ -1,5 +1,5 @@
-{{- /* if nodeportEnabled is true, always use the KubeBlocks 0.8 API */ -}}
-{{- if and .Values.useLegacyCompDef (not .Values.nodePortEnabled) }}
+{{- $useLegacyAPI := include "redis-cluster.useLegacyAPI" . }}
+{{- if eq $useLegacyAPI "true" }}
 {{- include "kblib.clusterCommon" . }}
   clusterDefinitionRef: redis  # ref clusterDefinition.name
   componentSpecs:
@@ -28,7 +28,7 @@
   {{- include "kblib.clusterCommon" . }}
   clusterDefinitionRef: redis  # ref clusterDefinition.name
   shardingSpecs:
-  {{- include "redis-cluster.shardingSpec" . | indent 6 }}
+  {{- include "redis-cluster.shardingSpec" . | indent 4 }}
   {{- else }}
   {{- if .Values.nodePortEnabled }}
   {{- include "redis-cluster.clusterCommonWithNodePort" . }}

--- a/addons/redis-cluster/values.schema.json
+++ b/addons/redis-cluster/values.schema.json
@@ -33,6 +33,14 @@
       "minimum": 1,
       "maximum": 5
     },
+    "shards": {
+      "description": "The number of shards in the redis cluster, only valid ",
+      "title": "shards",
+      "type": "number",
+      "default": 3,
+      "minimum": 3,
+      "maximum": 2048
+    },
     "cpu": {
       "title": "CPU",
       "description": "CPU cores.",
@@ -71,14 +79,14 @@
       "type": "boolean",
       "default": false,
       "title": "nodePortEnabled",
-      "description":"Whether NodePort service is enabled, default is true"
+      "description": "Whether NodePort service is enabled, default is true"
     },
     "twemproxy": {
       "title": "The redis twemproxy component",
       "type": "object",
       "properties": {
         "enabled": {
-          "description":"Whether have twemproxy component, default is false",
+          "description": "Whether have twemproxy component, default is false",
           "title": "twemproxy.enable",
           "type": "boolean",
           "default": false
@@ -114,7 +122,7 @@
       "type": "object",
       "properties": {
         "enabled": {
-          "description":"Whether have sentinel component, default is true",
+          "description": "Whether have sentinel component, default is true",
           "title": "sentinel.enable",
           "type": "boolean",
           "default": true
@@ -150,20 +158,6 @@
           "default": 3,
           "minimum": 1,
           "maximum": 5
-        }
-      }
-    },
-    "redisCluster":{
-      "title": "The official redis cluster mode",
-      "type": "object",
-      "properties": {
-        "shardCount": {
-          "description": "The number of shards in the redis cluster",
-          "title": "shardCount",
-          "type": "number",
-          "default": 3,
-          "minimum": 3,
-          "maximum": 2048
         }
       }
     }

--- a/addons/redis-cluster/values.yaml
+++ b/addons/redis-cluster/values.yaml
@@ -21,6 +21,9 @@ mode: replication
 ## if mode is cluster and replicas is 2, it means every shard has 1 primary and 1 secondary, the count of shards is specified by redisCluster.shardCount
 replicas: 2
 
+## @param shards if mode is cluster, specify the redis cluster shard count, the minimum value is 3
+shards: 3
+
 ## @param cpu
 ##
 cpu: 0.5
@@ -64,9 +67,3 @@ sentinel:
   memory: 0.2
   storage: 20
   replicas: 3
-
-## if mode is cluster, specify the redis cluster parameters
-## @param redisCluster.shardCount specify the number of shards in the cluster, the minimum value is 3
-redisCluster:
-  shardCount: 3
-


### PR DESCRIPTION
* rename `redisCluster.shardCount` to `shards`, like `replicas`
* add template `redis-cluster.useLegacyAPI` to check if use old KubeBlocks version API

```
helm template redis ./redis-cluster --set mode=cluster


apiVersion: apps.kubeblocks.io/v1alpha1
kind: Cluster
metadata:
  name: redis
  namespace: demo
  labels: 
    helm.sh/chart: redis-cluster-0.8.0
    app.kubernetes.io/version: "7.0.6"
    app.kubernetes.io/instance: redis
spec:
  clusterVersionRef: redis-7.0.6
  terminationPolicy: Delete  
  affinity:
    podAntiAffinity: Preferred
    topologyKeys:
      - kubernetes.io/hostname
    tenancy: SharedNode
  clusterDefinitionRef: redis  # ref clusterDefinition.name
  shardingSpecs:    
    - name: shard
      shards: 3
      template:
        name: redis
        componentDef: redis-cluster
        replicas: 2
        resources:
          limits:
            cpu: "0.5"
            memory:  "0.5Gi"
          requests:
            cpu: "0.5"
            memory:  "0.5Gi"
        volumeClaimTemplates:
          - name: data
            spec:
              accessModes:
                - ReadWriteOnce
              resources:
                requests:
                  storage: 20Gi
```