### PR TITLE
chore: support init parameters and custom parameters template

### DIFF
--- a/addons-cluster/mysql/templates/_parameters.tpl
+++ b/addons-cluster/mysql/templates/_parameters.tpl
@@ -1,0 +1,12 @@
+{{/*
+Define parameters template.
+*/}}
+{{- define "parameters.customTemplate" -}}
+{{- if .Values.parameterTemplate }}
+{{- if and ( not ( empty ( index .Values.parameterTemplate "templateRef" | default "" | trim ) ) ) ( not ( empty ( index .Values.parameterTemplate "namespace" | default "" | trim ) ) ) }}
+{{- $customTemplate := dict "mysql-replication-config" .Values.parameterTemplate }}
+annotations:
+  "config.kubeblocks.io/custom-template": {{ $customTemplate | toJson | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/addons-cluster/mysql/templates/cluster.yaml
+++ b/addons-cluster/mysql/templates/cluster.yaml
@@ -10,6 +10,7 @@ spec:
   topology: {{ .Values.topology }}
   componentSpecs:
     - name: mysql
+      {{- include "parameters.customTemplate" . | indent 6 }}
       serviceVersion: {{ .Values.version }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
       {{- include "mysql-cluster.replicaCount" . | indent 6 }}

--- a/addons-cluster/mysql/templates/init-parameters.yaml
+++ b/addons-cluster/mysql/templates/init-parameters.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.initParameters }}
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: Parameter
+metadata:
+  name: {{ include "kblib.clusterName" . }}-init-parameters
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "kblib.clusterLabels" . | nindent 4 }}
+    config.kubeblocks.io/init-parameters: "true"
+spec:
+  # Specifies the name of the Cluster resource that this operation is targeting.
+  clusterName: {{ include "kblib.clusterName" . }}
+  componentParameters:
+    - componentName: mysql
+      parameters:
+        {{- range $key, $value := $.Values.initParameters }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+{{- end }}

--- a/addons-cluster/mysql/values.yaml
+++ b/addons-cluster/mysql/values.yaml
@@ -48,3 +48,10 @@ orchestrator:
   clusterServiceSelector:
     clusterName: ""
     namespace: ""
+
+initParameters: {}
+  ## max_connections: 1000
+parameterTemplate:
+  templateRef: ""
+  namespace: ""
+  policy: "replace"


### PR DESCRIPTION
create mysql cluster with initParameters or custom parameter template

## set init parameters
* set init parameters: `--set initParameters.max_connections=20000,initParameters.innodb_buffer_pool_size=512MB`

## set custom parameter template
* set parameter template: `--set parameterTemplate.templateRef="my-template",parameterTemplate.namespace="test"`