### PR TITLE
chore: change default registry and namespace

### DIFF
--- a/.github/workflows/check-chart-pr-review.yml
+++ b/.github/workflows/check-chart-pr-review.yml
@@ -12,10 +12,15 @@ jobs:
   check-addons-helm:
     name: check addons helm
     if: github.event.review.state == 'approved'
+    strategy:
+      fail-fast: false
+      matrix:
+        registry: [ "", "dockerhub", "aliyun" ]
     uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.68
     with:
       CHART_DIR: "addons"
       APECD_REF: "v0.1.68"
+      SET_REGISTRY: "${{ matrix.registry }}"
     secrets: inherit
 
   check-addons-cluster-helm:

--- a/.github/workflows/check-chart-pr-review.yml
+++ b/.github/workflows/check-chart-pr-review.yml
@@ -12,17 +12,17 @@ jobs:
   check-addons-helm:
     name: check addons helm
     if: github.event.review.state == 'approved'
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.40
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.68
     with:
       CHART_DIR: "addons"
-      APECD_REF: "v0.1.40"
+      APECD_REF: "v0.1.68"
     secrets: inherit
 
   check-addons-cluster-helm:
     name: check addons cluster helm
     if: github.event.review.state == 'approved'
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.40
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.68
     with:
       CHART_DIR: "addons-cluster"
-      APECD_REF: "v0.1.40"
+      APECD_REF: "v0.1.68"
     secrets: inherit

--- a/.github/workflows/check-chart-push.yml
+++ b/.github/workflows/check-chart-push.yml
@@ -13,15 +13,15 @@ on:
 
 jobs:
   check-addons-helm:
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.40
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.68
     with:
       CHART_DIR: "addons"
-      APECD_REF: "v0.1.40"
+      APECD_REF: "v0.1.68"
     secrets: inherit
 
   check-addons-cluster-helm:
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.40
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.68
     with:
       CHART_DIR: "addons-cluster"
-      APECD_REF: "v0.1.40"
+      APECD_REF: "v0.1.68"
     secrets: inherit

--- a/.github/workflows/check-chart-push.yml
+++ b/.github/workflows/check-chart-push.yml
@@ -13,10 +13,15 @@ on:
 
 jobs:
   check-addons-helm:
+    strategy:
+      fail-fast: false
+      matrix:
+        registry: [ "", "dockerhub", "aliyun" ]
     uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.68
     with:
       CHART_DIR: "addons"
       APECD_REF: "v0.1.68"
+      SET_REGISTRY: "${{ matrix.registry }}"
     secrets: inherit
 
   check-addons-cluster-helm:

--- a/.github/workflows/release-addons-cluster-chart.yml
+++ b/.github/workflows/release-addons-cluster-chart.yml
@@ -68,23 +68,23 @@ run-name: Release Chart ${{ inputs.chart_dir }} ${{ inputs.chart_version }}
 jobs:
   release-chart:
     if: ${{ inputs.chart_dir != '' }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.52
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.68
     with:
       VERSION: "${{ inputs.chart_version }}"
       CHART_DIR: "addons-cluster"
       SPECIFY_CHART: "${{ inputs.chart_dir }}"
-      APECD_REF: "v0.1.52"
+      APECD_REF: "v0.1.68"
       PROJECT_ID: "150246"
     secrets: inherit
 
   release-chart-all:
     if: ${{ inputs.chart_dir == '' }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.52
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.68
     with:
       VERSION: "${{ inputs.chart_version }}"
       CHART_DIR: "addons-cluster"
       SPECIFY_CHART: "${{ inputs.chart_dir }}"
-      APECD_REF: "v0.1.52"
+      APECD_REF: "v0.1.68"
       ENABLE_JIHU: false
       PROJECT_ID: "150246"
     secrets: inherit
@@ -118,11 +118,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-addons-chart-dir.outputs.matrix) }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu.yml@v0.1.52
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu.yml@v0.1.68
     with:
       VERSION: "${{ inputs.chart_version }}"
       CHART_DIR: "addons-cluster"
       SPECIFY_CHART: "${{ matrix.addon-name }}"
-      APECD_REF: "v0.1.52"
+      APECD_REF: "v0.1.68"
       PROJECT_ID: "150246"
     secrets: inherit

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -69,22 +69,22 @@ run-name: Release Chart ${{ inputs.chart_dir }} ${{ inputs.chart_version }}
 jobs:
   release-chart:
     if: ${{ inputs.chart_dir != '' }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.52
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.68
     with:
       VERSION: "${{ inputs.chart_version }}"
       CHART_DIR: "addons"
       SPECIFY_CHART: "${{ inputs.chart_dir }}"
-      APECD_REF: "v0.1.52"
+      APECD_REF: "v0.1.68"
     secrets: inherit
 
   release-chart-all:
     if: ${{ inputs.chart_dir == '' }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.52
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.68
     with:
       VERSION: "${{ inputs.chart_version }}"
       CHART_DIR: "addons"
       SPECIFY_CHART: "${{ inputs.chart_dir }}"
-      APECD_REF: "v0.1.52"
+      APECD_REF: "v0.1.68"
       ENABLE_JIHU: false
     secrets: inherit
 
@@ -117,10 +117,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-addons-chart-dir.outputs.matrix) }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu.yml@v0.1.52
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu.yml@v0.1.68
     with:
       VERSION: "${{ inputs.chart_version }}"
       CHART_DIR: "addons"
       SPECIFY_CHART: "${{ matrix.addon-name }}"
-      APECD_REF: "v0.1.52"
+      APECD_REF: "v0.1.68"
     secrets: inherit

--- a/addons-cluster/pulsar/values.yaml
+++ b/addons-cluster/pulsar/values.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   resource.kubeblocks.io/ignore-constraint: "true"
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
 
 ## @param mode pulsar cluster topology mode: pulsar-basic-cluster and pulsar-enhanced-cluster
 ## pulsar-basic-cluster: contains broker, zookeeper and bookkeeper

--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/apecloud-mysql-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -10,6 +10,7 @@ image:
   tag: 8.0.30-5.beta3.20240330.g94d1caf.15
   # audit:
   #   tag: 8.0.30-5.beta3.auditlog.20231221.g6ba5e2e.14
+  # refer: https://github.com/apecloud/dbctl/blob/main/docker/Dockerfile
   dbctl:
     repository: apecloud/dbctl
     tag: "0.1.2"

--- a/addons/apecloud-postgresql/values.yaml
+++ b/addons/apecloud-postgresql/values.yaml
@@ -13,6 +13,8 @@ image:
   syncer:
     repository: apecloud/syncer
     tag: "0.1.8"
+
+  # refer: https://github.com/apecloud/dbctl/blob/main/docker/Dockerfile
   dbctl:
     repository: apecloud/dbctl
     tag: "0.1.2"

--- a/addons/apecloud-postgresql/values.yaml
+++ b/addons/apecloud-postgresql/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/apecloud-postgres
   tag: "14.11-0.7.3"
   digest: ""

--- a/addons/camellia-redis-proxy/values.yaml
+++ b/addons/camellia-redis-proxy/values.yaml
@@ -5,7 +5,7 @@
 image:
   # refer: https://github.com/caojiajun/camellia-jdk21-bootstraps/blob/main/docs/redis-proxy/Dockerfile
   # this is the image of camellia-redis-proxy, which is built from Dockerfile of Apecloud/camellia-redis-proxy forked from caojiajun/camellia-jdk21-bootstraps.
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/camellia-redis-proxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -14,7 +14,7 @@ image:
 busyboxImage:
   # if the value of busyboxImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   registry: ""
-  repository: apecloud/busybox
+  repository: busybox
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 1.36

--- a/addons/clickhouse/values.yaml
+++ b/addons/clickhouse/values.yaml
@@ -12,8 +12,8 @@ commonLabels: {}
 commonAnnotations: {}
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/clickhouse
+  registry: docker.io
+  repository: bitnami/clickhouse
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 22.9.4-debian-11-r1

--- a/addons/dmdb/values.yaml
+++ b/addons/dmdb/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/dm8_single
+  registry: docker.io
+  repository: biaobes/dm8_single
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.1.0"

--- a/addons/elasticsearch/values.yaml
+++ b/addons/elasticsearch/values.yaml
@@ -7,20 +7,20 @@ replicaCount: 1
 image:
   # bitnami/elasticsearch
   # docker pull bitnami/elasticsearch
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/elasticsearch
+  registry: docker.io
+  repository: elasticsearch
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "8.8.2"
   exporter:
-    repository: apecloud/elasticsearch-exporter
+    repository: prometheuscommunity/elasticsearch-exporter
     tag: "v1.7.0"
   plugin:
     repository: apecloud/elasticsearch-plugins
     tag: "8.8.2"
   tools:
     repository: apecloud/curl-jq
-    tag: latest
+    tag: 0.1.0
 
 exporter:
   service:

--- a/addons/elasticsearch/values.yaml
+++ b/addons/elasticsearch/values.yaml
@@ -15,6 +15,7 @@ image:
   exporter:
     repository: prometheuscommunity/elasticsearch-exporter
     tag: "v1.7.0"
+  # refer: https://github.com/apecloud/kubeblocks-addons/blob/main/addons/elasticsearch/plugins/Dockerfile
   plugin:
     repository: apecloud/elasticsearch-plugins
     tag: "8.8.2"

--- a/addons/etcd/values.yaml
+++ b/addons/etcd/values.yaml
@@ -25,8 +25,8 @@ tls:
 backupKeyThreshold: 6
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/etcd
+  registry: quay.io
+  repository: coreos/etcd
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag:
@@ -39,8 +39,8 @@ image:
 
 busyboxImage:
   # if the value of busyboxImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
-  registry: ""
-  repository: apecloud/busybox
+  registry: docker.io
+  repository: busybox
   pullPolicy: IfNotPresent
   # use static compile version
   tag: 1.35-musl

--- a/addons/flink/values.yaml
+++ b/addons/flink/values.yaml
@@ -6,15 +6,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   init:
-    repository: apecloud/busybox
+    repository: busybox
     tag: 1.28
   jobmanager:
-    repository: apecloud/flink
+    repository: flink
     tag: 1.16
   taskmanager:
-    repository: apecloud/flink
+    repository: flink
     tag: 1.16
   pullPolicy: IfNotPresent
 

--- a/addons/greatsql/templates/clusterdefinition.yaml
+++ b/addons/greatsql/templates/clusterdefinition.yaml
@@ -46,7 +46,7 @@ spec:
                     name: $(CONN_CREDENTIAL_SECRET_NAME)
                     key: password
           - name: mysql-exporter
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.prom.repository }}/{{ .Values.image.prom.mysqld_exporter.name}}:{{.Values.image.prom.mysqld_exporter.tag}}
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.prom.mysqld_exporter.repository}}:{{.Values.image.prom.mysqld_exporter.tag}}
             imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
             ports:
               - name: metrics

--- a/addons/greatsql/values.yaml
+++ b/addons/greatsql/values.yaml
@@ -1,13 +1,12 @@
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/greatsql
+  registry: docker.io
+  repository: greatsql/greatsql
   pullPolicy: IfNotPresent
   tag: 8.0.32-25
   prom:
-    repository: apecloud
     pullPolicy: IfNotPresent
     mysqld_exporter:
-      name: mysqld-exporter
+      repository: prom/mysqld-exporter
       tag: v0.14.0
 
 ## MySQL Authentication parameters

--- a/addons/greptimedb/templates/cmpv.yaml
+++ b/addons/greptimedb/templates/cmpv.yaml
@@ -22,12 +22,12 @@ spec:
     - name: datanode-0.3.2
       serviceVersion: 0.3.2
       images:
-        datanode: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:0.3.2
+        datanode: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:{{ .Values.images.greptimedb.tag }}
     - name: frontend-0.3.2
       serviceVersion: 0.3.2
       images:
-        frontend: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:0.3.2
+        frontend: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:{{ .Values.images.greptimedb.tag }}
     - name: meta-0.3.2
       serviceVersion: 0.3.2
       images:
-        meta: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:0.3.2
+        meta: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:{{ .Values.images.greptimedb.tag }}

--- a/addons/greptimedb/templates/cmpv.yaml
+++ b/addons/greptimedb/templates/cmpv.yaml
@@ -22,12 +22,12 @@ spec:
     - name: datanode-0.3.2
       serviceVersion: 0.3.2
       images:
-        datanode: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:{{ .Values.images.greptimedb.tag }}
+        datanode: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:0.3.2
     - name: frontend-0.3.2
       serviceVersion: 0.3.2
       images:
-        frontend: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:{{ .Values.images.greptimedb.tag }}
+        frontend: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:0.3.2
     - name: meta-0.3.2
       serviceVersion: 0.3.2
       images:
-        meta: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:{{ .Values.images.greptimedb.tag }}
+        meta: {{ .Values.images.greptimedb.registry | default .Values.images.registry }}/{{ .Values.images.greptimedb.repository }}:0.3.2

--- a/addons/greptimedb/values.yaml
+++ b/addons/greptimedb/values.yaml
@@ -10,19 +10,19 @@ clusterDomain: ".cluster.local"
 ## @param application images
 ##
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   pullPolicy: IfNotPresent
   greptimedb:
     registry: ""
-    repository: apecloud/greptimedb
+    repository: greptime/greptimedb
     tag: 0.3.2
   initializer:
     registry: ""
-    repository: apecloud/greptimedb-initializer
+    repository: greptime/greptimedb-initializer
     tag: 0.1.0-alpha.12
   busybox:
     registry: ""
-    repository: apecloud/busybox
+    repository: busybox
     tag: 1.35
 
 ## @param metasrv config

--- a/addons/influxdb/values.yaml
+++ b/addons/influxdb/values.yaml
@@ -2,13 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   pullPolicy: IfNotPresent
   influxdb:
-    repository: apecloud/influxdb
+    repository: bitnami/influxdb
     tag: 2.7.4-debian-11-r0
   init:
-    repository: apecloud/os-shell
+    repository: bitnami/os-shell
     tag: 11-debian-11-r93
 
 nameOverride: ""

--- a/addons/kafka/values.yaml
+++ b/addons/kafka/values.yaml
@@ -21,17 +21,17 @@ commonLabels: {}
 ## @param application images
 ##
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   pullPolicy: IfNotPresent
   kafka:
-    repository: apecloud/kafka
+    repository: bitnami/kafka
 #    tag: 3.4.0-debian-11-r22
     tag: 3.3.2-debian-11-r54
   kafkaExporter:
-    repository: apecloud/kafka-exporter
+    repository: bitnami/kafka-exporter
     tag: 1.6.0-debian-11-r67
   jmxExporter:
-    repository: apecloud/jmx-exporter
+    repository: bitnami/jmx-exporter
     tag: 0.18.0-debian-11-r20
 
 

--- a/addons/llm/values.yaml
+++ b/addons/llm/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: apecloud/vllm
   pullPolicy: IfNotPresent
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   # Overrides the image tag whose default is the chart appVersion.
   tag: v0.2.7-amd64
 imageDev:
@@ -10,9 +10,9 @@ imageDev:
   # if the value of imageDev.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   registry: ""
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
-  tagNew: latest-new
-  tagCodeShell: latest-codeshell
+  tag: 0.1.0
+  tagNew: 0.1.0-new
+  tagCodeShell: 0.1.0-codeshell
 model:
   # if the value of model.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   registry: ""

--- a/addons/loki/values.yaml
+++ b/addons/loki/values.yaml
@@ -2,27 +2,27 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   # Overrides the image tag whose default is the chart appVersion.
   write:
     tag: 3.0.0
-    repository: apecloud/loki
+    repository: grafana/loki
     pullPolicy: IfNotPresent
   read:
     tag: 3.0.0
-    repository: apecloud/loki
+    repository: grafana/loki
     pullPolicy: IfNotPresent
   backend:
     tag: 3.0.0
-    repository: apecloud/loki
+    repository: grafana/loki
     pullPolicy: IfNotPresent
   gateway:
     tag: 1.24-alpine
-    repository: apecloud/nginx-unprivileged
+    repository: nginxinc/nginx-unprivileged
     pullPolicy: IfNotPresent
 sidecarImage:
   registry: ""
-  repository: apecloud/k8s-sidecar
+  repository: kiwigrid/k8s-sidecar
   pullPolicy: IfNotPresent
   tag: 1.24.3
 

--- a/addons/mariadb/templates/cmpd.yaml
+++ b/addons/mariadb/templates/cmpd.yaml
@@ -22,7 +22,7 @@ spec:
           - name: MARIADB_ROOT_HOST
             value: {{ .Values.auth.rootHost | default "%" | quote }}
       - name: exporter
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.prom.repository }}/{{ .Values.image.prom.exporter.name}}:{{.Values.image.prom.exporter.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.prom.exporter.repository}}:{{.Values.image.prom.exporter.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         ports:
           - name: metrics

--- a/addons/mariadb/values.yaml
+++ b/addons/mariadb/values.yaml
@@ -2,15 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/mariadb
+  registry: docker.io
+  repository: mariadb
   pullPolicy: IfNotPresent
   tag: 10.6.15
   prom:
-    repository: apecloud
     pullPolicy: IfNotPresent
     exporter:
-      name: mysqld-exporter
+      repository: prom/mysqld-exporter
       tag: v0.14.0
 
 ## MySQL Authentication parameters

--- a/addons/milvus/values.yaml
+++ b/addons/milvus/values.yaml
@@ -8,23 +8,23 @@ fullnameOverride: ""
 ## @param application images
 ##
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   pullPolicy: IfNotPresent
   minio:
     registry: ""
-    repository: apecloud/minio
+    repository: minio/minio
     tag: RELEASE.2022-03-17T06-34-49Z
   ostools:
     registry: ""
-    repository: apecloud/os-shell
+    repository: bitnami/os-shell
     tag: 11-debian-11-r90
   operator:
     registry: ""
-    repository: apecloud/milvus-operator
+    repository: milvusdb/milvus-operator
     tag: v0.8.4
   milvus:
     registry: ""
-    repository: apecloud/milvus
+    repository: milvusdb/milvus
     tag: v2.3.2
   
 

--- a/addons/minio/values.yaml
+++ b/addons/minio/values.yaml
@@ -13,8 +13,8 @@ clusterDomain: cluster.local
 ## Set default image, imageTag, and imagePullPolicy. mode is used to indicate the
 ##
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/minio
+  registry: docker.io
+  repository: minio/minio
   tag: RELEASE.2024-06-29T01-20-47Z
   pullPolicy: IfNotPresent
 
@@ -27,7 +27,7 @@ imagePullSecrets: []
 mcImage:
   # if the value of mcImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   registry: ""
-  repository: apecloud/mc
+  repository: minio/mc
   tag: RELEASE.2024-04-18T16-45-29Z
   pullPolicy: IfNotPresent
 

--- a/addons/mogdb/templates/cmpv.yaml
+++ b/addons/mogdb/templates/cmpv.yaml
@@ -11,7 +11,7 @@ spec:
       images:
         mogdb: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:5.0.5
         helper: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:5.0.5
-        exporter: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:3.1.0
+        exporter: {{ .Values.metrics.image.registry | default ( .Values.image.registry  | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:3.1.0
   compatibilityRules:
     - releases: [mogdb-5.0.5]
       compDefs: [mogdb-5]

--- a/addons/mogdb/templates/swithover.yaml
+++ b/addons/mogdb/templates/swithover.yaml
@@ -35,8 +35,8 @@ spec:
       podSpec:
         containers:
           - name: switchover
-            image: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.2
-            imagePullPolicy: IfNotPresent
+            image: {{ .Values.tools.image.registry | default "docker.io" }}/{{ .Values.tools.image.repository }}:{{ .Values.tools.image.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.tools.image.pullPolicy }}
             command:
               - /bin/sh
               - -c

--- a/addons/mogdb/values.yaml
+++ b/addons/mogdb/values.yaml
@@ -5,11 +5,18 @@
 replicaCount: 1
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/mogdb
+  registry: swr.cn-north-4.myhuaweicloud.com
+  repository: mogdb/mogdb
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 5.0.5
+
+tools:
+  image:
+    registry: docker.io
+    repository: apecloud/kubeblocks-tools
+    tag: 0.8.2
+    pullPolicy: IfNotPresent
 
 
 dataMountPath: /var/lib/mogdb
@@ -42,7 +49,7 @@ metrics:
   image:
     # if the value of metrics.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
-    repository: apecloud/mogdb-exporter
+    repository: mogdb-cloud/mogdb-exporter
     tag: 3.1.0
     pullPolicy: IfNotPresent
   service:

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -11,6 +11,8 @@ image:
   syncer:
     repository: apecloud/syncer
     tag: "0.1.8"
+
+  # refer: https://github.com/apecloud/dbctl/blob/main/docker/Dockerfile
   dbctl:
     repository: apecloud/dbctl
     tag: "0.1.2"
@@ -18,6 +20,8 @@ image:
 componentServiceVersion:
   mongodb: 5.0.14
 
+# refer: https://github.com/apecloud/wal-g/blob/kb-dev/docker/wal-g/Dockerfile-mongo
+# this image is built from Dockerfile of apecloud/wal-g forked from wal-g/wal-g.
 walg:
   repository: apecloud/wal-g
   tag: mongo-latest

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/mongo
+  registry: docker.io
+  repository: mongo
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 5.0.14 # 6.0.3-debian-11-r0

--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -210,7 +210,7 @@ roles:
     - -r
     - /xtrabackup-2.4
     - /kubeblocks/xtrabackup
-  image: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/syncer:mysql
+  image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.syncer.repository }}:{{ .Values.image.syncer.tag }}
   imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
   name: init-xtrabackup
   volumeMounts:

--- a/addons/mysql/templates/actionset-volumesnapshot.yaml
+++ b/addons/mysql/templates/actionset-volumesnapshot.yaml
@@ -13,7 +13,7 @@ spec:
     value: {{ .Values.dataMountPath }}
   restore:
     prepareData:
-      image: {{ .Values.image.xtraBackupRegistry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackupRepository }}:8.0.32
+      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:8.0.32
       command:
       - bash
       - -c

--- a/addons/mysql/templates/actionset-xtrabackup.yaml
+++ b/addons/mysql/templates/actionset-xtrabackup.yaml
@@ -19,7 +19,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ .Values.image.xtraBackupRegistry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackupRepository }}:$(IMAGE_TAG)
+      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:$(IMAGE_TAG)
       runOnTargetPodNode: true
       command:
       - bash
@@ -31,7 +31,7 @@ spec:
         intervalSeconds: 5
   restore:
     prepareData:
-      image: {{ .Values.image.xtraBackupRegistry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackupRepository }}:$(IMAGE_TAG)
+      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:$(IMAGE_TAG)
       command:
       - bash
       - -c

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -13,7 +13,7 @@ image:
   xtraBackup:
     # if the value of image.xtraBackup.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
-    repository: apecloud/percona-xtrabackup
+    repository: perconalab/percona-xtrabackup
   syncer:
     repository: apecloud/syncer
     tag: 0.1.2

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -3,16 +3,17 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry:  apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/mysql
+  registry:  docker.io
+  repository: mysql
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   # example for mysql 8.0
   #tag: 8.0.33
   tag: 5.7.44
-  xtraBackupRepository: apecloud/percona-xtrabackup
-  # if the value of image.xtraBackupRegistry.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
-  xtraBackupRegistry: ""
+  xtraBackup:
+    # if the value of image.xtraBackup.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
+    registry: ""
+    repository: apecloud/percona-xtrabackup
   syncer:
     repository: apecloud/syncer
     tag: 0.1.2

--- a/addons/nebula/values.yaml
+++ b/addons/nebula/values.yaml
@@ -3,31 +3,31 @@ nebula:
   ## more info: check https://docs.nebula-graph.io/ for latest and LTS versions
   version: v3.5.0
   images:
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    registry: docker.io
     pullPolicy: IfNotPresent
     ## @param nebula.images.graphd, container image settings
     graphd:
       # if the value of nebula.images.graphd.registry is not specified using `--set`, it will be set to the value of 'nebula.images.registry' by default
       registry: ""
-      repository: apecloud/nebula-graphd
+      repository: vesoft/nebula-graphd
       tag: v3.5.0
     ## @param nebula.images.metad, container image settings
     metad:
       # if the value of nebula.images.metad.registry is not specified using `--set`, it will be set to the value of 'nebula.images.registry' by default
       registry: ""
-      repository: apecloud/nebula-metad
+      repository: vesoft/nebula-metad
       tag: v3.5.0
     ## @param nebula.images.storaged, container image settings
     storaged:
       # if the value of nebula.images.storaged.registry is not specified using `--set`, it will be set to the value of 'nebula.images.registry' by default
       registry: ""
-      repository: apecloud/nebula-storaged
+      repository: vesoft/nebula-storaged
       tag: v3.5.0
     ## @param nebula.images.console, container image settings
     console:
       # if the value of nebula.images.console.registry is not specified using `--set`, it will be set to the value of 'nebula.images.registry' by default
       registry: ""
-      repository: apecloud/nebula-console
+      repository: vesoft/nebula-console
       tag: v3.5.0
 
 clusterDomain: ".cluster.local"

--- a/addons/neon/values.yaml
+++ b/addons/neon/values.yaml
@@ -1,9 +1,9 @@
 version: latest
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   # -- Neondatabase image repository
-  repository: apecloud/neon
+  repository: perconalab/neon
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: "pg14-1.0.0"
 

--- a/addons/oceanbase-ce/values.yaml
+++ b/addons/oceanbase-ce/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   pullPolicy: IfNotPresent
   observer:
     repository: apecloud/oceanbase

--- a/addons/official-postgresql/values.yaml
+++ b/addons/official-postgresql/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/postgres
+  registry: docker.io
+  repository: postgres
   tag: 14.7
   digest: ""
   ## Specify a imagePullPolicy

--- a/addons/opengauss/values.yaml
+++ b/addons/opengauss/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/opengauss
+  registry: docker.io
+  repository: enmotech/opengauss
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 3.0.0

--- a/addons/openldap/values.yaml
+++ b/addons/openldap/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/openldap
+  registry: docker.io
+  repository: osixia/openldap
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "1.5.0"

--- a/addons/opensearch/values.yaml
+++ b/addons/opensearch/values.yaml
@@ -5,13 +5,13 @@
 replicaCount: 1
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/opensearch
+  registry: docker.io
+  repository: opensearchproject/opensearch
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   dashboard:
-    repository: apecloud/opensearch-dashboards
+    repository: opensearchproject/opensearch-dashboards
     tag: ""
 
 nameOverride: ""

--- a/addons/opentenbase/values.yaml
+++ b/addons/opentenbase/values.yaml
@@ -4,7 +4,7 @@
 
 # Related image configurations.
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/opentenbase
+  registry: docker.io
+  repository: domainlau/opentenbase
   tag: v2.5.0
   pullPolicy: IfNotPresent

--- a/addons/oracle/values.yaml
+++ b/addons/oracle/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/oracle
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/addons/orchestrator/values.yaml
+++ b/addons/orchestrator/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/orchestrator
   pullPolicy: IfNotPresent
   tag: v3.2.6

--- a/addons/orioledb/values.yaml
+++ b/addons/orioledb/values.yaml
@@ -1,8 +1,7 @@
 ## @section OrioleDB common parameters
 
 image:
-#  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/orioledb
   tag: beta1
   pullPolicy: IfNotPresent

--- a/addons/polardbx/templates/cmpd-cdc.yaml
+++ b/addons/polardbx/templates/cmpd-cdc.yaml
@@ -29,7 +29,7 @@ spec:
             value: $(SERVICE_PASSWORD)
     containers:
       - name: engine
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.cdc.name}}:{{.Values.images.polardbx.cdc.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.cdc.repository}}:{{.Values.images.polardbx.cdc.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         env:
           - name: switchCloud
@@ -82,7 +82,7 @@ spec:
           - name: log
             mountPath: /home/admin/logs
       - name: exporter
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.exporter.name}}:{{.Values.images.polardbx.exporter.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.exporter.repository}}:{{.Values.images.polardbx.exporter.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         args:
           - -web.listen-addr=:9104

--- a/addons/polardbx/templates/cmpd-cn.yaml
+++ b/addons/polardbx/templates/cmpd-cn.yaml
@@ -47,7 +47,7 @@ spec:
           - name: shared
             mountPath: /shared
       - name: init
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.init.name }}:{{.Values.images.polardbx.init.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.init.repository }}:{{.Values.images.polardbx.init.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         command: [ "sh" ]
         args: [ "-c", 'source /shared/env.sh && /polardbx-init' ]
@@ -146,7 +146,7 @@ spec:
             mountPath: /shared
     containers:
       - name: engine
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.cn.name}}:{{.Values.images.polardbx.cn.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.cn.repository}}:{{.Values.images.polardbx.cn.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         command:
           - /bin/bash
@@ -204,7 +204,7 @@ spec:
           - name: shared
             mountPath: /shared
       - name: exporter
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.exporter.name}}:{{.Values.images.polardbx.exporter.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.exporter.repository}}:{{.Values.images.polardbx.exporter.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         args:
           - -collectors.process

--- a/addons/polardbx/templates/cmpd-dn.yaml
+++ b/addons/polardbx/templates/cmpd-dn.yaml
@@ -39,7 +39,7 @@ spec:
         name: podinfo
     initContainers:
       - name: tools-updater
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.toolsUpdater.name }}:{{.Values.images.polardbx.toolsUpdater.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.toolsUpdater.repository }}:{{.Values.images.polardbx.toolsUpdater.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         command: [ "/bin/ash" ]
         args: [ "-c", "./hack/update.sh /target" ]
@@ -54,7 +54,7 @@ spec:
             mountPath: /target
     containers:
       - name: engine
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.dn.name}}:{{.Values.images.polardbx.dn.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.dn.repository}}:{{.Values.images.polardbx.dn.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         command: [ "/scripts/xstore-setup.sh" ]
         lifecycle:
@@ -148,7 +148,7 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
       - name: exporter
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.prom.repository }}/{{ .Values.images.prom.mysqld_exporter.name}}:{{.Values.images.prom.mysqld_exporter.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.prom.mysqld_exporter.repository}}:{{.Values.images.prom.mysqld_exporter.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.prom.pullPolicy }}
         ports:
           - name: metrics
@@ -214,7 +214,7 @@ spec:
   lifecycleAction:
     roleProbe:
       exec:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.roleProbe.image.repository }}/{{ .Values.roleProbe.image.name }}:{{ .Values.roleProbe.image.tag }}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.roleProbe.image.repository }}:{{ .Values.roleProbe.image.tag }}
         command:
           - sh
           - -c

--- a/addons/polardbx/templates/cmpd-gms.yaml
+++ b/addons/polardbx/templates/cmpd-gms.yaml
@@ -39,7 +39,7 @@ spec:
         name: podinfo
     initContainers:
       - name: tools-updater
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.toolsUpdater.name }}:{{.Values.images.polardbx.toolsUpdater.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.toolsUpdater.repository }}:{{.Values.images.polardbx.toolsUpdater.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         command: [ "/bin/ash" ]
         args: [ "-c", "./hack/update.sh /target" ]
@@ -54,7 +54,7 @@ spec:
             mountPath: /target
     containers:
       - name: engine
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.dn.name}}:{{.Values.images.polardbx.dn.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.polardbx.dn.repository}}:{{.Values.images.polardbx.dn.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
         command: [ "/scripts/xstore-setup.sh" ]
         lifecycle:
@@ -148,7 +148,7 @@ spec:
           - name: podinfo
             mountPath: /etc/podinfo
       - name: exporter
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.prom.repository }}/{{ .Values.images.prom.mysqld_exporter.name}}:{{.Values.images.prom.mysqld_exporter.tag}}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.images.prom.mysqld_exporter.repository}}:{{.Values.images.prom.mysqld_exporter.tag}}
         imagePullPolicy: {{ default "IfNotPresent" .Values.images.prom.pullPolicy }}
         ports:
           - name: metrics
@@ -210,7 +210,7 @@ spec:
   lifecycleAction:
     roleProbe:
       exec:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.roleProbe.image.repository }}/{{ .Values.roleProbe.image.name }}:{{ .Values.roleProbe.image.tag }}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.roleProbe.image.repository }}:{{ .Values.roleProbe.image.tag }}
         command:
           - sh
           - -c

--- a/addons/polardbx/values.yaml
+++ b/addons/polardbx/values.yaml
@@ -7,60 +7,57 @@ roleProbe:
   periodSeconds: 1
   timeoutSeconds: 1
   image:
-    repository: apecloud
-    name: mysql-client
+    repository: arey/mysql-client
     tag: latest
 
 # Related image configurations.
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
 
 images:
   polardbx:
     pullPolicy: IfNotPresent
     # Repo of polardbx default images. Default is polardbx.
-    repository: apecloud
 
     # Images for xstore(DN) tools updater.
     toolsUpdater:
-      name: xstore-tools
+      repository: polardbx/xstore-tools
       tag: v1.5.0
 
     # Image for DN engine
     dn:
-      name: polardbx-engine-2.0
+      repository: polardbx/polardbx-engine-2.0
       tag: 80-8.0.18-20231101115000
 
     # Image for CN engine
     cn:
-      name: polardbx-sql
+      repository: polardbx/polardbx-sql
       tag: 5.4.18-20231101115000
 
     # Image for CN initialization
     init:
-      name: polardbx-init
+      repository: polardbx/polardbx-init
       tag: v1.5.0
 
     # Image for CN engine
     cdc:
-      name: polardbx-cdc
+      repository: polardbx/polardbx-cdc
       tag: 5.4.18-20231101115000
 
     # Image for CN&CDC exporter
     exporter:
-      name: polardbx-exporter
+      repository: polardbx/polardbx-exporter
       tag: v1.5.0
 
   # Tool image settings for gms initialization
   mysql:
-    repository: apecloud/mysql
+    repository: mysql
     pullPolicy: IfNotPresent
     tag: "8.0.30"
 
   # Images for DN exporter
   prom:
-    repository: apecloud
     pullPolicy: IfNotPresent
     mysqld_exporter:
-      name: mysqld-exporter
+      repository: prom/mysqld-exporter
       tag: v0.14.0

--- a/addons/postgresql/templates/_helpers.tpl
+++ b/addons/postgresql/templates/_helpers.tpl
@@ -107,15 +107,15 @@ Define image
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}
 {{- end }}
 
-{{- define "postgresql.image150" -}}
+{{- define "postgresql.image.major12.minor150" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
 {{- end }}
 
-{{- define "postgresql.image080" -}}
+{{- define "postgresql.image.major14.minor080" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
 {{- end }}
 
-{{- define "postgresql.image070" -}}
+{{- define "postgresql.image.major15.minor070" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
 {{- end }}
 

--- a/addons/postgresql/templates/_helpers.tpl
+++ b/addons/postgresql/templates/_helpers.tpl
@@ -99,3 +99,38 @@ postgresql-15
 {{ include "postgresql.componentDefNamePrefix" . }}{{ .Values.componentDefinitionVersion.postgresql15 }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define image
+*/}}
+{{- define "redis.image140" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor140 }}
+{{- end }}
+
+{{- define "redis.image141" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor141 }}
+{{- end }}
+
+{{- define "redis.image150" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+{{- end }}
+
+{{- define "redis.image072" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor072 }}
+{{- end }}
+
+{{- define "redis.image080" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+{{- end }}
+
+{{- define "redis.image070" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+{{- end }}
+
+{{- define "pgbouncer.image" -}}
+{{ .Values.pgbouncer.image.registry | default (.Values.image.registry | default "docker.io") }}/{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
+{{- end }}
+
+{{- define "metrics.image" -}}
+{{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ default .Values.metrics.image.tag }}
+{{- end }}

--- a/addons/postgresql/templates/_helpers.tpl
+++ b/addons/postgresql/templates/_helpers.tpl
@@ -103,27 +103,27 @@ postgresql-15
 {{/*
 Define image
 */}}
-{{- define "redis.image140" -}}
+{{- define "postgresql.image140" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor140 }}
 {{- end }}
 
-{{- define "redis.image141" -}}
+{{- define "postgresql.image141" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor141 }}
 {{- end }}
 
-{{- define "redis.image150" -}}
+{{- define "postgresql.image150" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
 {{- end }}
 
-{{- define "redis.image072" -}}
+{{- define "postgresql.image072" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor072 }}
 {{- end }}
 
-{{- define "redis.image080" -}}
+{{- define "postgresql.image080" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
 {{- end }}
 
-{{- define "redis.image070" -}}
+{{- define "postgresql.image070" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
 {{- end }}
 

--- a/addons/postgresql/templates/_helpers.tpl
+++ b/addons/postgresql/templates/_helpers.tpl
@@ -103,20 +103,12 @@ postgresql-15
 {{/*
 Define image
 */}}
-{{- define "postgresql.image140" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor140 }}
-{{- end }}
-
-{{- define "postgresql.image141" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor141 }}
+{{- define "postgresql.repository" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}
 {{- end }}
 
 {{- define "postgresql.image150" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
-{{- end }}
-
-{{- define "postgresql.image072" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor072 }}
 {{- end }}
 
 {{- define "postgresql.image080" -}}
@@ -125,6 +117,10 @@ Define image
 
 {{- define "postgresql.image070" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+{{- end }}
+
+{{- define "pgbouncer.repository" -}}
+{{ .Values.pgbouncer.image.registry | default (.Values.image.registry | default "docker.io") }}/{{ .Values.pgbouncer.image.repository }}
 {{- end }}
 
 {{- define "pgbouncer.image" -}}

--- a/addons/postgresql/templates/componentdefinition-12.yaml
+++ b/addons/postgresql/templates/componentdefinition-12.yaml
@@ -140,7 +140,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+          image: {{ include "redis.image150" . }}
           command:
             - /bin/bash
             - -c
@@ -148,7 +148,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+          image: {{ include "redis.image150" . }}
           command:
             - /bin/bash
             - -c
@@ -158,7 +158,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+        image: {{ include "redis.image150" . }}
         exec:
           command:
             - psql
@@ -174,7 +174,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+        image: {{ include "redis.image150" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -185,7 +185,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+        image: {{ include "redis.image150" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -212,7 +212,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major12.minor150 }}
+        image: {{ include "redis.image150" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0
@@ -308,7 +308,7 @@ spec:
           - name: PGPASSWORD
             value: $(POSTGRES_PASSWORD)
       - name: pgbouncer
-        image: {{ .Values.pgbouncer.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.pgbouncer.image.repository }}:{{ default .Values.pgbouncer.image.tag }}
+        image: {{ include "pgbouncer.image" . }}
         imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy | quote }}
         securityContext:
           runAsUser: 0
@@ -360,7 +360,7 @@ spec:
         ports:
           - name: http-metrics
             containerPort: {{ .Values.metrics.service.port }}
-        image: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ default .Values.metrics.image.tag }}
+        image: {{ include "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         args:
           - "--extend.query-path=/opt/conf/custom-metrics.yaml"

--- a/addons/postgresql/templates/componentdefinition-12.yaml
+++ b/addons/postgresql/templates/componentdefinition-12.yaml
@@ -140,7 +140,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ include "redis.image150" . }}
+          image: {{ include "postgresql.image150" . }}
           command:
             - /bin/bash
             - -c
@@ -148,7 +148,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ include "redis.image150" . }}
+          image: {{ include "postgresql.image150" . }}
           command:
             - /bin/bash
             - -c
@@ -158,7 +158,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ include "redis.image150" . }}
+        image: {{ include "postgresql.image150" . }}
         exec:
           command:
             - psql
@@ -174,7 +174,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ include "redis.image150" . }}
+        image: {{ include "postgresql.image150" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -185,7 +185,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ include "redis.image150" . }}
+        image: {{ include "postgresql.image150" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -212,7 +212,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ include "redis.image150" . }}
+        image: {{ include "postgresql.image150" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/addons/postgresql/templates/componentdefinition-12.yaml
+++ b/addons/postgresql/templates/componentdefinition-12.yaml
@@ -140,7 +140,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ include "postgresql.image150" . }}
+          image: {{ include "postgresql.image.major12.minor150" . }}
           command:
             - /bin/bash
             - -c
@@ -148,7 +148,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ include "postgresql.image150" . }}
+          image: {{ include "postgresql.image.major12.minor150" . }}
           command:
             - /bin/bash
             - -c
@@ -158,7 +158,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ include "postgresql.image150" . }}
+        image: {{ include "postgresql.image.major12.minor150" . }}
         exec:
           command:
             - psql
@@ -174,7 +174,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ include "postgresql.image150" . }}
+        image: {{ include "postgresql.image.major12.minor150" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -185,7 +185,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ include "postgresql.image150" . }}
+        image: {{ include "postgresql.image.major12.minor150" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -212,7 +212,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ include "postgresql.image150" . }}
+        image: {{ include "postgresql.image.major12.minor150" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/addons/postgresql/templates/componentdefinition-14.yaml
+++ b/addons/postgresql/templates/componentdefinition-14.yaml
@@ -140,7 +140,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+          image: {{ include "redis.image080" . }}
           command:
             - /bin/bash
             - -c
@@ -148,7 +148,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+          image: {{ include "redis.image080" . }}
           command:
             - /bin/bash
             - -c
@@ -158,7 +158,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+        image: {{ include "redis.image080" . }}
         exec:
           command:
             - psql
@@ -174,7 +174,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+        image: {{ include "redis.image080" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -185,7 +185,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+        image: {{ include "redis.image080" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -212,7 +212,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major14.minor080 }}
+        image: {{ include "redis.image080" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0
@@ -308,7 +308,7 @@ spec:
           - name: PGPASSWORD
             value: $(POSTGRES_PASSWORD)
       - name: pgbouncer
-        image: {{ .Values.pgbouncer.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.pgbouncer.image.repository }}:{{ default .Values.pgbouncer.image.tag }}
+        image: {{ include "pgbouncer.image" . }}
         imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy | quote }}
         securityContext:
           runAsUser: 0
@@ -360,7 +360,7 @@ spec:
         ports:
           - name: http-metrics
             containerPort: {{ .Values.metrics.service.port }}
-        image: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ default .Values.metrics.image.tag }}
+        image: {{ include "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         args:
           - "--extend.query-path=/opt/conf/custom-metrics.yaml"

--- a/addons/postgresql/templates/componentdefinition-14.yaml
+++ b/addons/postgresql/templates/componentdefinition-14.yaml
@@ -140,7 +140,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ include "redis.image080" . }}
+          image: {{ include "postgresql.image080" . }}
           command:
             - /bin/bash
             - -c
@@ -148,7 +148,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ include "redis.image080" . }}
+          image: {{ include "postgresql.image080" . }}
           command:
             - /bin/bash
             - -c
@@ -158,7 +158,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ include "redis.image080" . }}
+        image: {{ include "postgresql.image080" . }}
         exec:
           command:
             - psql
@@ -174,7 +174,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ include "redis.image080" . }}
+        image: {{ include "postgresql.image080" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -185,7 +185,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ include "redis.image080" . }}
+        image: {{ include "postgresql.image080" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -212,7 +212,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ include "redis.image080" . }}
+        image: {{ include "postgresql.image080" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/addons/postgresql/templates/componentdefinition-14.yaml
+++ b/addons/postgresql/templates/componentdefinition-14.yaml
@@ -140,7 +140,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ include "postgresql.image080" . }}
+          image: {{ include "postgresql.image.major14.minor080" . }}
           command:
             - /bin/bash
             - -c
@@ -148,7 +148,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ include "postgresql.image080" . }}
+          image: {{ include "postgresql.image.major14.minor080" . }}
           command:
             - /bin/bash
             - -c
@@ -158,7 +158,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ include "postgresql.image080" . }}
+        image: {{ include "postgresql.image.major14.minor080" . }}
         exec:
           command:
             - psql
@@ -174,7 +174,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ include "postgresql.image080" . }}
+        image: {{ include "postgresql.image.major14.minor080" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -185,7 +185,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ include "postgresql.image080" . }}
+        image: {{ include "postgresql.image.major14.minor080" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -212,7 +212,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ include "postgresql.image080" . }}
+        image: {{ include "postgresql.image.major14.minor080" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/addons/postgresql/templates/componentdefinition-15.yaml
+++ b/addons/postgresql/templates/componentdefinition-15.yaml
@@ -306,7 +306,7 @@ spec:
           - name: PGPASSWORD
             value: $(POSTGRES_PASSWORD)
       - name: pgbouncer
-        image: {{ .Values.pgbouncer.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.pgbouncer.image.repository }}:{{ default .Values.pgbouncer.image.tag }}
+        image: {{ include "pgbouncer.image" . }}
         imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy | quote }}
         securityContext:
           runAsUser: 0
@@ -358,7 +358,7 @@ spec:
         ports:
           - name: http-metrics
             containerPort: {{ .Values.metrics.service.port }}
-        image: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ default .Values.metrics.image.tag }}
+        image: {{ include "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         args:
           - "--extend.query-path=/opt/conf/custom-metrics.yaml"

--- a/addons/postgresql/templates/componentdefinition-15.yaml
+++ b/addons/postgresql/templates/componentdefinition-15.yaml
@@ -142,7 +142,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ include "postgresql.image070" . }}
+          image: {{ include "postgresql.image.major15.minor070" . }}
           command:
             - /bin/bash
             - -c
@@ -150,7 +150,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ include "postgresql.image070" . }}
+          image: {{ include "postgresql.image.major15.minor070" . }}
           command:
             - /bin/bash
             - -c
@@ -160,7 +160,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ include "postgresql.image070" . }}
+        image: {{ include "postgresql.image.major15.minor070" . }}
         exec:
           command:
             - psql
@@ -176,7 +176,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ include "postgresql.image070" . }}
+        image: {{ include "postgresql.image.major15.minor070" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -187,7 +187,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ include "postgresql.image070" . }}
+        image: {{ include "postgresql.image.major15.minor070" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -214,7 +214,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ include "postgresql.image070" . }}
+        image: {{ include "postgresql.image.major15.minor070" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/addons/postgresql/templates/componentdefinition-15.yaml
+++ b/addons/postgresql/templates/componentdefinition-15.yaml
@@ -142,7 +142,7 @@ spec:
     switchover:
       withCandidate:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+          image: {{ include "postgresql.image070" . }}
           command:
             - /bin/bash
             - -c
@@ -150,7 +150,7 @@ spec:
             - curl -s http://$(KB_REPLICATION_PRIMARY_POD_FQDN):8008/switchover -XPOST -d '{"leader":"$(KB_REPLICATION_PRIMARY_POD_NAME)","candidate":"$(KB_SWITCHOVER_CANDIDATE_NAME)"}'
       withoutCandidate:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+          image: {{ include "postgresql.image070" . }}
           command:
             - /bin/bash
             - -c
@@ -160,7 +160,7 @@ spec:
       builtinHandler: postgresql
     {{/*
       customHandler:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+        image: {{ include "postgresql.image070" . }}
         exec:
           command:
             - psql
@@ -176,7 +176,7 @@ spec:
     */}}
     preTerminate:
       customHandler:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+        image: {{ include "postgresql.image070" . }}
         exec:
           command: ["/kb-scripts/etcd-clean.sh"]
   runtime:
@@ -187,7 +187,7 @@ spec:
       fsGroupChangePolicy: OnRootMismatch
     initContainers:
       - name: pg-init-container
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+        image: {{ include "postgresql.image070" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/init_container.sh
@@ -214,7 +214,7 @@ spec:
             name: tools
     containers:
       - name: postgresql
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tags.major15.minor070 }}
+        image: {{ include "postgresql.image070" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         securityContext:
           runAsUser: 0

--- a/addons/postgresql/templates/componentversion.yaml
+++ b/addons/postgresql/templates/componentversion.yaml
@@ -24,35 +24,35 @@ spec:
       changes:
       serviceVersion: 12.14.0
       images:
-        postgresql: {{ include "postgresql.image140" . }}
-        pgbouncer: {{ include "pgbouncer.image" . }}
+        postgresql: {{ include "postgresql.repository" . }}:12.14.0-pgvector-v0.6.1
+        pgbouncer: {{ include "pgbouncer.repository" . }}:1.19.0
     - name: 12.14.1
       changes:
       serviceVersion: 12.14.1
       images:
-        postgresql: {{ include "postgresql.image141" . }}
-        pgbouncer: {{ include "pgbouncer.image" . }}
+        postgresql: {{ include "postgresql.repository" . }}:12.14.1-pgvector-v0.6.1
+        pgbouncer: {{ include "pgbouncer.repository" . }}:1.19.0
     - name: 12.15.0
       changes:
       serviceVersion: 12.15.0 # {{ .Values.componentServiceVersion.postgresql12  }}
       images:
-        postgresql: {{ include "postgresql.image150" . }}
-        pgbouncer: {{ include "pgbouncer.image" . }}
+        postgresql: {{ include "postgresql.repository" . }}:12.15.0-pgvector-v0.6.1
+        pgbouncer: {{ include "pgbouncer.repository" . }}:1.19.0
     - name: 14.7.2
       changes:
       serviceVersion: 14.7.2
       images:
-        postgresql: {{ include "postgresql.image072" . }}
-        pgbouncer: {{ include "pgbouncer.image" . }}
+        postgresql: {{ include "postgresql.repository" . }}:14.7.2-pgvector-v0.6.1
+        pgbouncer: {{ include "pgbouncer.repository" . }}:1.19.0
     - name: 14.8.0
       changes:
       serviceVersion: 14.8.0 # {{ .Values.componentServiceVersion.postgresql14  }}
       images:
-        postgresql: {{ include "postgresql.image080" . }}
-        pgbouncer: {{ include "pgbouncer.image" . }}
+        postgresql: {{ include "postgresql.repository" . }}:14.8.0-pgvector-v0.6.1
+        pgbouncer: {{ include "pgbouncer.repository" . }}:1.19.0
     - name: 15.7.0
       changes:
       serviceVersion: 15.7.0 # {{ .Values.componentServiceVersion.postgresql15  }}
       images:
-        postgresql: {{ include "postgresql.image070" . }}
-        pgbouncer: {{ include "pgbouncer.image" . }}
+        postgresql: {{ include "postgresql.repository" . }}:15.7.0
+        pgbouncer: {{ include "pgbouncer.repository" . }}:1.19.0

--- a/addons/postgresql/templates/componentversion.yaml
+++ b/addons/postgresql/templates/componentversion.yaml
@@ -24,35 +24,35 @@ spec:
       changes:
       serviceVersion: 12.14.0
       images:
-        postgresql: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/spilo:12.14.0-pgvector-v0.6.1
-        pgbouncer: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pgbouncer:1.19.0
+        postgresql: {{ include "redis.image140" . }}
+        pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 12.14.1
       changes:
       serviceVersion: 12.14.1
       images:
-        postgresql: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/spilo:12.14.1-pgvector-v0.6.1
-        pgbouncer: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pgbouncer:1.19.0
+        postgresql: {{ include "redis.image141" . }}
+        pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 12.15.0
       changes:
       serviceVersion: 12.15.0 # {{ .Values.componentServiceVersion.postgresql12  }}
       images:
-        postgresql: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/spilo:12.15.0-pgvector-v0.6.1
-        pgbouncer: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pgbouncer:1.19.0
+        postgresql: {{ include "redis.image150" . }}
+        pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 14.7.2
       changes:
       serviceVersion: 14.7.2
       images:
-        postgresql: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/spilo:14.7.2-pgvector-v0.6.1
-        pgbouncer: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pgbouncer:1.19.0
+        postgresql: {{ include "redis.image072" . }}
+        pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 14.8.0
       changes:
       serviceVersion: 14.8.0 # {{ .Values.componentServiceVersion.postgresql14  }}
       images:
-        postgresql: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/spilo:14.8.0-pgvector-v0.6.1
-        pgbouncer: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pgbouncer:1.19.0
+        postgresql: {{ include "redis.image080" . }}
+        pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 15.7.0
       changes:
       serviceVersion: 15.7.0 # {{ .Values.componentServiceVersion.postgresql15  }}
       images:
-        postgresql: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/spilo:15.7.0
-        pgbouncer: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pgbouncer:1.19.0
+        postgresql: {{ include "redis.image070" . }}
+        pgbouncer: {{ include "pgbouncer.image" . }}

--- a/addons/postgresql/templates/componentversion.yaml
+++ b/addons/postgresql/templates/componentversion.yaml
@@ -24,35 +24,35 @@ spec:
       changes:
       serviceVersion: 12.14.0
       images:
-        postgresql: {{ include "redis.image140" . }}
+        postgresql: {{ include "postgresql.image140" . }}
         pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 12.14.1
       changes:
       serviceVersion: 12.14.1
       images:
-        postgresql: {{ include "redis.image141" . }}
+        postgresql: {{ include "postgresql.image141" . }}
         pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 12.15.0
       changes:
       serviceVersion: 12.15.0 # {{ .Values.componentServiceVersion.postgresql12  }}
       images:
-        postgresql: {{ include "redis.image150" . }}
+        postgresql: {{ include "postgresql.image150" . }}
         pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 14.7.2
       changes:
       serviceVersion: 14.7.2
       images:
-        postgresql: {{ include "redis.image072" . }}
+        postgresql: {{ include "postgresql.image072" . }}
         pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 14.8.0
       changes:
       serviceVersion: 14.8.0 # {{ .Values.componentServiceVersion.postgresql14  }}
       images:
-        postgresql: {{ include "redis.image080" . }}
+        postgresql: {{ include "postgresql.image080" . }}
         pgbouncer: {{ include "pgbouncer.image" . }}
     - name: 15.7.0
       changes:
       serviceVersion: 15.7.0 # {{ .Values.componentServiceVersion.postgresql15  }}
       images:
-        postgresql: {{ include "redis.image070" . }}
+        postgresql: {{ include "postgresql.image070" . }}
         pgbouncer: {{ include "pgbouncer.image" . }}

--- a/addons/postgresql/values.yaml
+++ b/addons/postgresql/values.yaml
@@ -12,6 +12,8 @@ fullnameOverride: ""
 ## @param image.debug Specify if debug values should be set
 ##
 image:
+  # refer: https://github.com/apecloud-inc/spilo/blob/main/postgres-appliance/Dockerfile
+  # this is the image of postgresql, which is built from Dockerfile of apecloud-inc/spilo forked from zalando/spilo.
   registry: docker.io
   repository: apecloud/spilo
   digest: ""
@@ -25,6 +27,8 @@ image:
       minor080: 14.8.0-pgvector-v0.6.1
     major15:
       minor070: 15.7.0
+
+  # refer: https://github.com/apecloud/dbctl/blob/main/docker/Dockerfile
   dbctl:
     repository: apecloud/dbctl
     tag: "0.1.2"

--- a/addons/postgresql/values.yaml
+++ b/addons/postgresql/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 ## @param image.debug Specify if debug values should be set
 ##
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/spilo
   digest: ""
   tags:

--- a/addons/pulsar/templates/componentversion-bkrecovery.yaml
+++ b/addons/pulsar/templates/componentversion-bkrecovery.yaml
@@ -14,9 +14,9 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        bookies-recovery: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:2.11.2
+        bookies-recovery: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v2_11_2.bookie.repository }}:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        bookies-recovery: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:3.0.2
+        bookies-recovery: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v3_0_2.bookie.repository }}:3.0.2

--- a/addons/pulsar/templates/componentversion-bookkeeper.yaml
+++ b/addons/pulsar/templates/componentversion-bookkeeper.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        bookies: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:2.11.2
+        bookies: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v2_11_2.bookie.repository }}:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        bookies: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:3.0.2
+        bookies: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v3_0_2.bookie.repository }}:3.0.2
 

--- a/addons/pulsar/templates/componentversion-broker.yaml
+++ b/addons/pulsar/templates/componentversion-broker.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        broker: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:2.11.2
+        broker: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v2_11_2.broker.repository }}:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        broker: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:3.0.2
+        broker: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v3_0_2.broker.repository }}:3.0.2
 

--- a/addons/pulsar/templates/componentversion-proxy.yaml
+++ b/addons/pulsar/templates/componentversion-proxy.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        proxy: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:2.11.2
+        proxy: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v2_11_2.proxy.repository }}:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        proxy: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:3.0.2
+        proxy: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v3_0_2.proxy.repository }}:3.0.2
 

--- a/addons/pulsar/templates/componentversion-zookeeper.yaml
+++ b/addons/pulsar/templates/componentversion-zookeeper.yaml
@@ -14,10 +14,10 @@ spec:
       changes:
       serviceVersion: 2.11.2
       images:
-        zookeeper: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:2.11.2
+        zookeeper: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v2_11_2.zookeeper.repository }}:2.11.2
     - name: 3.0.2
       changes:
       serviceVersion: 3.0.2
       images:
-        zookeeper: {{.Values.image.registry | default "docker.io" }}/apecloud/pulsar:3.0.2
+        zookeeper: {{.Values.image.registry | default "docker.io" }}/{{ .Values.images.v3_0_2.zookeeper.repository }}:3.0.2
 

--- a/addons/pulsar/values.yaml
+++ b/addons/pulsar/values.yaml
@@ -17,7 +17,7 @@ debugEnabled: false
 ## Default Pulsar image
 image:
   ## image.registry is the top level registry config
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/pulsar
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/addons/pulsar/values.yaml
+++ b/addons/pulsar/values.yaml
@@ -43,7 +43,7 @@ images:
 
   v2_11_2:
     bookie:
-      repository: ""
+      repository: apecloud/pulsar
       pullPolicy: ""
       tag: ""
 

--- a/addons/qdrant/values.yaml
+++ b/addons/qdrant/values.yaml
@@ -14,13 +14,13 @@ commonLabels: {}
 ## @param application images
 ##
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/qdrant
+  registry: docker.io
+  repository: qdrant/qdrant
   pullPolicy: IfNotPresent
   tag: "v1.8.4"
   tools:
     repository: apecloud/curl-jq
-    tag: latest
+    tag: 0.1.0
 
 ## @param debugEnabled enables containers' debug logging
 ##

--- a/addons/rabbitmq/values.yaml
+++ b/addons/rabbitmq/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   repository: apecloud/rabbitmq
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -125,20 +125,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Define image
 */}}
+{{- define "redis.repository" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}
+{{- end }}
+
 {{- define "redis.image" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
 {{- end }}
 
-{{- define "redis.image70" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor70 }}
+{{- define "redis-sentinel.repository" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}
 {{- end }}
 
 {{- define "redis-sentinel.image" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
 {{- end }}
 
-{{- define "redis-sentinel.image70" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor70 }}
+{{- define "redis-twemproxy.repository" -}}
+{{ .Values.redisTwemproxyImage.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.redisTwemproxyImage.repository }}
 {{- end }}
 
 {{- define "redis-twemproxy.image" -}}
@@ -147,6 +151,10 @@ Define image
 
 {{- define "busybox.image" -}}
 {{ .Values.busyboxImage.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag }}
+{{- end }}}
+
+{{- define "metrics.repository" -}}
+{{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository}}
 {{- end }}}
 
 {{- define "metrics.image" -}}

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -129,8 +129,16 @@ Define image
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
 {{- end }}
 
+{{- define "redis.image70" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor70 }}
+{{- end }}
+
 {{- define "redis-sentinel.image" -}}
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+{{- end }}
+
+{{- define "redis-sentinel.image70" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor70 }}
 {{- end }}
 
 {{- define "redis-twemproxy.image" -}}
@@ -139,6 +147,14 @@ Define image
 
 {{- define "busybox.image" -}}
 {{ .Values.busyboxImage.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag }}
+{{- end }}}
+
+{{- define "metrics.image" -}}
+{{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository}}:{{ .Values.metrics.image.tag }}
+{{- end }}}
+
+{{- define "apeDts.image" -}}
+{{ .Values.image.apeDts.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.apeDts.repository}}:{{ .Values.image.apeDts.tag }}
 {{- end }}}
 
 

--- a/addons/redis/templates/backupactionset.yaml
+++ b/addons/redis/templates/backupactionset.yaml
@@ -74,6 +74,6 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/restore-cluster.sh" | nindent 10 }}
-        image: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/apecloud/ape-dts:0.1.17
+        image: {{ include "apeDts.image" . }}
         onError: Fail
         runOnTargetPodNode: true

--- a/addons/redis/templates/componentdefinition-redis-cluster.yaml
+++ b/addons/redis/templates/componentdefinition-redis-cluster.yaml
@@ -238,7 +238,7 @@ spec:
                 - -c
                 - /scripts/redis-cluster-replica-member-leave.sh
       - name: metrics
-        image: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
+        image: {{ include "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         securityContext:
           runAsNonRoot: true

--- a/addons/redis/templates/componentdefinition-redis.yaml
+++ b/addons/redis/templates/componentdefinition-redis.yaml
@@ -234,7 +234,7 @@ spec:
                 - -c
                 - /scripts/redis-preStop.sh
       - name: metrics
-        image: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
+        image: {{ include "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         securityContext:
           runAsNonRoot: true

--- a/addons/redis/templates/componentversion-redis-cluster.yaml
+++ b/addons/redis/templates/componentversion-redis-cluster.yaml
@@ -14,11 +14,11 @@ spec:
       changes:
       serviceVersion: 7.2.4
       images:
-        redis-cluster: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/redis-stack-server:7.2.0-v10
-        metrics: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1
+        redis-cluster: {{ include "redis.image" . }}
+        metrics: {{ include "metrics.image" . }}
     - name: 7.0.6
       changes:
       serviceVersion: 7.0.6
       images:
-        redis-cluster: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/redis-stack-server:7.0.6-RC4
-        metrics: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1
+        redis-cluster: {{ include "redis.image70" . }}
+        metrics: {{ include "metrics.image" . }}

--- a/addons/redis/templates/componentversion-redis-cluster.yaml
+++ b/addons/redis/templates/componentversion-redis-cluster.yaml
@@ -14,11 +14,11 @@ spec:
       changes:
       serviceVersion: 7.2.4
       images:
-        redis-cluster: {{ include "redis.image" . }}
-        metrics: {{ include "metrics.image" . }}
+        redis-cluster: {{ include "redis.repository" . }}:7.2.0-v10
+        metrics: {{ include "metrics.repository" . }}:0.1.2-beta.1
     - name: 7.0.6
       changes:
       serviceVersion: 7.0.6
       images:
-        redis-cluster: {{ include "redis.image70" . }}
-        metrics: {{ include "metrics.image" . }}
+        redis-cluster: {{ include "redis.repository" . }}:7.0.6-RC4
+        metrics: {{ include "metrics.repository" . }}:0.1.2-beta.1

--- a/addons/redis/templates/componentversion-redis-sentinel.yaml
+++ b/addons/redis/templates/componentversion-redis-sentinel.yaml
@@ -14,9 +14,9 @@ spec:
       changes:
       serviceVersion: 7.2.4
       images:
-        redis-sentinel: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/redis-stack-server:7.2.0-v10
+        redis-sentinel: {{ include "redis-sentinel.image" . }}
     - name: 7.0.6
       changes:
       serviceVersion: 7.0.6
       images:
-        redis-sentinel: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/redis-stack-server:7.0.6-RC4
+        redis-sentinel: {{ include "redis-sentinel.image70" . }}

--- a/addons/redis/templates/componentversion-redis-sentinel.yaml
+++ b/addons/redis/templates/componentversion-redis-sentinel.yaml
@@ -14,9 +14,9 @@ spec:
       changes:
       serviceVersion: 7.2.4
       images:
-        redis-sentinel: {{ include "redis-sentinel.image" . }}
+        redis-sentinel: {{ include "redis-sentinel.repository" . }}:7.2.0-v10
     - name: 7.0.6
       changes:
       serviceVersion: 7.0.6
       images:
-        redis-sentinel: {{ include "redis-sentinel.image70" . }}
+        redis-sentinel: {{ include "redis-sentinel.repository" . }}:7.0.6-RC4

--- a/addons/redis/templates/componentversion-redis-twemproxy.yaml
+++ b/addons/redis/templates/componentversion-redis-twemproxy.yaml
@@ -13,4 +13,4 @@ spec:
       changes:
       serviceVersion: 0.5.0
       images:
-        redis-twemproxy: {{ include "redis-twemproxy.image" . }}
+        redis-twemproxy: {{ include "redis-twemproxy.repository" . }}:0.5.0

--- a/addons/redis/templates/componentversion-redis-twemproxy.yaml
+++ b/addons/redis/templates/componentversion-redis-twemproxy.yaml
@@ -13,4 +13,4 @@ spec:
       changes:
       serviceVersion: 0.5.0
       images:
-        redis-twemproxy: docker.io/malexer/twemproxy:0.5.0
+        redis-twemproxy: {{ include "redis-twemproxy.image" . }}

--- a/addons/redis/templates/componentversion-redis.yaml
+++ b/addons/redis/templates/componentversion-redis.yaml
@@ -14,11 +14,11 @@ spec:
       changes:
       serviceVersion: 7.2.4
       images:
-        redis: {{ include "redis.image" . }}
-        metrics: {{ include "metrics.image" . }}
+        redis: {{ include "redis.repository" . }}:7.2.0-v10
+        metrics: {{ include "metrics.repository" . }}:0.1.2-beta.1
     - name: 7.0.6
       changes:
       serviceVersion: 7.0.6
       images:
-        redis: {{ include "redis.image70" . }}
-        metrics: {{ include "metrics.image" . }}
+        redis: {{ include "redis.repository" . }}:7.0.6-RC4
+        metrics: {{ include "metrics.repository" . }}:0.1.2-beta.1

--- a/addons/redis/templates/componentversion-redis.yaml
+++ b/addons/redis/templates/componentversion-redis.yaml
@@ -14,11 +14,11 @@ spec:
       changes:
       serviceVersion: 7.2.4
       images:
-        redis: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/redis-stack-server:7.2.0-v10
-        metrics: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1
+        redis: {{ include "redis.image" . }}
+        metrics: {{ include "metrics.image" . }}
     - name: 7.0.6
       changes:
       serviceVersion: 7.0.6
       images:
-        redis: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/redis-stack-server:7.0.6-RC4
-        metrics: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1
+        redis: {{ include "redis.image70" . }}
+        metrics: {{ include "metrics.image" . }}

--- a/addons/redis/values.yaml
+++ b/addons/redis/values.yaml
@@ -23,19 +23,24 @@ image:
   # Redis Stack Server, which combines open source Redis with RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom,
   # is dual-licensed under the Redis Source Available License (RSALv2), as described below, and the Server Side Public License (SSPL)
   # For information about licensing per version, see https://redis.io/docs/stack/license/
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/redis-stack-server
+  registry: docker.io
+  repository: redis/redis-stack-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag:
     major7:
       minor70: 7.0.6-RC4
       minor72: 7.2.0-v10
+  apeDts:
+    registry: ""
+    repository: apecloud/ape-dts
+    tag: 0.1.17
+
 
 redisTwemproxyImage:
   # if the value of redisTwemproxyImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   registry: ""
-  repository: apecloud/twemproxy
+  repository: malexer/twemproxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 0.5.0
@@ -43,7 +48,7 @@ redisTwemproxyImage:
 busyboxImage:
   # if the value of busyboxImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   registry: ""
-  repository: apecloud/busybox
+  repository: busybox
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 1.36

--- a/addons/risingwave/values.yaml
+++ b/addons/risingwave/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 ## RisingWave image
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/risingwave
+  registry: ghcr.io
+  repository: risingwavelabs/risingwave
   pullPolicy: IfNotPresent
   tag: v1.0.0

--- a/addons/solr/values.yaml
+++ b/addons/solr/values.yaml
@@ -4,8 +4,8 @@
 
 images:
   solr:
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-    repository: apecloud/solr
+    registry: docker.io
+    repository: bitnami/solr
     pullPolicy: IfNotPresent
     tag: 8.11.2
 

--- a/addons/starrocks-ce/values.yaml
+++ b/addons/starrocks-ce/values.yaml
@@ -8,12 +8,12 @@ clusterVersionOverride: ""
 timezone: Asia/Shanghai
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   pullPolicy: IfNotPresent
   fe:
-    repository: apecloud/fe-ubuntu
+    repository: starrocks/fe-ubuntu
   be:
-    repository: apecloud/be-ubuntu
+    repository: starrocks/be-ubuntu
 
 fe:
   config: |

--- a/addons/tdengine/values.yaml
+++ b/addons/tdengine/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/tdengine
+  registry: docker.io
+  repository: tdengine/tdengine
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "3.0.5.0"

--- a/addons/tidb/templates/actionset.yaml
+++ b/addons/tidb/templates/actionset.yaml
@@ -8,7 +8,7 @@ spec:
   backupType: Full
   backup:
     backupData:
-      image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/br:{{ default .Chart.AppVersion .Values.image.tag }}
+      image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.br.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
       syncProgress:
         enabled: false
         intervalSeconds: 5
@@ -20,7 +20,7 @@ spec:
   restore:
     postReady:
     - job:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/br:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.br.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
         command:
         - bash
         - -c

--- a/addons/tidb/templates/componentdefinition-pd.yaml
+++ b/addons/tidb/templates/componentdefinition-pd.yaml
@@ -54,7 +54,7 @@ spec:
   lifecycleActions:
     roleProbe:
       exec:
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/pd:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.pd.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
         command:
           - bash
           - -c
@@ -73,7 +73,7 @@ spec:
         exec:
           # FIXME: seems like image is not needed
           # this action will be executed in lorry container
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/pd:{{ default .Chart.AppVersion .Values.image.tag }}
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.pd.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
           command:
             - bash
             - -c

--- a/addons/tidb/templates/componentdefinition-tikv.yaml
+++ b/addons/tidb/templates/componentdefinition-tikv.yaml
@@ -71,7 +71,7 @@ spec:
     memberLeave:
       customHandler:
         exec:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/pd:{{ default .Chart.AppVersion .Values.image.tag }}
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.pd.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
           command:
             - bash
             - -c

--- a/addons/tidb/templates/componentversion.yaml
+++ b/addons/tidb/templates/componentversion.yaml
@@ -9,11 +9,11 @@ spec:
     - name: "7.5.2"
       serviceVersion: "7.5.2"
       images:
-        pd: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/pd:v7.5.2
+        pd: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.pd.repository }}:v7.5.2
     - name: "7.1.5"
       serviceVersion: "7.1.5"
       images:
-        pd: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/pd:v7.1.5
+        pd: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.pd.repository }}:v7.1.5
   compatibilityRules:
     - compDefs:
         - "tidb-pd-7"
@@ -33,12 +33,12 @@ spec:
     - name: "7.5.2"
       serviceVersion: "7.5.2"
       images:
-        tidb: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/tidb:v7.5.2
+        tidb: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tidb.repository }}:v7.5.2
         slowlog: {{ .Values.image.helper.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.helper.repository }}/{{ .Values.image.helper.tag }}
     - name: "7.1.5"
       serviceVersion: "7.1.5"
       images:
-        tidb: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/tidb:v7.1.5
+        tidb: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tidb.repository }}:v7.1.5
         slowlog: {{ .Values.image.helper.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.helper.repository }}/{{ .Values.image.helper.tag }}
   compatibilityRules:
     - compDefs:
@@ -59,11 +59,11 @@ spec:
     - name: "7.5.2"
       serviceVersion: "7.5.2"
       images:
-        tikv: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/tikv:v7.5.2
+        tikv: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tikv.repository }}:v7.5.2
     - name: "7.1.5"
       serviceVersion: "7.1.5"
       images:
-        tikv: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/tikv:v7.1.5
+        tikv: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tikv.repository }}:v7.1.5
   compatibilityRules:
     - compDefs:
         - "tikv-7"

--- a/addons/tidb/templates/configconstraint.yaml
+++ b/addons/tidb/templates/configconstraint.yaml
@@ -55,7 +55,7 @@ spec:
               - cp
               - /pd-ctl
               - /kb-tools/pd-ctl
-            image: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}/pd:{{ default .Chart.AppVersion .Values.image.tag }}"
+            image: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.pd.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
 
   dynamicParameters:
     - log.level

--- a/addons/tidb/values.yaml
+++ b/addons/tidb/values.yaml
@@ -3,15 +3,22 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud
+  registry: docker.io
+  br:
+    repository: pingcap/br
+  pd:
+    repository: pingcap/pd
+  tidb:
+    repository: pingcap/tidb
+  tikv:
+    repository: pingcap/tikv
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v7.1.5"
   helper:
     ## if the value of image.helper.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
-    repository: "apecloud/busybox"
+    repository: busybox
     tag: 1.35
     pullPolicy: IfNotPresent
 

--- a/addons/victoria-metrics/values.yaml
+++ b/addons/victoria-metrics/values.yaml
@@ -3,21 +3,21 @@
 # Declare variables to be passed into your templates.
 images:
   # Overrides the image tag whose default is the chart appVersion.
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   vmsingle:
-    repository: apecloud/victoria-metrics
+    repository: victoriametrics/victoria-metrics
     pullPolicy: IfNotPresent
     tag: v1.101.0
   vminsert:
-    repository: apecloud/vminsert
+    repository: victoriametrics/vminsert
     pullPolicy: IfNotPresent
     tag: v1.101.0-cluster
   vmselect:
-    repository: apecloud/vmselect
+    repository: victoriametrics/vmselect
     pullPolicy: IfNotPresent
     tag: v1.101.0-cluster
   vmstorage:
-    repository: apecloud/vmstorage
+    repository: victoriametrics/vmstorage
     pullPolicy: IfNotPresent
     tag: v1.101.0-cluster
 

--- a/addons/weaviate/values.yaml
+++ b/addons/weaviate/values.yaml
@@ -15,8 +15,8 @@ commonLabels: {}
 ##
 images:
   pullPolicy: IfNotPresent
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/weaviate
+  registry: docker.io
+  repository: semitechnologies/weaviate
   tag: 1.19.6
 
 ## @param debugEnabled enables containers' debug logging
@@ -303,8 +303,8 @@ modules:
     # The configuration below is ignored if enabled==false
     fullnameOverride: contextionary
     tag: en0.16.0-v1.0.2
-    repo: apecloud/contextionary
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/contextionary
+    registry: docker.io
     replicas: 1
     envconfig:
       occurrence_weight_linear_factor: 0.75
@@ -352,8 +352,8 @@ modules:
     # https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers
     # for all supported models or build your own container.
     tag: distilbert-base-uncased
-    repo: apecloud/transformers-inference
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/transformers-inference
+    registry: docker.io
     replicas: 1
     fullnameOverride: transformers-inference
     probeInitialDelaySeconds: 120
@@ -406,8 +406,8 @@ modules:
         inferenceUrl: {}
 
         tag: facebook-dpr-ctx_encoder-single-nq-base
-        repo: apecloud/transformers-inference
-        registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+        repo: semitechnologies/transformers-inference
+        registry: docker.io
         replicas: 1
         fullnameOverride: transformers-inference-passage
         envconfig:
@@ -452,8 +452,8 @@ modules:
         inferenceUrl: {}
 
         tag: facebook-dpr-question_encoder-single-nq-base
-        repo: apecloud/transformers-inference
-        registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+        repo: semitechnologies/transformers-inference
+        registry: docker.io
         replicas: 1
         fullnameOverride: transformers-inference-query
         envconfig:
@@ -556,8 +556,8 @@ modules:
     # https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip
     # for all supported models or build your own container.
     tag: sentence-transformers-clip-ViT-B-32-multilingual-v1
-    repo: apecloud/multi2vec-clip
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/multi2vec-clip
+    registry: docker.io
     replicas: 1
     fullnameOverride: clip-inference
     envconfig:
@@ -597,8 +597,8 @@ modules:
     # You can do so by setting a value for the `inferenceUrl` here AND by setting the `enable` to `false`
     inferenceUrl: {}
     tag: bert-large-uncased-whole-word-masking-finetuned-squad-34d66b1
-    repo: apecloud/qna-transformers
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/qna-transformers
+    registry: docker.io
     replicas: 1
     fullnameOverride: qna-transformers
     envconfig:
@@ -676,8 +676,8 @@ modules:
     # You can do so by setting a value for the `inferenceUrl` here AND by setting the `enable` to `false`
     inferenceUrl: {}
     tag: resnet50
-    repo: apecloud/img2vec-pytorch
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/img2vec-pytorch
+    registry: docker.io
     replicas: 1
     fullnameOverride: img2vec-neural
     envconfig:
@@ -729,8 +729,8 @@ modules:
     # You can do so by setting a value for the `inferenceUrl` here AND by setting the `enable` to `false`
     inferenceUrl: {}
     tag: pyspellchecker-en
-    repo: apecloud/text-spellcheck-model
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/text-spellcheck-model
+    registry: docker.io
     replicas: 1
     fullnameOverride: text-spellcheck
 
@@ -765,8 +765,8 @@ modules:
     # You can do so by setting a value for the `inferenceUrl` here AND by setting the `enable` to `false`
     inferenceUrl: {}
     tag: dbmdz-bert-large-cased-finetuned-conll03-english-0.0.2
-    repo: apecloud/ner-transformers
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/ner-transformers
+    registry: docker.io
     replicas: 1
     fullnameOverride: ner-transformers
     envconfig:
@@ -817,8 +817,8 @@ modules:
     # You can do so by setting a value for the `inferenceUrl` here AND by setting the `enable` to `false`
     inferenceUrl: {}
     tag: facebook-bart-large-cnn-1.0.0
-    repo: apecloud/sum-transformers
-    registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repo: semitechnologies/sum-transformers
+    registry: docker.io
     replicas: 1
     fullnameOverride: sum-transformers
     envconfig:

--- a/addons/xinference/values.yaml
+++ b/addons/xinference/values.yaml
@@ -1,8 +1,7 @@
 image:
-  repository: apecloud/xinference
+  repository: xprobe/xinference
   pullPolicy: IfNotPresent
-  # registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry: docker.io
   # Overrides the image tag whose default is the chart appVersion.
   tag: v0.11.0
 

--- a/addons/yashandb/values.yaml
+++ b/addons/yashandb/values.yaml
@@ -3,15 +3,15 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/yashandb-personal
+  registry: registry.cn-shenzhen.aliyuncs.com
+  repository: jesseatyashan/yashandb-personal
   pullPolicy: IfNotPresent
   tag: 23.1.1.100
 
 busyboxImage:
   # if the value of busyboxImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
-  registry: ""
-  repository: apecloud/busybox
+  registry: docker.io
+  repository: busybox
   pullPolicy: IfNotPresent
   tag: 1.35
 

--- a/addons/zookeeper/templates/backupactionset.yaml
+++ b/addons/zookeeper/templates/backupactionset.yaml
@@ -8,7 +8,7 @@ spec:
   backupType: Full
   backup:
     backupData:
-      image: {{ .Values.images.registry | default "docker.io" }}/apecloud/zoocreeper:1.0.1
+      image: {{ .Values.images.zoocreeper.registry | default (.Values.images.registry | default "docker.io") }}/{{ .Values.images.zoocreeper.repository }}:{{ .Values.images.zoocreeper.tag }}
       runOnTargetPodNode: true
       command:
         - sh
@@ -22,7 +22,7 @@ spec:
   restore:
     postReady:
       - job:
-          image: {{ .Values.images.registry | default "docker.io" }}/apecloud/zoocreeper:1.0.1
+          image: {{ .Values.images.zoocreeper.registry | default (.Values.images.registry | default "docker.io") }}/{{ .Values.images.zoocreeper.repository }}:{{ .Values.images.zoocreeper.tag }}
           runOnTargetPodNode: true
           command:
             - sh

--- a/addons/zookeeper/values.yaml
+++ b/addons/zookeeper/values.yaml
@@ -8,6 +8,10 @@ images:
   pullPolicy: IfNotPresent
 
   tag: 3.7.2
+  zoocreeper:
+    registry: ""
+    repository: apecloud/zoocreeper
+    tag: 1.0.1
 
 metrics:
   enabled: true

--- a/addons/zookeeper/values.yaml
+++ b/addons/zookeeper/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 images:
-  registry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/zookeeper
+  registry: docker.io
+  repository: bitnami/zookeeper
   pullPolicy: IfNotPresent
 
   tag: 3.7.2


### PR DESCRIPTION
1. revert registry and repository
2. add workflow check `default`, `apecloud dockerhub` and `apecloud aliyun` images
ref https://github.com/apecloud/apecloud-cd/pull/389/files
3. release chart to github change all registry to `docker.io` and repository to `apecloud/*`
4. release chart to jihulab change all registry to `apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com` and repository to `apecloud/*`