### PR TITLE
chore: replace bitnami image repository with apecloud

### DIFF
--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -81,7 +81,7 @@ metrics:
   ## if the value of metrics.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
   image:
     registry: ""
-    repository: bitnami/mysqld-exporter
+    repository: apecloud/mysqld-exporter
     tag: 0.15.1
     pullPolicy: IfNotPresent
 

--- a/addons/clickhouse/values.yaml
+++ b/addons/clickhouse/values.yaml
@@ -15,7 +15,7 @@ commonAnnotations: {}
 
 image:
   registry: docker.io
-  repository: bitnami/clickhouse
+  repository: apecloud/clickhouse
   pullPolicy: IfNotPresent
 
 clickhouseVersions:

--- a/addons/influxdb/values.yaml
+++ b/addons/influxdb/values.yaml
@@ -10,10 +10,10 @@ image:
   registry: docker.io
   pullPolicy: IfNotPresent
   influxdb:
-    repository: bitnami/influxdb
+    repository: apecloud/influxdb
     tag: 2.7.11-debian-12-r18
   init:
-    repository: bitnami/os-shell
+    repository: apecloud/os-shell
     tag: 11-debian-11-r93
 
 configPath: /opt/bitnami/influxdb/etc

--- a/addons/milvus/values.yaml
+++ b/addons/milvus/values.yaml
@@ -17,7 +17,7 @@ images:
     tag: RELEASE.2022-03-17T06-34-49Z
   ostools:
     registry: ""
-    repository: bitnami/os-shell
+    repository: apecloud/os-shell
     tag: 11-debian-11-r90
   operator:
     registry: ""
@@ -25,7 +25,7 @@ images:
   milvus:
     registry: ""
     repository: milvusdb/milvus
-  
+
 
 livenessProbe:
   enabled: true

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -88,7 +88,7 @@ metrics:
   image:
     # if the value of metrics.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
-    repository: bitnami/mysqld-exporter
+    repository: apecloud/mysqld-exporter
     tag: 0.15.1
     pullPolicy: IfNotPresent
 

--- a/addons/zookeeper/values.yaml
+++ b/addons/zookeeper/values.yaml
@@ -20,7 +20,7 @@ versions:
 
 images:
   registry: docker.io
-  repository: bitnami/zookeeper
+  repository: apecloud/zookeeper
   pullPolicy: IfNotPresent
   tag: 3.7.2
 


### PR DESCRIPTION
* Replace bitnami image repository with apecloud because of https://github.com/bitnami/charts/issues/35164 