### PR TITLE
fix: set zookeeper volume size via kblib and change default storage size to 10Gi

### DIFF
--- a/addons-cluster/zookeeper/templates/cluster.yaml
+++ b/addons-cluster/zookeeper/templates/cluster.yaml
@@ -35,4 +35,4 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ print .Values.log "Gi" }}
+                storage: {{ print .Values.logStorage "Gi" }}

--- a/addons-cluster/zookeeper/templates/cluster.yaml
+++ b/addons-cluster/zookeeper/templates/cluster.yaml
@@ -14,20 +14,24 @@ spec:
       serviceAccountName: {{ include "kblib.serviceAccountName" . }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
       {{- include "kblib.componentResources" . | indent 6 }}
+      {{- include "kblib.componentStorages" . | indent 6 }}
+      {{- include "kblib.componentServices" . | indent 6 }}
       volumeClaimTemplates:
-        - name: data
+        - name: data # ref clusterDefinition components.containers.volumeMounts.name
           spec:
-            storageClassName: {{ .Values.persistence.data.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ .Values.persistence.data.size }}
+                storage: {{ print .Values.storage "Gi" }}
+            {{- if .Values.storageClassName }}
+            storageClassName: {{ .Values.storageClassName | quote }}
+            {{- end }}
         - name: log
           spec:
-            storageClassName: {{ .Values.persistence.log.storageClassName }}
+            storageClassName: {{ .Values.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ .Values.persistence.log.size }}
+                storage: {{ print .Values.log "Gi" }}

--- a/addons-cluster/zookeeper/templates/cluster.yaml
+++ b/addons-cluster/zookeeper/templates/cluster.yaml
@@ -14,7 +14,6 @@ spec:
       serviceAccountName: {{ include "kblib.serviceAccountName" . }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
       {{- include "kblib.componentResources" . | indent 6 }}
-      {{- include "kblib.componentStorages" . | indent 6 }}
       {{- include "kblib.componentServices" . | indent 6 }}
       volumeClaimTemplates:
         - name: data # ref clusterDefinition components.containers.volumeMounts.name

--- a/addons-cluster/zookeeper/templates/cluster.yaml
+++ b/addons-cluster/zookeeper/templates/cluster.yaml
@@ -29,7 +29,9 @@ spec:
             {{- end }}
         - name: log
           spec:
-            storageClassName: {{ .Values.storageClassName }}
+            {{- if .Values.storageClassName }}
+            storageClassName: {{ .Values.storageClassName | quote  }}
+            {{- end }}
             accessModes:
               - ReadWriteOnce
             resources:

--- a/addons-cluster/zookeeper/values.yaml
+++ b/addons-cluster/zookeeper/values.yaml
@@ -23,23 +23,7 @@ memory: 2
 #  cpu: 1
 #  memory: 1
 
-persistence:
-  ## `data` volume settings
-  ##
-  data:
-    ## @param shard[*].persistence.data.storageClassName Storage class of backing PVC
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    storageClassName:
-    ## @param shard[*].persistence.size Size of data volume
-    ##
-    size: 4Gi
-  log:
-    storageClassName:
-    ## @param shard[*].persistence.size Size of data volume
-    ##
-    size: 4Gi
+
+storage: 10
+
+log: 2

--- a/addons-cluster/zookeeper/values.yaml
+++ b/addons-cluster/zookeeper/values.yaml
@@ -26,4 +26,4 @@ memory: 2
 
 storage: 10
 
-log: 2
+logStorage: 2

--- a/addons/zookeeper/templates/backuppolicytemplate.yaml
+++ b/addons/zookeeper/templates/backuppolicytemplate.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     dataprotection.kubeblocks.io/is-default-policy-template: "true"
 spec:
-  clusterDefinitionRef: zookeeper
   backupPolicies:
     - componentDefs: [zookeeper]
       target:


### PR DESCRIPTION
When creating a Zookeeper cluster, the minimum storage value is set to 10Gi, but it's actually created with 4Gi.

fix cloud issue #5999