### PR TITLE
chore:add param for 0.9 victoria-metrics

### DIFF
--- a/addons-cluster/victoria-metrics-cluster/templates/cluster.yaml
+++ b/addons-cluster/victoria-metrics-cluster/templates/cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
   name: {{ include "clustername" . }}
-  labels: 
+  labels:
     {{- include "victoria-metrics-cluster.labels" . | nindent 4 }}
 spec:
   clusterDefinitionRef: victoria-metrics
@@ -14,6 +14,17 @@ spec:
       replicas: {{ .Values.replicas }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- include "kblib.componentStorages" . | indent 6 }}
+      env:
+        - name: RETENTION_PERIOD
+          value: "{{ .Values.retentionPeriod }}"
+        {{- with .Values.vmstorage.env }}
+        {{- range $key, $value := . }}
+        {{- if $value }}
+        - name: "VM_{{ $key }}"
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
     - name: vmselect
       {{- include "kblib.componentMonitor" . | indent 6 }}
       replicas: {{ .Values.vmselect.replicas }}
@@ -30,10 +41,19 @@ spec:
           memory: {{ .memory | quote }}
         {{- end }}
       {{- end }}
+      env:
+        {{- with .Values.vmselect.env }}
+        {{- range $key, $value := . }}
+        {{- if $value }}
+        - name: "VM_{{ $key }}"
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
     - name: vminsert
       {{- include "kblib.componentMonitor" . | indent 6 }}
       replicas: {{ .Values.vminsert.replicas | default 1 }}
-      {{- with  .Values.vminsert.resources }}
+      {{- with .Values.vminsert.resources }}
       resources:
         {{- with .limits }}
         limits:
@@ -46,3 +66,12 @@ spec:
           memory: {{ .memory | quote }}
         {{- end }}
       {{- end }}
+      env:
+        {{- with .Values.vminsert.env }}
+        {{- range $key, $value := . }}
+        {{- if $value }}
+        - name: "VM_{{ $key }}"
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}

--- a/addons-cluster/victoria-metrics-cluster/values.yaml
+++ b/addons-cluster/victoria-metrics-cluster/values.yaml
@@ -37,9 +37,41 @@ storage: 20
 vminsert:
   replicas: 1
   resources: {}
+  ## @param env, additional environment variables for vminsert
+  ## Prefix VM_ will be added automatically. Example: replicationFactor -> VM_replicationFactor
+  ## See https://docs.victoriametrics.com/cluster-victoriametrics/cluster-setup/#vminsert-flags
+  env:
+    replicationFactor: 1
+    maxConcurrentInserts: # Defaults to number of CPU cores
+    disableRerouting: true
+    maxInsertRequestSize: "32MiB" # 33554432
+    sortLabels: false
 
 ## @param vmselect configs
 ##
 vmselect:
   replicas: 1
   resources: {}
+  ## @param env, additional environment variables for vmselect
+  ## Prefix VM_ will be added automatically. Example: dedup.minScrapeInterval -> VM_dedup_minScrapeInterval
+  ## See https://docs.victoriametrics.com/cluster-victoriametrics/cluster-setup/#vmselect-flags
+  env: 
+    dedup.minScrapeInterval: "0ms" # Set > 0 only if replicationFactor > 1 for vminsert
+    search.maxConcurrentRequests: 16 # Defaults to 16
+    search.maxQueryDuration: "30s"
+    search.maxMemoryPerQuery: "0" # Defaults to 0 (unlimited)
+    search.logSlowQueryDuration: "5s"
+
+## @param vmstorage configs
+##
+vmstorage:
+  ## @param env, additional environment variables for vmstorage
+  ## Prefix VM_ will be added automatically. Example: retentionPeriod -> VM_retentionPeriod
+  ## See https://docs.victoriametrics.com/cluster-victoriametrics/cluster-setup/#vmstorage-flags
+  env:
+    retentionPeriod: "1" # Overrides the global retentionPeriod if set, unit is months by default
+    dedup.minScrapeInterval: "0ms" # Should match vmselect's setting if deduplication is enabled  
+    forceMergeAuthKey: ""
+    storage.minFreeDiskSpaceBytes: "10MB" # 10000000
+    inmemoryDataFlushInterval: "5s"
+    logNewSeries: false


### PR DESCRIPTION
kubeblocks v0.9 donnot support api 'restartOnFileChange', so this addon still need restart vminsert&vmselect by hand when vmstorage hscale 