### PR TITLE
chore: fix failed to delete encrypted backup for KB09

### DIFF
--- a/addons-cluster/mongodb-cluster/Chart.yaml
+++ b/addons-cluster/mongodb-cluster/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
 apiVersion: v2
 name: mongodb-cluster
 type: application
-version: 0.9.2
+version: 0.9.4
 description: A MongoDB cluster Helm chart for KubeBlocks
 dependencies:
   - name: kblib

--- a/addons-cluster/mysql-cluster/Chart.yaml
+++ b/addons-cluster/mysql-cluster/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
 apiVersion: v2
 name: mysql-cluster
 type: application
-version: 0.9.2
+version: 0.9.4
 description: MySQL is a widely used, open-source relational database management system (RDBMS)
 dependencies:
   - name: kblib

--- a/addons-cluster/postgresql-cluster/Chart.yaml
+++ b/addons-cluster/postgresql-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: postgresql-cluster
 type: application
-version: 0.9.7-beta.0
+version: 0.9.7
 description: A PostgreSQL (with Patroni HA) cluster Helm chart for KubeBlocks.
 
 dependencies:

--- a/addons/mongodb/Chart.yaml
+++ b/addons/mongodb/Chart.yaml
@@ -4,7 +4,7 @@ description: MongoDB is a document database designed for ease of application dev
 
 type: application
 
-version: 0.9.3
+version: 0.9.4
 
 appVersion: "5.0"
 

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -24,8 +24,8 @@ image:
     repository: apecloud/mongodb_exporter
     tag: "0.44.0"
   walg:
-    repository: apecloud/wal-g
-    tag: mongo-5.0.1
+    repository: apecloud/wal-g-mongo
+    tag: 3.0.0
 
 clusterVersionOverride: ""
 nameOverride: ""
@@ -39,7 +39,7 @@ roleProbe:
 ## Authentication parameters
 ##
 auth:
-  ## @param auth.password Password for the "mongodb" admin user, leave empty 
+  ## @param auth.password Password for the "mongodb" admin user, leave empty
   ## for random generated password.
   ##
   password:

--- a/addons/mysql/Chart.yaml
+++ b/addons/mysql/Chart.yaml
@@ -4,7 +4,7 @@ description: MySQL is a widely used, open-source relational database management 
 
 type: application
 
-version: 0.9.3
+version: 0.9.4
 
 appVersion: "8.0.33"
 

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -23,7 +23,7 @@ image:
     tag: 1.0.3
   walgImage:
     repository: apecloud/wal-g-mysql
-    tag: 2.0.1-1-ubuntu
+    tag: 3.0.0-ubuntu
 
 ## MySQL Cluster parameters
 cluster:

--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ description: A PostgreSQL (with Patroni HA) cluster definition Helm chart for Ku
 
 type: application
 
-version: 0.9.7-beta.0
+version: 0.9.7
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # and each PostgreSQL (with Patroni HA) version corresponds to a clusterVersion object.

--- a/addons/postgresql/values.yaml
+++ b/addons/postgresql/values.yaml
@@ -13,8 +13,8 @@ image:
   repository: apecloud/spilo
   digest: ""
   walg:
-    repository: apecloud/wal-g
-    tag: postgres-1.2
+    repository: apecloud/wal-g-pg
+    tag: 3.0.0
   init:
     repository: apecloud/spilo-init
     tag: "0.1"


### PR DESCRIPTION
* bump wal-g verstion to 3.0.0 to fix failed to delete encrypted backup
* update the modified addon version and keep cluster chart version consistent with addon version