### PR TITLE
chore: improve pg bpt version mapping

### DIFF
--- a/addons/postgresql/templates/backuppolicytemplate.yaml
+++ b/addons/postgresql/templates/backuppolicytemplate.yaml
@@ -39,21 +39,13 @@ spec:
         - name: IMAGE_TAG
           valueFrom:
             versionMapping:
+              {{- range .Values.versions }}
+              {{- range .minors }}
               - serviceVersions:
-                  - "12"
-                mappedValue: "12.15.0-pgvector-v0.6.1"
-              - serviceVersions:
-                  - "14"
-                mappedValue: "14.8.0-pgvector-v0.6.1"
-              - serviceVersions:
-                  - "15"
-                mappedValue: "15.7.0"
-              - serviceVersions:
-                  - "16"
-                mappedValue: "16.4.0"
-              - serviceVersions:
-                  - "17"
-                mappedValue: "17.5"
+                  - "{{ .version }}"
+                mappedValue: "{{ .tag }}"
+              {{- end }}
+              {{- end }}
       targetVolumes:
         volumeMounts:
           - name: data


### PR DESCRIPTION
BPT includes all minor versions mapping.

The rendered output:

```yaml
            versionMapping:
              - serviceVersions:
                  - "12.14.0"
                mappedValue: "12.14.0-pgvector-v0.6.1"
              - serviceVersions:
                  - "12.14.1"
                mappedValue: "12.14.1-pgvector-v0.6.1"
              - serviceVersions:
                  - "12.15.0"
                mappedValue: "12.15.0-pgvector-v0.6.1"
              - serviceVersions:
                  - "12.22.0"
                mappedValue: "12.22"
              - serviceVersions:
                  - "14.7.2"
                mappedValue: "14.7.2-pgvector-v0.6.1"
              - serviceVersions:
                  - "14.8.0"
                mappedValue: "14.8.0-pgvector-v0.6.1"
              - serviceVersions:
                  - "14.18.0"
                mappedValue: "14.18"
              - serviceVersions:
                  - "15.7.0"
                mappedValue: "15.7.0"
              - serviceVersions:
                  - "15.13.0"
                mappedValue: "15.13"
              - serviceVersions:
                  - "16.4.0"
                mappedValue: "16.4.0"
              - serviceVersions:
                  - "16.9.0"
                mappedValue: "16.9"
              - serviceVersions:
                  - "17.5.0"
                mappedValue: "17.5"
```