### PR TITLE
chore: change switchover example

### DIFF
--- a/addons/apecloud-postgresql/README.md
+++ b/addons/apecloud-postgresql/README.md
@@ -235,18 +235,18 @@ metadata:
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
   clusterName: ac-postgresql-cluster
-  type: Custom
-  customSpec:
-    components:
-    - componentName: postgresql
-      parameters:
-      - name: primary
-        value: ac-postgresql-cluster-postgresql-0
-      - name: candidate
-        value: ""
-    opsDefinitionRef: switchover
-    parallelism: 0
-  preConditionDeadlineSeconds: 0
+  type: Switchover
+  # Lists Switchover objects, each specifying a Component to perform the switchover operation.
+  switchover:
+    # Specifies the name of the Component.
+  - componentName: postgresql
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: ac-postgresql-cluster-postgresql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: ac-postgresql-cluster-postgresql-1
 
 ```
 

--- a/addons/clickhouse/README.md
+++ b/addons/clickhouse/README.md
@@ -353,7 +353,7 @@ Create a ClickHouse cluster with ch-keeper and clickhouse servers with multiple 
 apiVersion: apps.kubeblocks.io/v1
 kind: Cluster
 metadata:
-  name: cluster-sharding
+  name: clickhouse-sharding
   namespace: default
 spec:
   terminationPolicy: Delete
@@ -378,11 +378,16 @@ spec:
                 storage: 10Gi
   shardings:
     - name: shard
-      shards: 3  # need 3 shard
+      shards: 2 # with 2 shard
       template:
         name: clickhouse  # each shard is a clickhouse component, with 2 replicas
         componentDef: clickhouse-24
         replicas: 2
+        systemAccounts:
+          - name: admin # name of the system account
+            secretRef:
+              name: udf-shard-account-info
+              namespace: default
         resources:
           limits:
             cpu: "1"
@@ -398,13 +403,22 @@ spec:
               resources:
                 requests:
                   storage: 20Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: udf-shard-account-info
+  namespace: default
+type: Opaque
+data:
+  password: cGFzc3dvcmQxMjM=  # 'password123' in base64
 ```
 
 ```bash
 kubectl apply -f examples/clickhouse/cluster-sharding.yaml
 ```
 
-This example creates a clickhouse cluster with 3 shards, each shard has 2 replicas.
+This example creates a clickhouse cluster with 2 shards, each shard has 2 replicas.
 
 ### Horizontal scaling
 

--- a/addons/mongodb/README.md
+++ b/addons/mongodb/README.md
@@ -511,10 +511,9 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mongodb
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mongo-cluster-mongodb-0
 
 ```
 
@@ -540,10 +539,13 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mongodb
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: mongo-cluster-mongodb-2
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mongo-cluster-mongodb-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: mongo-cluster-mongodb-1
 
 ```
 

--- a/addons/mysql/README.md
+++ b/addons/mysql/README.md
@@ -498,10 +498,13 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mysql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: mysql-cluster-mysql-1
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mysql-cluster-mysql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: mysql-cluster-mysql-1
 
 ```
 
@@ -1007,12 +1010,12 @@ spec:
 kubectl apply -f examples/mysql/cluster-orc.yaml
 ```
 
-#### Switchover(switchover-orc.yaml)
+#### Switchover(switchover.yaml)
 
 You can switchover a specified instance as the new primary or leader of the cluster
 
 ```yaml
-# cat examples/mysql/switchover-orc.yaml
+# cat examples/mysql/switchover.yaml
 apiVersion: operations.kubeblocks.io/v1alpha1
 kind: OpsRequest
 metadata:
@@ -1020,19 +1023,19 @@ metadata:
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
   clusterName: mysql-cluster
-  type: Custom
+  type: Switchover
   # Lists Switchover objects, each specifying a Component to perform the switchover operation.
-  custom:
-    components:
-      - componentName: mysql
-        parameters:
-          - name: candidate
-            value: mysql-cluster-mysql-1
-    opsDefinitionName: mysql-orc-switchover # predefined opsdefinition for switchover
+  switchover:
+    # Specifies the name of the Component.
+  - componentName: mysql
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mysql-cluster-mysql-0
+
 ```
 
 ```bash
-kubectl apply -f examples/mysql/switchover-orc.yaml
+kubectl apply -f examples/mysql/switchover.yaml
 ```
 
 ## References

--- a/addons/postgresql/README.md
+++ b/addons/postgresql/README.md
@@ -510,10 +510,9 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: pg-cluster-postgresql-0
 
 ```
 
@@ -552,10 +551,13 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
     instanceName: pg-cluster-postgresql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: pg-cluster-postgresql-1
 
 ```
 

--- a/addons/victoria-metrics/README.md
+++ b/addons/victoria-metrics/README.md
@@ -34,7 +34,7 @@ VictoriaMetrics can run in two modes:
 
 ### Create
 
-Create a tdengine cluster:
+Create a VM cluster:
 
 ```yaml
 # cat examples/victoria-metrics/cluster.yaml
@@ -167,7 +167,7 @@ metadata:
   namespace: default
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
-  clusterName: vm-cluster-cluster
+  clusterName: vmcluster
   type: HorizontalScaling
   # Lists HorizontalScaling objects, each specifying scaling requirements for a Component, including desired total replica counts, configurations for new instances, modifications for existing instances, and instance downscaling options
   horizontalScaling:

--- a/addons/zookeeper/README.md
+++ b/addons/zookeeper/README.md
@@ -89,7 +89,7 @@ spec:
                 storage: 20Gi
         # Refers to the name of a volumeMount defined in
         # `componentDefinition.spec.runtime.containers[*].volumeMounts
-        - name: log
+        - name: snapshot-log
           spec:
             # The name of the StorageClass required by the claim.
             # If not specified, the StorageClass annotated with
@@ -99,7 +99,7 @@ spec:
             - ReadWriteOnce
             resources:
               requests:
-                storage: 2Gi
+                storage: 20Gi
 
 ```
 
@@ -331,7 +331,7 @@ spec:
                 # specify new size, and make sure it is larger than the current size
                 storage: 30Gi
       volumeClaimTemplates:
-        - name: log
+        - name: snapshot-log
           spec:
             storageClassName: ""
             accessModes:
@@ -566,14 +566,14 @@ spec:
             resources:
               requests:
                 storage: 20Gi
-        - name: log
+        - name: snapshot-log
           spec:
             storageClassName: ""
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 2Gi
+                storage: 20Gi
 ```
 
 ```bash

--- a/examples/apecloud-mysql/switchover-specified-instance.yaml
+++ b/examples/apecloud-mysql/switchover-specified-instance.yaml
@@ -10,7 +10,10 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mysql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: acmysql-cluster-mysql-2
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: acmysql-cluster-mysql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: acmysql-cluster-mysql-1

--- a/examples/apecloud-mysql/switchover.yaml
+++ b/examples/apecloud-mysql/switchover.yaml
@@ -10,7 +10,6 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mysql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: acmysql-cluster-mysql-0

--- a/examples/apecloud-postgresql/switchover.yaml
+++ b/examples/apecloud-postgresql/switchover.yaml
@@ -5,15 +5,15 @@ metadata:
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
   clusterName: ac-postgresql-cluster
-  type: Custom
-  customSpec:
-    components:
-    - componentName: postgresql
-      parameters:
-      - name: primary
-        value: ac-postgresql-cluster-postgresql-0
-      - name: candidate
-        value: ""
-    opsDefinitionRef: switchover
-    parallelism: 0
-  preConditionDeadlineSeconds: 0
+  type: Switchover
+  # Lists Switchover objects, each specifying a Component to perform the switchover operation.
+  switchover:
+    # Specifies the name of the Component.
+  - componentName: postgresql
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: ac-postgresql-cluster-postgresql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: ac-postgresql-cluster-postgresql-1

--- a/examples/etcd/switchover.yaml
+++ b/examples/etcd/switchover.yaml
@@ -10,7 +10,6 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: etcd
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: 'etcd-cluster-etcd-1'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: etcd-cluster-etcd-0

--- a/examples/mongodb/switchover-specified-instance.yaml
+++ b/examples/mongodb/switchover-specified-instance.yaml
@@ -10,7 +10,10 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mongodb
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: mongo-cluster-mongodb-2
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mongo-cluster-mongodb-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: mongo-cluster-mongodb-1

--- a/examples/mongodb/switchover.yaml
+++ b/examples/mongodb/switchover.yaml
@@ -10,7 +10,6 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mongodb
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mongo-cluster-mongodb-0

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -497,12 +497,12 @@ kubectl apply -f examples/mysql/orchestrator.yaml
 kubectl apply -f examples/mysql/cluster-orc.yaml
 ```
 
-#### Switchover(switchover-orc.yaml)
+#### Switchover(switchover.yaml)
 
 You can switchover a specified instance as the new primary or leader of the cluster
 
 ```bash
-kubectl apply -f examples/mysql/switchover-orc.yaml
+kubectl apply -f examples/mysql/switchover.yaml
 ```
 
 ## References

--- a/examples/mysql/switchover-specified-instance.yaml
+++ b/examples/mysql/switchover-specified-instance.yaml
@@ -12,8 +12,8 @@ spec:
   - componentName: mysql
     # Specifies the instance whose role will be transferred.
     # A typical usage is to transfer the leader role in a consensus system.
-    instanceName: mysql-cluster-mysql-1
+    instanceName: mysql-cluster-mysql-0
     # If CandidateName is specified, the role will be transferred to this instance.
     # The name must match one of the pods in the component.
     # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
-    candidateName: redis-replication-redis-2
+    candidateName: mysql-cluster-mysql-1

--- a/examples/mysql/switchover-specified-instance.yaml
+++ b/examples/mysql/switchover-specified-instance.yaml
@@ -10,7 +10,10 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mysql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
     instanceName: mysql-cluster-mysql-1
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: redis-replication-redis-2

--- a/examples/mysql/switchover.yaml
+++ b/examples/mysql/switchover.yaml
@@ -5,12 +5,11 @@ metadata:
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
   clusterName: mysql-cluster
-  type: Custom
+  type: Switchover
   # Lists Switchover objects, each specifying a Component to perform the switchover operation.
-  custom:
-    components:
-      - componentName: mysql
-        parameters:
-          - name: candidate
-            value: mysql-cluster-mysql-1
-    opsDefinitionName: mysql-orc-switchover # predefined opsdefinition for switchover
+  switchover:
+    # Specifies the name of the Component.
+  - componentName: mysql
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: mysql-cluster-mysql-0

--- a/examples/postgresql/switchover-specified-instance.yaml
+++ b/examples/postgresql/switchover-specified-instance.yaml
@@ -10,7 +10,10 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
     instanceName: pg-cluster-postgresql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: pg-cluster-postgresql-1

--- a/examples/postgresql/switchover.yaml
+++ b/examples/postgresql/switchover.yaml
@@ -10,7 +10,6 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: pg-cluster-postgresql-0

--- a/examples/redis/switchover-specified-instance.yaml
+++ b/examples/redis/switchover-specified-instance.yaml
@@ -4,13 +4,16 @@ metadata:
   name: redis-switchover-specify
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
-  clusterName: redis-cluster
+  clusterName: redis-replication
   type: Switchover
   # Lists Switchover objects, each specifying a Component to perform the switchover operation.
   switchover:
     # Specifies the name of the Component.
   - componentName: redis
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either: 
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: redis-cluster-redis-2
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: redis-replication-redis-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: redis-replication-redis-1

--- a/examples/redis/switchover.yaml
+++ b/examples/redis/switchover.yaml
@@ -4,13 +4,12 @@ metadata:
   name: redis-switchover
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
-  clusterName: redis-cluster
+  clusterName: redis-replication
   type: Switchover
   # Lists Switchover objects, each specifying a Component to perform the switchover operation.
   switchover:
     # Specifies the name of the Component.
   - componentName: redis
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either: 
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: redis-replication-redis-0

--- a/examples/vanilla-postgresql/switchover-specified-instance.yaml
+++ b/examples/vanilla-postgresql/switchover-specified-instance.yaml
@@ -10,7 +10,10 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
     instanceName: vanpg-cluster-postgresql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: vanpg-cluster-postgresql-1

--- a/examples/vanilla-postgresql/switchover.yaml
+++ b/examples/vanilla-postgresql/switchover.yaml
@@ -10,7 +10,6 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: vanpg-cluster-postgresql-0


### PR DESCRIPTION
```
kubectl explain OpsRequest.spec.switchover    
GROUP:      operations.kubeblocks.io
KIND:       OpsRequest
VERSION:    v1alpha1

FIELD: switchover <[]Object>


DESCRIPTION:
    Lists Switchover objects, each specifying a Component to perform the
    switchover operation.
    
FIELDS:
  candidateName	<string>
    If CandidateName is specified, the role will be transferred to this
    instance.
    The name must match one of the pods in the component.
    Refer to ComponentDefinition's Swtichover lifecycle action for more details.

  componentName	<string>
    Specifies the name of the Component as defined in the cluster.spec.

  componentObjectName	<string>
    Specifies the name of the Component object.

  instanceName	<string> -required-
    Specifies the instance whose role will be transferred. A typical usage is to
    transfer the leader role
    in a consensus system.
```