### PR TITLE
fix: redis proxy svc has a wrong port mapping

### DIFF
--- a/addons/redis/templates/clusterdefinition.yaml
+++ b/addons/redis/templates/clusterdefinition.yaml
@@ -246,7 +246,7 @@ spec:
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 22121
-                name: redis-proxy
+                name: redis-twemproxy
             volumeMounts:
               - name: data
                 mountPath: {{ .Values.dataMountPath }}


### PR DESCRIPTION
![image](https://github.com/apecloud/kubeblocks-addons/assets/11702171/c5b24605-670f-4e22-bb94-4e6d350b8cff)
