### PR TITLE
fix: Use FQDN for backend service to avoid DNS search domain issues

### DIFF
--- a/addons/loki/scripts/wait-index-gateway-ring.sh
+++ b/addons/loki/scripts/wait-index-gateway-ring.sh
@@ -11,14 +11,14 @@ MAX_WAIT="${MAX_WAIT:-300}"  # 5 minutes default
 ELAPSED=0
 
 echo "Waiting for index gateway ring to be ready..."
-echo "Backend service: ${BACKEND_SVC}.${KB_NAMESPACE}.svc.${CLUSTER_DOMAIN}:${BACKEND_PORT}"
+echo "Backend service: ${BACKEND_SVC}.${KB_NAMESPACE}.svc.${CLUSTER_DOMAIN}.:${BACKEND_PORT}"
 echo "Max wait time: ${MAX_WAIT} seconds"
 
 while [ $ELAPSED -lt $MAX_WAIT ]; do
     # Check if backend service is accessible
-    if curl -sf "http://${BACKEND_SVC}.${KB_NAMESPACE}.svc.${CLUSTER_DOMAIN}:${BACKEND_PORT}/ready" > /dev/null 2>&1; then
+    if curl -sf "http://${BACKEND_SVC}.${KB_NAMESPACE}.svc.${CLUSTER_DOMAIN}.:${BACKEND_PORT}/ready" > /dev/null 2>&1; then
         # Check ring for ACTIVE instances (parse HTML)
-        RING_HTML=$(curl -sf "http://${BACKEND_SVC}.${KB_NAMESPACE}.svc.${CLUSTER_DOMAIN}:${BACKEND_PORT}/indexgateway/ring" 2>/dev/null || echo "")
+        RING_HTML=$(curl -sf "http://${BACKEND_SVC}.${KB_NAMESPACE}.svc.${CLUSTER_DOMAIN}.:${BACKEND_PORT}/indexgateway/ring" 2>/dev/null || echo "")
         if [ -n "$RING_HTML" ]; then
             ACTIVE_COUNT=$(echo "$RING_HTML" | grep -o '<td>ACTIVE</td>' | wc -l || echo "0")
             if [ "$ACTIVE_COUNT" -gt "0" ]; then


### PR DESCRIPTION
## Problem

Loki init containers fail to resolve Kubernetes service DNS on **Alpine Linux (musl libc)**:

### Symptoms

```bash
Waiting for index gateway ring to be ready...
Backend service: logs-775b7c67d9-backend.kb-system.svc.cluster.local:3100
Max wait time: 300 seconds
Waiting for index gateway ring... (0/300 seconds)
Waiting for index gateway ring... (5/300 seconds)
Waiting for index gateway ring... (10/300 seconds)
Waiting for index gateway ring... (15/300 seconds)
Waiting for index gateway ring... (20/300 seconds)
Waiting for index gateway ring... (25/300 seconds)
Waiting for index gateway ring... (30/300 seconds)
Waiting for index gateway ring... (35/300 seconds)
Waiting for index gateway ring... (40/300 seconds)
```

```bash
me@k8s-master:~$ kubectl exec -it   logs-775b7c67d9-read-0 -n kb-system -c wait-index-gateway -- sh
/ # curl logs-775b7c67d9-backend.kb-system.svc.cluster.local:3100/ready
curl: (6) Could not resolve host: logs-775b7c67d9-backend.kb-system.svc.cluster.local
```

### Reproduction

Tested on **two different Kubernetes clusters** with the same issue:
1.  **k3d** cluster (v1.31.5+k3s1)
2.  **kubeadm** cluster (v1.35.2)
Both clusters exhibited the same DNS resolution failure in Alpine-based init containers.

## Solution

Append a trailing dot (`.`) to service DNS names to use **Fully Qualified Domain Names (FQDNs)**:

```bash
me@k8s-master:~$ kubectl exec -it   logs-775b7c67d9-read-0 -n kb-system -c wait-index-gateway -- sh
/ # curl logs-775b7c67d9-backend.kb-system.svc.cluster.local:3100/ready
curl: (6) Could not resolve host: logs-775b7c67d9-backend.kb-system.svc.cluster.local
/ # curl logs-775b7c67d9-backend.kb-system.svc.cluster.local.:3100/ready
ready

```
