### PR TITLE
fix(tidb): add minReadySeconds to fix reconfigure crash

### DIFF
--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -10,6 +10,7 @@ spec:
   provider: kubeblocks
   description: tidb's metadata server
   updateStrategy: BestEffortParallel
+  minReadySeconds: 30
   vars:
     - name: PD_LEADER_POD_NAME
       valueFrom:

--- a/addons/tidb/templates/cmpd-tidb.yaml
+++ b/addons/tidb/templates/cmpd-tidb.yaml
@@ -11,6 +11,7 @@ spec:
   description: tidb's SQL layer
   serviceKind: MySQL
   updateStrategy: BestEffortParallel
+  minReadySeconds: 30
   podManagementPolicy: Parallel
   vars:
     - name: CLUSTER_NAMESPACE

--- a/addons/tidb/templates/cmpd-tikv.yaml
+++ b/addons/tidb/templates/cmpd-tikv.yaml
@@ -10,6 +10,7 @@ spec:
   provider: kubeblocks
   description: a distributed transactional key-value database
   updateStrategy: BestEffortParallel
+  minReadySeconds: 30
   podManagementPolicy: Parallel
   vars:
     - name: CLUSTER_NAMESPACE


### PR DESCRIPTION
Fixes [#9918](https://github.com/apecloud/kubeblocks/issues/9918)

## Description
Fix OpsRequest Reconfiguring RestartPolicy issue that causes all instances except the last one to crash on configuration error.

## Changes
- Add minReadySeconds to TiDB ComponentDefinition
- Prevent all instances except last one from crashing
- Fix issue when RestartPolicy causes configuration error

## Testing
- Local testing completed
- Reconfiguration works as expected

## Acknowledgments
Thanks to @shanshanying for the suggestion!