### PR TITLE
fix(milvus): Change milvus metrics scrapePort from 9187 to 9091

### DIFF
--- a/addons/milvus/templates/clusterdefinition.yaml
+++ b/addons/milvus/templates/clusterdefinition.yaml
@@ -28,7 +28,7 @@ spec:
         builtIn: false
         exporterConfig:
           scrapePath: /metrics
-          scrapePort: 9187
+          scrapePort: 9091
       configSpecs:
         - name: config
           templateRef: milvus-config-template-{{ .Chart.Version }}


### PR DESCRIPTION
This pull request makes a minor configuration update to the Milvus cluster definition. The only change is adjusting the `scrapePort` for the exporter from 9187 to 9091.