### PR TITLE
chore: fix no matched image found for container init-syncer

### DIFF
--- a/addons/orioledb/templates/cmpv.yaml
+++ b/addons/orioledb/templates/cmpv.yaml
@@ -17,3 +17,4 @@ spec:
       serviceVersion: 16.4.0
       images:
         orioledb: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        init-syncer: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.syncer.repository }}:{{ .Values.image.syncer.tag }}


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/9048