### PR TITLE
fix: postgresql pitr not work

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -26,10 +26,12 @@ echo "#!/bin/bash" > ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 echo "[[ -d '${DATA_DIR}.old' ]] && mv -f ${DATA_DIR}.old/* ${DATA_DIR}/;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 echo "sync;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 chmod +x ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
-echo "restore_command='case "%f" in *history) cp ${PITR_DIR}/%f %p ;; *) mv ${PITR_DIR}/%f %p ;; esac'" > ${CONF_DIR}/recovery.conf;
-echo "recovery_target_time='${DP_RESTORE_TIME}'" >> ${CONF_DIR}/recovery.conf;
-echo "recovery_target_action='promote'" >> ${CONF_DIR}/recovery.conf;
-echo "recovery_target_timeline='latest'" >> ${CONF_DIR}/recovery.conf;
+cat << EOF >> "${CONF_DIR}/recovery.conf"
+restore_command='case "%f" in *history) cp ${PITR_DIR}/%f %p ;; *) mv ${PITR_DIR}/%f %p ;; esac'
+recovery_target_time='$( date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z' )'
+recovery_target_action='promote'
+recovery_target_timeline='latest'
+EOF
 mv ${DATA_DIR} ${DATA_DIR}.old;
 DP_log "done.";
 sync;

--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -26,7 +26,7 @@ echo "#!/bin/bash" > ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 echo "[[ -d '${DATA_DIR}.old' ]] && mv -f ${DATA_DIR}.old/* ${DATA_DIR}/;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 echo "sync;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 chmod +x ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
-cat << EOF >> "${CONF_DIR}/recovery.conf"
+cat << EOF > "${CONF_DIR}/recovery.conf"
 restore_command='case "%f" in *history) cp ${PITR_DIR}/%f %p ;; *) mv ${PITR_DIR}/%f %p ;; esac'
 recovery_target_time='$( date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z' )'
 recovery_target_action='promote'

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -55,13 +55,17 @@ config_wal_g_for_fetch_wal_log "${backupRepoPath}"
 mkdir -p ${CONF_DIR} && chmod 777 -R ${CONF_DIR};
 WALG_DIR=/home/postgres/pgdata/wal-g
 echo "restore_command='envdir ${WALG_DIR}/restore-env ${WALG_DIR}/wal-g wal-fetch %f %p >> ${RESTORE_SCRIPT_DIR}/wal-g.log 2>&1'" > ${CONF_DIR}/recovery.conf;
-if [[ ! -z ${DP_RESTORE_TIME} ]]; then
-   echo "recovery_target_time='${DP_RESTORE_TIME}'" >> ${CONF_DIR}/recovery.conf;
-   echo "recovery_target_action='promote'" >> ${CONF_DIR}/recovery.conf;
-   echo "recovery_target_timeline='latest'" >> ${CONF_DIR}/recovery.conf;
+if [[ ! -z "${DP_RESTORE_TIMESTAMP}" ]]; then
+    cat << EOF >> "${CONF_DIR}/recovery.conf"
+recovery_target_time='$( date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z' )'
+recovery_target_action='promote'
+recovery_target_timeline='latest'
+EOF
 else
-   echo "recovery_target='immediate'" >> ${CONF_DIR}/recovery.conf;
-   echo "recovery_target_action='promote'" >> ${CONF_DIR}/recovery.conf;
+    cat << EOF >> "${CONF_DIR}/recovery.conf"
+recovery_target='immediate'
+recovery_target_action='promote'
+EOF
 fi
 # this step is necessary, data dir must be empty for patroni
 mv ${DATA_DIR} ${DATA_DIR}.old

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -55,18 +55,17 @@ config_wal_g_for_fetch_wal_log "${backupRepoPath}"
 mkdir -p ${CONF_DIR} && chmod 777 -R ${CONF_DIR};
 WALG_DIR=/home/postgres/pgdata/wal-g
 
-cat << EOF > "${CONF_DIR}/recovery.conf"
-restore_command='envdir ${WALG_DIR}/restore-env ${WALG_DIR}/wal-g wal-fetch %f %p >> ${RESTORE_SCRIPT_DIR}/wal-g.log 2>&1'
-EOF
-
+restore_command_str="envdir ${WALG_DIR}/restore-env ${WALG_DIR}/wal-g wal-fetch %f %p >> ${RESTORE_SCRIPT_DIR}/wal-g.log 2>&1"
 if [[ ! -z "${DP_RESTORE_TIMESTAMP}" ]]; then
-    cat << EOF >> "${CONF_DIR}/recovery.conf"
+    cat << EOF > "${CONF_DIR}/recovery.conf"
+restore_command='${restore_command_str}'
 recovery_target_time='$( date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z' )'
 recovery_target_action='promote'
 recovery_target_timeline='latest'
 EOF
 else
-    cat << EOF >> "${CONF_DIR}/recovery.conf"
+    cat << EOF > "${CONF_DIR}/recovery.conf"
+restore_command='${restore_command_str}'
 recovery_target='immediate'
 recovery_target_action='promote'
 EOF

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -54,7 +54,11 @@ config_wal_g_for_fetch_wal_log "${backupRepoPath}"
 # 5. config restore command
 mkdir -p ${CONF_DIR} && chmod 777 -R ${CONF_DIR};
 WALG_DIR=/home/postgres/pgdata/wal-g
-echo "restore_command='envdir ${WALG_DIR}/restore-env ${WALG_DIR}/wal-g wal-fetch %f %p >> ${RESTORE_SCRIPT_DIR}/wal-g.log 2>&1'" > ${CONF_DIR}/recovery.conf;
+
+cat << EOF > "${CONF_DIR}/recovery.conf"
+restore_command='envdir ${WALG_DIR}/restore-env ${WALG_DIR}/wal-g wal-fetch %f %p >> ${RESTORE_SCRIPT_DIR}/wal-g.log 2>&1'
+EOF
+
 if [[ ! -z "${DP_RESTORE_TIMESTAMP}" ]]; then
     cat << EOF >> "${CONF_DIR}/recovery.conf"
 recovery_target_time='$( date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z' )'


### PR DESCRIPTION
- The problem is that in OpsRequest, the timestamp should be in RFC-3339 format. But PostgreSQL doesn't recognize RFC-3339 format. So we need to do a format conversion
- Fixed both in pg PITR restore & wal-g PITR restore
- Optimize the code style when saving multi-line to a file

Fix: #967 