### PR TITLE
fix: make kafka support headless svc/pod ip/nodeport network types

### DIFF
--- a/addons-cluster/kafka/templates/_helpers.tpl
+++ b/addons-cluster/kafka/templates/_helpers.tpl
@@ -66,17 +66,6 @@ Define kafka broker component name
 {{- end }}
 
 {{/*
-Define kafka cluster annotation keys for nodeport feature gate.
-*/}}
-{{- define "kafka-cluster.brokerAddrFeatureGate" -}}
-kubeblocks.io/enabled-pod-ordinal-svc: broker
-{{- if .Values.nodePortEnabled }}
-kubeblocks.io/enabled-node-port-svc: broker
-kubeblocks.io/disabled-cluster-ip-svc: broker
-{{- end }}
-{{- end }}
-
-{{/*
 Define kafka-exporter resources
 */}}
 {{- define "kafka-exporter.resources" }}

--- a/addons-cluster/kafka/templates/cluster.yaml
+++ b/addons-cluster/kafka/templates/cluster.yaml
@@ -4,10 +4,6 @@ metadata:
   name: {{ include "kblib.clusterName" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
-  {{/*
-  annotations:
-  */}}
-{{/*    {{- include "kafka-cluster.brokerAddrFeatureGate" . | nindent 4 }}*/}}
 spec:
   clusterDef: kafka # ref clusterdefinition.name
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
@@ -38,10 +34,10 @@ spec:
         - name: KB_KAFKA_CONTROLLER_HEAP
           value: "{{ .Values.controllerHeap }}"
         - name: KB_BROKER_DIRECT_POD_ACCESS
-          {{- if .Values.nodePortEnabled }}
-          value: "false"
-          {{- else }}
+          {{- if .Values.fixedPodIPEnabled }}
           value: "true"
+          {{- else }}
+          value: "false"
           {{- end }}
       {{- if .Values.storageEnable }}
       volumeClaimTemplates:
@@ -87,10 +83,10 @@ spec:
         - name: KB_KAFKA_CONTROLLER_HEAP
           value: "{{ .Values.controllerHeap }}"
         - name: KB_BROKER_DIRECT_POD_ACCESS
-          {{- if .Values.nodePortEnabled }}
-          value: "false"
-          {{- else }}
+          {{- if .Values.fixedPodIPEnabled }}
           value: "true"
+          {{- else }}
+          value: "false"
           {{- end }}
       {{- if .Values.storageEnable }}
       volumeClaimTemplates:

--- a/addons-cluster/kafka/values.schema.json
+++ b/addons-cluster/kafka/values.schema.json
@@ -183,7 +183,13 @@
       "type": "boolean",
       "default": false,
       "title": "nodePortEnabled",
-      "description":"Whether NodePort service is enabled, default is false"
+      "description":"Whether to enable NodePort mode in Kafka's `advertised.listeners`"
+    },
+    "fixedPodIPEnabled": {
+      "type": "boolean",
+      "default": false,
+      "title": "fixedPodIPEnabled",
+      "description":"Whether to enable fixed Pod IP mode in Kafka's `advertised.listeners`"
     }
   }
 }

--- a/addons-cluster/kafka/values.yaml
+++ b/addons-cluster/kafka/values.yaml
@@ -74,4 +74,11 @@ brokerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
 controllerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
 
 ## @param nodePortEnabled
+## Whether to enable NodePort mode.
+## If set to true, Kafka's `advertised.listeners` will use the NodePort address, suitable for scenarios where clients are outside the Kubernetes cluster but can access the NodePort.
 nodePortEnabled: false
+
+## @param fixedPodIPEnabled
+## Whether to enable fixed Pod IP mode.
+## If set to true, Kafka's `advertised.listeners` will use the Pod IP address, suitable for scenarios where clients can directly communicate with the Kafka Pod's network.
+fixedPodIPEnabled: false

--- a/addons/kafka/templates/clusterdefinition.yaml
+++ b/addons/kafka/templates/clusterdefinition.yaml
@@ -64,8 +64,8 @@ spec:
           compDef: {{ include "kafka-broker.cmpdRegexpPattern" . }}
       orders:
         provision:
-          - kafka-broker
           - kafka-controller
+          - kafka-broker
         terminate:
           - kafka-controller
           - kafka-broker

--- a/addons/kafka/templates/clusterdefinition.yaml
+++ b/addons/kafka/templates/clusterdefinition.yaml
@@ -67,8 +67,8 @@ spec:
           - kafka-controller
           - kafka-broker
         terminate:
-          - kafka-controller
           - kafka-broker
+          - kafka-controller
         update:
           - kafka-broker
           - kafka-controller

--- a/examples/kafka/cluster-combined.yaml
+++ b/examples/kafka/cluster-combined.yaml
@@ -32,8 +32,11 @@ spec:
           value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP # use this ENV to set CONTOLLER_HEAP
           value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
-        - name: KB_BROKER_DIRECT_POD_ACCESS # set to FALSE for node-port
-          value: "true"
+          # Whether to enable direct Pod IP address access mode.
+          # - If set to 'true', Kafka clients will connect to Brokers using the Pod IP address directly.
+          # - If set to 'false', Kafka clients will connect to Brokers using the Headless Service's FQDN.
+        - name: KB_BROKER_DIRECT_POD_ACCESS
+          value: "false"
       # Update `replicas` to your need.
       replicas: 1
       # Specifies the resources required by the Component.


### PR DESCRIPTION
make kafka support headless svc/pod ip/nodeport network types