### PR TITLE
chore: fix release addon image error

### DIFF
--- a/docker/Dockerfile-charts
+++ b/docker/Dockerfile-charts
@@ -5,6 +5,8 @@ COPY docker/custom-scripts/package-all-helm-charts.sh /tmp/package-all-helm-char
 
 COPY addons addons
 
+COPY addons-cluster/kblib addons-cluster/kblib
+
 RUN bash /tmp/package-all-helm-charts.sh /tmp/charts
 
 RUN rm -rf addons


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks-addons/actions/runs/9758635750/job/26933605961
![image](https://github.com/apecloud/kubeblocks-addons/assets/109708205/613cdbd7-4d4b-4517-b723-0e1c05aa111c)
