### PR TITLE
chore: update es tls

### DIFF
--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -14,23 +14,23 @@ else
     READINESS_PROBE_PROTOCOL=http
 fi
 ENDPOINT="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
-COMMON_OPTIONS="--connect-timeout 3 -k -u root:${ELASTIC_USER_PASSWORD}"
+COMMON_OPTIONS="--connect-timeout 3 -k -u elastic:${ELASTIC_PASSWORD}"
 
 # Function to create a local superuser using elasticsearch-users command
 # This is needed to authenticate API calls when security is enabled
-function add_local_user()
-{
-    username=$1
-    password=$2
-    result=$(bin/elasticsearch-users useradd ${username} -r superuser -p "${password}" 2>&1)
-    if [ $? != 0 ]; then
-        echo "${result}" | grep 'already exists'
-        if [ $? != 0 ]; then
-            echo "Failed to create user ${user}"
-            exit 1
-        fi
-    fi
-}
+# function add_local_user()
+# {
+#     username=$1
+#     password=$2
+#     result=$(bin/elasticsearch-users useradd ${username} -r superuser -p "${password}" 2>&1)
+#     if [ $? != 0 ]; then
+#         echo "${result}" | grep 'already exists'
+#         if [ $? != 0 ]; then
+#             echo "Failed to create user ${user}"
+#             exit 1
+#         fi
+#     fi
+# }
 
 # Function to reset password for built-in users using ES API
 function reset_password()
@@ -65,16 +65,18 @@ if grep '\- master\|master: true' config/elasticsearch.yml > /dev/null 2>&1; the
             echo "waiting for elasticsearch to start..."
             sleep 1
         done
-        
-        # If security is enabled, create a temporary root user for API authentication
-        if [ -n "${KB_TLS_CERT_FILE}" ]; then
-            echo "add root user"
-            add_local_user root ${ELASTIC_USER_PASSWORD}
-        fi
-        
+
+        # # If security is enabled, create a temporary root user for API authentication
+        # if [ -n "${KB_TLS_CERT_FILE}" ]; then
+        #     echo "add root user"
+        #     add_local_user root ${ELASTIC_USER_PASSWORD}
+        # fi
+
         wait_for_cluster_health
         touch ${CLUSTER_FORMED_FILE}
     fi
+else
+    exit 0
 fi
 
 # The following operations only need to be performed on master-0
@@ -100,11 +102,11 @@ echo "wait for cluster ready"
 wait_for_cluster_health
 
 # Reset built-in elastic user's password
-echo "reset elastic password"
-reset_password elastic ${ELASTIC_USER_PASSWORD}
-if [ $? != 0 ]; then
-    exit 1
-fi
+# echo "reset elastic password"
+# reset_password elastic ${ELASTIC_USER_PASSWORD}
+# if [ $? != 0 ]; then
+#     exit 1
+# fi
 
 # Configure kibana_system user
 # For ES versions < 7.8, kibana_system user needs to be created manually

--- a/addons/elasticsearch/templates/componentdefinition-elasticsearch.yaml
+++ b/addons/elasticsearch/templates/componentdefinition-elasticsearch.yaml
@@ -64,6 +64,17 @@ items:
           name: elastic
           optional: false
           password: Required
+    - name: ELASTIC_PASSWORD
+      value: $(ELASTIC_USER_PASSWORD)
+    - name: ES_PASSWORD
+      value: $(ELASTIC_USER_PASSWORD)
+    - name: ES_USERNAME
+      valueFrom:
+        credentialVarRef:
+          compDef: elasticsearch-8
+          name: elastic
+          optional: false
+          username: Required
     - name: KIBANA_SYSTEM_USER_PASSWORD
       valueFrom:
         credentialVarRef:
@@ -172,6 +183,7 @@ items:
             else
               /tini -- /usr/local/bin/docker-entrypoint.sh
             fi
+
         lifecycle:
           postStart:
             exec:
@@ -238,6 +250,7 @@ items:
         command:
           - /bin/elasticsearch_exporter
           - "--es.uri=http://localhost:9200"
+          - "--es.ssl-skip-verify"
         ports:
         - name: metrics
           containerPort: {{.Values.exporter.service.port}}

--- a/examples/elasticsearch/es-multi-node-tls.yaml
+++ b/examples/elasticsearch/es-multi-node-tls.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: myes2
+  namespace: default
+  annotations:
+    kubeblocks.io/extra-env: '{"master-roles":"master", "dit-roles":"data,ingest,transform","mode":"multi-node"}'
+spec:
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: master
+      componentDef: elasticsearch-8
+      serviceVersion: 8.8.2
+      # System accounts and TLS configuration for Elasticsearch cluster
+      systemAccounts:
+      - name: elastic        # Superuser account with full cluster privileges
+        secretRef:
+          name: es-master-account-elastic
+          namespace: default
+      - name: kibana_system  # Account used by Kibana to communicate with Elasticsearch
+        secretRef:
+          name: es-master-account-kibana-system
+          namespace: default
+      tls: true              # Enable TLS for secure communication
+      issuer:
+        name: UserProvided   # Using user-provided certificates
+        secretRef:
+          name: es-tls-certs # Secret containing TLS certificates
+          ca: ca.crt         # CA certificate
+          cert: tls.crt      # Server certificate
+          key: tls.key       # Private key
+      disableExporter: false
+      podUpdatePolicy: Recreate
+      replicas: 1
+      resources:
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi
+    - name: dit
+      componentDef: elasticsearch-8
+      serviceVersion: 8.8.2
+      systemAccounts:
+      - name: elastic
+        secretRef:
+          name: es-master-account-elastic
+          namespace: default
+      - name: kibana_system
+        secretRef:
+          name: es-master-account-kibana-system
+          namespace: default
+      tls: true
+      issuer:
+        name: UserProvided
+        secretRef:
+          name: es-tls-certs
+          ca: ca.crt
+          cert: tls.crt
+          key: tls.key
+      disableExporter: false
+      podUpdatePolicy: Recreate
+      replicas: 3
+      resources:
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi
+---
+apiVersion: v1
+data:
+  password: OTQxdHhTNDlqdA==
+  username: ZWxhc3RpYw==
+kind: Secret
+metadata:
+  name: es-master-account-elastic
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  password: Tk92NzM0MTV1Tg==
+  username: a2liYW5hX3N5c3RlbQ==
+kind: Secret
+metadata:
+  name: es-master-account-kibana-system
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  ca.crt: <REPLACE_CA_CRT>
+  tls.crt: <REPLACE_TLS_CRT>
+  tls.key: <REPLACE_TLS_KEY>
+kind: Secret
+metadata:
+  name: e'stls-certs
+  namespace: default
+type: Opaque


### PR DESCRIPTION
- Modified post-start-hook.sh to:
  * Change authentication from root to elastic user
  * Add early exit for non-master nodes
  * Comment out built-in password reset functionality

- Updated componentdefinition-elasticsearch.yaml to:
  * Add ELASTIC_PASSWORD and ES_PASSWORD environment variables
  * Add ES_USERNAME credential reference
  * Add ssl-skip-verify flag to exporter

- Added new multi-node TLS example configuration (es-multi-node-tls.yaml):
  * Includes detailed comments explaining system accounts and TLS setup
  * Configures master and data/ingest/transform nodes
  * Sets up required secrets for accounts and certificates