### PR TITLE
chore: fix create rw error container compute not found

### DIFF
--- a/addons/risingwave/templates/cmpd-connector.yaml
+++ b/addons/risingwave/templates/cmpd-connector.yaml
@@ -40,7 +40,7 @@ spec:
           - name: RW_TOTAL_MEMORY_BYTES
             valueFrom:
               resourceFieldRef:
-                containerName: compute
+                containerName: connector
                 resource: limits.memory
         ports:
           - containerPort: 50051


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/9295