### PR TITLE
fix: add minSessionTimeout for zookeeper

### DIFF
--- a/addons/zookeeper/config/zookeeper-config.tpl
+++ b/addons/zookeeper/config/zookeeper-config.tpl
@@ -1,5 +1,9 @@
 # The number of milliseconds of each tick
 tickTime=2000
+# Minimum and maximum session timeouts in milliseconds that the server will allow the client to negotiate.
+# Defaults to 2 * tickTime and 20 * tickTime respectively.
+minSessionTimeout=4000
+maxSessionTimeout=40000
 # The number of ticks that the initial
 # synchronization phase can take
 initLimit=10

--- a/addons/zookeeper/config/zookeeper-params_schema.cue
+++ b/addons/zookeeper/config/zookeeper-params_schema.cue
@@ -31,8 +31,11 @@
 	// Limits the number of concurrent connections (at the socket level) that a single client, identified by IP address, may make to a single member of the ZooKeeper ensemble. This is used to prevent certain classes of DoS attacks, including file descriptor exhaustion. The default is 60. Setting this to 0 entirely removes the limit on concurrent connections.
 	"maxClientCnxns"?: int
 
-	// New in 3.3.0: the maximum session timeout in milliseconds that the server will allow the client to negotiate.
+	// New in 3.3.0: the maximum session timeout in milliseconds that the server will allow the client to negotiate. Defaults to 20 * tickTime.
 	"maxSessionTimeout"?: int
+
+	// New in 3.3.0: the minimum session timeout in milliseconds that the server will allow the client to negotiate. Defaults to 2 * tickTime.
+	"minSessionTimeout"?: int
 
 	// New in 3.4.0: When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs in the dataDir and dataLogDir respectively and deletes the rest. Defaults to 3. Minimum value is 3.
 	"autopurge.snapRetainCount"?: int


### PR DESCRIPTION
* fix https://github.com/apecloud/apecloud/issues/10466