### PR TITLE
chore: fix undefined variable CERT_FILE

### DIFF
--- a/addons/clickhouse/configs/client.xml.tpl
+++ b/addons/clickhouse/configs/client.xml.tpl
@@ -3,6 +3,8 @@
   <password from_env="CLICKHOUSE_ADMIN_PASSWORD"/>
   {{- if $.component.tlsConfig -}}
   {{- $CA_FILE := getCAFile -}}
+  {{- $CERT_FILE := getCertFile -}}
+  {{- $KEY_FILE := getKeyFile }}
   <secure>true</secure>
   <port from_env="CLICKHOUSE_TCP_SECURE_PORT"/>
   <openSSL>


### PR DESCRIPTION
fix https://github.com/apecloud/apecloud/issues/16659
```
Warning Warning 13s (x11 over 36s) component-controller failed to render configmap: [failed to render configuration template[cm:clickhouse-client-tpl][key:config.xml], error: [template: clickhouse-client-tpl:11: undefined variable "$CERT_FILE"]]
```