### PR TITLE
chore: output logs to both file and stdout

### DIFF
--- a/addons/elasticsearch/configs/elasticsearch-7-log4j2.properties
+++ b/addons/elasticsearch/configs/elasticsearch-7-log4j2.properties
@@ -29,11 +29,17 @@ appender.rolling.strategy.action.condition.nested_condition.exceeds = 1GB
 
 ################################################
 
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = ECSJsonLayout
+
 ################################################
 
 rootLogger.level = info
 rootLogger.appenderRef.rolling.ref = rolling
+rootLogger.appenderRef.console.ref = console
 
+######## Deprecation JSON #######################
 appender.deprecation_rolling.type = Console
 appender.deprecation_rolling.name = deprecation_rolling
 appender.deprecation_rolling.layout.type = ESJsonLayout

--- a/addons/elasticsearch/configs/elasticsearch-8-log4j2.properties
+++ b/addons/elasticsearch/configs/elasticsearch-8-log4j2.properties
@@ -25,10 +25,15 @@ appender.rolling.strategy.action.condition.nested_condition.exceeds = 1GB
 
 ################################################
 
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = ECSJsonLayout
+
 ################################################
 
 rootLogger.level = info
 rootLogger.appenderRef.rolling.ref = rolling
+rootLogger.appenderRef.console.ref = console
 
 ######## Deprecation JSON #######################
 appender.deprecation_rolling.type = Console


### PR DESCRIPTION
Sending logs to stdout is helpful for debugging if the pod crashes immediately after starting.