### PR TITLE
Revert "chore: set pg max_worker_processes to 8" (#1696)

### DIFF
--- a/addons/orioledb/config/pg16-config.tpl
+++ b/addons/orioledb/config/pg16-config.tpl
@@ -167,7 +167,7 @@
   max_standby_streaming_delay = '300000ms'
   max_sync_workers_per_subscription = '2'
   max_wal_senders = '64'
-  max_worker_processes = '8'
+  max_worker_processes = '{{ max $phy_cpu 8 }}'
   min_parallel_index_scan_size = '512kB'
   min_parallel_table_scan_size = '8MB'
 

--- a/addons/postgresql/config/pg12-config.tpl
+++ b/addons/postgresql/config/pg12-config.tpl
@@ -168,7 +168,7 @@ max_standby_archive_delay = '300000ms'
 max_standby_streaming_delay = '300000ms'
 max_sync_workers_per_subscription = '2'
 max_wal_senders = '64'
-max_worker_processes = '8'
+max_worker_processes = '{{ max $phy_cpu 8 }}'
 min_parallel_index_scan_size = '512kB'
 min_parallel_table_scan_size = '8MB'
 

--- a/addons/postgresql/config/pg14-config.tpl
+++ b/addons/postgresql/config/pg14-config.tpl
@@ -168,7 +168,7 @@ max_standby_archive_delay = '300000ms'
 max_standby_streaming_delay = '300000ms'
 max_sync_workers_per_subscription = '2'
 max_wal_senders = '64'
-max_worker_processes = '8'
+max_worker_processes = '{{ max $phy_cpu 8 }}'
 min_parallel_index_scan_size = '512kB'
 min_parallel_table_scan_size = '8MB'
 

--- a/addons/postgresql/config/pg15-config.tpl
+++ b/addons/postgresql/config/pg15-config.tpl
@@ -168,7 +168,7 @@ max_standby_archive_delay = '300000ms'
 max_standby_streaming_delay = '300000ms'
 max_sync_workers_per_subscription = '2'
 max_wal_senders = '64'
-max_worker_processes = '8'
+max_worker_processes = '{{ max $phy_cpu 8 }}'
 min_parallel_index_scan_size = '512kB'
 min_parallel_table_scan_size = '8MB'
 

--- a/addons/postgresql/config/pg16-config.tpl
+++ b/addons/postgresql/config/pg16-config.tpl
@@ -167,10 +167,10 @@
   max_standby_streaming_delay = '300000ms'
   max_sync_workers_per_subscription = '2'
   max_wal_senders = '64'
-  max_worker_processes = '8'
+  max_worker_processes = '{{ max $phy_cpu 8 }}'
   min_parallel_index_scan_size = '512kB'
   min_parallel_table_scan_size = '8MB'
-
+  
   {{- $max_wal_size := min ( max ( div $phy_memory 2097152 ) 4096 ) 32768 }}
   {{- $min_wal_size := min ( max ( div $phy_memory 8388608 ) 2048 ) 8192 }}
   {{- $data_disk_size := getComponentPVCSizeByName $.component "data" }}
@@ -182,7 +182,7 @@
   {{- end }}
   max_wal_size = '{{- printf "%dMB" $max_wal_size }}'
   min_wal_size = '{{- printf "%dMB" $min_wal_size }}'
-
+  
   old_snapshot_threshold = '-1'
   parallel_leader_participation = 'True'
   password_encryption = 'md5'
@@ -268,7 +268,7 @@
   work_mem = '{{ printf "%dkB" ( max ( div $phy_memory 4194304 ) 4096 ) }}'
   xmlbinary = 'base64'
   xmloption = 'content'
-
+  
   autovacuum_vacuum_insert_scale_factor = '0.2'
   autovacuum_vacuum_insert_threshold = '1000'
   client_connection_check_interval = '0'

--- a/addons/vanilla-postgresql/config/pg12-config.tpl
+++ b/addons/vanilla-postgresql/config/pg12-config.tpl
@@ -164,7 +164,7 @@ max_standby_archive_delay = '300000ms'
 max_standby_streaming_delay = '300000ms'
 max_sync_workers_per_subscription = '2'
 max_wal_senders = '64'
-max_worker_processes = '8'
+max_worker_processes = '{{ max $phy_cpu 8 }}'
 min_parallel_index_scan_size = '512kB'
 min_parallel_table_scan_size = '8MB'
 

--- a/addons/vanilla-postgresql/config/pg14-config.tpl
+++ b/addons/vanilla-postgresql/config/pg14-config.tpl
@@ -164,7 +164,7 @@ max_standby_archive_delay = '300000ms'
 max_standby_streaming_delay = '300000ms'
 max_sync_workers_per_subscription = '2'
 max_wal_senders = '64'
-max_worker_processes = '8'
+max_worker_processes = '{{ max $phy_cpu 8 }}'
 min_parallel_index_scan_size = '512kB'
 min_parallel_table_scan_size = '8MB'
 

--- a/addons/vanilla-postgresql/config/pg15-config.tpl
+++ b/addons/vanilla-postgresql/config/pg15-config.tpl
@@ -164,7 +164,7 @@ max_standby_archive_delay = '300000ms'
 max_standby_streaming_delay = '300000ms'
 max_sync_workers_per_subscription = '2'
 max_wal_senders = '64'
-max_worker_processes = '8'
+max_worker_processes = '{{ max $phy_cpu 8 }}'
 min_parallel_index_scan_size = '512kB'
 min_parallel_table_scan_size = '8MB'
 


### PR DESCRIPTION
(cherry picked from commit e229953af1393e7f7285b80caa31682044be65fc)