### PR TITLE
feat: elasticsearch use custom plugins to support cdc

### DIFF
--- a/addons-cluster/elasticsearch/templates/_helpers.tpl
+++ b/addons-cluster/elasticsearch/templates/_helpers.tpl
@@ -157,12 +157,6 @@ serviceRefs:
 
 {{- define "elasticsearch-cluster.envs" }}
 env:
-  - name: ELASTICSEARCH_MODE
-    {{- if .Values.remoteSetting.isStandby }}
-    value: "standby"
-    {{- else }}
-    value: "{{ .Values.mode }}"
-    {{- end }}
   {{- if .Values.remoteSetting.isStandby }}
   - name: ELASTICSEARCH_REPLAY_START_TIME_MS
     value: "{{ .Values.remoteSetting.replaySettings.startTimeMs }}"

--- a/addons-cluster/elasticsearch/templates/_helpers.tpl
+++ b/addons-cluster/elasticsearch/templates/_helpers.tpl
@@ -143,3 +143,30 @@ systemAccounts:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}
+
+{{- define "elasticsearch-cluster.remoteServiceRef" }}
+{{- if and .Values.remoteSetting.isStandby .Values.remoteSetting.primarySettings.host .Values.remoteSetting.primarySettings.port }}
+serviceRefs:
+- name: remote-instances
+  {{- if .Values.remoteSetting.primarySettings.serviceDescriptorNamespace }}
+  namespace: {{ .Values.remoteSetting.primarySettings.serviceDescriptorNamespace }}
+  {{- end }}
+  serviceDescriptor: {{ include "kblib.clusterName" . }}-remote-desc
+{{- end }}
+{{- end -}}
+
+{{- define "elasticsearch-cluster.envs" }}
+env:
+  - name: ELASTICSEARCH_MODE
+    {{- if .Values.remoteSetting.isStandby }}
+    value: "standby"
+    {{- else }}
+    value: "{{ .Values.mode }}"
+    {{- end }}
+  {{- if .Values.remoteSetting.isStandby }}
+  - name: ELASTICSEARCH_REPLAY_START_TIME_MS
+    value: "{{ .Values.remoteSetting.replaySettings.startTimeMs }}"
+  - name: ELASTICSEARCH_REPLAY_IS_START_AFTER_RUNNING
+    value: "{{ .Values.remoteSetting.replaySettings.isStartAfterRunning }}"
+  {{- end }}
+{{- end -}}

--- a/addons-cluster/elasticsearch/templates/cluster-multi-node.yaml
+++ b/addons-cluster/elasticsearch/templates/cluster-multi-node.yaml
@@ -22,6 +22,8 @@ spec:
       {{- include "kblib.componentStorages" $ | indent 6 }}
       {{- include "elasticsearch-cluster.tls" $ | indent 6 }}
       {{- include "elasticsearch-cluster.accounts" $ | indent 6 }}
+      {{- include "elasticsearch-cluster.remoteServiceRef" . | indent 6 }}
+      {{- include "elasticsearch-cluster.envs" . | indent 6 }}
     - name: data
       componentDef: elasticsearch-data-{{ include "elasticsearch.majorVersion" $ }}
       serviceVersion: {{ include "elasticsearch.version" $ }}
@@ -36,6 +38,8 @@ spec:
       {{- include "kblib.componentStorages" $ | indent 6 }}
       {{- include "elasticsearch-cluster.tls" $ | indent 6 }}
       {{- include "elasticsearch-cluster.accounts" $ | indent 6 }}
+      {{- include "elasticsearch-cluster.remoteServiceRef" . | indent 6 }}
+      {{- include "elasticsearch-cluster.envs" . | indent 6 }}
   {{- if .Values.enableKibana }}
     - name: kibana
       componentDef: kibana-{{ include "elasticsearch.majorVersion" . }}

--- a/addons-cluster/elasticsearch/templates/cluster-single-node.yaml
+++ b/addons-cluster/elasticsearch/templates/cluster-single-node.yaml
@@ -24,6 +24,8 @@ spec:
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- include "kblib.componentStorages" . | indent 6 }}
       {{- include "elasticsearch-cluster.accounts" . | indent 6 }}
+      {{- include "elasticsearch-cluster.remoteServiceRef" . | indent 6 }}
+      {{- include "elasticsearch-cluster.envs" . | indent 6 }}
   {{- if .Values.enableKibana }}
     - name: kibana
       componentDef: kibana-{{ include "elasticsearch.majorVersion" . }}

--- a/addons-cluster/elasticsearch/templates/remote-service-descriptor.yaml
+++ b/addons-cluster/elasticsearch/templates/remote-service-descriptor.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.remoteSetting.isStandby .Values.remoteSetting.primaryHost .Values.remoteSetting.primaryPort }}
+{{- if and .Values.remoteSetting.isStandby .Values.remoteSetting.primarySettings.host .Values.remoteSetting.primarySettings.port }}
 apiVersion: apps.kubeblocks.io/v1
 kind: ServiceDescriptor
 metadata:
   name: {{ include "kblib.clusterName" . }}-remote-desc
-  {{- if .Values.remoteSetting.serviceDescriptorNamespace }}
-  namespace: {{ .Values.remoteSetting.serviceDescriptorNamespace }}
+  {{- if .Values.remoteSetting.primarySettings.serviceDescriptorNamespace }}
+  namespace: {{ .Values.remoteSetting.primarySettings.serviceDescriptorNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -13,22 +13,22 @@ spec:
   serviceKind: elasticsearch
   serviceVersion: {{ .Values.version }}
   host:
-    value: "{{ .Values.remoteSetting.primaryHost }}"
+    value: "{{ .Values.remoteSetting.primarySettings.host }}"
   port:
-    value: "{{ .Values.remoteSetting.primaryPort }}"
-  {{- if and .Values.remoteSetting.standbyAccountSecret.name .Values.remoteSetting.standbyAccountSecret.userKey .Values.remoteSetting.standbyAccountSecret.passwordKey }}
+    value: "{{ .Values.remoteSetting.primarySettings.port }}"
+  {{- if and .Values.remoteSetting.primarySettings.accountSecret.name .Values.remoteSetting.primarySettings.accountSecret.userKey .Values.remoteSetting.primarySettings.accountSecret.passwordKey }}
   auth:
     username:
       valueFrom:
         secretKeyRef:
-          key: {{ .Values.remoteSetting.standbyAccountSecret.userKey }}
-          name: {{ .Values.remoteSetting.standbyAccountSecret.name }}
+          key: {{ .Values.remoteSetting.primarySettings.accountSecret.userKey }}
+          name: {{ .Values.remoteSetting.primarySettings.accountSecret.name }}
           optional: false
     password:
       valueFrom:
         secretKeyRef:
-          key: {{ .Values.remoteSetting.standbyAccountSecret.passwordKey }}
-          name: {{ .Values.remoteSetting.standbyAccountSecret.name }}
+          key: {{ .Values.remoteSetting.primarySettings.accountSecret.passwordKey }}
+          name: {{ .Values.remoteSetting.primarySettings.accountSecret.name }}
           optional: false
   {{- end }}
 {{- end }}

--- a/addons-cluster/elasticsearch/templates/remote-service-descriptor.yaml
+++ b/addons-cluster/elasticsearch/templates/remote-service-descriptor.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.remoteSetting.isStandby .Values.remoteSetting.primaryHost .Values.remoteSetting.primaryPort }}
+apiVersion: apps.kubeblocks.io/v1
+kind: ServiceDescriptor
+metadata:
+  name: {{ include "kblib.clusterName" . }}-remote-desc
+  {{- if .Values.remoteSetting.serviceDescriptorNamespace }}
+  namespace: {{ .Values.remoteSetting.serviceDescriptorNamespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
+spec:
+  serviceKind: elasticsearch
+  serviceVersion: {{ .Values.version }}
+  host:
+    value: "{{ .Values.remoteSetting.primaryHost }}"
+  port:
+    value: "{{ .Values.remoteSetting.primaryPort }}"
+  {{- if and .Values.remoteSetting.standbyAccountSecret.name .Values.remoteSetting.standbyAccountSecret.userKey .Values.remoteSetting.standbyAccountSecret.passwordKey }}
+  auth:
+    username:
+      valueFrom:
+        secretKeyRef:
+          key: {{ .Values.remoteSetting.standbyAccountSecret.userKey }}
+          name: {{ .Values.remoteSetting.standbyAccountSecret.name }}
+          optional: false
+    password:
+      valueFrom:
+        secretKeyRef:
+          key: {{ .Values.remoteSetting.standbyAccountSecret.passwordKey }}
+          name: {{ .Values.remoteSetting.standbyAccountSecret.name }}
+          optional: false
+  {{- end }}
+{{- end }}

--- a/addons-cluster/elasticsearch/values.yaml
+++ b/addons-cluster/elasticsearch/values.yaml
@@ -48,3 +48,19 @@ tls:
   kibanaAccountSecretName:
 
 enableKibana: true
+
+remoteSetting:
+  isStandby: false
+  replaySettings:
+    ## Whether to start replay immediately after successful startup
+    isStartAfterRunning: false
+    ## Start time of replay, unit: ms
+    startTimeMs: 0
+  primarySettings:
+    serviceDescriptorNamespace: ""
+    host: ""
+    port: ""
+    accountSecret:
+      name: ""
+      userKey: ""
+      passwordKey: ""

--- a/addons-cluster/elasticsearch/values.yaml
+++ b/addons-cluster/elasticsearch/values.yaml
@@ -59,8 +59,8 @@ remoteSetting:
   primarySettings:
     serviceDescriptorNamespace: ""
     host: ""
-    port: ""
+    port: "9200"
     accountSecret:
       name: ""
-      userKey: ""
-      passwordKey: ""
+      userKey: "username"
+      passwordKey: "password"

--- a/addons/elasticsearch/configs/elasticsearch-6.yml.tpl
+++ b/addons/elasticsearch/configs/elasticsearch-6.yml.tpl
@@ -70,6 +70,7 @@ network:
   publish_host: ${POD_IP}
 
 node:
+  #__CUSTOM_PLUGIN_EXTRA_CONFIGS__
   attr:
     k8s_node_name: ${NODE_NAME}
     {{- if eq $zoneAwareEnabled "true" }}

--- a/addons/elasticsearch/configs/elasticsearch-7.yml.tpl
+++ b/addons/elasticsearch/configs/elasticsearch-7.yml.tpl
@@ -73,6 +73,7 @@ network:
   publish_host: ${POD_IP}
 
 node:
+  #__CUSTOM_PLUGIN_EXTRA_CONFIGS__
   attr:
     k8s_node_name: ${NODE_NAME}
     {{- if eq $zoneAwareEnabled "true" }}

--- a/addons/elasticsearch/configs/elasticsearch-8.yml.tpl
+++ b/addons/elasticsearch/configs/elasticsearch-8.yml.tpl
@@ -68,6 +68,7 @@ network:
   publish_host: ${POD_IP}
 
 node:
+  #__CUSTOM_PLUGIN_EXTRA_CONFIGS__
   attr:
     k8s_node_name: ${NODE_NAME}
     {{- if eq $zoneAwareEnabled "true" }}

--- a/addons/elasticsearch/scripts/entrypoint.sh
+++ b/addons/elasticsearch/scripts/entrypoint.sh
@@ -70,35 +70,42 @@ if [ -f "${CLUSTER_FORMED_FILE}" ]; then
   sed -i '/# INITIAL_MASTER_NODES_BLOCK_START/,/# INITIAL_MASTER_NODES_BLOCK_END/d' config/elasticsearch.yml
 fi
 
-# keep replay config idempotent across restarts
-sed -i '/^node\.source_extract_start_time:/d' config/elasticsearch.yml
-sed -i '/^node\.source_extract_idx_host:/d' config/elasticsearch.yml
-sed -i '/^node\.source_extract_idx_user:/d' config/elasticsearch.yml
-sed -i '/^node\.source_extract_idx_password:/d' config/elasticsearch.yml
-sed -i '/^node\.source_extract_enabled:/d' config/elasticsearch.yml
-sed -i '/^node\.extract_idx_host:/d' config/elasticsearch.yml
-sed -i '/^node\.extract_idx_user:/d' config/elasticsearch.yml
-sed -i '/^node\.extract_idx_password:/d' config/elasticsearch.yml
+TMP_NODE_EXTRA_CONFIG=$(mktemp /tmp/es-node-extra-config.XXXXXX)
+: > "${TMP_NODE_EXTRA_CONFIG}"
 
 if [ "${ELASTICSEARCH_MODE}" = "standby" ] && [ -n "${REMOTE_PRIMARY_HOST}" ] && [ -n "${REMOTE_PRIMARY_PORT}" ] && [ -n "${ELASTICSEARCH_REPLAY_START_TIME_MS}" ]; then
   {
-    printf '\nnode.source_extract_start_time: %s\n' "${ELASTICSEARCH_REPLAY_START_TIME_MS}"
-    printf 'node.source_extract_idx_host: "%s:%s"\n' "${REMOTE_PRIMARY_HOST}" "${REMOTE_PRIMARY_PORT}"
-    printf 'node.source_extract_idx_user: "%s"\n' "${REMOTE_PRIMARY_USER:-}"
-    printf 'node.source_extract_idx_password: "%s"\n' "${REMOTE_PRIMARY_PASSWORD:-}"
+    printf '  source_extract_start_time: %s\n' "${ELASTICSEARCH_REPLAY_START_TIME_MS}"
+    printf '  source_extract_idx_host: "%s:%s"\n' "${REMOTE_PRIMARY_HOST}" "${REMOTE_PRIMARY_PORT}"
+    printf '  source_extract_idx_user: "%s"\n' "${REMOTE_PRIMARY_USER:-}"
+    printf '  source_extract_idx_password: "%s"\n' "${REMOTE_PRIMARY_PASSWORD:-}"
     if [ "${ELASTICSEARCH_REPLAY_IS_START_AFTER_RUNNING}" = "true" ]; then
-      printf 'node.source_extract_enabled: true\n'
+      printf '  source_extract_enabled: true\n'
     fi
-  } >> config/elasticsearch.yml
+  } >> "${TMP_NODE_EXTRA_CONFIG}"
 fi
 
-if [ -d plugins ] && [ -n "$(find plugins -mindepth 1 -maxdepth 1 -type d -name 'es-extract-*' -print -quit)" ]; then
+if [ -d /usr/share/elasticsearch/plugins ] && [ -n "$(find /usr/share/elasticsearch/plugins -mindepth 1 -maxdepth 1 -type d -name 'es-extract-*' -print -quit)" ]; then
   {
-    printf '\nnode.extract_idx_host: "%s:%s"\n' "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}"
-    printf 'node.extract_idx_user: "%s"\n' "${ELASTIC_USERNAME:-}"
-    printf 'node.extract_idx_password: "%s"\n' "${ELASTIC_PASSWORD:-}"
-  } >> config/elasticsearch.yml
+    printf '  extract_idx_host: "%s:%s"\n' "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT:-9200}"
+    printf '  extract_idx_user: "%s"\n' "${ELASTIC_USERNAME:-elastic}"
+    printf '  extract_idx_password: "%s"\n' "${ELASTIC_PASSWORD:-}"
+  } >> "${TMP_NODE_EXTRA_CONFIG}"
 fi
+
+if [ -s "${TMP_NODE_EXTRA_CONFIG}" ]; then
+  TMP_NODE_EXTRA_SED_SCRIPT=$(mktemp /tmp/es-node-extra-sed.XXXXXX)
+  {
+    printf '/^  #__CUSTOM_PLUGIN_EXTRA_CONFIGS__$/c\\\n'
+    sed 's/[\\&]/\\&/g; s/$/\\/' "${TMP_NODE_EXTRA_CONFIG}"
+  } > "${TMP_NODE_EXTRA_SED_SCRIPT}"
+  sed -i -f "${TMP_NODE_EXTRA_SED_SCRIPT}" config/elasticsearch.yml
+  rm -f "${TMP_NODE_EXTRA_SED_SCRIPT}"
+else
+  sed -i '/^  #__CUSTOM_PLUGIN_EXTRA_CONFIGS__$/d' config/elasticsearch.yml
+fi
+
+rm -f "${TMP_NODE_EXTRA_CONFIG}"
 
 if [ -f /bin/tini ]; then
   /bin/tini -- /usr/local/bin/docker-entrypoint.sh

--- a/addons/elasticsearch/scripts/entrypoint.sh
+++ b/addons/elasticsearch/scripts/entrypoint.sh
@@ -69,6 +69,37 @@ fi
 if [ -f "${CLUSTER_FORMED_FILE}" ]; then
   sed -i '/# INITIAL_MASTER_NODES_BLOCK_START/,/# INITIAL_MASTER_NODES_BLOCK_END/d' config/elasticsearch.yml
 fi
+
+# keep replay config idempotent across restarts
+sed -i '/^node\.source_extract_start_time:/d' config/elasticsearch.yml
+sed -i '/^node\.source_extract_idx_host:/d' config/elasticsearch.yml
+sed -i '/^node\.source_extract_idx_user:/d' config/elasticsearch.yml
+sed -i '/^node\.source_extract_idx_password:/d' config/elasticsearch.yml
+sed -i '/^node\.source_extract_enabled:/d' config/elasticsearch.yml
+sed -i '/^node\.extract_idx_host:/d' config/elasticsearch.yml
+sed -i '/^node\.extract_idx_user:/d' config/elasticsearch.yml
+sed -i '/^node\.extract_idx_password:/d' config/elasticsearch.yml
+
+if [ "${ELASTICSEARCH_MODE}" = "standby" ] && [ -n "${REMOTE_PRIMARY_HOST}" ] && [ -n "${REMOTE_PRIMARY_PORT}" ] && [ -n "${ELASTICSEARCH_REPLAY_START_TIME_MS}" ]; then
+  {
+    printf '\nnode.source_extract_start_time: %s\n' "${ELASTICSEARCH_REPLAY_START_TIME_MS}"
+    printf 'node.source_extract_idx_host: "%s:%s"\n' "${REMOTE_PRIMARY_HOST}" "${REMOTE_PRIMARY_PORT}"
+    printf 'node.source_extract_idx_user: "%s"\n' "${REMOTE_PRIMARY_USER:-}"
+    printf 'node.source_extract_idx_password: "%s"\n' "${REMOTE_PRIMARY_PASSWORD:-}"
+    if [ "${ELASTICSEARCH_REPLAY_IS_START_AFTER_RUNNING}" = "true" ]; then
+      printf 'node.source_extract_enabled: true\n'
+    fi
+  } >> config/elasticsearch.yml
+fi
+
+if [ -d plugins ] && [ -n "$(find plugins -mindepth 1 -maxdepth 1 -type d -name 'es-extract-*' -print -quit)" ]; then
+  {
+    printf '\nnode.extract_idx_host: "%s:%s"\n' "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}"
+    printf 'node.extract_idx_user: "%s"\n' "${ELASTIC_USERNAME:-}"
+    printf 'node.extract_idx_password: "%s"\n' "${ELASTIC_PASSWORD:-}"
+  } >> config/elasticsearch.yml
+fi
+
 if [ -f /bin/tini ]; then
   /bin/tini -- /usr/local/bin/docker-entrypoint.sh
 elif [ -f /tini ]; then

--- a/addons/elasticsearch/scripts/entrypoint.sh
+++ b/addons/elasticsearch/scripts/entrypoint.sh
@@ -73,7 +73,7 @@ fi
 TMP_NODE_EXTRA_CONFIG=$(mktemp /tmp/es-node-extra-config.XXXXXX)
 : > "${TMP_NODE_EXTRA_CONFIG}"
 
-if [ "${ELASTICSEARCH_MODE}" = "standby" ] && [ -n "${REMOTE_PRIMARY_HOST}" ] && [ -n "${REMOTE_PRIMARY_PORT}" ] && [ -n "${ELASTICSEARCH_REPLAY_START_TIME_MS}" ]; then
+if [ -n "${REMOTE_PRIMARY_HOST}" ] && [ -n "${REMOTE_PRIMARY_PORT}" ] && [ -n "${ELASTICSEARCH_REPLAY_START_TIME_MS}" ]; then
   {
     printf '  source_extract_start_time: %s\n' "${ELASTICSEARCH_REPLAY_START_TIME_MS}"
     printf '  source_extract_idx_host: "%s:%s"\n' "${REMOTE_PRIMARY_HOST}" "${REMOTE_PRIMARY_PORT}"

--- a/addons/elasticsearch/templates/_helpers.tpl
+++ b/addons/elasticsearch/templates/_helpers.tpl
@@ -377,6 +377,24 @@ runtime:
       volumeMounts:
         - mountPath: /mnt/local-bin
           name: local-bin
+    - name: install-custom-plugins
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command:
+        - sh
+        - -c
+        - |
+          /plugins/pick-plugins.sh all $ELASTICSEARCH_VERSION /mnt/local-plugins
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+      volumeMounts:
+        - mountPath: /mnt/local-plugins
+          name: local-plugins 
   containers:
     - name: elasticsearch
       imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -771,3 +789,45 @@ runtime:
   securityContext:
     fsGroup: 1000
 {{- end }}
+
+{{- define "elasticsearch.commonVars" -}}
+- name: ELASTICSEARCH_VERSION
+  valueFrom:
+    componentVarRef:
+      optional: false
+      serviceVersion: Required
+- name: REMOTE_PRIMARY_HOST
+  valueFrom:
+    serviceRefVarRef:
+      name: remote-instances
+      optional: true
+      host: Required
+- name: REMOTE_PRIMARY_PORT
+  valueFrom:
+    serviceRefVarRef:
+      name: remote-instances
+      optional: true
+      port: Required
+- name: REMOTE_PRIMARY_USER
+  valueFrom:
+    serviceRefVarRef:
+      name: remote-instances
+      optional: true
+      username: Optional
+- name: REMOTE_PRIMARY_PASSWORD
+  valueFrom:
+    serviceRefVarRef:
+      name: remote-instances
+      optional: true
+      password: Optional
+{{- end -}}
+
+{{- define "elasticsearch.remoteServiceRef" }}
+{{- if and .Values.remoteSetting.isStandby .Values.remoteSetting.primarySettings.host .Values.remoteSetting.primarySettings.port }}
+serviceRefDeclarations:
+- name: remote-instances
+  serviceRefDeclarationSpecs:
+    - serviceKind: elasticsearch
+      serviceVersion: "^*"
+{{- end }}
+{{- end -}}

--- a/addons/elasticsearch/templates/_helpers.tpl
+++ b/addons/elasticsearch/templates/_helpers.tpl
@@ -327,6 +327,24 @@ runtime:
       volumeMounts:
         - mountPath: /tmp/plugins
           name: plugins
+    - name: prepare-custom-plugins
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command:
+        - sh
+        - -c
+        - |
+          /plugins/pick-plugins.sh all $ELASTICSEARCH_VERSION /mnt/local-plugins
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+      volumeMounts:
+        - mountPath: /mnt/local-plugins
+          name: local-plugins       
     - name: install-plugins
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command:
@@ -377,24 +395,6 @@ runtime:
       volumeMounts:
         - mountPath: /mnt/local-bin
           name: local-bin
-    - name: install-custom-plugins
-      imagePullPolicy: {{ .Values.image.pullPolicy }}
-      command:
-        - sh
-        - -c
-        - |
-          /plugins/pick-plugins.sh all $ELASTICSEARCH_VERSION /mnt/local-plugins
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
-        privileged: false
-        runAsNonRoot: true
-        runAsUser: 1000
-      volumeMounts:
-        - mountPath: /mnt/local-plugins
-          name: local-plugins 
   containers:
     - name: elasticsearch
       imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -796,6 +796,10 @@ runtime:
     componentVarRef:
       optional: false
       serviceVersion: Required
+- name: ELASTICSEARCH_PORT
+  value: "9200"
+- name: ELASTIC_USERNAME
+  value: "elastic"
 - name: REMOTE_PRIMARY_HOST
   valueFrom:
     serviceRefVarRef:
@@ -823,11 +827,10 @@ runtime:
 {{- end -}}
 
 {{- define "elasticsearch.remoteServiceRef" }}
-{{- if and .Values.remoteSetting.isStandby .Values.remoteSetting.primarySettings.host .Values.remoteSetting.primarySettings.port }}
 serviceRefDeclarations:
 - name: remote-instances
   serviceRefDeclarationSpecs:
     - serviceKind: elasticsearch
       serviceVersion: "^*"
-{{- end }}
+  optional: true
 {{- end -}}

--- a/addons/elasticsearch/templates/cmpd-es-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-6.yaml
@@ -15,12 +15,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-7.yaml
@@ -15,12 +15,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-8.yaml
@@ -15,12 +15,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-data-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-data-6.yaml
@@ -18,12 +18,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-data-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-data-7.yaml
@@ -18,12 +18,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-data-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-data-8.yaml
@@ -18,12 +18,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-master-6.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-master-6.yaml
@@ -15,12 +15,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-master-7.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-master-7.yaml
@@ -15,12 +15,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpd-es-master-8.yaml
+++ b/addons/elasticsearch/templates/cmpd-es-master-8.yaml
@@ -15,12 +15,9 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: es-cm
       restartOnFileChange: true
+  {{ include "elasticsearch.remoteServiceRef" . | nindent 2 }}
   vars:
-    - name: ELASTICSEARCH_VERSION
-      valueFrom:
-        componentVarRef:
-          optional: false
-          serviceVersion: Required
+    {{ include "elasticsearch.commonVars" . | nindent 4 }}  
     - name: ELASTIC_USER_PASSWORD
       valueFrom:
         credentialVarRef:

--- a/addons/elasticsearch/templates/cmpv-es.yaml
+++ b/addons/elasticsearch/templates/cmpv-es.yaml
@@ -33,6 +33,7 @@ spec:
       memberleave: {{ $imageRegistry }}/{{ $.Values.image.tools.repository }}:{{ $.Values.image.tools.tag }}
       install-es-agent: {{ $imageRegistry }}/{{ $.Values.image.agent.repository }}:{{ $.Values.image.agent.tag }}
       es-agent: {{ $imageRegistry }}/{{ $.Values.image.repository }}:{{ index . 2 }}
+      install-custom-plugins: {{ $imageRegistry }}/{{ $.Values.image.custom-plugins.repository }}:{{ $.Values.image.custom-plugins.tag }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/addons/elasticsearch/templates/cmpv-es.yaml
+++ b/addons/elasticsearch/templates/cmpv-es.yaml
@@ -33,7 +33,7 @@ spec:
       memberleave: {{ $imageRegistry }}/{{ $.Values.image.tools.repository }}:{{ $.Values.image.tools.tag }}
       install-es-agent: {{ $imageRegistry }}/{{ $.Values.image.agent.repository }}:{{ $.Values.image.agent.tag }}
       es-agent: {{ $imageRegistry }}/{{ $.Values.image.repository }}:{{ index . 2 }}
-      install-custom-plugins: {{ $imageRegistry }}/{{ $.Values.image.custom-plugins.repository }}:{{ $.Values.image.custom-plugins.tag }}
+      prepare-custom-plugins: {{ $imageRegistry }}/{{ $.Values.image.customPlugins.repository }}:{{ $.Values.image.customPlugins.tag }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/addons/elasticsearch/values.yaml
+++ b/addons/elasticsearch/values.yaml
@@ -28,7 +28,7 @@ image:
   tools:
     repository: apecloud/curl-jq
     tag: 0.1.0
-  custom-plugins:
+  customPlugins:
     repository: apecloud/elasticsearch-custom-plugins
     tag: 0.1.0
   kibana:

--- a/addons/elasticsearch/values.yaml
+++ b/addons/elasticsearch/values.yaml
@@ -28,6 +28,9 @@ image:
   tools:
     repository: apecloud/curl-jq
     tag: 0.1.0
+  custom-plugins:
+    repository: apecloud/elasticsearch-custom-plugins
+    tag: 0.1.0
   kibana:
     repository: apecloud/kibana
     tag: "8.8.2"


### PR DESCRIPTION
This PR adds a new init container in the Elasticsearch component definition to initialize custom plugins.

  Current support is limited to these Elasticsearch versions:
  - `8.15.5`
  - `7.10.2`
  - `6.8.23`

  For unsupported versions, the custom plugin will not be loaded.

  Two plugin types are introduced:
  - `extract`: records events
  - `sink`: replays data based on events produced by `extract`

  Both plugins support dynamic enable/disable via configuration.

  A disaster recovery Elasticsearch instance can be initialized through `remoteSetting`, for example:

  ```yaml
  remoteSetting:
    isStandby: false
    replaySettings:
      ## Whether to start replay immediately after successful startup
      isStartAfterRunning: false
      ## Start time of replay, unit: ms
      startTimeMs: 0
    primarySettings:
      serviceDescriptorNamespace: ""
      host: ""
      port: "9200"
      accountSecret:
        name: ""
        userKey: "username"
        passwordKey: "password"
```

  Related:

  - elasticsearch-cdc [doc](https://infracreate.feishu.cn/docx/EVJbdgRsZobIXnxA9VDcSvYWng9?from=from_copylink): https://github.com/apecloud/elasticsearch-cdc
  - custom plugins image: https://github.com/apecloud/containers/pull/113
