### PR TITLE
chore: fix apecloud-addon-charts trivy vulnerabilities

### DIFF
--- a/docker/Dockerfile-charts
+++ b/docker/Dockerfile-charts
@@ -1,5 +1,5 @@
 # Build image that contains all dependent helm charts
-FROM alpine/helm:3.12.1 as builder
+FROM alpine/helm:3.17.3 as builder
 
 COPY docker/custom-scripts/package-all-helm-charts.sh /tmp/package-all-helm-charts.sh
 
@@ -11,7 +11,7 @@ RUN bash /tmp/package-all-helm-charts.sh /tmp/charts
 
 RUN rm -rf addons
 
-FROM docker.io/alpine:edge as dist
+FROM docker.io/alpine:3.22 as dist
 
 COPY --from=builder /tmp/charts /charts
 USER 65532:65532


### PR DESCRIPTION
fix
```
trivy image --format table --severity CRITICAL,HIGH --ignore-unfixed  apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-addon-charts:clickhouse-0.9.3

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                      Target                                      │  Type  │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-addon-charts- │ alpine │        2        │    -    │
│ :clickhouse-0.9.3 (alpine 3.22.0_alpha20250108)                                  │        │                 │         │
└──────────────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-addon-charts:clickhouse-0.9.3 (alpine 3.22.0_alpha20250108)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                          Title                           │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-12797 │ HIGH     │ fixed  │ 3.3.2-r4          │ 3.3.3-r0      │ openssl: RFC7250 handshakes with unauthenticated servers │
│            │                │          │        │                   │               │ don't abort as expected                                  │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-12797               │
├────────────┤                │          │        │                   │               │                                                          │
│ libssl3    │                │          │        │                   │               │                                                          │
│            │                │          │        │                   │               │                                                          │
│            │                │          │        │                   │               │                                                          │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────┘

📣 Notices:
  - Version 0.67.2 of Trivy is now available, current version is 0.63.0

To suppress version checks, run Trivy scans with the --skip-version-check flag
```