### PR TITLE
chore: clickhouse add storage configuration, fix hscale and disable sharding for 0.9

### DIFF
--- a/addons-cluster/clickhouse-cluster/values.yaml
+++ b/addons-cluster/clickhouse-cluster/values.yaml
@@ -9,8 +9,9 @@ fullnameOverride: ""
 mode: cluster
 
 ## Sharding configuration
+# sharding topology is not stable in kb 0.9, it's recommended to set sharding to false
 shards: 1
-sharding: true
+sharding: false
 
 ## Number of ClickHouse replicas per shard to deploy
 replicas: 2

--- a/addons/clickhouse/configs/storage.xml.tpl
+++ b/addons/clickhouse/configs/storage.xml.tpl
@@ -9,7 +9,7 @@
           </disk2>
       </disks>
       <policies>
-          <multi_disk_policy>
+          <default>
               <volumes>
                   <volume1>
                       <disk>disk1</disk>
@@ -18,7 +18,7 @@
                       <disk>disk2</disk>
                   </volume2>
               </volumes>
-          </multi_disk_policy>
+          </default>
       </policies>
   </storage_configuration>
 </clickhouse>

--- a/addons/clickhouse/configs/storage.xml.tpl
+++ b/addons/clickhouse/configs/storage.xml.tpl
@@ -9,7 +9,8 @@
           </disk2>
       </disks>
       <policies>
-          <default>
+          <!-- change multi_disk_policy to default to override the default storage when creating a table -->
+          <multi_disk_policy>
               <volumes>
                   <volume1>
                       <disk>disk1</disk>
@@ -18,7 +19,7 @@
                       <disk>disk2</disk>
                   </volume2>
               </volumes>
-          </default>
+          </multi_disk_policy>
       </policies>
   </storage_configuration>
 </clickhouse>

--- a/addons/clickhouse/configs/storage.xml.tpl
+++ b/addons/clickhouse/configs/storage.xml.tpl
@@ -1,0 +1,24 @@
+<clickhouse>
+  <storage_configuration>
+      <disks>
+          <disk1>
+              <path>/var/lib/clickhouse/disk1/</path>
+          </disk1>
+          <disk2>
+              <path>/var/lib/clickhouse/disk2/</path>
+          </disk2>
+      </disks>
+      <policies>
+          <multi_disk_policy>
+              <volumes>
+                  <volume1>
+                      <disk>disk1</disk>
+                  </volume1>
+                  <volume2>
+                      <disk>disk2</disk>
+                  </volume2>
+              </volumes>
+          </multi_disk_policy>
+      </policies>
+  </storage_configuration>
+</clickhouse>

--- a/addons/clickhouse/dashboards/clickhouse.json
+++ b/addons/clickhouse/dashboards/clickhouse.json
@@ -22,10 +22,10 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${datasource}"
         },
         "enable": true,
-        "expr": "resets(ClickHouseAsyncMetrics_Uptime{instance=~\"$instance\"}[$__rate_interval])",
+        "expr": "resets(ClickHouseAsyncMetrics_Uptime{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval])",
         "hide": false,
         "iconColor": "rgba(255, 96, 96, 1)",
         "name": "Restarts",
@@ -42,7 +42,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 14192,
   "graphTooltip": 1,
-  "id": 24,
+  "id": null,
   "links": [
     {
       "asDropdown": false,
@@ -62,9 +62,8 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -128,10 +127,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseMetrics_VersionInteger",
+          "expr": "ClickHouseMetrics_VersionInteger{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -141,10 +140,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseMetrics_Revision",
+          "expr": "ClickHouseMetrics_Revision{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -155,10 +154,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseAsyncMetrics_NumberOfTables",
+          "expr": "ClickHouseAsyncMetrics_NumberOfTables{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -169,10 +168,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseAsyncMetrics_Uptime",
+          "expr": "ClickHouseAsyncMetrics_Uptime{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -183,10 +182,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseAsyncMetrics_NumberOfDatabases",
+          "expr": "ClickHouseAsyncMetrics_NumberOfDatabases{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -208,90 +207,72 @@
           "options": {
             "excludeByName": {
               "Time 1": true,
-              "Time 10": true,
               "Time 2": true,
               "Time 3": true,
               "Time 4": true,
               "Time 5": true,
-              "Time 6": true,
-              "Time 7": true,
-              "Time 8": true,
-              "Time 9": true,
-              "Value #A 2": true,
-              "Value #B 2": true,
-              "Value #C 2": true,
-              "Value #D 2": true,
-              "Value #E 2": true,
               "__name__ 1": true,
-              "__name__ 10": true,
               "__name__ 2": true,
               "__name__ 3": true,
               "__name__ 4": true,
               "__name__ 5": true,
-              "__name__ 6": true,
-              "__name__ 7": true,
-              "__name__ 8": true,
-              "__name__ 9": true,
               "job 1": true,
-              "job 10": true,
               "job 2": true,
               "job 3": true,
               "job 4": true,
               "job 5": true,
-              "job 6": true,
-              "job 7": true,
-              "job 8": true,
-              "job 9": true
+              "pod 2": true,
+              "pod 3": true,
+              "pod 4": true,
+              "pod 5": true, "app_kubernetes_io_instance 2": true,
+              "kubeblocks_component_name 2": true,
+              "apps_kubeblocks_io_component_name 2": true,
+              "app_kubernetes_io_instance 3": true,
+              "kubeblocks_component_name 3": true,
+              "apps_kubeblocks_io_component_name 3": true,
+              "app_kubernetes_io_instance 4": true,
+              "kubeblocks_component_name 4": true,
+              "apps_kubeblocks_io_component_name 4": true,
+              "app_kubernetes_io_instance 5": true,
+              "kubeblocks_component_name 5": true,
+              "apps_kubeblocks_io_component_name 5": true,
+              "app_kubernetes_io_component": true,
+              "app_kubernetes_io_managed_by": true,
+              "app_kubernetes_io_name": true,
+              "app_kubernetes_io_version": true,
+              "http_scheme": true,
+              "kubeblocks_clusterdefinition": true,
+              "kubeblocks_componentdefinition": true,
+              "kubeblocks_instance": true,
+              "kubeblocks_role": true,
+              "namespace": true,
+              "net_host_name": true,
+              "net_host_port": true,
+              "node": true,
+              "replicas": true,
+              "server_address": true,
+              "server_port": true,
+              "service_instance_id": true,
+              "service_name": true,
+              "url_scheme": true
             },
             "indexByName": {
-              "Time 1": 6,
-              "Time 10": 37,
-              "Time 2": 9,
-              "Time 3": 13,
-              "Time 4": 16,
-              "Time 5": 20,
-              "Time 6": 23,
-              "Time 7": 27,
-              "Time 8": 30,
-              "Time 9": 34,
-              "Value #A 1": 1,
-              "Value #A 2": 12,
-              "Value #B 1": 2,
-              "Value #B 2": 19,
-              "Value #C 1": 3,
-              "Value #C 2": 26,
-              "Value #D 1": 5,
-              "Value #D 2": 33,
-              "Value #E 1": 4,
-              "Value #E 2": 40,
-              "__name__ 1": 7,
-              "__name__ 10": 38,
-              "__name__ 2": 10,
-              "__name__ 3": 14,
-              "__name__ 4": 17,
-              "__name__ 5": 21,
-              "__name__ 6": 24,
-              "__name__ 7": 28,
-              "__name__ 8": 31,
-              "__name__ 9": 35,
-              "instance": 0,
-              "job 1": 8,
-              "job 10": 39,
-              "job 2": 11,
-              "job 3": 15,
-              "job 4": 18,
-              "job 5": 22,
-              "job 6": 25,
-              "job 7": 29,
-              "job 8": 32,
-              "job 9": 36
+              "namespace": 0,
+              "cluster": 1,
+              "component": 2,
+              "instance": 3,
+              "version": 4,
+              "revision": 5,
+              "tables": 6,
+              "uptime": 7,
+              "databases": 8
             },
             "renameByName": {
-              "Value #A 1": "version",
-              "Value #B 1": "revision",
-              "Value #C 1": "tables",
-              "Value #D 1": "uptime",
-              "Value #E 1": "databases"
+              "Value #A": "version",
+              "Value #B": "revision",
+              "Value #C": "tables",
+              "Value #D": "uptime",
+              "Value #E": "databases"
             }
           }
         }
@@ -306,7 +287,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Total amount of memory (bytes) allocated by the server.",
       "fill": 0,
@@ -350,10 +331,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseMetrics_MemoryTracking",
+          "expr": "ClickHouseMetrics_MemoryTracking{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -400,7 +381,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of connections to TCP server (clients with native interface), also included server-server distributed query connections. \nNumber of connections to HTTP server",
       "fill": 0,
@@ -444,10 +425,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseMetrics_TCPConnection",
+          "expr": "ClickHouseMetrics_TCPConnection{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "interval": "",
           "legendFormat": "tcp - {{instance}}",
           "refId": "A"
@@ -455,10 +436,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "ClickHouseMetrics_HTTPConnection",
+          "expr": "ClickHouseMetrics_HTTPConnection{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "http - {{instance}}",
@@ -506,7 +487,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of times the number of query processing threads was lowered due to slow reads.",
       "fill": 0,
@@ -550,10 +531,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBackoff{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time((irate(ClickHouseProfileEvents_ReadBackoff{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -561,10 +542,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_ReadBackoff{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_ReadBackoff{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -612,7 +593,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of reads from a file that were slow. This indicate system overload. Thresholds are controlled by read_backoff_* settings.",
       "fill": 0,
@@ -656,10 +637,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_SlowRead{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_SlowRead{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -667,10 +648,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_SlowRead{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_SlowRead{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -715,7 +696,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -729,7 +710,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -744,7 +725,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of queries to be interpreted and potentially executed. Does not include queries that failed to parse or were rejected due to AST size limits, quota limits or limits on the number of simultaneously running queries. May include internal queries initiated by ClickHouse itself. Does not count subqueries.",
       "fill": 0,
@@ -788,10 +769,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_Query{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_Query{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -799,10 +780,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_Query{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_Query{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -850,7 +831,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Same as Queries, but only for SELECT queries.",
       "fill": 0,
@@ -894,10 +875,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectQuery{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -905,10 +886,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_SelectQuery{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_SelectQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -956,7 +937,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Same as Queries, but only for INSERT queries.",
       "fill": 0,
@@ -1000,10 +981,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_InsertQuery{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_InsertQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -1011,10 +992,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_InsertQuery{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_InsertQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -1062,7 +1043,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Same as Failed queries, but only for SELECT queries.",
       "fill": 0,
@@ -1106,10 +1087,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_FailedSelectQuery{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_FailedSelectQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -1117,10 +1098,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_FailedSelectQuery{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_FailedSelectQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -1168,7 +1149,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of failed queries.",
       "fill": 0,
@@ -1212,10 +1193,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_FailedQuery{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_FailedQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -1223,10 +1204,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_FailedQuery{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_FailedQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -1274,7 +1255,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of times when memory limit exceeded for query.",
       "fill": 0,
@@ -1318,10 +1299,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_QueryMemoryLimitExceeded{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_QueryMemoryLimitExceeded{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -1329,10 +1310,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_QueryMemoryLimitExceeded{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_QueryMemoryLimitExceeded{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -1380,7 +1361,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Number of queries that are stopped and waiting due to 'priority' setting.",
       "fill": 0,
@@ -1424,10 +1405,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseMetrics_QueryPreempted{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseMetrics_QueryPreempted{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -1435,10 +1416,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseMetrics_QueryPreempted{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseMetrics_QueryPreempted{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -1486,7 +1467,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Same as Failed queries, but only for INSERT queries.",
       "fill": 0,
@@ -1530,10 +1511,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "max_over_time( (irate(ClickHouseProfileEvents_FailedInsertQuery{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+          "expr": "max_over_time( (irate(ClickHouseProfileEvents_FailedInsertQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
           "interval": "",
           "legendFormat": "peaks - {{instance}}",
           "refId": "A"
@@ -1541,10 +1522,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "rate(ClickHouseProfileEvents_FailedInsertQuery{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+          "expr": "rate(ClickHouseProfileEvents_FailedInsertQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
           "hide": false,
           "interval": "",
           "legendFormat": "trend - {{instance}}",
@@ -1592,7 +1573,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Avg queries latencies",
       "fill": 0,
@@ -1636,10 +1617,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "increase(ClickHouseProfileEvents_QueryTimeMicroseconds{instance=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_Query{instance=~\"$instance\"}[$__rate_interval])",
+          "expr": "increase(ClickHouseProfileEvents_QueryTimeMicroseconds{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_Query{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) or (increase(ClickHouseProfileEvents_Query{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) == 0) * 0",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1687,7 +1668,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Avg SELECT queries latencies",
       "fill": 0,
@@ -1731,10 +1712,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "increase(ClickHouseProfileEvents_SelectQueryTimeMicroseconds{instance=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_SelectQuery{instance=~\"$instance\"}[$__rate_interval])",
+          "expr": "increase(ClickHouseProfileEvents_SelectQueryTimeMicroseconds{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_SelectQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) or (increase(ClickHouseProfileEvents_SelectQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval])==0) * 0",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1781,7 +1762,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "description": "Avg INSERT queries latencies",
       "fill": 0,
@@ -1789,7 +1770,7 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
+        "x": 0,
         "y": 59
       },
       "hiddenSeries": false,
@@ -1825,10 +1806,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "increase(ClickHouseProfileEvents_InsertQueryTimeMicroseconds{instance=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_InsertQuery{instance=~\"$instance\"}[$__rate_interval])",
+          "expr": "increase(ClickHouseProfileEvents_InsertQueryTimeMicroseconds{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_InsertQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) or (increase(ClickHouseProfileEvents_InsertQuery{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval])==0) * 0",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -1872,7 +1853,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -1889,7 +1870,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of rows INSERTed to all tables.",
           "fieldConfig": {
@@ -1937,10 +1918,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_InsertedRows{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_InsertedRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -1948,10 +1929,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_InsertedRows{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_InsertedRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -1999,7 +1980,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of bytes (uncompressed; for columns as they stored in memory) INSERTed to all tables.",
           "fieldConfig": {
@@ -2047,10 +2028,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_InsertedBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_InsertedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2058,10 +2039,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_InsertedBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_InsertedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2109,7 +2090,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the INSERT of a block to a MergeTree table was throttled due to high number of active data parts for partition.",
           "fieldConfig": {
@@ -2157,10 +2138,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DelayedInserts{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2168,10 +2149,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_DelayedInserts{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_DelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2219,7 +2200,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the INSERT of a block to a MergeTree table was rejected with 'Too many parts' exception due to high number of active data parts for partition.",
           "fieldConfig": {
@@ -2267,10 +2248,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_RejectedInserts{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_RejectedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2278,10 +2259,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_RejectedInserts{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_RejectedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2329,7 +2310,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Total number of milliseconds spent while the INSERT of a block to a MergeTree table was throttled due to high number of active data parts for partition.",
           "fieldConfig": {
@@ -2377,10 +2358,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "increase(ClickHouseProfileEvents_DelayedInsertsMilliseconds{instance=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_DelayedInserts{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "increase(ClickHouseProfileEvents_DelayedInsertsMilliseconds{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_DelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) or (increase(ClickHouseProfileEvents_DelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval])==0) * 0",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -2426,7 +2407,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -2438,7 +2419,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -2455,7 +2436,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of data parts selected to read from a MergeTree table.",
           "fieldConfig": {
@@ -2503,10 +2484,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedParts{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedParts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2514,10 +2495,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_SelectedParts{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_SelectedParts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2565,7 +2546,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of (non-adjacent) ranges in all data parts selected to read from a MergeTree table.",
           "fieldConfig": {
@@ -2613,10 +2594,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedRanges{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedRanges{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2624,10 +2605,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_SelectedRanges{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_SelectedRanges{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2675,7 +2656,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of marks (index granules) selected to read from a MergeTree table.",
           "fieldConfig": {
@@ -2723,10 +2704,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedMarks{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedMarks{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2734,10 +2715,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_SelectedMarks{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_SelectedMarks{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2785,7 +2766,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of rows SELECTed from all tables.",
           "fieldConfig": {
@@ -2833,10 +2814,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedRows{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2844,10 +2825,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_SelectedRows{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_SelectedRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -2895,7 +2876,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of bytes (uncompressed; for columns as they stored in memory) SELECTed from all tables.",
           "fieldConfig": {
@@ -2943,10 +2924,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_SelectedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -2954,10 +2935,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_SelectedBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_SelectedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3003,7 +2984,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -3015,7 +2996,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -3032,7 +3013,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the 'lseek' function was called.",
           "fieldConfig": {
@@ -3080,10 +3061,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_Seek{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_Seek{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3091,10 +3072,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_Seek{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_Seek{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3142,7 +3123,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of files opened",
           "fieldConfig": {
@@ -3190,10 +3171,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_FileOpen{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_FileOpen{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3201,10 +3182,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_FileOpen{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_FileOpen{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3252,7 +3233,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of reads (read/pread) from a file descriptor. Does not include sockets.",
           "fieldConfig": {
@@ -3300,10 +3281,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorRead{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorRead{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3311,10 +3292,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorRead{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorRead{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3362,7 +3343,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of writes (write/pwrite) to a file descriptor. Does not include sockets.",
           "fieldConfig": {
@@ -3410,10 +3391,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWrite{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWrite{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3421,10 +3402,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWrite{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWrite{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3472,7 +3453,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the read (read/pread) from a file descriptor have failed.",
           "fieldConfig": {
@@ -3520,10 +3501,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3531,10 +3512,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3582,7 +3563,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the read (read/pread) from a file descriptor have failed.",
           "fieldConfig": {
@@ -3630,10 +3611,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3641,10 +3622,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadFailed{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3692,7 +3673,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of bytes read from file descriptors. If the file is compressed, this will show the compressed data size.",
           "fieldConfig": {
@@ -3740,10 +3721,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3751,10 +3732,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReadBufferFromFileDescriptorReadBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3802,7 +3783,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of bytes written to file descriptors. If the file is compressed, this will show compressed data size.",
           "fieldConfig": {
@@ -3850,10 +3831,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWriteBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWriteBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3861,10 +3842,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWriteBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWriteBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -3912,7 +3893,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of bytes (the number of bytes before decompression) read from compressed sources (files, network).",
           "fieldConfig": {
@@ -3960,10 +3941,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadCompressedBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReadCompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -3971,10 +3952,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReadCompressedBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReadCompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4022,7 +4003,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of uncompressed bytes (the number of bytes after decompression) read from compressed sources (files, network).",
           "fieldConfig": {
@@ -4070,10 +4051,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_CompressedReadBufferBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_CompressedReadBufferBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4081,10 +4062,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_CompressedReadBufferBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_CompressedReadBufferBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4132,7 +4113,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of compressed blocks (the blocks of data that are compressed independent of each other) read from compressed sources (files, network).",
           "fieldConfig": {
@@ -4180,10 +4161,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_CompressedReadBufferBlocks{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_CompressedReadBufferBlocks{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4191,10 +4172,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_CompressedReadBufferBlocks{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_CompressedReadBufferBlocks{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4240,7 +4221,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -4252,7 +4233,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -4269,7 +4250,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of Replicated tables that are currently in readonly state due to re-initialization after ZooKeeper session loss or due to startup without ZooKeeper configured.",
           "fieldConfig": {
@@ -4317,10 +4298,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_ReadonlyReplica",
+              "expr": "ClickHouseMetrics_ReadonlyReplica{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -4367,7 +4348,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times a data part was failed to download from replica of a ReplicatedMergeTree table.",
           "fieldConfig": {
@@ -4415,10 +4396,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartFailedFetches{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartFailedFetches{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4426,10 +4407,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartFailedFetches{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartFailedFetches{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4477,7 +4458,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times a data part was downloaded from replica of a ReplicatedMergeTree table.",
           "fieldConfig": {
@@ -4525,10 +4506,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartFetches{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartFetches{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4536,10 +4517,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartFetches{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartFetches{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4587,7 +4568,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times we prefer to download already merged part from replica of ReplicatedMergeTree table instead of performing a merge ourself (usually we prefer doing a merge ourself to save network traffic). This happens when we have not all source parts to perform a merge or when the data part is old enough.",
           "fieldConfig": {
@@ -4635,10 +4616,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartFetchesOfMerged{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartFetchesOfMerged{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4646,10 +4627,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartFetchesOfMerged{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartFetchesOfMerged{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4697,7 +4678,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times data parts of ReplicatedMergeTree tables were successfully merged.",
           "fieldConfig": {
@@ -4745,10 +4726,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartMerges{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedPartMerges{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4756,10 +4737,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartMerges{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReplicatedPartMerges{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4807,7 +4788,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times a data part that we wanted doesn't exist on any replica (even on replicas that are offline right now). That data parts are definitely lost. This is normal due to asynchronous replication (if quorum inserts were not enabled), when the replica on which the data part was written was failed and when it became online after fail it doesn't contain that data part.",
           "fieldConfig": {
@@ -4855,10 +4836,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedDataLoss{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ReplicatedDataLoss{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -4866,10 +4847,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ReplicatedDataLoss{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ReplicatedDataLoss{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -4915,7 +4896,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -4927,7 +4908,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -4944,7 +4925,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of launched background merges.",
           "fieldConfig": {
@@ -4992,10 +4973,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_Merge{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_Merge{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5003,10 +4984,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_Merge{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_Merge{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5054,7 +5035,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Rows read for background merges. This is the number of rows before merge.",
           "fieldConfig": {
@@ -5102,10 +5083,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergedRows{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergedRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5113,10 +5094,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MergedRows{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MergedRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5164,7 +5145,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Uncompressed bytes (for columns as they stored in memory) that was read for background merges. This is the number before merge.",
           "fieldConfig": {
@@ -5212,10 +5193,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergedUncompressedBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergedUncompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5223,10 +5204,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MergedUncompressedBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MergedUncompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5274,7 +5255,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Avg merge duration",
           "fieldConfig": {
@@ -5322,10 +5303,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "increase(ClickHouseProfileEvents_MergesTimeMilliseconds{instance=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_Merge{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "increase(ClickHouseProfileEvents_MergesTimeMilliseconds{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_Merge{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -5373,7 +5354,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of rows INSERTed to MergeTree tables.",
           "fieldConfig": {
@@ -5421,10 +5402,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterRows{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5432,10 +5413,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterRows{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterRows{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5483,7 +5464,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of blocks INSERTed to MergeTree tables. Each block forms a data part of level zero.",
           "fieldConfig": {
@@ -5531,10 +5512,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterBlocks{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterBlocks{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5542,10 +5523,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterBlocks{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterBlocks{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5593,7 +5574,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Uncompressed bytes (for columns as they stored in memory) INSERTed to MergeTree tables.",
           "fieldConfig": {
@@ -5641,10 +5622,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterUncompressedBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterUncompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5652,10 +5633,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterUncompressedBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterUncompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5703,7 +5684,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Bytes written to filesystem for data INSERTed to MergeTree tables.",
           "fieldConfig": {
@@ -5751,10 +5732,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterCompressedBytes{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MergeTreeDataWriterCompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5762,10 +5743,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterCompressedBytes{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MergeTreeDataWriterCompressedBytes{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -5813,7 +5794,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Disk space reserved for currently running background merges. It is slightly more than the total size of currently merging parts.",
           "fieldConfig": {
@@ -5861,10 +5842,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_DiskSpaceReservedForMerge",
+              "expr": "ClickHouseMetrics_DiskSpaceReservedForMerge{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -5909,7 +5890,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -5921,7 +5902,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -5938,7 +5919,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -5986,10 +5967,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_UncompressedCacheHits{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_UncompressedCacheHits{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -5997,10 +5978,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_UncompressedCacheHits{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_UncompressedCacheHits{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -6048,7 +6029,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -6096,10 +6077,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_UncompressedCacheMisses{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_UncompressedCacheMisses{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -6107,10 +6088,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_UncompressedCacheMisses{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_UncompressedCacheMisses{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -6158,7 +6139,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -6206,10 +6187,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MarkCacheHits{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MarkCacheHits{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -6217,10 +6198,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MarkCacheHits{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MarkCacheHits{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -6268,7 +6249,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -6316,10 +6297,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MarkCacheMisses{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_MarkCacheMisses{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -6327,10 +6308,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_MarkCacheMisses{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_MarkCacheMisses{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -6376,7 +6357,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -6388,7 +6369,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -6405,7 +6386,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "The part is generating now, it is not in data_parts list.",
           "fieldConfig": {
@@ -6453,10 +6434,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsTemporary",
+              "expr": "ClickHouseMetrics_PartsTemporary{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -6503,7 +6484,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "The part is in data_parts, but not used for SELECTs.",
           "fieldConfig": {
@@ -6551,10 +6532,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsPreCommitted",
+              "expr": "ClickHouseMetrics_PartsPreCommitted{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -6601,7 +6582,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "The part is in data_parts, but not used for SELECTs.",
           "fieldConfig": {
@@ -6649,10 +6630,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsCommitted",
+              "expr": "ClickHouseMetrics_PartsCommitted{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -6699,7 +6680,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Not active data part, but could be used by only current SELECTs, could be deleted after SELECTs finishes.",
           "fieldConfig": {
@@ -6747,10 +6728,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsOutdated",
+              "expr": "ClickHouseMetrics_PartsOutdated{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -6797,7 +6778,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Not active data part with identity refcounter, it is deleting right now by a cleaner.",
           "fieldConfig": {
@@ -6845,7 +6826,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "ClickHouseMetrics_PartsDeleting",
@@ -6895,7 +6876,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Part was moved to another disk and should be deleted in own destructor.",
           "fieldConfig": {
@@ -6943,7 +6924,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "ClickHouseMetrics_PartsDeleteOnDestroy",
@@ -6993,7 +6974,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Wide parts.",
           "fieldConfig": {
@@ -7041,10 +7022,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsWide",
+              "expr": "ClickHouseMetrics_PartsWide{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -7091,7 +7072,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Compact parts.",
           "fieldConfig": {
@@ -7139,10 +7120,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsCompact",
+              "expr": "ClickHouseMetrics_PartsCompact{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -7181,111 +7162,13 @@
           "yaxis": {
             "align": false
           }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "description": "In-memory parts.",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 59
-          },
-          "hiddenSeries": false,
-          "id": 121,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "maxDataPoints": 200,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "exemplar": false,
-              "expr": "ClickHouseMetrics_PartsInMemory",
-              "interval": "",
-              "legendFormat": "{{instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "In-memory",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "transparent": true,
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:176",
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:177",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
         }
       ],
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -7297,7 +7180,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -7314,7 +7197,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of connections to remote servers sending data that was INSERTed into Distributed tables. Both synchronous and asynchronous mode.",
           "fieldConfig": {
@@ -7362,10 +7245,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_DistributedSend",
+              "expr": "ClickHouseMetrics_DistributedSend{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -7412,7 +7295,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of pending files to process for asynchronous insertion into Distributed tables. Number of files for every shard is summed.",
           "fieldConfig": {
@@ -7460,10 +7343,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_DistributedFilesToInsert",
+              "expr": "ClickHouseMetrics_DistributedFilesToInsert{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -7510,7 +7393,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the INSERT of a block to a Distributed table was throttled due to high number of pending bytes.",
           "fieldConfig": {
@@ -7558,10 +7441,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedDelayedInserts{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedDelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -7569,10 +7452,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_DistributedDelayedInserts{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_DistributedDelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -7620,7 +7503,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times the INSERT of a block to a Distributed table was rejected with 'Too many bytes' exception due to high number of pending bytes.",
           "fieldConfig": {
@@ -7668,10 +7551,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedRejectedInserts{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedRejectedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -7679,10 +7562,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_DistributedRejectedInserts{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_DistributedRejectedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -7730,7 +7613,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Total number of milliseconds spent while the INSERT of a block to a Distributed table was throttled due to high number of pending bytes.",
           "fieldConfig": {
@@ -7778,10 +7661,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "increase(ClickHouseProfileEvents_DistributedDelayedInsertsMilliseconds{instance=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_DistributedDelayedInserts{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "increase(ClickHouseProfileEvents_DistributedDelayedInsertsMilliseconds{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) / increase(ClickHouseProfileEvents_DistributedDelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) or (increase(ClickHouseProfileEvents_DistributedDelayedInserts{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval])==0) * 0",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -7829,7 +7712,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Total count when distributed connection fails with retry",
           "fieldConfig": {
@@ -7877,10 +7760,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedConnectionFailTry{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedConnectionFailTry{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -7888,10 +7771,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_DistributedConnectionFailTry{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_DistributedConnectionFailTry{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -7939,7 +7822,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Total count when distributed connection fails after all retries finished",
           "fieldConfig": {
@@ -7987,10 +7870,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedConnectionFailAtAll{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedConnectionFailAtAll{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -7998,10 +7881,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_DistributedConnectionFailAtAll{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_DistributedConnectionFailAtAll{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -8049,7 +7932,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -8097,10 +7980,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedSyncInsertionTimeoutExceeded{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_DistributedSyncInsertionTimeoutExceeded{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -8108,10 +7991,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_DistributedSyncInsertionTimeoutExceeded{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_DistributedSyncInsertionTimeoutExceeded{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -8157,7 +8040,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -8169,7 +8052,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -8186,9 +8069,9 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
-          "description": "Number of active tasks in BackgroundProcessingPool (merges, mutations, or replication queue bookkeeping)",
+          "description": "Number of active merges and mutations in an associated background pool",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -8234,10 +8117,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundPoolTask",
+              "expr": "ClickHouseMetrics_BackgroundMergesAndMutationsPoolTask",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8284,7 +8167,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of active tasks in BackgroundFetchesPool",
           "fieldConfig": {
@@ -8332,10 +8215,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundFetchesPoolTask",
+              "expr": "ClickHouseMetrics_BackgroundFetchesPoolTask{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8382,7 +8265,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of active tasks in BackgroundProcessingPool for moves",
           "fieldConfig": {
@@ -8430,10 +8313,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundMovePoolTask",
+              "expr": "ClickHouseMetrics_BackgroundMovePoolTask{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8480,7 +8363,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of active tasks in BackgroundSchedulePool. This pool is used for periodic ReplicatedMergeTree tasks, like cleaning old data parts, altering data parts, replica re-initialization, etc.",
           "fieldConfig": {
@@ -8528,10 +8411,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundSchedulePoolTask",
+              "expr": "ClickHouseMetrics_BackgroundSchedulePoolTask{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8578,7 +8461,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of active tasks in BackgroundBufferFlushSchedulePool. This pool is used for periodic Buffer flushes",
           "fieldConfig": {
@@ -8626,10 +8509,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundBufferFlushSchedulePoolTask",
+              "expr": "ClickHouseMetrics_BackgroundBufferFlushSchedulePoolTask{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8676,7 +8559,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of active tasks in BackgroundDistributedSchedulePool. This pool is used for distributed sends that is done in background.",
           "fieldConfig": {
@@ -8724,10 +8607,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundDistributedSchedulePoolTask",
+              "expr": "ClickHouseMetrics_BackgroundDistributedSchedulePoolTask{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8774,7 +8657,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of active tasks in BackgroundProcessingPool for message streaming",
           "fieldConfig": {
@@ -8822,10 +8705,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "ClickHouseMetrics_BackgroundMessageBrokerSchedulePoolTask",
+              "expr": "ClickHouseMetrics_BackgroundMessageBrokerSchedulePoolTask{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -8870,7 +8753,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -8882,7 +8765,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -8899,7 +8782,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -8947,10 +8830,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperInit{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperInit{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -8958,10 +8841,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperInit{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperInit{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9009,7 +8892,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9057,10 +8940,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperTransactions{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperTransactions{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9068,10 +8951,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperTransactions{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperTransactions{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9119,7 +9002,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9167,10 +9050,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperList{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperList{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9178,10 +9061,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperList{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperList{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9229,7 +9112,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9277,10 +9160,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperCreate{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperCreate{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9288,10 +9171,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperCreate{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperCreate{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9339,7 +9222,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9387,10 +9270,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperRemove{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperRemove{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9398,10 +9281,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperRemove{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperRemove{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9449,7 +9332,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9497,10 +9380,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperExists{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperExists{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9508,10 +9391,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperExists{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperExists{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9559,7 +9442,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9607,10 +9490,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperGet{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperGet{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9618,10 +9501,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperGet{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperGet{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9669,7 +9552,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9717,10 +9600,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperSet{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperSet{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9728,10 +9611,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperSet{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperSet{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9779,7 +9662,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9827,10 +9710,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperMulti{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperMulti{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9838,10 +9721,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperMulti{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperMulti{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9889,7 +9772,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -9937,10 +9820,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperCheck{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperCheck{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -9948,10 +9831,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperCheck{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperCheck{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -9999,7 +9882,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -10047,10 +9930,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperClose{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperClose{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -10058,10 +9941,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperClose{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperClose{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -10109,7 +9992,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -10157,10 +10040,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperWatchResponse{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperWatchResponse{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -10168,10 +10051,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperWatchResponse{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperWatchResponse{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -10219,7 +10102,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -10267,10 +10150,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperUserExceptions{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperUserExceptions{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -10278,10 +10161,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperUserExceptions{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperUserExceptions{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -10329,7 +10212,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -10377,10 +10260,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperHardwareExceptions{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperHardwareExceptions{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -10388,10 +10271,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperHardwareExceptions{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperHardwareExceptions{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -10439,7 +10322,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -10487,10 +10370,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperBytesReceived{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperBytesReceived{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -10498,10 +10381,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperBytesReceived{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperBytesReceived{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -10549,7 +10432,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -10597,10 +10480,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperBytesSent{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_ZooKeeperBytesSent{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -10608,10 +10491,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_ZooKeeperBytesSent{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_ZooKeeperBytesSent{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -10659,7 +10542,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of sessions (connections) to ZooKeeper. Should be no more than one, because using more than one connection to ZooKeeper may lead to bugs due to lack of linearizability (stale reads) that ZooKeeper consistency model allows.",
           "fieldConfig": {
@@ -10707,7 +10590,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "ClickHouseMetrics_ZooKeeperSession",
@@ -10757,7 +10640,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of ephemeral nodes hold in ZooKeeper.",
           "fieldConfig": {
@@ -10805,7 +10688,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "ClickHouseMetrics_EphemeralNode",
@@ -10855,7 +10738,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of watches (event subscriptions) in ZooKeeper.",
           "fieldConfig": {
@@ -10903,7 +10786,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "ClickHouseMetrics_ZooKeeperWatch",
@@ -10953,7 +10836,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of requests to ZooKeeper in fly.",
           "fieldConfig": {
@@ -11001,7 +10884,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
               "expr": "ClickHouseMetrics_ZooKeeperRequest",
@@ -11051,7 +10934,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "description": "Number of times an error happened while trying to remove ephemeral node. This is not an issue, because our implementation of ZooKeeper library guarantee that the session will expire and the node will be removed.",
           "fieldConfig": {
@@ -11099,10 +10982,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "max_over_time( (irate(ClickHouseProfileEvents_CannotRemoveEphemeralNode{instance=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
+              "expr": "max_over_time( (irate(ClickHouseProfileEvents_CannotRemoveEphemeralNode{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[2m]))[$__rate_interval:15s] ) * $peaks",
               "interval": "",
               "legendFormat": "peaks - {{instance}}",
               "refId": "A"
@@ -11110,10 +10993,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "prometheus"
+                "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "rate(ClickHouseProfileEvents_CannotRemoveEphemeralNode{instance=~\"$instance\"}[$__rate_interval]) * $trends",
+              "expr": "rate(ClickHouseProfileEvents_CannotRemoveEphemeralNode{namespace=~\"$namespace\", app_kubernetes_io_instance=~\"$cluster\", apps_kubeblocks_io_component_name=~\"$component\", pod=~\"$instance\"}[$__rate_interval]) * $trends",
               "hide": false,
               "interval": "",
               "legendFormat": "trend - {{instance}}",
@@ -11159,7 +11042,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -11198,25 +11081,61 @@
         "type": "datasource"
       },
       {
+        "allValue": ".+",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${datasource}"
         },
-        "definition": "label_values(ClickHouseAsyncMetrics_Uptime, instance)",
+        "definition": "label_values(ClickHouseAsyncMetrics_Uptime,namespace)",
         "hide": 0,
         "includeAll": true,
-        "label": "Node",
+        "label": "namespace",
         "multi": true,
-        "name": "instance",
+        "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(ClickHouseAsyncMetrics_Uptime, instance)",
-          "refId": "StandardVariableQuery"
+          "query": "label_values(ClickHouseAsyncMetrics_Uptime,namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{namespace=\"$namespace\"},app_kubernetes_io_instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(ClickHouseAsyncMetrics_Uptime{namespace=\"$namespace\"},app_kubernetes_io_instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -11226,6 +11145,70 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{namespace=\"$namespace\", app_kubernetes_io_instance=\"$cluster\"},apps_kubeblocks_io_component_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "component",
+        "multi": true,
+        "name": "component",
+        "options": [],
+        "query": {
+          "query": "label_values(ClickHouseAsyncMetrics_Uptime{namespace=\"$namespace\", app_kubernetes_io_instance=\"$cluster\"},apps_kubeblocks_io_component_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{namespace=\"$namespace\", app_kubernetes_io_instance=\"$cluster\", apps_kubeblocks_io_component_name=\"$component\"},pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(ClickHouseAsyncMetrics_Uptime{namespace=\"$namespace\", app_kubernetes_io_instance=\"$cluster\", apps_kubeblocks_io_component_name=\"$component\"},pod)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
         "current": {

--- a/addons/clickhouse/templates/cmpd-ch.yaml
+++ b/addons/clickhouse/templates/cmpd-ch.yaml
@@ -70,17 +70,19 @@ spec:
   configs:
     - name: clickhouse-tpl
       templateRef: clickhouse-tpl
+      constraintRef: clickhouse-constraints
       volumeName: config
       namespace: {{ .Release.Namespace }}
       reRenderResourceTypes:
         - hscale
     - name: clickhouse-user-tpl
       templateRef: clickhouse-user-tpl
+      constraintRef: clickhouse-constraints
       volumeName: user-config
       namespace: {{ .Release.Namespace }}
-      constraintRef: clickhouse-constraints
     - name: clickhouse-client-tpl
       templateRef: clickhouse-client-tpl
+      constraintRef: clickhouse-constraints
       volumeName: client-config
       namespace: {{ .Release.Namespace }}
   systemAccounts:

--- a/addons/clickhouse/templates/cmpd-ch.yaml
+++ b/addons/clickhouse/templates/cmpd-ch.yaml
@@ -72,6 +72,8 @@ spec:
       templateRef: clickhouse-tpl
       volumeName: config
       namespace: {{ .Release.Namespace }}
+      reRenderResourceTypes:
+        - hscale
     - name: clickhouse-user-tpl
       templateRef: clickhouse-user-tpl
       volumeName: user-config

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -130,6 +130,7 @@ spec:
   configs:
     - name: clickhouse-keeper-tpl
       templateRef: clickhouse-keeper-tpl
+      constraintRef: clickhouse-constraints
       volumeName: config
       namespace: {{ .Release.Namespace }}
       reRenderResourceTypes:

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -132,6 +132,8 @@ spec:
       templateRef: clickhouse-keeper-tpl
       volumeName: config
       namespace: {{ .Release.Namespace }}
+      reRenderResourceTypes:
+        - hscale
   systemAccounts:
     - name: admin
       initAccount: true

--- a/addons/clickhouse/templates/configmap.yaml
+++ b/addons/clickhouse/templates/configmap.yaml
@@ -12,6 +12,8 @@ metadata:
 data:
   00_default_overrides.xml: |
     {{- .Files.Get "configs/00_default_overrides.xml.tpl" | nindent 4 }}
+  storage.xml: |
+    {{- .Files.Get "configs/storage.xml.tpl" | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/examples/clickhouse/README.md
+++ b/examples/clickhouse/README.md
@@ -87,3 +87,9 @@ kubectl patch cluster clickhouse-cluster -p '{"spec":{"terminationPolicy":"WipeO
 
 kubectl delete cluster clickhouse-cluster
 ```
+
+### Add self configuration
+https://clickhouse.com/docs/en/operations/configuration-files
+If you want to add self configuration
+- If the cluster not exist, you can add the configuration file to the `addons/clickhouse/configs` and then add it into the `addons/clickhouse/templates/configmap.json`
+- If the cluster exist, you can follow the [Configure](reconfig.yaml)

--- a/examples/clickhouse/README.md
+++ b/examples/clickhouse/README.md
@@ -90,6 +90,7 @@ kubectl delete cluster clickhouse-cluster
 
 ### Add self configuration
 https://clickhouse.com/docs/en/operations/configuration-files
-If you want to add self configuration
-- If the cluster not exist, you can add the configuration file to the `addons/clickhouse/configs` and then add it into the `addons/clickhouse/templates/configmap.json`
-- If the cluster exist, you can follow the [Configure](reconfig.yaml)
+
+If you want to add self configuration:
+- Cluster not exist, you can add the configuration file to the `addons/clickhouse/configs` and then add it into the `addons/clickhouse/templates/configmap.json`
+- Cluster exist, you can follow the [Configure](reconfig.yaml)

--- a/examples/clickhouse/README.md
+++ b/examples/clickhouse/README.md
@@ -75,10 +75,13 @@ kubectl apply -f examples/clickhouse/start.yaml
 ```
 
 ### [Configure](reconfig.yaml)
+https://clickhouse.com/docs/en/operations/configuration-files
+
 Configure parameters with the specified components in the cluster
 ```bash
 kubectl apply -f examples/clickhouse/reconfig.yaml
 ```
+To add your own configuration file, place it in the `addons/clickhouse/configs` directory and include it in the `addons/clickhouse/templates/configmap.json` file. Then, rerender the ClickHouse addon.
 
 ### Delete
 If you want to delete the cluster and all its resource, you can modify the termination policy and then delete the cluster
@@ -87,10 +90,3 @@ kubectl patch cluster clickhouse-cluster -p '{"spec":{"terminationPolicy":"WipeO
 
 kubectl delete cluster clickhouse-cluster
 ```
-
-### Add self configuration
-https://clickhouse.com/docs/en/operations/configuration-files
-
-If you want to add self configuration:
-- Cluster not exist, you can add the configuration file to the `addons/clickhouse/configs` and then add it into the `addons/clickhouse/templates/configmap.json`
-- Cluster exist, you can follow the [Configure](reconfig.yaml)


### PR DESCRIPTION
changed:
- storage configuration: User can override default storage policy or create different storage policy in xml configuration, if need to use different storage policy, need to bypass policy name when creating tables.
![image](https://github.com/user-attachments/assets/b88c5a05-7a72-482a-8b9b-9477daf4b4f7)
- fix hscale
- disable sharding
