### PR TITLE
feat: support set storage class for clusters

### DIFF
--- a/addons/apecloud-mysql-cluster/values.schema.json
+++ b/addons/apecloud-mysql-cluster/values.schema.json
@@ -60,6 +60,11 @@
       "minimum": 1,
       "maximum": 10000
     },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
+    },
     "proxyEnabled": {
       "title": "Proxy",
       "description": "Enable proxy or not.",

--- a/addons/camellia-redis-proxy-cluster/values.schema.json
+++ b/addons/camellia-redis-proxy-cluster/values.schema.json
@@ -49,6 +49,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/kblib/templates/_storages.tpl
+++ b/addons/kblib/templates/_storages.tpl
@@ -10,4 +10,7 @@ volumeClaimTemplates:
       resources:
         requests:
           storage: {{ print .Values.storage "Gi" }}
+      {{- if .Values.storageClassName }}
+      storageClassName: {{ .Values.storageClassName | quote }}
+      {{- end }}
 {{- end }}

--- a/addons/minio-cluster/values.schema.json
+++ b/addons/minio-cluster/values.schema.json
@@ -43,6 +43,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/mogdb-cluster/values.schema.json
+++ b/addons/mogdb-cluster/values.schema.json
@@ -53,6 +53,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/mongodb-cluster/values.schema.json
+++ b/addons/mongodb-cluster/values.schema.json
@@ -59,6 +59,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/official-postgresql-cluster/values.schema.json
+++ b/addons/official-postgresql-cluster/values.schema.json
@@ -59,6 +59,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/opengauss-cluster/values.schema.json
+++ b/addons/opengauss-cluster/values.schema.json
@@ -52,6 +52,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/oracle-cluster/values.schema.json
+++ b/addons/oracle-cluster/values.schema.json
@@ -52,6 +52,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/oracle-mysql-cluster/values.schema.json
+++ b/addons/oracle-mysql-cluster/values.schema.json
@@ -49,6 +49,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 500
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/orioledb-cluster/values.schema.json
+++ b/addons/orioledb-cluster/values.schema.json
@@ -54,6 +54,11 @@
       "minimum": 1,
       "maximum": 10000
     },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
+    },
     "etcd": {
       "type": "object",
       "title": "The patroni dependency etcd Schema",

--- a/addons/postgresql-cluster/values.schema.json
+++ b/addons/postgresql-cluster/values.schema.json
@@ -59,6 +59,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/qdrant-cluster/values.schema.json
+++ b/addons/qdrant-cluster/values.schema.json
@@ -59,6 +59,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/redis-cluster/values.schema.json
+++ b/addons/redis-cluster/values.schema.json
@@ -68,6 +68,11 @@
       "minimum": 1,
       "maximum": 10000
     },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
+    },
     "nodePortEnabled": {
       "type": "boolean",
       "default": false,

--- a/addons/tdengine-cluster/values.schema.json
+++ b/addons/tdengine-cluster/values.schema.json
@@ -59,6 +59,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }

--- a/addons/yashandb-cluster/values.schema.json
+++ b/addons/yashandb-cluster/values.schema.json
@@ -49,6 +49,11 @@
       "default": 20,
       "minimum": 1,
       "maximum": 500
+    },
+    "storageClassName": {
+      "title": "Storage Class Name",
+      "description": "Storage class name of the data volume",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
- Support set storage class in `kblib.componentStorages`
- Adapt the value schema for all the addons if they use this template

Fix: #457 