### PR TITLE
chore: add auto cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-auto.yml
+++ b/.github/workflows/cherry-pick-auto.yml
@@ -1,0 +1,18 @@
+name: Cherry Pick Auto
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
+      - release-*
+
+env:
+  GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+jobs:
+  cherry-pick:
+    if: ${{ github.event.pull_request.merged == true && (github.base_ref == 'main' || startsWith(github.base_ref, 'release-')) }}
+    uses: apecloud/apecloud-cd/.github/workflows/pull-request-cherry-pick-auto.yml@v0.1.88
+    secrets: inherit

--- a/.github/workflows/cherry-pick-label-check.yml
+++ b/.github/workflows/cherry-pick-label-check.yml
@@ -1,0 +1,15 @@
+name: Cherry Pick Label Check
+
+on:
+  pull_request_target:
+    types: [ labeled, unlabeled, synchronize ]
+    branches:
+      - main
+      - release-*
+
+jobs:
+  pr-label-check:
+    uses: apecloud/apecloud-cd/.github/workflows/pull-request-label-check.yml@v0.1.88
+    with:
+      CHECK_LABEL: "pick"
+    secrets: inherit

--- a/.github/workflows/cherry-pick-usage.yml
+++ b/.github/workflows/cherry-pick-usage.yml
@@ -1,0 +1,17 @@
+name: Cherry Pick Usage
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - main
+      - release-*
+
+env:
+  GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+jobs:
+  cherry-pick-usage:
+    uses: apecloud/apecloud-cd/.github/workflows/pull-request-cherry-pick-usage.yml@v0.1.88
+    secrets: inherit

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,14 +1,15 @@
-name: CHERRY-PICK
+name: Cherry Pick Or Label Pick
+
 on:
   issue_comment:
     types: [created]
 
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   cherry-pick:
-    name: Cherry Pick
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick')
     runs-on: ubuntu-latest
     steps:
@@ -21,3 +22,20 @@ jobs:
         uses: apecloud-inc/gha-cherry-pick@v1
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+
+  pick-meassge:
+    needs: [ cherry-pick ]
+    if: ${{ failure() || cancelled() }}
+    uses: apecloud/apecloud-cd/.github/workflows/feishui-message.yml@v0.1.88
+    with:
+      TYPE: "5"
+      BOT_TYPE: "specify"
+      BOT_WEBHOOK: "${{ vars.CHERRY_PICK_BOT_WEBHOOK }}"
+      CONTENT: " ${{ github.repository }} ${{ github.event.comment.body }} error"
+      PR_NUMBER: "${{ github.event.issue.number }}"
+    secrets: inherit
+
+  label-pick:
+    if: ${{ github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/pick') || contains(github.event.comment.body, '/nopick')) }}
+    uses: apecloud/apecloud-cd/.github/workflows/pull-request-label-pick.yml@v0.1.88
+    secrets: inherit


### PR DESCRIPTION
**Auto Cherry-pick Instructions**
```
Usage:
  - /nopick: Not auto cherry-pick when PR merged.
  - /pick: Auto cherry-pick to all default branches when PR merged (release-0.9).
  - /pick: release-x.x [release-x.x]: Auto cherry-pick to the specified branch when PR merged.

Example:
  - /nopick
  - /pick
  - /pick release-0.9
```