### PR TITLE
chore: remove tidb slowlog container

### DIFF
--- a/addons/tidb/templates/cmpd-tidb.yaml
+++ b/addons/tidb/templates/cmpd-tidb.yaml
@@ -82,18 +82,6 @@ spec:
             mountPath: /var/log/tidb
           - name: config
             mountPath: /etc/tidb
-      - name: slowlog
-        imagePullPolicy: IfNotPresent
-        command:
-          - bin/sh
-          - -c
-          - |
-            echo "start slowlog..."
-            touch /var/log/tidb/slowlog
-            tail -n0 -F /var/log/tidb/slowlog;
-        volumeMounts:
-          - name: slowlog
-            mountPath: /var/log/tidb
     volumes:
       - name: slowlog
         emptyDir: {}


### PR DESCRIPTION
Slowlog is stored in file. This container merely displays it. Due to some signal handling problems, this container blocks the pod grace shutdown process. So I think the easiest way is to delete it.