### PR TITLE
fix: kafka support nodeport feature in KB 0.9

### DIFF
--- a/addons-cluster/kafka-cluster/templates/cluster.yaml
+++ b/addons-cluster/kafka-cluster/templates/cluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "kblib.clusterName" . }}
   labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
   annotations:
-    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"{{ $.Values.saslEnable }}","KB_KAFKA_BROKER_HEAP":"{{ $.Values.brokerHeap }}","KB_KAFKA_CONTROLLER_HEAP":"{{ $.Values.controllerHeap }}","KB_KAFKA_PUBLIC_ACCESS":"{{ $.Values.extra.publiclyAccessible }}", "KB_KAFKA_BROKER_NODEPORT": "{{ $.Values.nodePortEnabled }}"}'
-    {{- include "kafka-cluster.brokerAddrFeatureGate" . | nindent 4 }}
+    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"{{ $.Values.saslEnable }}","KB_KAFKA_BROKER_HEAP":"{{ $.Values.brokerHeap }}","KB_KAFKA_CONTROLLER_HEAP":"{{ $.Values.controllerHeap }}","KB_KAFKA_PUBLIC_ACCESS":"{{ $.Values.extra.publiclyAccessible }}"}'
+{{/*    {{- include "kafka-cluster.brokerAddrFeatureGate" . | nindent 4 }}*/}}
 spec:
   clusterDefinitionRef: kafka # ref clusterdefinition.name
   clusterVersionRef: {{ .Values.version }}
@@ -30,11 +30,7 @@ spec:
       serviceName: bootstrap
       componentSelector: broker
       spec:
-        {{- if .Values.nodePortEnabled }}
-        type: NodePort
-        {{- else }}
         type: ClusterIP
-        {{- end }}
         ports:
           - name: kafka-client
             targetPort: 9092
@@ -53,8 +49,13 @@ spec:
       replicas: {{ $.Values.replicas }}
       monitor: {{ $.Values.monitorEnable }}
       serviceAccountName: {{ include "kblib.serviceAccountName" . }}
+      services:
+        {{- if $.Values.nodePortEnabled }}
+        - name: advertised-listener
+          serviceType: NodePort
+          podService: true
+        {{- end }}
       {{- include "kblib.componentResources" . | indent 6 }}
-      {{- include "kblib.componentServices" . | indent 6 }}
       {{- if $.Values.storageEnable }}
       volumeClaimTemplates:
         - name: data
@@ -87,8 +88,13 @@ spec:
       replicas: {{ $.Values.brokerReplicas }}
       monitor: {{ $.Values.monitorEnable }}
       serviceAccountName: {{ include "kblib.serviceAccountName" . }}
+      services:
+        {{- if $.Values.nodePortEnabled }}
+        - name: advertised-listener
+          serviceType: NodePort
+          podService: true
+        {{- end }}
       {{- include "kblib.componentResources" . | indent 6 }}
-      {{- include "kblib.componentServices" . | indent 6 }}
       {{- if $.Values.storageEnable }}
       volumeClaimTemplates:
         - name: data

--- a/addons/kafka/scripts/kafka-server-setup.tpl
+++ b/addons/kafka/scripts/kafka-server-setup.tpl
@@ -111,10 +111,45 @@ if [[ -n "$KB_KAFKA_BROKER_HEAP" ]]; then
   echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
 fi
 
-extract_ordinal_from_pod_name() {
-  local pod_name="$1"
-  local ordinal="${pod_name##*-}"
-  echo "$ordinal"
+extract_ordinal_from_object_name() {
+    local object_name="$1"
+    local ordinal="${object_name##*-}"
+    echo "$ordinal"
+}
+
+parse_advertised_svc_if_exist() {
+    local pod_name="${KB_POD_NAME}"
+
+    if [[ -z "${BROKER_ADVERTISED_PORT}" ]]; then
+        echo "Environment variable BROKER_ADVERTISED_PORT not found. Ignoring."
+        return 0
+    fi
+
+    # the value format of BROKER_ADVERTISED_PORT is "pod1Svc:advertisedPort1,pod2Svc:advertisedPort2,..."
+    IFS=',' read -ra advertised_ports <<< "${BROKER_ADVERTISED_PORT}"
+    echo "find advertised_ports:${advertised_ports}"
+    local found=false
+    pod_name_ordinal=$(extract_ordinal_from_object_name "$pod_name")
+    echo "find pod_name_ordinal:${pod_name_ordinal}"
+    for advertised_port in "${advertised_ports[@]}"; do
+        IFS=':' read -ra parts <<< "$advertised_port"
+        local svc_name="${parts[0]}"
+        local port="${parts[1]}"
+        svc_name_ordinal=$(extract_ordinal_from_object_name "$svc_name")
+        echo "find svc_name:${svc_name},port:${port},svc_name_ordinal:${svc_name_ordinal}"
+        if [[ "$svc_name_ordinal" == "$pod_name_ordinal" ]]; then
+            echo "Found matching svcName and port for podName '$pod_name', BROKER_ADVERTISED_PORT: $BROKER_ADVERTISED_PORT. svcName: $svc_name, port: $port."
+            advertised_svc_port_value="$port"
+            advertised_svc_host_value="$KB_HOST_IP"
+            found=true
+            break
+        fi
+    done
+
+    if [[ "$found" == false ]]; then
+        echo "Error: No matching svcName and port found for podName '$pod_name', BROKER_ADVERTISED_PORT: $BROKER_ADVERTISED_PORT. Exiting."
+        exit 1
+    fi
 }
 
 # cfg setting
@@ -127,23 +162,18 @@ if [[ "broker,controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] || [[ "broker" = "$KAF
       rm -f "$KAFKA_CFG_METADATA_LOG_DIR/__cluster_metadata-0/quorum-state"
     fi
 
-    cluster_domain={{ .clusterDomain }}
-    headless_domain="${KB_POD_NAME}.${KB_CLUSTER_COMP_NAME}-headless.${KB_NAMESPACE}.svc.${cluster_domain}"
+    headless_domain="${KB_POD_FQDN}${cluster_domain}"
+    parse_advertised_svc_if_exist
 
-    if [[ "true" == "$KB_KAFKA_BROKER_NODEPORT" ]]; then
-      # enable NodePort, use node ip + mapped port as client connection
-      pod_ordinal=$(extract_ordinal_from_pod_name $KB_POD_NAME)
-      node_port_env_name="BROKER_NODE_PORT_${pod_ordinal}"
-      eval node_port="\$${node_port_env_name}"
-      nodeport_domain="${KB_HOST_IP}:${node_port}"
-      #export KAFKA_CFG_LISTENERS="CONTROLLER://:9093,INTERNAL://:9094,CLIENT://:${node_port}"
-      #echo "[cfg]KAFKA_CFG_LISTENERS=$KAFKA_CFG_LISTENERS"
-      export KAFKA_CFG_ADVERTISED_LISTENERS="INTERNAL://${headless_domain}:9094,CLIENT://${nodeport_domain}"
-      echo "[cfg]KAFKA_CFG_ADVERTISED_LISTENERS=$KAFKA_CFG_ADVERTISED_LISTENERS"
+    if [ -n "$advertised_svc_host_value" ] && [ -n "$advertised_svc_port_value" ]; then
+    # enable NodePort, use node ip + mapped port as client connection
+    nodeport_domain="${advertised_svc_host_value}:${advertised_svc_port_value}"
+    export KAFKA_CFG_ADVERTISED_LISTENERS="INTERNAL://${headless_domain}:9094,CLIENT://${nodeport_domain}"
+    echo "[cfg]KAFKA_CFG_ADVERTISED_LISTENERS=$KAFKA_CFG_ADVERTISED_LISTENERS"
     else
-      # default, use headless service url as client connection
-      export KAFKA_CFG_ADVERTISED_LISTENERS="INTERNAL://${headless_domain}:9094,CLIENT://${headless_domain}:9092"
-      echo "[cfg]KAFKA_CFG_ADVERTISED_LISTENERS=$KAFKA_CFG_ADVERTISED_LISTENERS"
+    # default, use headless service url as client connection
+    export KAFKA_CFG_ADVERTISED_LISTENERS="INTERNAL://${headless_domain}:9094,CLIENT://${headless_domain}:9092"
+    echo "[cfg]KAFKA_CFG_ADVERTISED_LISTENERS=$KAFKA_CFG_ADVERTISED_LISTENERS"
     fi
 fi
 

--- a/addons/kafka/templates/componentdef-broker.yaml
+++ b/addons/kafka/templates/componentdef-broker.yaml
@@ -12,18 +12,10 @@ metadata:
   {{- end }}
 spec:
   services:
-    - name: broker
-      serviceName: broker
-      generatePodOrdinalService: true
-      spec:
-        type: ClusterIP
-        ports:
-          - name: broker
-            port: 9092
-            targetPort: kafka-client
-    - name: broker-nodeport
-      serviceName: broker-nodeport
-      generatePodOrdinalService: true
+    - name: advertised-listener
+      serviceName: advertised-listener
+      podService: true
+      disableAutoProvision: true
       spec:
         type: NodePort
         ports:
@@ -37,15 +29,13 @@ spec:
           name: admin
           username: Required
           optional: false
-      ## if the kafka NodePort type Service with name suffix broker-{0,1...} is set, the BROKER_NODE_PORT_{0,1...} will be available
-    - name: BROKER_NODE_PORT
+    - name: BROKER_ADVERTISED_PORT
       valueFrom:
         serviceVarRef:
-          compDef: kafka-broker
-          name: broker-nodeport
-          generatePodOrdinalServiceVar: true
+          compDef: {{ include "kafka-broker.componentDefName" . }}
+          name: advertised-listener
           optional: true
-          nodePort:
+          port:
             name: broker
             option: Optional
   provider: kubeblocks

--- a/addons/kafka/templates/componentdef-combine.yaml
+++ b/addons/kafka/templates/componentdef-combine.yaml
@@ -12,18 +12,10 @@ metadata:
   {{- end }}
 spec:
   services:
-    - name: broker
-      serviceName: broker
-      generatePodOrdinalService: true
-      spec:
-        type: ClusterIP
-        ports:
-          - name: broker
-            port: 9092
-            targetPort: kafka-client
-    - name: broker-nodeport
-      serviceName: broker-nodeport
-      generatePodOrdinalService: true
+    - name: advertised-listener
+      serviceName: advertised-listener
+      podService: true
+      disableAutoProvision: true
       spec:
         type: NodePort
         ports:
@@ -37,15 +29,13 @@ spec:
           name: admin
           username: Required
           optional: false
-      ## if the kafka NodePort type Service with name suffix broker-{0,1...} is set, the BROKER_NODE_PORT_{0,1...} will be available
-    - name: BROKER_NODE_PORT
+    - name: BROKER_ADVERTISED_PORT
       valueFrom:
         serviceVarRef:
-          compDef: kafka-combine
-          name: broker-nodeport
-          generatePodOrdinalServiceVar: true
+          compDef: {{ include "kafka-combine.componentDefName" . }}
+          name: advertised-listener
           optional: true
-          nodePort:
+          port:
             name: broker
             option: Optional
   provider: kubeblocks

--- a/examples/kafka/cluster-combined-cmpd.yaml
+++ b/examples/kafka/cluster-combined-cmpd.yaml
@@ -5,12 +5,7 @@ metadata:
   namespace: default
   annotations:
     # kafka broker's jvm heap setting
-    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"false","KB_KAFKA_BROKER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_CONTROLLER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_PUBLIC_ACCESS":"false", "KB_KAFKA_BROKER_NODEPORT": "false"}'
-    # Define kafka cluster annotation keys for nodeport feature gate.
-    kubeblocks.io/enabled-pod-ordinal-svc: broker
-    # enable NodePort
-    # kubeblocks.io/enabled-node-port-svc: broker
-    # kubeblocks.io/disabled-cluster-ip-svc: broker
+    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"false","KB_KAFKA_BROKER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_CONTROLLER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_PUBLIC_ACCESS":"false"}'
 spec:
   # Specifies the behavior when a Cluster is deleted.
   # - `DoNotTerminate`: Prevents deletion of the Cluster. This policy ensures that all resources remain intact.
@@ -41,6 +36,12 @@ spec:
     componentDef: kafka-combine
     tls: false
     replicas: 1
+    serviceVersion: 3.3.2
+    # Explicitly enable the 'advertised-listener' component service. Once enabled, it supports accessing the Kafka cluster in the network accessible by NodePort
+    #    services:
+    #      - name: advertised-listener
+    #        podService: true
+    #        serviceType: NodePort
     affinity:
       podAntiAffinity: Preferred
       topologyKeys:

--- a/examples/kafka/cluster-separated-cmpd.yaml
+++ b/examples/kafka/cluster-separated-cmpd.yaml
@@ -5,12 +5,7 @@ metadata:
   namespace: default
   annotations:
     # kafka broker's jvm heap setting
-    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"false","KB_KAFKA_BROKER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_CONTROLLER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_PUBLIC_ACCESS":"false", "KB_KAFKA_BROKER_NODEPORT": "false"}'
-    # Define kafka cluster annotation keys for nodeport feature gate.
-    kubeblocks.io/enabled-pod-ordinal-svc: broker
-    # enable NodePort
-    # kubeblocks.io/enabled-node-port-svc: broker
-    # kubeblocks.io/disabled-cluster-ip-svc: broker
+    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"false","KB_KAFKA_BROKER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_CONTROLLER_HEAP":"-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64","KB_KAFKA_PUBLIC_ACCESS":"false"}'
 spec:
   # Specifies the behavior when a Cluster is deleted.
   # - `DoNotTerminate`: Prevents deletion of the Cluster. This policy ensures that all resources remain intact.
@@ -38,6 +33,11 @@ spec:
     componentDef: kafka-broker
     tls: false
     replicas: 1
+    # Explicitly enable the 'advertised-listener' component service. Once enabled, it supports accessing the Kafka cluster in the network accessible by NodePort
+    #    services:
+    #      - name: advertised-listener
+    #        podService: true
+    #        serviceType: NodePort
     affinity:
       podAntiAffinity: Preferred
       topologyKeys:


### PR DESCRIPTION
use 'podService' & 'serviceVarRef' to support client advertised listeners with the NodePort network type in KB 0.9