### PR TITLE
chore: adjust doris update strategy

### DIFF
--- a/addons/doris/templates/cmpd-be.yaml
+++ b/addons/doris/templates/cmpd-be.yaml
@@ -11,7 +11,6 @@ spec:
   provider: kubeblocks
   description: A Doris BE component definition for Kubernetes
   serviceKind: doris-be
-  updateStrategy: Parallel
   podManagementPolicy: Parallel
   services:
   - name: be

--- a/addons/doris/templates/cmpd-fe.yaml
+++ b/addons/doris/templates/cmpd-fe.yaml
@@ -11,7 +11,6 @@ spec:
   provider: kubeblocks
   description: A Doris FE component definition for Kubernetes
   # The FE can only perform leader election when the majority of members are active.
-  updateStrategy: BestEffortParallel
   podManagementPolicy: Parallel
   serviceKind: doris-fe
   services:


### PR DESCRIPTION
`BestEffortParallel` will cause fe vscale failed, use default update strategy instead.