### PR TITLE
chore: modify loki default config

### DIFF
--- a/addons/loki/configs/loki-config.tpl
+++ b/addons/loki/configs/loki-config.tpl
@@ -60,8 +60,11 @@ limits_config:
   max_cache_freshness_per_query: 10m
   reject_old_samples: true
   reject_old_samples_max_age: 168h
-  retention_period: 48h
+  retention_period: 168h
   split_queries_by_interval: 2h
+
+querier:
+  max_concurrent: 50
 
 schema_config:
   configs:


### PR DESCRIPTION
- The original log retention time is too short; 7 to 15 days is a more suitable default value.
- Add the `querier` configuration, increase `max_concurrent`, make sure log queries within 7 days require two batches at most.