### PR TITLE
fix: Solve the problem of backup failure when using pg_basebackup.

### DIFF
--- a/addons/postgresql/templates/actionset-pgbasebackup.yaml
+++ b/addons/postgresql/templates/actionset-pgbasebackup.yaml
@@ -11,7 +11,7 @@ spec:
     - name: DATA_DIR
       value: {{ .Values.dataMountPath }}/pgroot/data
     - name: IMAGE_TAG
-      value: 14.8.0-pgvector-v0.6.1
+      value: 16.4.0-pgvector-v0.7.4
   backup:
     preBackup: []
     postBackup: []

--- a/addons/postgresql/templates/actionset-postgresql-pitr.yaml
+++ b/addons/postgresql/templates/actionset-postgresql-pitr.yaml
@@ -29,7 +29,7 @@ spec:
     - name: SWITCH_WAL_INTERVAL_SECONDS
       value: "600"
     - name: IMAGE_TAG
-      value: 14.8.0-pgvector-v0.6.1
+      value: 16.4.0-pgvector-v0.7.4
   restore:
     prepareData:
       image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:$(IMAGE_TAG)


### PR DESCRIPTION
**Describe the bug**
Backup failure when using pg_basebackup for PostgreSQL 16.4.0

**To Reproduce**
Steps to reproduce the behavior:
1. kbcli version is 0.9.1
```bash
$ kbcli version
Kubernetes: v1.30.2
KubeBlocks: 0.9.1
kbcli: 0.9.1

$ kbcli addon list
NAME                           VERSION        PROVIDER    STATUS     AUTO-INSTALL
...
postgresql                     0.9.0          community   Enabled    true
...
```
2. Create a postgresql 16.4.0 cluster
```bash
cat <<EOF | kubectl apply -f -
apiVersion: apps.kubeblocks.io/v1alpha1
kind: Cluster
metadata:
  name: rds-1
  namespace: rds-postgresql
spec:
  clusterDefinitionRef: postgresql
  clusterVersionRef: postgresql-16.4.0
  terminationPolicy: Delete
  affinity:
    podAntiAffinity: Preferred
    topologyKeys:
    - kubernetes.io/hostname
  tolerations:
    - key: kb-data
      operator: Equal
      value: 'true'
      effect: NoSchedule
  componentSpecs:
  - name: postgresql
    componentDefRef: postgresql
    enabledLogs:
    - running
    disableExporter: true
    replicas: 2
    resources:
      limits:
        cpu: '1'
        memory: 2Gi
      requests:
        cpu: '1'
        memory: 2Gi
    volumeClaimTemplates:
    - name: data
      spec:
        accessModes:
        - ReadWriteOnce
        storageClassName: hostpath
        resources:
          requests:
            storage: 20Gi
EOF
```
3. Backup database
```bash
$ kbcli cluster backup rds-1 --method pg-basebackup
Backup backup-rds-postgresql-rds-1-20241004213223 created successfully, you can view the progress:
	kbcli cluster list-backups --name=backup-rds-postgresql-rds-1-20241004213223 -n rds-postgresql
```
4. See error
```bash
$ kbcli cluster list-backups
NAME                                             NAMESPACE        SOURCE-CLUSTER      METHOD          STATUS                        TOTAL-SIZE   DURATION   CREATE-TIME                  COMPLETION-TIME              EXPIRATION
...
backup-rds-postgresql-rds-1-20241004213223       rds-postgresql   rds-1               pg-basebackup   Failed                                                Oct 04,2024 21:32 UTC+0800

$ kbcli cluster describe-backup backup-rds-postgresql-rds-1-20241004213223
Name: backup-rds-postgresql-rds-1-20241004213223	Cluster: rds-1	Namespace: rds-postgresql

Spec:
  Method:             pg-basebackup
  Policy Name:        rds-1-postgresql-backup-policy

Status:
  Phase:              Failed
  ActionSet Name:     postgres-basebackup
  Repository:         my-repo
  Start Time:         Oct 04,2024 21:32 UTC+0800
  Path:               /rds-postgresql/rds-1-c94db9a7-62ba-415d-b387-91f4d2a44531/postgresql/backup-rds-postgresql-rds-1-20241004213223

Warning Events:
TIME                         TYPE      REASON            OBJECT                                              MESSAGE
Oct 04,2024 21:32 UTC+0800   Warning   ReconcileFailed   Backup/backup-rds-postgresql-rds-1-20241004213223   Reconciling failed, error: there are failed actions, you can obtain the more informations in the....

$ k describe backup backup-rds-postgresql-rds-1-20241004213223
....
Status:
  Actions:
    Action Type:           Job
    Completion Timestamp:  2024-10-04T13:32:58Z
    Failure Reason:        Log Collector Output: Password:
pg_basebackup: error: incompatible server version 16.4 (Ubuntu 16.4-1.pgdg22.04+1)
failed with exit code 1

    Name:  dp-backup-0
    Object Ref:
      API Version:       batch/v1
      Kind:              Job
      Name:              dp-backup-0-backup-rds-postgresql-rds-1-20241004213223-a4e44859
      Namespace:         rds-postgresql
```
