### PR TITLE
chore: add name of template in clickhouse/cluster-standalone example

### DIFF
--- a/examples/clickhouse/cluster-standalone.yaml
+++ b/examples/clickhouse/cluster-standalone.yaml
@@ -20,6 +20,7 @@ spec:
     - name: clickhouse
       shards: 1
       template:
+        name: clickhouse
         replicas: 1
         systemAccounts:
           - name: admin


### PR DESCRIPTION
Otherwise it would fail with:

```bash
Warning  Warning                          9m49s (x13 over 10m)  cluster-controller  Cluster.apps.kubeblocks.io "clickhouse-standalone" is invalid: spec.shardings[0].template.name: Invalid value: "": spec.shardings[0].template.name in body should match '^[a-z]([a-z0-9\-]*[a-z0-9])?$'
```