### PR TITLE
chore: mysql support to set architecture

### DIFF
--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -244,13 +244,6 @@ roles:
 {{- end }}
 
 {{- define "mysql.spec.runtime.entrypoint" -}}
-# Auto-detect architecture and disable jemalloc on ARM64
-ARCH=$(uname -m)
-if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-  echo "Detected ARM64 architecture ($ARCH), disabling jemalloc"
-  unset LD_PRELOAD
-fi
-
 mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog,temp}
 if [ -f {{ .Values.dataMountPath }}/plugin/audit_log.so ]; then
   cp {{ .Values.dataMountPath }}/plugin/audit_log.so /usr/lib64/mysql/plugin/
@@ -312,6 +305,8 @@ mysql-exporter: {{ .Values.metrics.image.registry | default ( .Values.image.regi
 Generate LD_PRELOAD environment variable - always set, but will be cleared at runtime for ARM64
 */}}
 {{- define "mysql.spec.runtime.ldPreloadEnv" -}}
+{{- if ne (.Values.architecture | default "") "arm64" }}
 - name: LD_PRELOAD
   value: /tools/lib/libjemalloc.so.2
+{{- end }}
 {{- end -}}

--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -247,7 +247,7 @@ roles:
 mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog,temp}
 if [ -f {{ .Values.dataMountPath }}/plugin/audit_log.so ]; then
   cp {{ .Values.dataMountPath }}/plugin/audit_log.so /usr/lib64/mysql/plugin/
-fi
+fi 
 if [ -d /etc/pki/tls ]; then
   mkdir -p {{ .Values.dataMountPath }}/tls/
   cp -L /etc/pki/tls/*.pem {{ .Values.dataMountPath }}/tls/

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -99,6 +99,9 @@ metrics:
 
 dataMountPath: /var/lib/mysql
 
+## @param architecture CPU architecture. Leave empty to enable jemalloc by default, set to "arm64" to disable jemalloc
+architecture: ""
+
 ## @param orche
 orchestrator:
   metaBackends:


### PR DESCRIPTION
This pr https://github.com/apecloud/kubeblocks-addons/pull/2080 modify the container entrypoint command that will make the container restart if upgrade, so revert it and add a helm parameter to set the architecture.