### PR TITLE
fix: loki volume permission error

### DIFF
--- a/addons/loki/templates/cmpd-backend.yaml
+++ b/addons/loki/templates/cmpd-backend.yaml
@@ -35,6 +35,8 @@ spec:
               matchLabels:
                 app.kubernetes.io/component: backend
             topologyKey: kubernetes.io/hostname
+    securityContext:
+      fsGroup: 10001
     containers:
       - name: backend
         imagePullPolicy: {{ .Values.images.pullPolicy }}

--- a/addons/loki/templates/cmpd-read.yaml
+++ b/addons/loki/templates/cmpd-read.yaml
@@ -35,6 +35,8 @@ spec:
               matchLabels:
                 app.kubernetes.io/component: read
             topologyKey: kubernetes.io/hostname
+    securityContext:
+      fsGroup: 10001
     containers:
       - name: read
         imagePullPolicy: {{ .Values.images.pullPolicy }}

--- a/addons/loki/templates/cmpd-write.yaml
+++ b/addons/loki/templates/cmpd-write.yaml
@@ -35,6 +35,8 @@ spec:
               matchLabels:
                 app.kubernetes.io/component: write
             topologyKey: kubernetes.io/hostname
+    securityContext:
+      fsGroup: 10001
     containers:
       - name: write
         imagePullPolicy: {{ .Values.images.pullPolicy }}


### PR DESCRIPTION
On some cloud managed k8s, mounted PV have 755 permission, thus preventing loki user (used by loki container) creating data files.