### PR TITLE
chore: do not run pgbouncer as root

### DIFF
--- a/addons/postgresql/scripts/pgbouncer_setup.sh
+++ b/addons/postgresql/scripts/pgbouncer_setup.sh
@@ -62,4 +62,5 @@ else
 fi
 
 chown -R pgbouncer:pgbouncer /opt/bitnami/pgbouncer/conf/ /opt/bitnami/pgbouncer/logs/ /opt/bitnami/pgbouncer/tmp/
-/opt/bitnami/scripts/pgbouncer/run.sh
+
+su pgbouncer -c "/opt/bitnami/scripts/pgbouncer/run.sh"


### PR DESCRIPTION
* fix https://github.com/apecloud/kubeblocks/issues/9645