### PR TITLE
fix: set pvc for loki-write (0.9 branch)

### DIFF
--- a/addons-cluster/loki-cluster/templates/cluster.yaml
+++ b/addons-cluster/loki-cluster/templates/cluster.yaml
@@ -27,6 +27,7 @@
     - name: write
       {{- include "kblib.componentMonitor" . | indent 6 }}
       replicas: {{ .Values.write.replicas }}
+      {{- include "kblib.componentStorages" . | indent 6 }}
       {{- with .Values.write.resources }}
       resources:
         {{- with .limits }}


### PR DESCRIPTION
ref https://github.com/apecloud/kubeblocks-addons/pull/2046/