### PR TITLE
chore: improve kafka image registry

### DIFF
--- a/addons/kafka/templates/componentdef-broker.yaml
+++ b/addons/kafka/templates/componentdef-broker.yaml
@@ -94,7 +94,7 @@ spec:
       fsGroup: 1001
     containers:
       - name: kafka
-        image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.kafka.repository }}:{{ default .Chart.AppVersion .Values.images.kafka.tag }}
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.kafka.repository }}:{{ default .Chart.AppVersion .Values.images.kafka.tag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -191,7 +191,7 @@ spec:
             mountPath: /tools/server-jaas.properties
             subPath: server-jaas.properties
       - name: jmx-exporter
-        image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.jmxExporter.repository }}:{{ .Values.images.jmxExporter.tag }}
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.jmxExporter.repository }}:{{ .Values.images.jmxExporter.tag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         securityContext:
           runAsNonRoot: true

--- a/addons/kafka/templates/componentdef-combine.yaml
+++ b/addons/kafka/templates/componentdef-combine.yaml
@@ -97,7 +97,7 @@ spec:
       fsGroup: 1001
     containers:
       - name: kafka
-        image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.kafka.repository }}:{{ default .Chart.AppVersion .Values.images.kafka.tag }}
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.kafka.repository }}:{{ default .Chart.AppVersion .Values.images.kafka.tag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -194,7 +194,7 @@ spec:
             mountPath: /tools/server-jaas.properties
             subPath: server-jaas.properties
       - name: jmx-exporter
-        image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.jmxExporter.repository }}:{{ .Values.images.jmxExporter.tag }}
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.jmxExporter.repository }}:{{ .Values.images.jmxExporter.tag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         securityContext:
           runAsNonRoot: true

--- a/addons/kafka/templates/componentdef-controller.yaml
+++ b/addons/kafka/templates/componentdef-controller.yaml
@@ -51,7 +51,7 @@ spec:
       fsGroup: 1001
     containers:
       - name: kafka
-        image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.kafka.repository }}:{{ default .Chart.AppVersion .Values.images.kafka.tag }}
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.kafka.repository }}:{{ default .Chart.AppVersion .Values.images.kafka.tag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -128,7 +128,7 @@ spec:
             mountPath: /opt/bitnami/scripts/kafka-env.sh
             subPath: kafka-env.sh
       - name: jmx-exporter
-        image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.jmxExporter.repository }}:{{ .Values.images.jmxExporter.tag }}
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.jmxExporter.repository }}:{{ .Values.images.jmxExporter.tag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         securityContext:
           runAsNonRoot: true

--- a/addons/kafka/templates/componentdef-exporter.yaml
+++ b/addons/kafka/templates/componentdef-exporter.yaml
@@ -43,7 +43,7 @@ spec:
       fsGroup: 1001
     containers:
     - name: kafka-exporter
-      image: {{ .Values.images.registry | default "docker.io/bitnami/" }}{{ .Values.images.kafkaExporter.repository }}:{{ .Values.images.kafkaExporter.tag }}
+      image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.kafkaExporter.repository }}:{{ .Values.images.kafkaExporter.tag }}
       imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
       securityContext:
         runAsNonRoot: true

--- a/addons/kafka/values.yaml
+++ b/addons/kafka/values.yaml
@@ -21,17 +21,17 @@ commonLabels: {}
 ## @param application images
 ##
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/
+  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
   pullPolicy: IfNotPresent
   kafka:
-    repository: kafka
+    repository: apecloud/kafka
 #    tag: 3.4.0-debian-11-r22
     tag: 3.3.2-debian-11-r54
   kafkaExporter:
-    repository: kafka-exporter
+    repository: apecloud/kafka-exporter
     tag: 1.6.0-debian-11-r67
   jmxExporter:
-    repository: jmx-exporter
+    repository: apecloud/jmx-exporter
     tag: 0.18.0-debian-11-r20
 
 


### PR DESCRIPTION
The `images.registry` keep consistent with other addons.