### PR TITLE
chore: set `wal_keep_size` by data disk size

### DIFF
--- a/addons/postgresql/config/pg12-config.tpl
+++ b/addons/postgresql/config/pg12-config.tpl
@@ -174,7 +174,7 @@ min_parallel_table_scan_size = '8MB'
 
 {{- $max_wal_size := min ( max ( div $phy_memory 2097152 ) 4096 ) 32768 }}
 {{- $min_wal_size := min ( max ( div $phy_memory 8388608 ) 2048 ) 8192 }}
-{{- $wal_keep_segments := 96 }}
+{{- $wal_keep_segments := 64 }}
 {{- $data_disk_size := getComponentPVCSizeByName $.component "data" }}
 {{/* if data disk lt 5G , set max_wal_size to 256MB and wal_keep_segments to 8 (128MB) */}}
 {{- $disk_min_limit := mul 5 1024 1024 1024 }}

--- a/addons/postgresql/config/pg14-config.tpl
+++ b/addons/postgresql/config/pg14-config.tpl
@@ -183,7 +183,7 @@ min_parallel_table_scan_size = '8MB'
 
 {{- $max_wal_size := min ( max ( div $phy_memory 2097152 ) 4096 ) 32768 }}
 {{- $min_wal_size := min ( max ( div $phy_memory 8388608 ) 2048 ) 8192 }}
-{{- $wal_keep_size := 1536 }}
+{{- $wal_keep_size := 1024 }}
 {{- $data_disk_size := getComponentPVCSizeByName $.component "data" }}
 {{/* if data disk lt 5G , set max_wal_size to 256MB and wal_keep_size to 128MB */}}
 {{- $disk_min_limit := mul 5 1024 1024 1024 }}

--- a/addons/postgresql/config/pg15-config.tpl
+++ b/addons/postgresql/config/pg15-config.tpl
@@ -183,7 +183,7 @@ min_parallel_table_scan_size = '8MB'
 
 {{- $max_wal_size := min ( max ( div $phy_memory 2097152 ) 4096 ) 32768 }}
 {{- $min_wal_size := min ( max ( div $phy_memory 8388608 ) 2048 ) 8192 }}
-{{- $wal_keep_size := 1536 }}
+{{- $wal_keep_size := 1024 }}
 {{- $data_disk_size := getComponentPVCSizeByName $.component "data" }}
 {{/* if data disk lt 5G , set max_wal_size to 256MB and wal_keep_size to 128MB */}}
 {{- $disk_min_limit := mul 5 1024 1024 1024 }}

--- a/addons/postgresql/config/pg16-config.tpl
+++ b/addons/postgresql/config/pg16-config.tpl
@@ -182,7 +182,7 @@ min_parallel_table_scan_size = '8MB'
 
 {{- $max_wal_size := min ( max ( div $phy_memory 2097152 ) 4096 ) 32768 }}
 {{- $min_wal_size := min ( max ( div $phy_memory 8388608 ) 2048 ) 8192 }}
-{{- $wal_keep_size := 1536 }}
+{{- $wal_keep_size := 1024 }}
 {{- $data_disk_size := getComponentPVCSizeByName $.component "data" }}
 {{/* if data disk lt 5G , set max_wal_size to 256MB and wal_keep_size to 128MB */}}
 {{- $disk_min_limit := mul 5 1024 1024 1024 }}

--- a/addons/postgresql/config/pg17-config.tpl
+++ b/addons/postgresql/config/pg17-config.tpl
@@ -174,7 +174,7 @@ min_parallel_table_scan_size = '8MB'
 
 {{- $max_wal_size := min ( max ( div $phy_memory 2097152 ) 4096 ) 32768 }}
 {{- $min_wal_size := min ( max ( div $phy_memory 8388608 ) 2048 ) 8192 }}
-{{- $wal_keep_size := 1536 }}
+{{- $wal_keep_size := 1024 }}
 {{- $data_disk_size := getComponentPVCSizeByName $.component "data" }}
 {{/* if data disk lt 5G , set max_wal_size to 256MB and wal_keep_size to 128MB */}}
 {{- $disk_min_limit := mul 5 1024 1024 1024 }}


### PR DESCRIPTION
* fix https://github.com/apecloud/kubeblocks-addons/issues/2367

Set `wal_keep_size` based on the data disk size.