### PR TITLE
chore: chagne pg scope label

### DIFF
--- a/addons-cluster/postgresql/templates/_helpers.tpl
+++ b/addons-cluster/postgresql/templates/_helpers.tpl
@@ -20,8 +20,6 @@ Define postgresql ComponentSpec with ComponentDefinition.
   componentSpecs:
     - name: {{ include "postgresql-cluster.component-name" . }}
       serviceVersion: {{ .Values.version }}
-      labels:
-        {{- include "postgresql-cluster.patroni-scope-label" . | indent 8 }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
       {{- include "postgresql-cluster.replicaCount" . | indent 6 }}
       {{- include "kblib.componentResources" . | indent 6 }}
@@ -56,10 +54,3 @@ Define postgresql componentName
 {{- define "postgresql-cluster.component-name" -}}
 postgresql
 {{- end }}
-
-{{/*
-Define patroni scope label which postgresql cluster depends on, the named pattern is `apps.kubeblocks.postgres.patroni/scope: <clusterName>-<componentName>`
-*/}}
-{{- define "postgresql-cluster.patroni-scope-label" }}
-apps.kubeblocks.postgres.patroni/scope: {{ include "kblib.clusterName" . }}-{{ include "postgresql-cluster.component-name" . }}
-{{- end -}}

--- a/addons/postgresql/README.md
+++ b/addons/postgresql/README.md
@@ -82,21 +82,6 @@ spec:
       # Component's headless Service.
       # Valid options are [true, false]
       disableExporter: false
-      # Specifies Labels to override or add for underlying Pods, PVCs, Account & TLS
-      # Secrets, Services Owned by Component.
-      labels:
-        # PostgreSQL's CMPD specifies `KUBERNETES_SCOPE_LABEL=apps.kubeblocks.postgres.patroni/scope` through ENVs
-        # The KUBERNETES_SCOPE_LABEL is used to define the label key that Patroni will use to tag Kubernetes resources.
-        # This helps Patroni identify which resources belong to the specified scope (or cluster) used to define the label key
-        # that Patroni will use to tag Kubernetes resources.
-        # This helps Patroni identify which resources belong to the specified scope (or cluster).
-        #
-        # Note: DO NOT REMOVE THIS LABEL
-        # update the value w.r.t your cluster name
-        # the value must follow the format <cluster.metadata.name>-postgresql
-        # which is pg-cluster-postgresql in this examples
-        # replace `pg-cluster` with your cluster name
-        apps.kubeblocks.postgres.patroni/scope: pg-cluster-postgresql
       # Update `replicas` to your need.
       replicas: 2
       # Specifies the resources required by the Component.
@@ -260,8 +245,6 @@ spec:
   componentSpecs:
     - name: postgresql
       serviceVersion: "14.7.2"
-      labels:
-        apps.kubeblocks.postgres.patroni/scope: pg-cluster-postgresql
       replicas: 2 # Update `replicas` to 1 for scaling in, and to 3 for scaling out
 ```
 
@@ -856,9 +839,6 @@ spec:
     - name: postgresql
       serviceVersion: "14.7.2"
       disableExporter: true
-      labels:
-        # NOTE: update the label accordingly
-        apps.kubeblocks.postgres.patroni/scope: pg-restore-postgresql
       replicas: 2
       resources:
         limits:
@@ -1160,21 +1140,6 @@ spec:
       # Component's headless Service.
       # Valid options are [true, false]
       disableExporter: false
-      # Specifies Labels to override or add for underlying Pods, PVCs, Account & TLS
-      # Secrets, Services Owned by Component.
-      labels:
-        # PostgreSQL's CMPD specifies `KUBERNETES_SCOPE_LABEL=apps.kubeblocks.postgres.patroni/scope` through ENVs
-        # The KUBERNETES_SCOPE_LABEL is used to define the label key that Patroni will use to tag Kubernetes resources.
-        # This helps Patroni identify which resources belong to the specified scope (or cluster) used to define the label key
-        # that Patroni will use to tag Kubernetes resources.
-        # This helps Patroni identify which resources belong to the specified scope (or cluster).
-        #
-        # Note: DO NOT REMOVE THIS LABEL
-        # update the value w.r.t your cluster name
-        # the value must follow the format <cluster.metadata.name>-postgresql
-        # which is pg-cluster-postgresql in this examples
-        # replace `pg-cluster` with your cluster name
-        apps.kubeblocks.postgres.patroni/scope: pg-cluster-postgresql
       # Update `replicas` to your need.
       replicas: 2
       # Specifies the resources required by the Component.

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -340,11 +340,11 @@ spec:
           - name: SCOPE
             value: $(POSTGRES_COMPONENT_NAME)
           - name: KUBERNETES_SCOPE_LABEL
-            value: "apps.kubeblocks.postgres.patroni/scope"
+            value: "workloads.kubeblocks.io/instance"
           - name: KUBERNETES_ROLE_LABEL
             value: "apps.kubeblocks.postgres.patroni/role"
           - name: KUBERNETES_LABELS
-            value: '{"app.kubernetes.io/managed-by":"kubeblocks","app.kubernetes.io/instance":"$(CLUSTER_NAME)","apps.kubeblocks.io/component-name":"$(POSTGRES_COMPONENT_SHORT_NAME)","apps.kubeblocks.postgres.patroni/scope":"$(POSTGRES_COMPONENT_NAME)"}'
+            value: '{"app.kubernetes.io/managed-by":"kubeblocks","app.kubernetes.io/instance":"$(CLUSTER_NAME)","apps.kubeblocks.io/component-name":"$(POSTGRES_COMPONENT_SHORT_NAME)","workloads.kubeblocks.io/instance":"$(POSTGRES_COMPONENT_NAME)"}'
           - name: RESTORE_DATA_DIR
             value: /home/postgres/pgdata/kb_restore
           - name: KB_PG_CONFIG_PATH

--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -135,8 +135,6 @@ spec:
   componentSpecs:
     - name: postgresql
       serviceVersion: "14.7.2"
-      labels:
-        apps.kubeblocks.postgres.patroni/scope: pg-cluster-postgresql
       replicas: 2 # Update `replicas` to 1 for scaling in, and to 3 for scaling out
 ```
 

--- a/examples/postgresql/cluster.yaml
+++ b/examples/postgresql/cluster.yaml
@@ -31,21 +31,6 @@ spec:
       # Component's headless Service.
       # Valid options are [true, false]
       disableExporter: false
-      # Specifies Labels to override or add for underlying Pods, PVCs, Account & TLS
-      # Secrets, Services Owned by Component.
-      labels:
-        # PostgreSQL's CMPD specifies `KUBERNETES_SCOPE_LABEL=apps.kubeblocks.postgres.patroni/scope` through ENVs
-        # The KUBERNETES_SCOPE_LABEL is used to define the label key that Patroni will use to tag Kubernetes resources.
-        # This helps Patroni identify which resources belong to the specified scope (or cluster) used to define the label key
-        # that Patroni will use to tag Kubernetes resources.
-        # This helps Patroni identify which resources belong to the specified scope (or cluster).
-        #
-        # Note: DO NOT REMOVE THIS LABEL
-        # update the value w.r.t your cluster name
-        # the value must follow the format <cluster.metadata.name>-postgresql
-        # which is pg-cluster-postgresql in this examples
-        # replace `pg-cluster` with your cluster name
-        apps.kubeblocks.postgres.patroni/scope: pg-cluster-postgresql
       # Update `replicas` to your need.
       replicas: 2
       # Specifies the resources required by the Component.

--- a/examples/postgresql/restore.yaml
+++ b/examples/postgresql/restore.yaml
@@ -14,9 +14,6 @@ spec:
     - name: postgresql
       serviceVersion: "14.7.2"
       disableExporter: true
-      labels:
-        # NOTE: update the label accordingly
-        apps.kubeblocks.postgres.patroni/scope: pg-restore-postgresql
       replicas: 2
       resources:
         limits:


### PR DESCRIPTION

Use the existing label "workloads.kubeblocks.io/instance" as the scope label for PostgreSQL to avoid requiring users to explicitly specify the label when creating a cluster.