### PR TITLE
fix: kafka domain

### DIFF
--- a/addons/kafka/scripts/kafka-server-setup.tpl
+++ b/addons/kafka/scripts/kafka-server-setup.tpl
@@ -162,7 +162,7 @@ if [[ "broker,controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] || [[ "broker" = "$KAF
       rm -f "$KAFKA_CFG_METADATA_LOG_DIR/__cluster_metadata-0/quorum-state"
     fi
 
-    headless_domain="${KB_POD_FQDN}${cluster_domain}"
+    headless_domain="${KB_POD_FQDN}.${CLUSTER_DOMAIN}"
     parse_advertised_svc_if_exist
 
     # Todo: currently only nodeport and clusterip network modes are supported. LoadBalance is not supported yet and needs future support.

--- a/addons/kafka/scripts/kafka-server-zk-setup.sh.tpl
+++ b/addons/kafka/scripts/kafka-server-zk-setup.sh.tpl
@@ -183,7 +183,7 @@ parse_advertised_svc_if_exist() {
 }
 
 # cfg setting
-headless_domain="${KB_POD_FQDN}${cluster_domain}"
+headless_domain="${KB_POD_FQDN}.${CLUSTER_DOMAIN}"
 parse_advertised_svc_if_exist
 
 # Todo: currently only nodeport and clusterip network modes are supported. LoadBalance is not supported yet and needs future support.


### PR DESCRIPTION
The `advertised.listeners` in `server.properties` of Kafka is missing **cluster domain** information
<img width="3334" height="220" alt="image" src="https://github.com/user-attachments/assets/77699bd1-3e6a-49e6-b109-8e54639cb621" />
