### PR TITLE
fix: [pulsar] the order of bkrecovery component is incorrectly

### DIFF
--- a/addons/pulsar/templates/clusterdefinition.yaml
+++ b/addons/pulsar/templates/clusterdefinition.yaml
@@ -46,14 +46,14 @@ spec:
           compDef: {{ include "pulsar.bkRecoveryCmpdRegexPattern" . }}
       orders:
         provision:
-          - zookeeper,bookies-recovery
+          - zookeeper
           - broker,bookies
-          - proxy
+          - proxy,bookies-recovery
         terminate:
-          - proxy
+          - proxy,bookies-recovery
           - broker,bookies
-          - zookeeper,bookies-recovery
+          - zookeeper
         update:
-          - zookeeper,bookies-recovery
+          - zookeeper
           - broker,bookies
-          - proxy
+          - proxy,bookies-recovery


### PR DESCRIPTION
change the pulsar topology component order