### PR TITLE
chore: fix etcd examples cluster-tls.yaml not found

### DIFF
--- a/addons/apecloud-mysql/README.md
+++ b/addons/apecloud-mysql/README.md
@@ -513,10 +513,9 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mysql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: acmysql-cluster-mysql-0
 
 ```
 
@@ -542,10 +541,13 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: mysql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: acmysql-cluster-mysql-2
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: acmysql-cluster-mysql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: acmysql-cluster-mysql-1
 
 ```
 

--- a/addons/vanilla-postgresql/README.md
+++ b/addons/vanilla-postgresql/README.md
@@ -392,10 +392,9 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
-    instanceName: '*'
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: vanpg-cluster-postgresql-0
 
 ```
 
@@ -435,10 +434,13 @@ spec:
   switchover:
     # Specifies the name of the Component.
   - componentName: postgresql
-    # Specifies the instance to become the primary or leader during a switchover operation. The value of `instanceName` can be either:
-    # - "*" (wildcard value): - Indicates no specific instance is designated as the primary or leader.
-    # - A valid instance name (pod name)
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
     instanceName: vanpg-cluster-postgresql-0
+    # If CandidateName is specified, the role will be transferred to this instance.
+    # The name must match one of the pods in the component.
+    # Refer to ComponentDefinition's Swtichover lifecycle action for more details.
+    candidateName: vanpg-cluster-postgresql-1
 
 ```
 

--- a/examples/etcd/README.md
+++ b/examples/etcd/README.md
@@ -45,10 +45,10 @@ kubectl apply -f examples/etcd/cluster.yaml
 To create etcd cluster with TLS enabled,
 
 ```bash
-kubectl apply -f examples/etcd/cluster-tls.yaml
+kubectl apply -f examples/etcd/cluster-with-tls.yaml
 ```
 
-Compared to the default configuration, the only difference here is the `tls` and `issuer` fields in the `cluster-tls.yaml` file.
+Compared to the default configuration, the only difference here is the `tls` and `issuer` fields in the `cluster-with-tls.yaml` file.
 
 ```yaml
 tls: true  # enable tls


### PR DESCRIPTION
1. support auto extend addons readme with examples
2. fix etcd examples cluster-tls.yaml not found
![image](https://github.com/user-attachments/assets/2fb96e18-45cf-4d97-9c70-f87563757113)
