### PR TITLE
feat: redis-restore-by-keys

### DIFF
--- a/addons/redis/dataprotection/pitr-restore.sh
+++ b/addons/redis/dataprotection/pitr-restore.sh
@@ -50,10 +50,11 @@ function get_files_to_restore() {
   esac
 }
 
+mkdir -p ${DATA_DIR}
 res=$(find ${DATA_DIR} -type f)
 data_protection_file=${DATA_DIR}/.kb-data-protection
-if [ ! -z "${res}" ] && [ ! -f ${data_protection_file} ]; then
-  echo "${DATA_DIR} is not empty! Please make sure that the directory is empty before restoring the backup."
+if [ -n "${res}" ] && [ ! -f ${data_protection_file} ]; then
+  DP_error "${DATA_DIR} is not empty! Please make sure that the directory is empty before restoring the backup."
   exit 1
 fi
 # touch placeholder file

--- a/addons/redis/dataprotection/restore-keys.sh
+++ b/addons/redis/dataprotection/restore-keys.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+if [ -z "$DP_RESTORE_KEY_PATTERNS" ]; then
+    echo "DP_RESTORE_KEY_PATTERNS is not set. Exiting..."
+    exit 0
+fi
+
+# lua script to migrate keys from local redis instance to the cluster to be restored.
+LUA_SCRIPT=$(cat <<'EOF'
+local pattern = ARGV[1]
+local destination_host = ARGV[2]
+local destination_port = ARGV[3]
+local db = tonumber(ARGV[4])
+local destination_username= ARGV[5]
+local destination_password= ARGV[6]
+
+local cursor = "0"
+local batch_size = 300
+local timeout = 5000
+local retry_limit = 3
+
+local function migrate_key(key)
+    local attempt = 0
+    local success = false
+
+    while attempt < retry_limit and not success do
+        attempt = attempt + 1
+        local ok, err = pcall(function()
+            redis.call("MIGRATE", destination_host, destination_port, key, db, timeout, "AUTH2", destination_username, destination_password)
+        end)
+
+        if ok then
+            success = true
+        else
+            redis.log(redis.LOG_WARNING, "Migration failed for key " .. key .. " on attempt " .. attempt .. ": " .. err)
+        end
+    end
+
+    if not success then
+        redis.log(redis.LOG_ERR, "Migration failed for key " .. key .. " after " .. retry_limit .. " attempts")
+        return "Migration failed for key " .. key
+    end
+    return nil
+end
+
+local migration_failed = false
+redis.call("SELECT", db)
+-- scan keys with pattern and migrate them to destination redis instance
+repeat
+    local scan_result = redis.call("SCAN", cursor, "MATCH", pattern, "COUNT", batch_size)
+    cursor = scan_result[1]
+    local keys = scan_result[2]
+
+    for i, key in ipairs(keys) do
+        local result = migrate_key(key, db)
+        if result then
+            migration_failed = true
+        end
+    end
+until cursor == "0"
+
+if migration_failed then
+    return "Migration completed with errors for database: " .. db .. " and pattern: " .. pattern
+else
+    return "Migration completed successfully for database: " .. db .. " and pattern: " .. pattern
+end
+
+EOF
+)
+
+# start local redis instance
+LOCAL_DATA_DIR="${DATA_DIR}/.restore_keys"
+redis-stack-server --dir "$LOCAL_DATA_DIR"  --appendonly "yes" &
+while ! redis-cli ping | grep -q "PONG"; do
+    echo "Waiting for Redis to start..."
+    sleep 1
+done
+
+# use comma  as delimiter to split patterns
+IFS=',' read -r -a patterns_array <<< "$DP_RESTORE_KEY_PATTERNS"
+DB_COUNT=$(redis-cli -h ${DP_DB_HOST} -p ${DP_DB_PORT} -a ${REDIS_DEFAULT_PASSWORD} CONFIG GET databases | awk 'NR==2')
+pids=()
+
+echo "start migration for all databases and patterns..."
+# migrate keys for each database and pattern in parallel
+for db in $(seq 0 $((DB_COUNT - 1))); do
+    for pattern in "${patterns_array[@]}"; do
+        (
+            #echo "Migrating pattern '$pattern' from database '$db'"
+            redis-cli  --eval <(echo "$LUA_SCRIPT") , "$pattern" "$DP_DB_HOST" "$DP_DB_PORT" "$db" "$REDIS_DEFAULT_USER" "$REDIS_DEFAULT_PASSWORD"
+        ) &
+        pids+=($!)
+    done
+done
+
+for pid in "${pids[@]}"; do
+    wait $pid
+done
+
+# as the MIGRATE command transform data in binary format, which will corrupt aof file, we need to trigger BGREWRITEAOF after migration.
+redis-cli -h ${DP_DB_HOST} -p ${DP_DB_PORT} -a ${REDIS_DEFAULT_PASSWORD} BGREWRITEAOF
+mv "${LOCAL_DATA_DIR}/users.acl" "$DATA_DIR"
+rm -rf "$LOCAL_DATA_DIR"
+echo "Migration completed for all databases and patterns!"

--- a/addons/redis/dataprotection/switch-data-dir.sh
+++ b/addons/redis/dataprotection/switch-data-dir.sh
@@ -1,0 +1,4 @@
+if [ -n "$DP_RESTORE_KEY_PATTERNS" ]; then
+    DP_log "DP_RESTORE_KEY_PATTERNS is set, switching data directory to ${DATA_DIR}/.restore_keys"
+    DATA_DIR="${DATA_DIR}/.restore_keys"
+fi

--- a/addons/redis/templates/backupactionset.yaml
+++ b/addons/redis/templates/backupactionset.yaml
@@ -33,8 +33,18 @@ spec:
       - bash
       - -c
       - |
+        {{- .Files.Get "dataprotection/switch-data-dir.sh" | nindent 8 }}
         {{- .Files.Get "dataprotection/restore.sh" | nindent 8 }}
-    postReady: []
+    postReady:
+    - job:
+        command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/restore-keys.sh" | nindent 10 }}
+        image: {{ include "redis.image" . }}
+        onError: Fail
+        runOnTargetPodNode: true
 ---
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: ActionSet
@@ -119,6 +129,16 @@ spec:
       - |
         #!/bin/bash
         {{- .Files.Get "dataprotection/common-scripts.sh" | nindent 8 }}
+        {{- .Files.Get "dataprotection/switch-data-dir.sh" | nindent 8 }}
         {{- .Files.Get "dataprotection/pitr-restore.sh" | nindent 8 }}
-    postReady: []
+    postReady:
+    - job:
+        command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/restore-keys.sh" | nindent 10 }}
+        image: {{ include "redis.image" . }}
+        onError: Fail
+        runOnTargetPodNode: true
     baseBackupRequired: false


### PR DESCRIPTION
# Support redis restore by multiply key patterns.

We can apply the key restoration by
```bash
kbcli cluster restore --backup "backup_name" --restore-keys  "a*,b*"
```
"a*" and "b*" represent the patterns of keys we want to restore, and split by comma.
for the details of the key pattern, refer to [Redis/KEYS](https://redis.io/docs/latest/commands/keys/)

## Implementation
1. We inject the key patterns into the restore pod as the environment variable `DP_RESTORE_KEY_PATTERNS`.
2. Let the prepareData job pull full data to a different directory.
3. Then in the postReady job, we start a local redis instance based on the full data,  and [SCAN](https://redis.io/docs/latest/commands/scan/) keys
by pattern then [MIGRATE](https://redis.io/docs/latest/commands/migrate/) the selected keys to the target redis instance.
