### PR TITLE
fix: vanilla postgresql duplicate reload script name in 0.9

### DIFF
--- a/addons/vanilla-postgresql/templates/_helpers.tpl
+++ b/addons/vanilla-postgresql/templates/_helpers.tpl
@@ -204,6 +204,13 @@ Generate scripts configmap
 {{- end }}
 
 {{/*
+Define vanilla postgresql scripts configMap template name
+*/}}
+{{- define "vanilla-postgresql.reloader.scripts" -}}
+vanilla-postgresql-reload-tools-script
+{{- end -}}
+
+{{/*
 Generate scripts configmap
 */}}
 {{- define "vanilla-postgresql.extend.reload.scripts" -}}

--- a/addons/vanilla-postgresql/templates/configconstraint-12.yaml
+++ b/addons/vanilla-postgresql/templates/configconstraint-12.yaml
@@ -12,7 +12,7 @@ spec:
       command:
         - "update-parameter.sh"
       scriptConfig:
-        scriptConfigMapRef: reload-tools-script
+        scriptConfigMapRef: {{ include "vanilla-postgresql.reloader.scripts" . }}
         namespace: {{ .Release.Namespace }}
       toolsSetup:
         mountPoint: /kb_tools

--- a/addons/vanilla-postgresql/templates/configconstraint-14.yaml
+++ b/addons/vanilla-postgresql/templates/configconstraint-14.yaml
@@ -12,7 +12,7 @@ spec:
       command:
         - "update-parameter.sh"
       scriptConfig:
-        scriptConfigMapRef: reload-tools-script
+        scriptConfigMapRef: {{ include "vanilla-postgresql.reloader.scripts" . }}
         namespace: {{ .Release.Namespace }}
       toolsSetup:
         mountPoint: /kb_tools

--- a/addons/vanilla-postgresql/templates/configconstraint-15.yaml
+++ b/addons/vanilla-postgresql/templates/configconstraint-15.yaml
@@ -12,7 +12,7 @@ spec:
       command:
         - "update-parameter.sh"
       scriptConfig:
-        scriptConfigMapRef: reload-tools-script
+        scriptConfigMapRef: {{ include "vanilla-postgresql.reloader.scripts" . }}
         namespace: {{ .Release.Namespace }}
       toolsSetup:
         mountPoint: /kb_tools

--- a/addons/vanilla-postgresql/templates/scripts.yaml
+++ b/addons/vanilla-postgresql/templates/scripts.yaml
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: reload-tools-script
+  name: {{ include "vanilla-postgresql.reloader.scripts" . }}
   labels:
     {{- include "vanilla-postgresql.labels" . | nindent 4 }}
 data:


### PR DESCRIPTION
* fix #https://github.com/apecloud/kubeblocks/issues/8957