### PR TITLE
chore: replace bitnami repository with apecloud

### DIFF
--- a/addons/influxdb/values.yaml
+++ b/addons/influxdb/values.yaml
@@ -10,13 +10,13 @@ image:
   registry: docker.io
   pullPolicy: IfNotPresent
   influxdb:
-    repository: bitnami/influxdb
+    repository: apecloud/influxdb
     tag:
       major2:
         # Must be greater than or equal to version r18
         minor711: 2.7.11-debian-12-r18
   init:
-    repository: bitnami/os-shell
+    repository: apecloud/os-shell
     tag: 11-debian-11-r93
 
 configPath: /opt/bitnami/influxdb/etc

--- a/addons/milvus/values.yaml
+++ b/addons/milvus/values.yaml
@@ -26,7 +26,7 @@ images:
     tag: RELEASE.2022-03-17T06-34-49Z
   ostools:
     registry: ""
-    repository: bitnami/os-shell
+    repository: apecloud/os-shell
     tag: 11-debian-11-r90
 
 livenessProbe:

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -84,7 +84,7 @@ metrics:
   image:
     # if the value of metrics.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
-    repository: bitnami/mysqld-exporter
+    repository: bapecloud/mysqld-exporter
     tag: 0.15.1
     pullPolicy: IfNotPresent
 

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -84,7 +84,7 @@ metrics:
   image:
     # if the value of metrics.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
-    repository: bapecloud/mysqld-exporter
+    repository: apecloud/mysqld-exporter
     tag: 0.15.1
     pullPolicy: IfNotPresent
 

--- a/addons/solr/values.yaml
+++ b/addons/solr/values.yaml
@@ -5,7 +5,7 @@
 images:
   solr:
     registry: docker.io
-    repository: bitnami/solr
+    repository: apecloud/solr
     pullPolicy: IfNotPresent
     tag: 8.11.2
 

--- a/addons/zookeeper/values.yaml
+++ b/addons/zookeeper/values.yaml
@@ -4,7 +4,7 @@
 
 images:
   registry: docker.io
-  repository: bitnami/zookeeper
+  repository: apecloud/zookeeper
   pullPolicy: IfNotPresent
 
   tag: 3.7.2


### PR DESCRIPTION
* Replace bitnami image repository with apecloud because of https://github.com/bitnami/charts/issues/35164