### PR TITLE
fix: add per pod svc for orchestrator

### DIFF
--- a/addons/orchestrator/configs/orchestrator.tpl
+++ b/addons/orchestrator/configs/orchestrator.tpl
@@ -27,6 +27,8 @@
   "RaftBind": "${ORC_POD_NAME}",
   "DefaultRaftPort": 10008,
   "RaftNodes": [ ${ORC_PEERS} ],
+  "RaftAdvertise" : "${ORC_ADVERTISE_SVC}",
+  "HTTPAdvertise" : "http://${ORC_ADVERTISE_SVC}:80",
 
   "ApplyMySQLPromotionAfterMasterFailover": true,
   "DetachLostReplicasAfterMasterFailover": true,

--- a/addons/orchestrator/templates/cmpd-raft.yaml
+++ b/addons/orchestrator/templates/cmpd-raft.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "orchestrator.annotations" . | nindent 4 }}
 spec:
   {{- include "orchestrator.cmpd.spec.common" . | nindent 2 }}
+  podManagementPolicy: Parallel
   roles:
     - name: primary
       updatePriority: 2
@@ -52,12 +53,13 @@ spec:
       valueFrom:
         clusterVarRef:
           clusterUID: Required
-    - name: ORC_POD_FQDN_LIST
+    - name: ORC_PER_POD_SVC
       valueFrom:
-        componentVarRef:
-          compDef: {{ include "orchestrator.componentDefName" . }}
+        serviceVarRef:
+          name: advertise
           optional: false
-          podFQDNs: Required
+          host: Required
+
   lifecycleActions:
     roleProbe:
       periodSeconds: {{ .Values.roleProbe.periodSeconds }}
@@ -83,6 +85,19 @@ spec:
           - name: orc-http
             port: 80
             targetPort: orc-http
+    - name: advertise
+      serviceName: advertise
+      spec:
+        type: ClusterIP
+        ports:
+        - name: orc-http
+          port: 80
+          targetPort: orc-http
+        - name: raft
+          port: 10008
+          targetPort: raft
+      podService: true
+      disableAutoProvision: false
   runtime:
     containers:
       - name: orchestrator


### PR DESCRIPTION
- fix: https://github.com/apecloud/kubeblocks/issues/9981

Relevant discussion are found:
- https://github.com/openark/orchestrator/issues/593
- https://github.com/bitpoke/mysql-operator/pull/359

Create Per Pod SVC, config RaftAdvertise and HTTPAdvertise