### PR TITLE
fix: set file permissions for tidb's script files

### DIFF
--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -56,6 +56,7 @@ spec:
       template: {{ include "tidb.cmScriptsName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: scripts
+      defaultMode: 0555
   configs:
     - name: pd-configuration
       template: {{ include "tidb.pd.configTplName" . }}


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/9099