### PR TITLE
feat: support kafka exporter when tls is enabled

### DIFF
--- a/addons/kafka/scripts/kafka-exporter-setup.sh.tpl
+++ b/addons/kafka/scripts/kafka-exporter-setup.sh.tpl
@@ -21,7 +21,7 @@
 {{- $servers := "" }}
 {{- range $i, $e := until $replicas }}
   {{- $podFQDN := printf "%s-%s-%d.%s-%s-headless.%s.svc.%s" $clusterName $component.name $i $clusterName $component.name $namespace $.clusterDomain }}
-  {{- $server := printf "--kafka.server=%s:9092 \\\n" $podFQDN }}
+  {{- $server := printf "--kafka.server=%s:9094 \\\n" $podFQDN }}
   {{- $servers = printf "%s\t%s" $servers $server }}
 {{- end }}
 {{ $servers = trimSuffix " \\\n" $servers}}

--- a/addons/kafka/scripts/kafka-exporter-setup.tpl
+++ b/addons/kafka/scripts/kafka-exporter-setup.tpl
@@ -21,7 +21,7 @@
 {{- $servers := "" }}
 {{- range $i, $e := until $replicas }}
   {{- $podFQDN := printf "%s-%s-%d.%s-%s-headless.%s.svc.%s" $clusterName $component.name $i $clusterName $component.name $namespace $.clusterDomain }}
-  {{- $server := printf "--kafka.server=%s:9092 \\\n" $podFQDN }}
+  {{- $server := printf "--kafka.server=%s:9094 \\\n" $podFQDN }}
   {{- $servers = printf "%s\t%s" $servers $server }}
 {{- end }}
 {{ $servers = trimSuffix " \\\n" $servers}}


### PR DESCRIPTION
Describe: After setting up an SSL connection on port 9092, the original monitoring components required a new communication port. The Kafka cluster had reserved an internal port 9094. Therefore, adjustments were made in the startup script of the exporter.

Test: Whether SSL is enabled or not, the Kafka cluster run correctly.