### PR TITLE
fix: change pulsar bookies min-replica from 3 to 2

### DIFF
--- a/addons-cluster/pulsar-cluster/templates/validate.yaml
+++ b/addons-cluster/pulsar-cluster/templates/validate.yaml
@@ -4,15 +4,10 @@
   {{- end }}
 {{- end }}
 {{- if .Values.bookies.replicaCount }}
-  {{- if lt (int .Values.bookies.replicaCount) 3 }}
-    {{ fail "Pulsar bookies replicas cannot be less than 3." }}
+  {{- if lt (int .Values.bookies.replicaCount) 2 }}
+    {{ fail "Pulsar bookies replicas cannot be less than 2." }}
   {{- end }}
 {{- end }}
-{{/*{{- if .Values.bookiesRecovery.replicaCount }}*/}}
-{{/*  {{- if lt (int .Values.bookiesRecovery.replicaCount) 3 }}*/}}
-{{/*    {{ fail "Pulsar bookiesRecovery replicas cannot be less than 3." }}*/}}
-{{/*  {{- end }}*/}}
-{{/*{{- end }}*/}}
 {{- if .Values.bookies.mode }}
   {{- if and (ne .Values.bookies.mode "generic") (ne .Values.bookies.mode "selfVerifying") }}
     {{ fail "pulsar bookies mode only supported [generic,selfVerifying]" }}

--- a/addons/pulsar/Chart.yaml
+++ b/addons/pulsar/Chart.yaml
@@ -4,7 +4,7 @@ description: Apache Pulsar is an open-source, distributed messaging and streamin
 
 type: application
 
-version: 0.9.0
+version: 0.9.1
 
 # appVersion specifies the version of the Pulsar database to be created,
 # and this value should be consistent with an existing clusterVersion.


### PR DESCRIPTION
change pulsar bookies min-replica from 3 to 2：

In the broker default configuration, both 'managedLedgerDefaultWriteQuorum' and 'managedLedgerDefaultAckQuorum' are 2, so the minimum requirement for boolies replica is 2.