### PR TITLE
feat: upgrade pulsar to 0.9 API

### DIFF
--- a/addons-cluster/pulsar-cluster/templates/_helpers.tpl
+++ b/addons-cluster/pulsar-cluster/templates/_helpers.tpl
@@ -81,16 +81,29 @@ Pulsar ZooKeeper service ref
 serviceRefs:
 - name: pulsarZookeeper
   namespace: {{ .Values.serviceReference.zookeeper.namespace | default .Release.Namespace }}
+  {{- if .Values.serviceReference.zookeeper.clusterServiceSelector }}
+  clusterServiceSelector:
+    cluster: {{ .Values.serviceReference.zookeeper.clusterServiceSelector.cluster }}
+    {{- if .Values.serviceReference.zookeeper.clusterServiceSelector.service}}
+    service:
+    {{- if .Values.serviceReference.zookeeper.clusterServiceSelector.service.component}}
+      component: {{.Values.serviceReference.zookeeper.clusterServiceSelector.service.component}}
+    {{- end}}
+      service: client
+    {{- if .Values.serviceReference.zookeeper.clusterServiceSelector.service.port}}
+      port: {{.Values.serviceReference.zookeeper.clusterServiceSelector.service.port}}
+    {{- end}}
+    {{- end}}
+    {{- if .Values.serviceReference.zookeeper.clusterServiceSelector.credential}}
+    credential:
+      component: {{.Values.serviceReference.zookeeper.clusterServiceSelector.credential.component}}
+      name: {{.Values.serviceReference.zookeeper.clusterServiceSelector.credential.name}}
+    {{- end}}
+  {{- end}}
   {{- if .Values.serviceReference.zookeeper.serviceDescriptor }}
-  serviceDescriptor: {{ .Values.serviceReference.zookeeper.serviceDescriptor }}
-  {{- else }}
-  {{- if .Values.serviceReference.zookeeper.cluster }}
-  cluster: {{ .Values.serviceReference.zookeeper.cluster }}
-  {{- else }}
-  cluster: {{ include "kblib.clusterName" . }}-zookeeper
+    serviceDescriptor: {{.Values.serviceReference.zookeeper.serviceDescriptor}}
   {{- end }}
   {{- end }}
-{{- end}}
 {{- end}}
 }}
 

--- a/addons-cluster/pulsar-cluster/templates/cluster.yaml
+++ b/addons-cluster/pulsar-cluster/templates/cluster.yaml
@@ -79,7 +79,7 @@ spec:
     {{- end }}
     {{- end }}
   componentSpecs:
-  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (.Values.proxy.enabled) }}
+  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (and (eq .Values.mode "") .Values.proxy.enabled) }}
     - name: proxy
     {{- if not  $topologyEnable }}
       componentDef: pulsar-proxy
@@ -101,7 +101,7 @@ spec:
       {{- end }}
       {{- end }}
     {{- end }}
-  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (.Values.bookiesRecovery.enabled) }}
+  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") ( and (eq .Values.mode "") .Values.bookiesRecovery.enabled) }}
     - name: bookies-recovery
     {{- if not $topologyEnable }}
       componentDef: pulsar-bkrecovery

--- a/addons-cluster/pulsar-cluster/templates/cluster.yaml
+++ b/addons-cluster/pulsar-cluster/templates/cluster.yaml
@@ -33,11 +33,7 @@ spec:
       serviceName: proxy
       componentSelector: proxy
       spec:
-        {{- if .Values.nodePortEnabled }}
-        type: NodePort
-        {{- else }}
         type: ClusterIP
-        {{- end }}
         ports:
           - name: pulsar
             port: 6650

--- a/addons-cluster/pulsar-cluster/templates/cluster.yaml
+++ b/addons-cluster/pulsar-cluster/templates/cluster.yaml
@@ -129,6 +129,12 @@ spec:
       {{- end }}
       {{ include "pulsar-zookeeper-ref" . | nindent 6 }}
       monitor: {{ .Values.monitor.enabled | default false }}
+      {{- if .Values.nodePortEnabled }}
+      services:
+        - name: advertised-listener
+          serviceType: NodePort
+          podService: true
+      {{- end }}
       replicas: {{ .Values.broker.replicaCount | default 3 }}
       {{- with  .Values.broker.resources }}
       resources:

--- a/addons-cluster/pulsar-cluster/templates/cluster.yaml
+++ b/addons-cluster/pulsar-cluster/templates/cluster.yaml
@@ -79,7 +79,7 @@ spec:
     {{- end }}
     {{- end }}
   componentSpecs:
-  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (and (eq .Values.mode "") .Values.proxy.enabled) }}
+  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (and (not $topologyEnable) .Values.proxy.enabled) }}
     - name: proxy
     {{- if not  $topologyEnable }}
       componentDef: pulsar-proxy
@@ -101,7 +101,7 @@ spec:
       {{- end }}
       {{- end }}
     {{- end }}
-  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") ( and (eq .Values.mode "") .Values.bookiesRecovery.enabled) }}
+  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") ( and (not $topologyEnable) .Values.bookiesRecovery.enabled) }}
     - name: bookies-recovery
     {{- if not $topologyEnable }}
       componentDef: pulsar-bkrecovery

--- a/addons-cluster/pulsar-cluster/templates/cluster.yaml
+++ b/addons-cluster/pulsar-cluster/templates/cluster.yaml
@@ -14,9 +14,12 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  clusterDefinitionRef: pulsar
-  clusterVersionRef: {{ .Values.version }}
   terminationPolicy: {{ $.Values.terminationPolicy }}
+  {{- $topologyEnable :=  eq .Values.mode "" | default false }}
+  {{- if $topologyEnable}}
+  clusterDefinitionRef: pulsar
+  topology: {{ .Values.mode }}
+  {{- end }}
   affinity:
     {{- with $.Values.topologyKeys }}
     topologyKeys: {{ . | toYaml | nindent 6 }}
@@ -76,10 +79,9 @@ spec:
     {{- end }}
     {{- end }}
   componentSpecs:
-    {{- if .Values.proxy.enabled }}
+  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (.Values.proxy.enabled) }}
     - name: proxy
-      componentDefRef: pulsar-proxy
-      {{- if eq .Values.version "pulsar-3.0.2" }}
+    {{- if not  $topologyEnable }}
       componentDef: pulsar-proxy
       {{- end }}
       {{ include "pulsar-zookeeper-ref" . | nindent 6 }}
@@ -99,9 +101,30 @@ spec:
       {{- end }}
       {{- end }}
     {{- end }}
+  {{- if or (eq .Values.mode "pulsar-enhanced-cluster") (.Values.bookiesRecovery.enabled) }}
+    - name: bookies-recovery
+    {{- if not $topologyEnable }}
+      componentDef: pulsar-bkrecovery
+      {{- end }}
+      {{ include "pulsar-zookeeper-ref" . | nindent 6 }}
+      monitor: {{ .Values.monitor.enabled | default false }}
+      replicas: {{ .Values.bookiesRecovery.replicaCount | default 3 }}
+    {{- with  .Values.bookiesRecovery.resources }}
+      resources:
+      {{- if .limits }}
+        limits:
+          cpu: {{ .limits.cpu | quote }}
+          memory: {{ .limits.memory | quote }}
+      {{- end }}
+      {{- if .requests }}
+        requests:
+          cpu: {{ .requests.cpu | quote }}
+          memory: {{ .requests.memory | quote }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
     - name: broker
-      componentDefRef: pulsar-broker
-      {{- if eq .Values.version "pulsar-3.0.2" }}
+      {{- if not  $topologyEnable }}
       componentDef: pulsar-broker
       {{- end }}
       {{ include "pulsar-zookeeper-ref" . | nindent 6 }}
@@ -120,32 +143,8 @@ spec:
           memory: {{ .requests.memory | quote }}
       {{- end }}
       {{- end }}
-    {{- if .Values.bookiesRecovery.enabled }}
-    - name: bookies-recovery
-      componentDefRef: bookies-recovery
-      {{- if eq .Values.version "pulsar-3.0.2" }}
-      componentDef: pulsar-bkrecovery
-      {{- end }}
-      {{ include "pulsar-zookeeper-ref" . | nindent 6 }}
-      monitor: {{ .Values.monitor.enabled | default false }}
-      replicas: {{ .Values.bookiesRecovery.replicaCount | default 3 }}
-      {{- with  .Values.bookiesRecovery.resources }}
-      resources:
-      {{- if .limits }}
-        limits:
-          cpu: {{ .limits.cpu | quote }}
-          memory: {{ .limits.memory | quote }}
-      {{- end }}
-      {{- if .requests }}
-        requests:
-          cpu: {{ .requests.cpu | quote }}
-          memory: {{ .requests.memory | quote }}
-      {{- end }}
-      {{- end }}
-    {{- end }}
     - name: bookies
-      componentDefRef: bookies
-      {{- if eq .Values.version "pulsar-3.0.2" }}
+      {{- if not  $topologyEnable }}
       componentDef: pulsar-bookkeeper
       {{- end }}
       {{ include "pulsar-zookeeper-ref" . | nindent 6 }}
@@ -193,8 +192,7 @@ spec:
       {{- end }}
     {{- if not .Values.serviceReference.enabled }}
     - name: zookeeper
-      componentDefRef: zookeeper
-      {{- if eq .Values.version "pulsar-3.0.2" }}
+      {{- if not  $topologyEnable }}
       componentDef: pulsar-zookeeper
       {{- end }}
       monitor: {{ .Values.monitor.enabled | default false }}

--- a/addons-cluster/pulsar-cluster/templates/tests/benchmark.yaml
+++ b/addons-cluster/pulsar-cluster/templates/tests/benchmark.yaml
@@ -85,7 +85,7 @@ metadata:
 spec:
   containers:
     - name: omb-k2k
-      image: docker.io/apecloud/omb:0.1
+      image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/omb:0.1
       command: ['bin/benchmark']
       args: 
         - --drivers 

--- a/addons-cluster/pulsar-cluster/templates/tests/benchmark.yaml
+++ b/addons-cluster/pulsar-cluster/templates/tests/benchmark.yaml
@@ -85,7 +85,7 @@ metadata:
 spec:
   containers:
     - name: omb-k2k
-      image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/omb:0.1
+      image: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/omb:0.1
       command: ['bin/benchmark']
       args: 
         - --drivers 

--- a/addons-cluster/pulsar-cluster/templates/tests/benchmark.yaml
+++ b/addons-cluster/pulsar-cluster/templates/tests/benchmark.yaml
@@ -85,7 +85,7 @@ metadata:
 spec:
   containers:
     - name: omb-k2k
-      image: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/omb:0.1
+      image: {{.Values.image.registry}}/apecloud/omb:0.1
       command: ['bin/benchmark']
       args: 
         - --drivers 

--- a/addons-cluster/pulsar-cluster/values.yaml
+++ b/addons-cluster/pulsar-cluster/values.yaml
@@ -10,11 +10,14 @@ terminationPolicy: WipeOut
 commonAnnotations:
   resource.kubeblocks.io/ignore-constraint: "true"
 
+image:
+  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+
 ## @param mode pulsar cluster topology mode: pulsar-basic-cluster and pulsar-enhanced-cluster
 ## pulsar-basic-cluster: contains broker, zookeeper and bookkeeper
 ## pulsar-enhanced-cluster: contains broker, zookeeper, bookkeeper, proxy and bkrecovery
 ## If you want to use any other topologies, such as adding only a proxy to the pulsar-basic-cluster, this parameter needs to be set to "".
-mode: pulsar-basic-cluster
+mode: pulsar-enhanced-cluster
 
 ## Monitoring configurations
 monitor:
@@ -72,10 +75,10 @@ bookies:
     enabled: true
     data:
       storageClassName:
-      size: 20Gi
+      size: 8Gi
     log:
       storageClassName:
-      size: 20Gi
+      size: 8Gi
 
 ## Bookies-recovery configuration
 bookiesRecovery:
@@ -99,7 +102,7 @@ bookiesRecovery:
 zookeeper:
   ## @param zookeeper.replicaCount Number of Zookeeper replicas
   ##
-  replicaCount: 3
+  replicaCount: 1
 
   ## Zookeeper workload pod resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -119,10 +122,10 @@ zookeeper:
     enabled: true
     data:
       storageClassName:
-      size: 20Gi
+      size: 8Gi
     log:
       storageClassName:
-      size: 20Gi
+      size: 8Gi
 
   ## @param keeper.tolerations Tolerations for *Keeper pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/addons-cluster/pulsar-cluster/values.yaml
+++ b/addons-cluster/pulsar-cluster/values.yaml
@@ -1,6 +1,6 @@
 ## @param version Pulsar Cluster version
 ##
-version: pulsar-2.11.2
+version: pulsar-3.0.2
 
 ## @param terminationPolicy define Cluster termination policy. One of DoNotTerminate, Halt, Delete, WipeOut.
 ##
@@ -9,6 +9,12 @@ terminationPolicy: WipeOut
 ## Annotation configurations
 commonAnnotations:
   resource.kubeblocks.io/ignore-constraint: "true"
+
+## @param mode pulsar cluster topology mode: pulsar-basic-cluster and pulsar-enhanced-cluster
+## pulsar-basic-cluster: contains broker, zookeeper and bookkeeper
+## pulsar-enhanced-cluster: contains broker, zookeeper, bookkeeper, proxy and bkrecovery
+## If you want to use any other topologies, such as adding only a proxy to the pulsar-basic-cluster, this parameter needs to be set to nil.
+mode: pulsar-basic-cluster
 
 ## Monitoring configurations
 monitor:
@@ -66,10 +72,10 @@ bookies:
     enabled: true
     data:
       storageClassName:
-      size: 20Gi
+      size: 10Gi
     log:
       storageClassName:
-      size: 20Gi
+      size: 10Gi
 
 ## Bookies-recovery configuration
 bookiesRecovery:
@@ -113,10 +119,10 @@ zookeeper:
     enabled: true
     data:
       storageClassName:
-      size: 20Gi
+      size: 2Gi
     log:
       storageClassName:
-      size: 20Gi
+      size: 2Gi
 
   ## @param keeper.tolerations Tolerations for *Keeper pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -125,7 +131,7 @@ zookeeper:
 
 broker:
   ## @param broker.replicaCount Number of Broker replicas
-  replicaCount: 3
+  replicaCount: 1
 
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -183,7 +189,16 @@ serviceReference:
     namespace: ""
     ## if zookeeper service is provided by another KubeBlocks Cluster，please specify cluster name which is referenced.
     ## Please do not specify both cluster and serviceDescriptor at the same time.
-    cluster: ""
+    clusterServiceSelector:
+      cluster:
+      service:
+        component:
+        service:
+        port:
+      credential:
+        component:
+        name:
+
     ## if zookeeper service is provided by external source, please create the ServiceDescriptor Object of zookeeper in target namespace firstly, then specify the serviceDescriptor name here.
     ## Please do not specify both cluster and serviceDescriptor at the same time.
     serviceDescriptor: ""

--- a/addons-cluster/pulsar-cluster/values.yaml
+++ b/addons-cluster/pulsar-cluster/values.yaml
@@ -13,7 +13,7 @@ commonAnnotations:
 ## @param mode pulsar cluster topology mode: pulsar-basic-cluster and pulsar-enhanced-cluster
 ## pulsar-basic-cluster: contains broker, zookeeper and bookkeeper
 ## pulsar-enhanced-cluster: contains broker, zookeeper, bookkeeper, proxy and bkrecovery
-## If you want to use any other topologies, such as adding only a proxy to the pulsar-basic-cluster, this parameter needs to be set to nil.
+## If you want to use any other topologies, such as adding only a proxy to the pulsar-basic-cluster, this parameter needs to be set to "".
 mode: pulsar-basic-cluster
 
 ## Monitoring configurations
@@ -72,10 +72,10 @@ bookies:
     enabled: true
     data:
       storageClassName:
-      size: 10Gi
+      size: 20Gi
     log:
       storageClassName:
-      size: 10Gi
+      size: 20Gi
 
 ## Bookies-recovery configuration
 bookiesRecovery:
@@ -119,10 +119,10 @@ zookeeper:
     enabled: true
     data:
       storageClassName:
-      size: 2Gi
+      size: 20Gi
     log:
       storageClassName:
-      size: 2Gi
+      size: 20Gi
 
   ## @param keeper.tolerations Tolerations for *Keeper pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/addons/pulsar/config/bookies-env.tpl
+++ b/addons/pulsar/config/bookies-env.tpl
@@ -11,20 +11,12 @@ PULSAR_MEM: -XX:MinRAMPercentage=25 -XX:MaxRAMPercentage=50 {{ $MaxDirectMemoryS
 {{- $clusterName := $.cluster.metadata.name }}
 {{- $namespace := $.cluster.metadata.namespace }}
 {{- $pulsar_zk_from_service_ref := fromJson "{}" }}
-{{- $pulsar_zk_from_component := fromJson "{}" }}
 
 {{- if index $.component "serviceReferences" }}
   {{- range $i, $e := $.component.serviceReferences }}
     {{- if eq $i "pulsarZookeeper" }}
       {{- $pulsar_zk_from_service_ref = $e }}
       {{- break }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- range $i, $e := $.cluster.spec.componentSpecs }}
-  {{- if index $e "componentDefRef" }}
-    {{- if eq $e.componentDefRef "zookeeper" }}
-      {{- $pulsar_zk_from_component = $e }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/addons/pulsar/config/bookies-recovery-env.tpl
+++ b/addons/pulsar/config/bookies-recovery-env.tpl
@@ -37,8 +37,8 @@ PULSAR_MEM: -XX:MinRAMPercentage=25 -XX:MaxRAMPercentage=50 {{ $MaxDirectMemoryS
 # Try to get zookeeper from service reference first, if zookeeper service reference is empty, get default zookeeper componentDef in ClusterDefinition
 {{- $zk_server := "" }}
 {{- if $pulsar_zk_from_service_ref }}
-  {{- if and (index $pulsar_zk_from_service_ref.spec "endpoint") (index $pulsar_zk_from_service_ref.spec "port") }}
-     {{- $zk_server = printf "%s:%s" $pulsar_zk_from_service_ref.spec.endpoint.value $pulsar_zk_from_service_ref.spec.port.value }}
+  {{- if index $pulsar_zk_from_service_ref.spec "endpoint" }}
+     {{- $zk_server = $pulsar_zk_from_service_ref.spec.endpoint.value }}
   {{- else }}
      {{- $zk_server = printf "%s-zookeeper.%s.svc:2181" $clusterName $namespace }}
   {{- end }}

--- a/addons/pulsar/config/broker-env.tpl
+++ b/addons/pulsar/config/broker-env.tpl
@@ -10,20 +10,12 @@ PULSAR_MEM: -XX:MinRAMPercentage=30 -XX:MaxRAMPercentage=30 {{ $MaxDirectMemoryS
 {{- $clusterName := $.cluster.metadata.name }}
 {{- $namespace := $.cluster.metadata.namespace }}
 {{- $pulsar_zk_from_service_ref := fromJson "{}" }}
-{{- $pulsar_zk_from_component := fromJson "{}" }}
 
 {{- if index $.component "serviceReferences" }}
   {{- range $i, $e := $.component.serviceReferences }}
     {{- if eq $i "pulsarZookeeper" }}
       {{- $pulsar_zk_from_service_ref = $e }}
       {{- break }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- range $i, $e := $.cluster.spec.componentSpecs }}
-  {{- if index $e "componentDefRef" }}
-    {{- if eq $e.componentDefRef "zookeeper" }}
-      {{- $pulsar_zk_from_component = $e }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/addons/pulsar/config/proxy-env.tpl
+++ b/addons/pulsar/config/proxy-env.tpl
@@ -10,7 +10,6 @@ PULSAR_MEM: -XX:MinRAMPercentage=30 -XX:MaxRAMPercentage=30 {{ $MaxDirectMemoryS
 {{- $clusterName := $.cluster.metadata.name }}
 {{- $namespace := $.cluster.metadata.namespace }}
 {{- $pulsar_zk_from_service_ref := fromJson "{}" }}
-{{- $pulsar_zk_from_component := fromJson "{}" }}
 
 {{- if index $.component "serviceReferences" }}
   {{- range $i, $e := $.component.serviceReferences }}
@@ -20,19 +19,12 @@ PULSAR_MEM: -XX:MinRAMPercentage=30 -XX:MaxRAMPercentage=30 {{ $MaxDirectMemoryS
     {{- end }}
   {{- end }}
 {{- end }}
-{{- range $i, $e := $.cluster.spec.componentSpecs }}
-  {{- if index $e "componentDefRef" }}
-    {{- if eq $e.componentDefRef "zookeeper" }}
-      {{- $pulsar_zk_from_component = $e }}
-    {{- end }}
-  {{- end }}
-{{- end }}
 
 # Try to get zookeeper from service reference first, if zookeeper service reference is empty, get default zookeeper componentDef in ClusterDefinition
 {{- $zk_server := "" }}
 {{- if $pulsar_zk_from_service_ref }}
-  {{- if and (index $pulsar_zk_from_service_ref.spec "endpoint") (index $pulsar_zk_from_service_ref.spec "port") }}
-     {{- $zk_server = printf "%s:%s" $pulsar_zk_from_service_ref.spec.endpoint.value $pulsar_zk_from_service_ref.spec.port.value }}
+  {{- if index $pulsar_zk_from_service_ref.spec "endpoint" }}
+     {{- $zk_server = $pulsar_zk_from_service_ref.spec.endpoint.value }}
   {{- else }}
      {{- $zk_server = printf "%s-zookeeper.%s.svc:2181" $clusterName $namespace }}
   {{- end }}

--- a/addons/pulsar/scripts/init-bookies.sh
+++ b/addons/pulsar/scripts/init-bookies.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "waiting zookeeper ready..."
+echo "waiting zookeeper:${zkServers} ready..."
 zkDomain="${zkServers%%:*}"
 until echo ruok | nc -q 1 ${zkDomain} 2181 | grep imok; do
   sleep 1;

--- a/addons/pulsar/scripts/init-proxy.sh
+++ b/addons/pulsar/scripts/init-proxy.sh
@@ -1,16 +1,9 @@
 #!/bin/sh
 if [ -n "${metadataStoreUrl}" ]; then
-  echo "waiting for zookeeper to be ready..."
+  echo "waiting for zookeeper:{${metadataStoreUrl} to be ready..."
   zkDomain="${metadataStoreUrl%%:*}"
   until echo ruok | nc -q 1 ${zkDomain} 2181 | grep imok; do
     sleep 1;
   done;
   echo "zk is ready..."
-fi
-
-if [ -n "${brokerSVC}" ]; then
-  echo "waiting for broker to be ready..."
-  while [ "$(curl -s -o /dev/null -w '%{http_code}' http://${brokerSVC}:80/status.html)" -ne "200" ]; do
-    echo "pulsar cluster isn't initialized yet..."; sleep 1;
-  done
 fi

--- a/addons/pulsar/scripts/start-bookies.sh
+++ b/addons/pulsar/scripts/start-bookies.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
 set -x
+
+python3 /kb-scripts/merge_pulsar_config.py conf/bookkeeper.conf /opt/pulsar/conf/bookkeeper.conf;
+bin/apply-config-from-env.py conf/bookkeeper.conf;
+
+journalDirectories=$(grep 'journalDirectories' /pulsar/conf/bookkeeper.conf | grep -v '#' | cut -d '=' -f 2)
+ledgerDirectories=$(grep 'ledgerDirectories' /pulsar/conf/bookkeeper.conf | grep -v '#' | cut -d '=' -f 2)
 mkdir -p ${journalDirectories}/current && mkdir -p ${ledgerDirectories}/current
 journalRes=`ls -A ${journalDirectories}/current`
 ledgerRes=`ls -A ${ledgerDirectories}/current`
+
 if [[ -z $journalRes && -z $ledgerRes ]]; then
+   echo "journalRes and ledgerRes directory is empty, check whether the remote cookies is empty either"
    host_ip_port="${KB_POD_FQDN}${cluster_domain}:3181"
+   zkLedgersRootPath=$(grep 'zkLedgersRootPath' /pulsar/conf/bookkeeper.conf | grep -v '#' | cut -d '=' -f 2)
    zNode="${zkLedgersRootPath}/cookies/${host_ip_port}"
+
    # if current dir are empty but bookieId exists in zookeeper, delete it
    if zkURL=${zkServers} python3 /kb-scripts/zookeeper.py get ${zNode}; then
      echo "Warning: exist redundant bookieID ${zNode}"
      zkURL=${zkServers} python3 /kb-scripts/zookeeper.py delete ${zNode};
    fi
 fi
-python3 /kb-scripts/merge_pulsar_config.py conf/bookkeeper.conf /opt/pulsar/conf/bookkeeper.conf;
-bin/apply-config-from-env.py conf/bookkeeper.conf;
+
 OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie;

--- a/addons/pulsar/scripts/start-broker.sh
+++ b/addons/pulsar/scripts/start-broker.sh
@@ -1,23 +1,53 @@
 #!/bin/bash
 set -x
 
-extract_ordinal_from_pod_name() {
-  local pod_name="$1"
-  local ordinal="${pod_name##*-}"
+extract_ordinal_from_object_name() {
+  local object_name="$1"
+  local ordinal="${object_name##*-}"
   echo "$ordinal"
 }
 
-make_nodeport_domain() {
-  local nodeport_env_name="$1"
-  eval port="\$${nodeport_env_name}"
-  echo "${KB_HOST_IP}:${port}"
+parse_advertised_svc_if_exist() {
+  local pod_name="${KB_POD_NAME}"
+  local pod_service_list="${1}"
+
+  if [[ "$pod_service_list" == "" ]]; then
+    echo "Ignoring."
+    return 0
+  fi
+
+  # the value format of $pod_service_list is "pod1Svc:advertisedPort1,pod2Svc:advertisedPort2,..."
+  IFS=',' read -ra advertised_ports <<< "$pod_service_list"
+  echo "~~~~~~advertised_ports:${advertised_ports}"
+  local found=false
+  pod_name_ordinal=$(extract_ordinal_from_object_name "$pod_name")
+  echo "~~~~~~pod_name_ordinal:${pod_name_ordinal}"
+  for advertised_port in "${advertised_ports[@]}"; do
+    IFS=':' read -ra parts <<< "$advertised_port"
+    local svc_name="${parts[0]}"
+    local port="${parts[1]}"
+    svc_name_ordinal=$(extract_ordinal_from_object_name "$svc_name")
+    echo "~~~~~~svc_name:${svc_name},port:${port},svc_name_ordinal:${svc_name_ordinal}"
+    if [[ "$svc_name_ordinal" == "$pod_name_ordinal" ]]; then
+      echo "Found matching svcName and port for podName '$pod_name', BROKER_ADVERTISED_PORT: $pod_service_list. svcName: $svc_name, port: $port."
+      advertised_svc_port_value="$port"
+      found=true
+      break
+    fi
+  done
+
+  if [[ "$found" == false ]]; then
+    echo "Error: No matching svcName and port found for podName '$pod_name', BROKER_ADVERTISED_PORT: $pod_service_list. Exiting."
+    exit 1
+  fi
 }
 
 if [[ "true" == "$KB_PULSAR_BROKER_NODEPORT" ]]; then
   echo "init NodePort config:"
-  pod_ordinal=$(extract_ordinal_from_pod_name "$KB_POD_NAME")
-  nodeport_pulsar_domain=$(make_nodeport_domain "NODE_PORT_PULSAR_${pod_ordinal}")
-  nodeport_kafka_domain=$(make_nodeport_domain "NODE_PORT_KAFKA_${pod_ordinal}")
+  parse_advertised_svc_if_exist "${ADVERTISED_PORT_PULSAR}"
+  nodeport_pulsar_domain="${KB_HOST_IP}:${advertised_svc_port_value}"
+  parse_advertised_svc_if_exist "${ADVERTISED_PORT_KAFKA}"
+  nodeport_kafka_domain="${KB_HOST_IP}:${advertised_svc_port_value}"
   export PULSAR_PREFIX_advertisedListeners="cluster:pulsar://${nodeport_pulsar_domain}"
   echo "[cfg]set PULSAR_PREFIX_advertisedListeners=${PULSAR_PREFIX_advertisedListeners}"
   export PULSAR_PREFIX_kafkaAdvertisedListeners="CLIENT://${nodeport_kafka_domain}"

--- a/addons/pulsar/templates/_helpers.tpl
+++ b/addons/pulsar/templates/_helpers.tpl
@@ -73,3 +73,12 @@ Generate scripts configmap
 {{- $.Files.Get $path | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate major version of cluster
+*/}}
+{{- define "pulsar.major.version" -}}
+{{- $version := default .Chart.AppVersion .Values.clusterVersionOverride -}}
+{{- $majorVersion := (split "." $version)._0 -}}
+{{- printf "%s" ($majorVersion)}}
+{{- end }}

--- a/addons/pulsar/templates/_helpers.tpl
+++ b/addons/pulsar/templates/_helpers.tpl
@@ -54,14 +54,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create full image name
 */}}
 {{- define "pulsar.imageFullName" -}}
-{{- printf "%s/%s:%s" ( .image.registry | default .root.Values.image.registry ) ( .image.repository | default .root.Values.image.repository ) ( .image.tag | default .root.Values.image.tag | default .root.Chart.AppVersion ) -}}
+{{- printf "%s/%s:%s" ( .Values.image.registry | default .root.Values.image.registry ) (  .Values.image.repository | default .root.Values.image.repository ) ( .Values.image.tag | default .root.Values.image.tag | default .root.Chart.AppVersion ) -}}
 {{- end -}}
 
 {{/*
 Create image pull policy
 */}}
 {{- define "pulsar.imagePullPolicy" -}}
-{{- printf "%s" ( .image.pullPolicy | default .root.Values.image.pullPolicy | default "IfNotPresent" ) -}}
+{{- printf "%s" ( .Values.image.pullPolicy | default .root.Values.image.pullPolicy | default "IfNotPresent" ) -}}
 {{- end -}}
 
 {{/*

--- a/addons/pulsar/templates/_helpers.tpl
+++ b/addons/pulsar/templates/_helpers.tpl
@@ -54,14 +54,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create full image name
 */}}
 {{- define "pulsar.imageFullName" -}}
-{{- printf "%s/%s:%s" ( .Values.image.registry | default .root.Values.image.registry ) (  .Values.image.repository | default .root.Values.image.repository ) ( .Values.image.tag | default .root.Values.image.tag | default .root.Chart.AppVersion ) -}}
+{{- printf "%s/%s:%s" ( .image.registry | default .root.Values.image.registry ) (  .image.repository | default .root.Values.image.repository ) ( .image.tag | default .root.Values.image.tag | default .root.Chart.AppVersion ) -}}
 {{- end -}}
 
 {{/*
 Create image pull policy
 */}}
 {{- define "pulsar.imagePullPolicy" -}}
-{{- printf "%s" ( .Values.image.pullPolicy | default .root.Values.image.pullPolicy | default "IfNotPresent" ) -}}
+{{- printf "%s" ( .image.pullPolicy | default .root.Values.image.pullPolicy | default "IfNotPresent" ) -}}
 {{- end -}}
 
 {{/*

--- a/addons/pulsar/templates/clusterdefinition-zookeeper.yaml
+++ b/addons/pulsar/templates/clusterdefinition-zookeeper.yaml
@@ -9,7 +9,7 @@ spec:
   connectionCredential:
     username: ""
     password: ""
-    endpoint: "$(SVC_FQDN)"
+    endpoint: "$(SVC_FQDN):$(SVC_PORT_client)"
     port: "$(SVC_PORT_client)"
   componentDefs:
     - name: zookeeper

--- a/addons/pulsar/templates/clusterdefinition.yaml
+++ b/addons/pulsar/templates/clusterdefinition.yaml
@@ -201,12 +201,17 @@ spec:
       characterType: pulsar-proxy
       statefulSpec:
         updateStrategy: BestEffortParallel
-      componentDefRef:
-      - componentDefName: pulsar-broker
-        componentRefEnv:
-        - name: brokerSVC
-          valueFrom:
-            type: ServiceRef
+{{/*      componentDefRef:*/}}
+{{/*      - componentDefName: pulsar-broker*/}}
+{{/*        componentRefEnv:*/}}
+{{/*        - name: brokerSVC*/}}
+{{/*          valueFrom:*/}}
+{{/*            type: ServiceRef*/}}
+      serviceRefDeclarations:
+        - name: pulsarZookeeper
+          serviceRefDeclarationSpecs:
+            - serviceKind: zookeeper
+              serviceVersion: ^3.8.\d{1,2}$
       configSpecs:
         - name: proxy-env
           templateRef: {{ include "pulsar.name" . }}-proxy-env-tpl
@@ -273,10 +278,10 @@ spec:
             {{- end }}
             - name: SERVICE_PORT
               value: "8080"
-            - name: brokerWebServiceURL
-              value: http://$(brokerSVC):80
-            - name: brokerServiceURL
-              value: pulsar://$(brokerSVC):6650
+{{/*            - name: brokerWebServiceURL*/}}
+{{/*              value: http://$(brokerSVC):80*/}}
+{{/*            - name: brokerServiceURL*/}}
+{{/*              value: pulsar://$(brokerSVC):6650*/}}
             - name: clusterName
               value: $(KB_NAMESPACE)-$(KB_CLUSTER_COMP_NAME)
             - name: webServicePort
@@ -451,6 +456,11 @@ spec:
       characterType: pulsar-bookie-recovery
       statefulSpec:
         updateStrategy: BestEffortParallel
+      serviceRefDeclarations:
+        - name: pulsarZookeeper
+          serviceRefDeclarationSpecs:
+            - serviceKind: zookeeper
+              serviceVersion: ^3.8.\d{1,2}$
       configSpecs:
       - name: bookies-recovery-env
         templateRef: {{ include "pulsar.name" . }}-recovery-env-tpl

--- a/addons/pulsar/templates/clusterdefinition.yaml
+++ b/addons/pulsar/templates/clusterdefinition.yaml
@@ -631,3 +631,26 @@ spec:
       exporter:
         scrapePath: /metrics
         scrapePort: http
+
+  topologies:
+    - name: pulsar-basic-cluster
+      components:
+        - name: broker
+          compDef: pulsar-broker-{{include "pulsar.major.version" .}}
+        - name: bookies
+          compDef: pulsar-bookkeeper-{{include "pulsar.major.version" .}}
+        - name: zookeeper
+          compDef: pulsar-zookeeper-{{include "pulsar.major.version" .}}
+      default: true
+    - name: pulsar-enhanced-cluster
+      components:
+        - name: broker
+          compDef: pulsar-broker-{{include "pulsar.major.version" .}}
+        - name: bookies
+          compDef: pulsar-bookkeeper-{{include "pulsar.major.version" .}}
+        - name: zookeeper
+          compDef: pulsar-zookeeper-{{include "pulsar.major.version" .}}
+        - name: proxy
+          compDef: pulsar-proxy-{{include "pulsar.major.version" .}}
+        - name: bookies-recovery
+          compDef: pulsar-bkrecovery-{{include "pulsar.major.version" .}}

--- a/addons/pulsar/templates/clusterdefinition.yaml
+++ b/addons/pulsar/templates/clusterdefinition.yaml
@@ -642,6 +642,16 @@ spec:
         - name: zookeeper
           compDef: pulsar-zookeeper-{{include "pulsar.major.version" .}}
       default: true
+      orders:
+        provision:
+          - zookeeper
+          - broker,bookies
+        terminate:
+          - broker,bookies
+          - zookeeper
+        update:
+          - zookeeper
+          - broker,bookies
     - name: pulsar-enhanced-cluster
       components:
         - name: broker
@@ -654,3 +664,16 @@ spec:
           compDef: pulsar-proxy-{{include "pulsar.major.version" .}}
         - name: bookies-recovery
           compDef: pulsar-bkrecovery-{{include "pulsar.major.version" .}}
+      orders:
+        provision:
+          - zookeeper,bookies-recovery
+          - broker,bookies
+          - proxy
+        terminate:
+          - proxy
+          - broker,bookies
+          - zookeeper,bookies-recovery
+        update:
+          - zookeeper,bookies-recovery
+          - broker,bookies
+          - proxy

--- a/addons/pulsar/templates/componentdef-bkrecovery.yaml
+++ b/addons/pulsar/templates/componentdef-bkrecovery.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ComponentDefinition
 metadata:
-  name: pulsar-bkrecovery
+  name: pulsar-bkrecovery-{{include "pulsar.major.version" .}}
   labels:
       {{- include "pulsar.labels" . | nindent 4 }}
 spec:
@@ -14,6 +14,7 @@ spec:
       serviceRefDeclarationSpecs:
         - serviceKind: zookeeper
           serviceVersion: ^3.8.\d{1,2}$
+      optional: true
   updateStrategy: BestEffortParallel
   configs:
     - name: bookies-recovery-env

--- a/addons/pulsar/templates/componentdef-bookkeeper.yaml
+++ b/addons/pulsar/templates/componentdef-bookkeeper.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ComponentDefinition
 metadata:
-  name: pulsar-bookkeeper
+  name: pulsar-bookkeeper-{{include "pulsar.major.version" .}}
   labels:
       {{- include "pulsar.labels" . | nindent 4 }}
 spec:
@@ -14,6 +14,7 @@ spec:
       serviceRefDeclarationSpecs:
         - serviceKind: zookeeper
           serviceVersion: ^3.8.\d{1,2}$
+      optional: true
   updateStrategy: BestEffortParallel
   configs:
     - name: bookies-env
@@ -27,10 +28,10 @@ spec:
         - init-bookies
         - bookies
     - name: bookies-config
-      templateRef: {{ include "pulsar.name" . }}3-bookies-config-tpl
+      templateRef: {{ include "pulsar.name" . }}{{include "pulsar.major.version" .}}-bookies-config-tpl
       namespace: {{ .Release.Namespace }}
       volumeName: pulsar-bookies-config
-      constraintRef: pulsar3-bookies-cc
+      constraintRef: pulsar{{include "pulsar.major.version" .}}-bookies-cc
   scripts:
     - name: pulsar-scripts
       templateRef: {{ include "pulsar.name" . }}-scripts

--- a/addons/pulsar/templates/componentdef-broker.yaml
+++ b/addons/pulsar/templates/componentdef-broker.yaml
@@ -10,39 +10,27 @@ spec:
   serviceKind: pulsar
   serviceVersion: {{ default .Chart.AppVersion .Values.clusterVersionOverride }}
   vars:
-    - name: NODE_PORT_PULSAR
+    - name: ADVERTISED_PORT_PULSAR
       valueFrom:
         serviceVarRef:
-          compDef: pulsar-broker
-          name: broker-nodeport
+          compDef: pulsar-broker-{{include "pulsar.major.version" .}}
+          name: advertised-listener
           optional: true
           port:
             name: pulsar
             option: Optional
-    - name: NODE_PORT_KAFKA
+    - name: ADVERTISED_PORT_KAFKA
       valueFrom:
         serviceVarRef:
-          compDef: pulsar-broker
-          name: broker-nodeport
+          compDef: pulsar-broker-{{include "pulsar.major.version" .}}
+          name: advertised-listener
           optional: true
           port:
             name: kafka-client
             option: Optional
   services:
-    - name: broker-clusterip
-      serviceName: clusterip
-      podService: true
-      spec:
-        type: ClusterIP
-        ports:
-          - name: pulsar
-            port: 6650
-            targetPort: pulsar
-          - name: kafka-client
-            port: 9092
-            targetPort: kafka-client
-    - name: broker-nodeport
-      serviceName: nodeport
+    - name: advertised-listener
+      serviceName: advertised-listener
       podService: true
       disableAutoProvision: true
       spec:

--- a/addons/pulsar/templates/componentdef-broker.yaml
+++ b/addons/pulsar/templates/componentdef-broker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ComponentDefinition
 metadata:
-  name: pulsar-broker
+  name: pulsar-broker-{{include "pulsar.major.version" .}}
   labels:
       {{- include "pulsar.labels" . | nindent 4 }}
 spec:
@@ -14,7 +14,7 @@ spec:
       valueFrom:
         serviceVarRef:
           compDef: pulsar-broker
-          name: nodeport
+          name: broker-nodeport
           optional: true
           port:
             name: pulsar
@@ -23,7 +23,7 @@ spec:
       valueFrom:
         serviceVarRef:
           compDef: pulsar-broker
-          name: nodeport
+          name: broker-nodeport
           optional: true
           port:
             name: kafka-client
@@ -59,6 +59,7 @@ spec:
       serviceRefDeclarationSpecs:
         - serviceKind: zookeeper
           serviceVersion: ^3.8.\d{1,2}$
+      optional: true
   updateStrategy: BestEffortParallel
   configs:
     - name: broker-env
@@ -73,9 +74,9 @@ spec:
         - init-pulsar-client-config
       volumeName: broker-env
     - name: broker-config
-      templateRef: {{ include "pulsar.name" . }}3-broker-config-tpl
+      templateRef: {{ include "pulsar.name" . }}{{include "pulsar.major.version" .}}-broker-config-tpl
       namespace: {{ .Release.Namespace }}
-      constraintRef: pulsar3-brokers-cc
+      constraintRef: pulsar{{include "pulsar.major.version" .}}-brokers-cc
       volumeName: pulsar-config
   scripts:
     - name: pulsar-scripts

--- a/addons/pulsar/templates/componentdef-proxy.yaml
+++ b/addons/pulsar/templates/componentdef-proxy.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ComponentDefinition
 metadata:
-  name: pulsar-proxy
+  name: pulsar-proxy-{{include "pulsar.major.version" .}}
   labels:
       {{- include "pulsar.labels" . | nindent 4 }}
 spec:
@@ -14,6 +14,7 @@ spec:
       serviceRefDeclarationSpecs:
         - serviceKind: zookeeper
           serviceVersion: ^3.8.\d{1,2}$
+      optional: true
   updateStrategy: BestEffortParallel
   configs:
     - name: proxy-env
@@ -27,10 +28,10 @@ spec:
         - proxy
         - check-broker
     - name: proxy-config
-      templateRef: {{ include "pulsar.name" . }}3-proxy-config-tpl
+      templateRef: {{ include "pulsar.name" . }}{{include "pulsar.major.version" .}}-proxy-config-tpl
       namespace: {{ .Release.Namespace }}
       volumeName: pulsar-proxy-config
-      constraintRef: pulsar3-proxy-cc
+      constraintRef: pulsar{{include "pulsar.major.version" .}}-proxy-cc
   scripts:
     - name: pulsar-scripts
       templateRef: {{ include "pulsar.name" . }}-scripts

--- a/addons/pulsar/templates/componentdef-zookeeper.yaml
+++ b/addons/pulsar/templates/componentdef-zookeeper.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ComponentDefinition
 metadata:
-  name: pulsar-zookeeper
+  name: pulsar-zookeeper-{{include "pulsar.major.version" .}}
   labels:
       {{- include "pulsar.labels" . | nindent 4 }}
 spec:

--- a/addons/pulsar/templates/componentversion-bkrecovery.yaml
+++ b/addons/pulsar/templates/componentversion-bkrecovery.yaml
@@ -14,9 +14,9 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        bookies-recovery: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        bookies-recovery: {{.Values.image.registry}}/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        bookies-recovery: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        bookies-recovery: {{.Values.image.registry}}/apecloud/pulsar:3.0.2

--- a/addons/pulsar/templates/componentversion-bkrecovery.yaml
+++ b/addons/pulsar/templates/componentversion-bkrecovery.yaml
@@ -14,9 +14,9 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        bookies-recovery: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        bookies-recovery: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        bookies-recovery: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        bookies-recovery: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2

--- a/addons/pulsar/templates/componentversion-bkrecovery.yaml
+++ b/addons/pulsar/templates/componentversion-bkrecovery.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ComponentVersion
+metadata:
+  name: pulsar-bkrecovery
+spec:
+  compatibilityRules:
+    - compDefs:
+        - pulsar-bkrecovery
+      releases:
+        - 2.11.2
+        - 3.0.2
+  releases:
+    - name: 2.11.2
+      changes:
+      serviceVersion: 2.11.2
+      images:
+        bookies-recovery: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+    - name: 3.0.2
+      changes:
+      serviceVersion: 3.0.2
+      images:
+        bookies-recovery: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2

--- a/addons/pulsar/templates/componentversion-bookkeeper.yaml
+++ b/addons/pulsar/templates/componentversion-bookkeeper.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        bookies: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        bookies: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        bookies: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        bookies: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-bookkeeper.yaml
+++ b/addons/pulsar/templates/componentversion-bookkeeper.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        bookies: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        bookies: {{.Values.image.registry}}/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        bookies: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        bookies: {{.Values.image.registry}}/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-bookkeeper.yaml
+++ b/addons/pulsar/templates/componentversion-bookkeeper.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ComponentVersion
+metadata:
+  name: pulsar-bookkeeper
+spec:
+  compatibilityRules:
+    - compDefs:
+        - pulsar-bookkeeper
+      releases:
+        - 2.11.2
+        - 3.0.2
+  releases:
+    - name: 2.11.2
+      changes:
+      serviceVersion: 2.11.2
+      images:
+        bookies: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+    - name: 3.0.2
+      changes:
+      serviceVersion: 3.0.2
+      images:
+        bookies: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+

--- a/addons/pulsar/templates/componentversion-broker.yaml
+++ b/addons/pulsar/templates/componentversion-broker.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        broker: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        broker: {{.Values.image.registry}}/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        broker: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        broker: {{.Values.image.registry}}/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-broker.yaml
+++ b/addons/pulsar/templates/componentversion-broker.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ComponentVersion
+metadata:
+  name: pulsar-broker
+spec:
+  compatibilityRules:
+    - compDefs:
+        - pulsar-broker
+      releases:
+        - 2.11.2
+        - 3.0.2
+  releases:
+    - name: 2.11.2
+      changes:
+      serviceVersion: 2.11.2
+      images:
+        broker: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+    - name: 3.0.2
+      changes:
+      serviceVersion: 3.0.2
+      images:
+        broker: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+

--- a/addons/pulsar/templates/componentversion-broker.yaml
+++ b/addons/pulsar/templates/componentversion-broker.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        broker: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        broker: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        broker: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        broker: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-proxy.yaml
+++ b/addons/pulsar/templates/componentversion-proxy.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        proxy: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        proxy: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        proxy: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        proxy: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-proxy.yaml
+++ b/addons/pulsar/templates/componentversion-proxy.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ComponentVersion
+metadata:
+  name: pulsar-proxy
+spec:
+  compatibilityRules:
+    - compDefs:
+        - pulsar-proxy
+      releases:
+        - 2.11.2
+        - 3.0.2
+  releases:
+    - name: 2.11.2
+      changes:
+      serviceVersion: 2.11.2
+      images:
+        proxy: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+    - name: 3.0.2
+      changes:
+      serviceVersion: 3.0.2
+      images:
+        proxy: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+

--- a/addons/pulsar/templates/componentversion-proxy.yaml
+++ b/addons/pulsar/templates/componentversion-proxy.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        proxy: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        proxy: {{.Values.image.registry}}/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        proxy: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        proxy: {{.Values.image.registry}}/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-zookeeper.yaml
+++ b/addons/pulsar/templates/componentversion-zookeeper.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        zookeeper: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        zookeeper: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        zookeeper: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        zookeeper: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/templates/componentversion-zookeeper.yaml
+++ b/addons/pulsar/templates/componentversion-zookeeper.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ComponentVersion
+metadata:
+  name: pulsar-zookeeper
+spec:
+  compatibilityRules:
+    - compDefs:
+        - pulsar-zookeeper
+      releases:
+        - 2.11.2
+        - 3.0.2
+  releases:
+    - name: 2.11.2
+      changes:
+      serviceVersion: 2.11.2
+      images:
+        zookeeper: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+    - name: 3.0.2
+      changes:
+      serviceVersion: 3.0.2
+      images:
+        zookeeper: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+

--- a/addons/pulsar/templates/componentversion-zookeeper.yaml
+++ b/addons/pulsar/templates/componentversion-zookeeper.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        zookeeper: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:2.11.2
+        zookeeper: {{.Values.image.registry}}/apecloud/pulsar:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        zookeeper: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar:3.0.2
+        zookeeper: {{.Values.image.registry}}/apecloud/pulsar:3.0.2
 

--- a/addons/pulsar/values.yaml
+++ b/addons/pulsar/values.yaml
@@ -17,7 +17,7 @@ debugEnabled: false
 ## Default Pulsar image
 image:
   ## image.registry is the top level registry config
-  registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
   repository: apecloud/pulsar
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
what's changed

1. add topologies
 Pulsar supports three different cluster topologies, with two defined in clusterDefinition and one defined manually as creating the cluster:
- pulsar-basic-cluster
Configured in the pulsar-cluster/values.yaml file
This cluster topology includes three components: broker, zookeeper and bookkeeper
- pulsar-enhanced-cluster
Configured in the pulsar-cluster/values.yaml file
This cluster topology includes five components: broker, zookeeper, bookkeeper, proxy and bkrecovery
- Unspecified topology (i.e. topology: nil)
In this case, you can individually configure the proxy.enabled and bkrecovery.enabled options
This cluster approach allows more flexible composition of the required components
With all three topologies, you can configure serviceRef of external zookeeper service.
2. replace clusterDefinition and clusterVersion with componentDefinition and componentVerison.
3. update Vars definition like serviceRef and service.

Test
With all kinds of topologies, the cluster can run correctly.