### PR TITLE
fix: add podUpdatePolicy to all ComponentDefinition templates

### DIFF
--- a/addons/apecloud-mysql/templates/cmpd-apecloudmysql.yaml
+++ b/addons/apecloud-mysql/templates/cmpd-apecloudmysql.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "apecloud-mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "apecloud-mysql.spec.common" . | nindent 2 }}
   configs:
     - name: mysql-consensusset-config

--- a/addons/apecloud-mysql/templates/cmpd-wescale-controller.yaml
+++ b/addons/apecloud-mysql/templates/cmpd-wescale-controller.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "apecloud-mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   description: wescale controller
   serviceKind: wescale-ctrl

--- a/addons/apecloud-mysql/templates/cmpd-wescale.yaml
+++ b/addons/apecloud-mysql/templates/cmpd-wescale.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "apecloud-mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   description: wescale
   serviceKind: wescale

--- a/addons/clickhouse/templates/cmpd-ch.yaml
+++ b/addons/clickhouse/templates/cmpd-ch.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "clickhouse.annotations" . | nindent 4 }}
     apps.kubeblocks.io/skip-immutable-check: "true"
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "clickhouse.annotations" . | nindent 4 }}
     apps.kubeblocks.io/skip-immutable-check: "true"
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: clickhouse-keeper

--- a/addons/elasticsearch/templates/cmpd-es-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-6.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 6.8.23
   configs:
     - name: es-cm

--- a/addons/elasticsearch/templates/cmpd-es-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-7.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 7.10.1
   configs:
     - name: es-cm

--- a/addons/elasticsearch/templates/cmpd-es-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-8.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 8.8.2
   configs:
     - name: es-cm

--- a/addons/elasticsearch/templates/cmpd-es-data-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-data-6.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 6.8.23
   replicasLimit:
     minReplicas: 2

--- a/addons/elasticsearch/templates/cmpd-es-data-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-data-7.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 7.10.1
   replicasLimit:
     minReplicas: 2

--- a/addons/elasticsearch/templates/cmpd-es-data-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-data-8.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 8.8.2
   replicasLimit:
     minReplicas: 2

--- a/addons/elasticsearch/templates/cmpd-es-master-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-master-6.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 6.8.23
   configs:
     - name: es-cm

--- a/addons/elasticsearch/templates/cmpd-es-master-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-master-7.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 7.10.1
   configs:
     - name: es-cm

--- a/addons/elasticsearch/templates/cmpd-es-master-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-master-8.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "elasticsearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 8.8.2
   configs:
     - name: es-cm

--- a/addons/elasticsearch/templates/cmpd-kibana-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-kibana-6.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 6.8.23
   configs:
   - name: kibana-cm

--- a/addons/elasticsearch/templates/cmpd-kibana-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-kibana-7.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 7.10.1
   configs:
   - name: kibana-cm

--- a/addons/elasticsearch/templates/cmpd-kibana-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-kibana-8.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "elasticsearch.labels" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   serviceVersion: 8.8.2
   configs:
   - name: kibana-cm

--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "etcd.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/falkordb/templates/cmpd-falkordb-cluster.yaml
+++ b/addons/falkordb/templates/cmpd-falkordb-cluster.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     {{- include "falkordb.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: An official v{{ .major }}.0 FalkorDB Cluster(distributed implementation of FalkorDB) component definition for Kubernetes
   serviceKind: falkordb-cluster

--- a/addons/falkordb/templates/cmpd-falkordb-sentinel.yaml
+++ b/addons/falkordb/templates/cmpd-falkordb-sentinel.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     {{- include "falkordb.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A falkordb Sentinel v{{ .major }}.0 component definition for Kubernetes
   serviceKind: falkordb-sent

--- a/addons/falkordb/templates/cmpd-falkordb.yaml
+++ b/addons/falkordb/templates/cmpd-falkordb.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     {{- include "falkordb.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A falkordb v{{ .major }}.0 component definition for Kubernetes
   serviceKind: falkordb

--- a/addons/greptimedb/templates/cmpd-datanode.yaml
+++ b/addons/greptimedb/templates/cmpd-datanode.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "greptimedb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/greptimedb/templates/cmpd-frontend.yaml
+++ b/addons/greptimedb/templates/cmpd-frontend.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "greptimedb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/greptimedb/templates/cmpd-meta.yaml
+++ b/addons/greptimedb/templates/cmpd-meta.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "greptimedb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/influxdb/templates/cmpd-data.yaml
+++ b/addons/influxdb/templates/cmpd-data.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "influxdb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Apecloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/influxdb/templates/cmpd-meta.yaml
+++ b/addons/influxdb/templates/cmpd-meta.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "influxdb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Apecloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/influxdb/templates/cmpd-standalone.yaml
+++ b/addons/influxdb/templates/cmpd-standalone.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "influxdb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/kafka/templates/cmpd-broker-27.yaml
+++ b/addons/kafka/templates/cmpd-broker-27.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "kafka.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Kafka 2.x broker component definition
   serviceKind: kafka

--- a/addons/kafka/templates/cmpd-broker.yaml
+++ b/addons/kafka/templates/cmpd-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "kafka.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Kafka broker component definition
   serviceKind: kafka

--- a/addons/kafka/templates/cmpd-combine.yaml
+++ b/addons/kafka/templates/cmpd-combine.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "kafka.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: |-
     Kafka servers that act as both brokers and controllers are referred to as "combined" servers. Combined servers

--- a/addons/kafka/templates/cmpd-controller.yaml
+++ b/addons/kafka/templates/cmpd-controller.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "kafka.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Kafka controller that act as controllers (kraft) only server.
   serviceKind: kafka-controller

--- a/addons/kafka/templates/cmpd-exporter.yaml
+++ b/addons/kafka/templates/cmpd-exporter.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "kafka.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: |-
     Kafka servers that act as both brokers and controllers are referred to as "combined" servers. Combined servers

--- a/addons/llm/templates/cmpd-ggml.yaml
+++ b/addons/llm/templates/cmpd-ggml.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "llm.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   serviceKind: ggml
   updateStrategy: BestEffortParallel

--- a/addons/llm/templates/cmpd-vllm.yaml
+++ b/addons/llm/templates/cmpd-vllm.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "llm.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   serviceKind: vllm
   updateStrategy: BestEffortParallel

--- a/addons/loki/templates/cmpd-backend.yaml
+++ b/addons/loki/templates/cmpd-backend.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "loki.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A Loki component definition for Kubernetes
   labels:

--- a/addons/loki/templates/cmpd-gateway.yaml
+++ b/addons/loki/templates/cmpd-gateway.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "loki.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A Loki component definition for Kubernetes
   serviceKind: loki-gateway

--- a/addons/loki/templates/cmpd-read.yaml
+++ b/addons/loki/templates/cmpd-read.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "loki.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A Loki component definition for Kubernetes
   labels:

--- a/addons/loki/templates/cmpd-write.yaml
+++ b/addons/loki/templates/cmpd-write.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "loki.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A Loki component definition for Kubernetes
   labels:

--- a/addons/mariadb/templates/cmpd.yaml
+++ b/addons/mariadb/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mariadb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/milvus/templates/cmpd-data.yaml
+++ b/addons/milvus/templates/cmpd-data.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/milvus/templates/cmpd-index.yaml
+++ b/addons/milvus/templates/cmpd-index.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/milvus/templates/cmpd-minio.yaml
+++ b/addons/milvus/templates/cmpd-minio.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: "High Performance, Kubernetes Native Object Storage"
   serviceKind: milvus-minio

--- a/addons/milvus/templates/cmpd-mixcoord.yaml
+++ b/addons/milvus/templates/cmpd-mixcoord.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/milvus/templates/cmpd-proxy.yaml
+++ b/addons/milvus/templates/cmpd-proxy.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/milvus/templates/cmpd-query.yaml
+++ b/addons/milvus/templates/cmpd-query.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/milvus/templates/cmpd-standalone.yaml
+++ b/addons/milvus/templates/cmpd-standalone.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "milvus.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/minio/templates/cmpd.yaml
+++ b/addons/minio/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "minio.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Minio is a High Performance Object Storage.
   serviceKind: minio

--- a/addons/mogdb/templates/cmpd.yaml
+++ b/addons/mogdb/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mogdb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: MogDB
   serviceKind: mogdb

--- a/addons/mongodb/templates/cmpd-config-server.yaml
+++ b/addons/mongodb/templates/cmpd-config-server.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   serviceKind: mongodb
   serviceVersion: "8.0.17"

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   serviceKind: mongodb
   serviceVersion: "8.0.17"

--- a/addons/mongodb/templates/cmpd-mongos.yaml
+++ b/addons/mongodb/templates/cmpd-mongos.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   serviceKind: mongodb
   serviceVersion: "8.0.17"

--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   description: MongoDB is a document database designed for ease of application development and scaling.
   serviceKind: mongodb

--- a/addons/mysql/templates/cmpd-mysql57-orc.yaml
+++ b/addons/mysql/templates/cmpd-mysql57-orc.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql-orc.spec.common" . | nindent 2 }}
   serviceVersion: 5.7.44
   lifecycleActions:

--- a/addons/mysql/templates/cmpd-mysql57.yaml
+++ b/addons/mysql/templates/cmpd-mysql57.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql.spec.common" . | nindent 2 }}
   serviceVersion: 5.7.44
   configs:

--- a/addons/mysql/templates/cmpd-mysql80-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-mgr.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql.spec.common" . | nindent 2 }}
   serviceVersion: 8.0.33
   configs:

--- a/addons/mysql/templates/cmpd-mysql80-orc.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-orc.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql-orc.spec.common" . | nindent 2 }}
 
   lifecycleActions:

--- a/addons/mysql/templates/cmpd-mysql80.yaml
+++ b/addons/mysql/templates/cmpd-mysql80.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql.spec.common" . | nindent 2 }}
   serviceVersion: 8.0.33
   configs:

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql.spec.common" . | nindent 2 }}
   serviceVersion: 8.4.2
   configs:

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "mysql.spec.common" . | nindent 2 }}
   serviceVersion: 8.4.2
   configs:

--- a/addons/mysql/templates/cmpd-proxysql.yaml
+++ b/addons/mysql/templates/cmpd-proxysql.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: mysql proxy definition for Kubernetes
   serviceKind: proxysql

--- a/addons/nebula/templates/cmpd-graphd.yaml
+++ b/addons/nebula/templates/cmpd-graphd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "nebula.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: nebula

--- a/addons/nebula/templates/cmpd-metad.yaml
+++ b/addons/nebula/templates/cmpd-metad.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "nebula.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: nebula

--- a/addons/nebula/templates/cmpd-storaged.yaml
+++ b/addons/nebula/templates/cmpd-storaged.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "nebula.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: nebula

--- a/addons/neo4j/templates/cmpd.yaml
+++ b/addons/neo4j/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "neo4j.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   description: Neo4j is a highly scalable, robust native graph database.
   serviceKind: neo4j

--- a/addons/neon/templates/cmpd-compute.yaml
+++ b/addons/neon/templates/cmpd-compute.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "neon.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   description: A neon compute component definition for Kubernetes
   provider: KubeBlocks
   serviceKind: neon-compute

--- a/addons/neon/templates/cmpd-pageserver.yaml
+++ b/addons/neon/templates/cmpd-pageserver.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "neon.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   description: A neon pageserver component definition for Kubernetes
   provider: KubeBlocks
   serviceKind: neon-pageserver

--- a/addons/neon/templates/cmpd-safekeeper.yaml
+++ b/addons/neon/templates/cmpd-safekeeper.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "neon.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   description: A neon safekeeper component definition for Kubernetes
   provider: KubeBlocks
   serviceKind: neon-safekeeper

--- a/addons/neon/templates/cmpd-storagebroker.yaml
+++ b/addons/neon/templates/cmpd-storagebroker.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "neon.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   description: A neon storagebroker component definition for Kubernetes
   provider: KubeBlocks
   serviceKind: neon-storagebroker

--- a/addons/opensearch/templates/cmpd-dashboard.yaml
+++ b/addons/opensearch/templates/cmpd-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "opensearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/opensearch/templates/cmpd.yaml
+++ b/addons/opensearch/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "opensearch.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/orchestrator/templates/cmpd-raft.yaml
+++ b/addons/orchestrator/templates/cmpd-raft.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "orchestrator.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "orchestrator.cmpd.spec.common" . | nindent 2 }}
   podManagementPolicy: Parallel
   roles:

--- a/addons/orchestrator/templates/cmpd-shared-backend.yaml
+++ b/addons/orchestrator/templates/cmpd-shared-backend.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "orchestrator.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "orchestrator.cmpd.spec.common" . | nindent 2 }}
   services:
     - name: orchestrator

--- a/addons/orioledb/templates/cmpd.yaml
+++ b/addons/orioledb/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "orioledb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "orioledb.spec.common" . | nindent 2 }}
   serviceVersion: {{ .Values.componentServiceVersion.orioledb }}
   configs:

--- a/addons/polardbx/templates/cmpd-cdc.yaml
+++ b/addons/polardbx/templates/cmpd-cdc.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "polardbx.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/polardbx/templates/cmpd-cn.yaml
+++ b/addons/polardbx/templates/cmpd-cn.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "polardbx.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/polardbx/templates/cmpd-dn.yaml
+++ b/addons/polardbx/templates/cmpd-dn.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "polardbx.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/polardbx/templates/cmpd-gms.yaml
+++ b/addons/polardbx/templates/cmpd-gms.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "polardbx.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     {{- include "postgresql.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A PostgreSQL (with Patroni HA) component definition for Kubernetes
   serviceKind: postgresql

--- a/addons/pulsar/templates/cmpd-bookies-recovery-2.yaml
+++ b/addons/pulsar/templates/cmpd-bookies-recovery-2.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar bookies recovery component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-bookies-recovery-3.yaml
+++ b/addons/pulsar/templates/cmpd-bookies-recovery-3.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar bookies recovery component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-bookies-recovery-4.yaml
+++ b/addons/pulsar/templates/cmpd-bookies-recovery-4.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar bookies recovery component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-bookkeeper-2.yaml
+++ b/addons/pulsar/templates/cmpd-bookkeeper-2.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar bookkeeper component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-bookkeeper-3.yaml
+++ b/addons/pulsar/templates/cmpd-bookkeeper-3.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar bookkeeper component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-bookkeeper-4.yaml
+++ b/addons/pulsar/templates/cmpd-bookkeeper-4.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar bookkeeper component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-broker-2.yaml
+++ b/addons/pulsar/templates/cmpd-broker-2.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar broker component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-broker-3.yaml
+++ b/addons/pulsar/templates/cmpd-broker-3.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar broker component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-broker-4.yaml
+++ b/addons/pulsar/templates/cmpd-broker-4.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar broker component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-proxy-2.yaml
+++ b/addons/pulsar/templates/cmpd-proxy-2.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar proxy component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-proxy-3.yaml
+++ b/addons/pulsar/templates/cmpd-proxy-3.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar proxy component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-proxy-4.yaml
+++ b/addons/pulsar/templates/cmpd-proxy-4.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar proxy component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-zookeeper-2.yaml
+++ b/addons/pulsar/templates/cmpd-zookeeper-2.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar zookeeper component definition
   serviceKind: pulsar

--- a/addons/pulsar/templates/cmpd-zookeeper-3.yaml
+++ b/addons/pulsar/templates/cmpd-zookeeper-3.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "pulsar.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Pulsar zookeeper component definition
   serviceKind: pulsar

--- a/addons/qdrant/templates/cmpd.yaml
+++ b/addons/qdrant/templates/cmpd.yaml
@@ -8,6 +8,7 @@ metadata:
     apps.kubeblocks.io/skip-immutable-check: "true"
     {{- include "qdrant.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: High-performance, massive-scale Vector Database for the next generation of AI.
   serviceKind: qdrant

--- a/addons/rabbitmq/templates/cmpd.yaml
+++ b/addons/rabbitmq/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "rabbitmq.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks.io
   description: RabbitMQ is a reliable and mature messaging and streaming broker.
   serviceKind: rabbitmq

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -21,6 +21,7 @@ metadata:
   annotations:
     {{- include "redis.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: An official v{{ .major }}.0 Redis Cluster(distributed implementation of Redis) component definition for Kubernetes
   serviceKind: redis-cluster

--- a/addons/redis/templates/cmpd-redis-sentinel.yaml
+++ b/addons/redis/templates/cmpd-redis-sentinel.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     {{- include "redis.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A Redis Sentinel v{{ .major }}.0 component definition for Kubernetes
   serviceKind: redis-sentinel

--- a/addons/redis/templates/cmpd-redis-twemproxy.yaml
+++ b/addons/redis/templates/cmpd-redis-twemproxy.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "redis.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: KubeBlocks
   description: A Twemproxy component definition for Kubernetes
   serviceKind: redis-twemproxy

--- a/addons/redis/templates/cmpd-redis.yaml
+++ b/addons/redis/templates/cmpd-redis.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     {{- include "redis.annotations" $ | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A Redis v{{ .major }}.0 component definition for Kubernetes
   serviceKind: redis

--- a/addons/risingwave/templates/cmpd-compactor.yaml
+++ b/addons/risingwave/templates/cmpd-compactor.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "risingwave.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: risingwave

--- a/addons/risingwave/templates/cmpd-compute.yaml
+++ b/addons/risingwave/templates/cmpd-compute.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "risingwave.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: risingwave

--- a/addons/risingwave/templates/cmpd-connector.yaml
+++ b/addons/risingwave/templates/cmpd-connector.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "risingwave.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: risingwave

--- a/addons/risingwave/templates/cmpd-frontend.yaml
+++ b/addons/risingwave/templates/cmpd-frontend.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "risingwave.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: risingwave

--- a/addons/risingwave/templates/cmpd-meta.yaml
+++ b/addons/risingwave/templates/cmpd-meta.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "risingwave.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: {{ .Chart.Description }}
   serviceKind: risingwave

--- a/addons/rocketmq/templates/cmpd-broker.yaml
+++ b/addons/rocketmq/templates/cmpd-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "rocketmq.annotations" . | nindent 4}}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: community
   serviceKind: {{ .Chart.Name }}-broker
   description: RocketMQ Broker

--- a/addons/rocketmq/templates/cmpd-dashboard.yaml
+++ b/addons/rocketmq/templates/cmpd-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "rocketmq.annotations" . | nindent 4}}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: community
   serviceKind: {{ .Chart.Name }}-dashboard
   description: RocketMQ Dashboard

--- a/addons/rocketmq/templates/cmpd-exporter.yaml
+++ b/addons/rocketmq/templates/cmpd-exporter.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "rocketmq.annotations" . | nindent 4}}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: community
   serviceKind: {{ .Chart.Name }}-exporter
   description: RocketMQ Exporter

--- a/addons/rocketmq/templates/cmpd-nameserver.yaml
+++ b/addons/rocketmq/templates/cmpd-nameserver.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "rocketmq.annotations" . | nindent 4}}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: community
   serviceKind: {{ .Chart.Name }}-namesrv
   description: RocketMQ NameServer

--- a/addons/starrocks-ce/templates/cmpd-be.yaml
+++ b/addons/starrocks-ce/templates/cmpd-be.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "starrocks.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A StarRocks BE component definition for Kubernetes
   serviceKind: starrocks-be

--- a/addons/starrocks-ce/templates/cmpd-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpd-fe.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "starrocks.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A StarRocks FE component definition for Kubernetes
   # The FE can only perform leader election when the majority of members are active.

--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "tidb.labels" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: tidb's metadata server
   updateStrategy: BestEffortParallel

--- a/addons/tidb/templates/cmpd-tidb.yaml
+++ b/addons/tidb/templates/cmpd-tidb.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "tidb.labels" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: tidb's SQL layer
   serviceKind: MySQL

--- a/addons/tidb/templates/cmpd-tikv.yaml
+++ b/addons/tidb/templates/cmpd-tikv.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "tidb.labels" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: a distributed transactional key-value database
   updateStrategy: BestEffortParallel

--- a/addons/vanilla-postgresql/templates/cmpd-12.yaml
+++ b/addons/vanilla-postgresql/templates/cmpd-12.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "vanilla-postgresql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "vanilla-postgresql.spec.common" . | nindent 2 }}
   serviceVersion: {{ .Values.defaultServiceVersion.major12 }}
   configs:

--- a/addons/vanilla-postgresql/templates/cmpd-14.yaml
+++ b/addons/vanilla-postgresql/templates/cmpd-14.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "vanilla-postgresql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "vanilla-postgresql.spec.common" . | nindent 2 }}
   serviceVersion: {{ .Values.defaultServiceVersion.major14 }}
   configs:

--- a/addons/vanilla-postgresql/templates/cmpd-15.yaml
+++ b/addons/vanilla-postgresql/templates/cmpd-15.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "vanilla-postgresql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "vanilla-postgresql.spec.common" . | nindent 2 }}
   serviceVersion: {{ .Values.defaultServiceVersion.major15 }}
   configs:
@@ -39,6 +40,7 @@ metadata:
   annotations:
     {{- include "vanilla-postgresql.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   {{- include "vanilla-postgresql.spec.common" (merge (dict "accountName" "supabase_admin") .)| nindent 2 }}
   serviceVersion: {{ .Values.defaultServiceVersion.supabaseMajor15 }}
   configs:

--- a/addons/victoria-metrics/templates/cmpd-vminsert.yaml
+++ b/addons/victoria-metrics/templates/cmpd-vminsert.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "victoria-metrics.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A VictoriaMetrics component definition for Kubernetes
   serviceKind: vminsert

--- a/addons/victoria-metrics/templates/cmpd-vmselect.yaml
+++ b/addons/victoria-metrics/templates/cmpd-vmselect.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "victoria-metrics.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A VictoriaMetrics component definition for Kubernetes
   serviceKind: vmselect

--- a/addons/victoria-metrics/templates/cmpd-vmstorage.yaml
+++ b/addons/victoria-metrics/templates/cmpd-vmstorage.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "victoria-metrics.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: A VictoriaMetrics component definition for Kubernetes
   serviceKind: vmstorage

--- a/addons/weaviate/templates/cmpd.yaml
+++ b/addons/weaviate/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "weaviate.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Weaviate is an open source vector database that is robust, scalable, cloud-native, and fast.
   serviceKind: weaviate

--- a/addons/xinference/templates/cmpd.yaml
+++ b/addons/xinference/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "xinference.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: kubeblocks
   description: Xinference is a powerful and versatile library designed to serve language, speech recognition, and multimodal models.
   serviceKind: xinference

--- a/addons/yashandb/templates/cmpd.yaml
+++ b/addons/yashandb/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "yashandb.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: Community
   description: YashanDB is a new database system completely independently designed and developed by SICS.
   serviceKind: {{ .Chart.Name }}

--- a/addons/zookeeper/templates/cmpd.yaml
+++ b/addons/zookeeper/templates/cmpd.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- include "zookeeper.annotations" . | nindent 4 }}
 spec:
+  podUpdatePolicy: PreferInPlace
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}


### PR DESCRIPTION
## Summary

When `podUpdatePolicy` is not explicitly set in cmpd templates, the KubeBlocks operator defaults it to `PreferInPlace` after creation. This changes the `apps.kubeblocks.io/immutable-hash` annotation, causing the addon controller to mark ComponentDefinitions as Unavailable with `"immutable fields can't be updated"` on next reconciliation.

## Changes

Adds `podUpdatePolicy: PreferInPlace` to all 122 ComponentDefinition template files across all addons, ensuring the hash is stable from creation.

**Affected addons:** apecloud-mysql, clickhouse, elasticsearch, etcd, falkordb, greptimedb, influxdb, kafka, llm, loki, mariadb, milvus, minio, mogdb, mongodb, mysql, nebula, neo4j, neon, opensearch, orchestrator, orioledb, polardbx, postgresql, pulsar, qdrant, rabbitmq, redis, risingwave, rocketmq, starrocks-ce, tidb, vanilla-postgresql, victoria-metrics, weaviate, xinference, yashandb, zookeeper

## Verification

1. Install any addon (e.g. `helm upgrade -i kb-addon-rabbitmq kubeblocks-addons/rabbitmq -n kubeblocks-system`)
2. Check ComponentDefinition has `podUpdatePolicy: PreferInPlace` set: `kubectl get cmpd <name> -o yaml | grep podUpdatePolicy`
3. Verify hash remains stable across reconciliation cycles: `kubectl get cmpd <name> -o jsonpath='{.metadata.annotations.apps\.kubeblocks\.io/immutable-hash}'`

## Companion PR

- apecloud/kubeblocks#10095: zeros `PodUpdatePolicy`/`PodUpgradePolicy` in `cmpdHash()` (root cause fix in the hash function itself)