### PR TITLE
[Feature] add TLS support for qdrant

### DIFF
--- a/addons/qdrant/scripts/qdrant-backup.sh
+++ b/addons/qdrant/scripts/qdrant-backup.sh
@@ -23,8 +23,15 @@ function save_backup_size() {
     echo "{\"totalSize\":\"$TOTAL_SIZE\"}" >"${DP_BACKUP_INFO_FILE}"
 }
 
-endpoint=http://${DP_DB_HOST}:6333
-collectionRes=$(curl ${endpoint}/collections)
+if [ "${TLS_ENABLED:-}" = "true" ]; then
+  endpoint=https://${DP_DB_HOST}:6333
+  CURL_TLS="-k"
+else
+  endpoint=http://${DP_DB_HOST}:6333
+  CURL_TLS=""
+fi
+
+collectionRes=$(curl $CURL_TLS ${endpoint}/collections)
 collections=$(echo ${collectionRes}  | jq -r '.result.collections[].name')
 if [ -z $collections ]; then
    save_backup_size
@@ -33,15 +40,15 @@ fi
 # snapshot all collections
 for c in ${collections}; do
   echo "INFO: start to snapshot collection ${c}..."
-  snapshot=$(curl -XPOST ${endpoint}/collections/${c}/snapshots)
+  snapshot=$(curl $CURL_TLS -XPOST ${endpoint}/collections/${c}/snapshots)
   status=$(echo ${snapshot} | jq '.status')
   if [ "${status}" != "ok" ] && [ "${status}" != "\"ok\"" ]; then
     echo "backup failed, status: ${status}"
     exit 1
   fi
   name=$(echo ${snapshot} | jq -r '.result.name')
-  curl -v --fail-with-body ${endpoint}/collections/${c}/snapshots/${name} | datasafed push - "/${c}.snapshot"
-  curl -XDELETE ${endpoint}/collections/${c}/snapshots/${name}
+  curl $CURL_TLS -v --fail-with-body ${endpoint}/collections/${c}/snapshots/${name} | datasafed push - "/${c}.snapshot"
+  curl $CURL_TLS -XDELETE ${endpoint}/collections/${c}/snapshots/${name}
   echo "INFO: snapshot collection ${c} successfully."
 done
 save_backup_size

--- a/addons/qdrant/scripts/qdrant-member-leave.sh
+++ b/addons/qdrant/scripts/qdrant-member-leave.sh
@@ -15,20 +15,28 @@ load_common_library() {
 load_common_library
 current_pod_fqdn=$(get_target_pod_fqdn_from_pod_fqdn_vars "$QDRANT_POD_FQDN_LIST" "$CURRENT_POD_NAME")
 
-curl http://${current_pod_fqdn}:6333/cluster | grep $KB_LEAVE_MEMBER_POD_NAME
+if [ "${TLS_ENABLED:-}" = "true" ]; then
+  SCHEME="https"
+  CURL_TLS="-k"
+else
+  SCHEME="http"
+  CURL_TLS=""
+fi
+
+curl $CURL_TLS ${SCHEME}://${current_pod_fqdn}:6333/cluster | grep $KB_LEAVE_MEMBER_POD_NAME
 # if the member is not in the cluster, exit directly
 if [ $? -ne 0 ]; then
   echo "member ${KB_LEAVE_MEMBER_POD_NAME} is not in the cluster"
   exit 0
 fi
 
-leave_peer_uri=http://${KB_LEAVE_MEMBER_POD_FQDN}:6333
-cluster_info=`curl -s ${leave_peer_uri}/cluster`
+leave_peer_uri=${SCHEME}://${KB_LEAVE_MEMBER_POD_FQDN}:6333
+cluster_info=`curl $CURL_TLS -s ${leave_peer_uri}/cluster`
 leave_peer_id=`echo "${cluster_info}"| jq -r .result.peer_id`
 leader_peer_id=`echo "${cluster_info}" | jq -r .result.raft_info.leader`
 
 move_shards() {
-    cols=`curl -s ${leave_peer_uri}/collections`
+    cols=`curl $CURL_TLS -s ${leave_peer_uri}/collections`
     col_count=`echo ${cols} | jq -r '.result.collections | length'`
     if [[ ${col_count} -eq 0 ]]; then
         echo "no collections found in the cluster"
@@ -36,7 +44,7 @@ move_shards() {
     fi
     col_names=`echo ${cols} | jq -r '.result.collections[].name'`
     for col_name in ${col_names}; do
-        col_cluster_info=`curl -s ${leave_peer_uri}/collections/${col_name}/cluster`
+        col_cluster_info=`curl $CURL_TLS -s ${leave_peer_uri}/collections/${col_name}/cluster`
         col_shard_count=`echo ${col_cluster_info} | jq -r '.result.local_shards[] | length'`
         if [[ ${col_shard_count} -eq 0 ]]; then
             echo "no shards found in collection ${col_name}"
@@ -46,13 +54,13 @@ move_shards() {
         leave_shard_ids=`echo ${col_cluster_info} | jq -r '.result.local_shards[].shard_id'`
         for shard_id in ${leave_shard_ids}; do
             echo "move shard ${shard_id} in col_name ${col_name} from ${leave_peer_id} to ${leader_peer_id}"
-            curl -s -X POST -H "Content-Type: application/json" \
+            curl $CURL_TLS -s -X POST -H "Content-Type: application/json" \
                 -d '{"move_shard":{"shard_id": '${shard_id}',"to_peer_id": '${leader_peer_id}',"from_peer_id": '${leave_peer_id}}}'' \
                 ${leave_peer_uri}/collections/${col_name}/cluster
         done
 
         while true; do
-            col_cluster_info=`curl -s ${leave_peer_uri}/collections/${col_name}/cluster`
+            col_cluster_info=`curl $CURL_TLS -s ${leave_peer_uri}/collections/${col_name}/cluster`
             leave_shard_ids=`echo ${col_cluster_info} | jq -r '.result.local_shards[].shard_id'`
             if [ -z "${leave_shard_ids}" ]; then
                 echo "all shards in collection ${col_name} has been moved"
@@ -65,7 +73,7 @@ move_shards() {
 
 remove_peer() {
     echo "remove peer ${leave_peer_id} from cluster"
-    curl -v -XDELETE ${leave_peer_uri}/cluster/peer/${leave_peer_id}
+    curl $CURL_TLS -v -XDELETE ${leave_peer_uri}/cluster/peer/${leave_peer_id}
 }
 
 leave_member() {

--- a/addons/qdrant/scripts/qdrant-restore.sh
+++ b/addons/qdrant/scripts/qdrant-restore.sh
@@ -5,6 +5,14 @@ set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
+if [ "${TLS_ENABLED:-}" = "true" ]; then
+  QDRANT_SCHEME=https
+  CURL_TLS="-k"
+else
+  QDRANT_SCHEME=http
+  CURL_TLS=""
+fi
+
 SNAPSHOT_DIR="${DATA_DIR}/_dp_snapshots"
 mkdir -p "${SNAPSHOT_DIR}"
 for snapshot in $(datasafed list /) ; do
@@ -18,7 +26,7 @@ for snapshot in $(datasafed list /) ; do
   datasafed pull "${snapshot}" "${SNAPSHOT_DIR}/${snapshot}"
 
   while true; do
-    curl -X POST "http://${DP_DB_HOST}:6333/collections/${collection_name}/snapshots/upload?priority=snapshot" \
+    curl $CURL_TLS -X POST "${QDRANT_SCHEME}://${DP_DB_HOST}:6333/collections/${collection_name}/snapshots/upload?priority=snapshot" \
       -H 'Content-Type:multipart/form-data' \
       -F "snapshot=@${SNAPSHOT_DIR}/${snapshot}" > /tmp/qdrant-restore.log 2>&1
     if grep -q '"status":"ok"' /tmp/qdrant-restore.log; then

--- a/addons/qdrant/scripts/qdrant-setup.sh
+++ b/addons/qdrant/scripts/qdrant-setup.sh
@@ -23,13 +23,37 @@ load_common_library
 current_pod_fqdn=$(get_target_pod_fqdn_from_pod_fqdn_vars "$QDRANT_POD_FQDN_LIST" "$CURRENT_POD_NAME")
 boostrap_node_fqdn=$(get_boostrap_node)
 
+# TLS setup
+if [ "${TLS_ENABLED:-}" = "true" ]; then
+  cat > /tmp/tls.yaml <<EOF
+service:
+  enable_tls: true
+
+tls:
+  cert: ${TLS_MOUNT_PATH}/tls.crt
+  key: ${TLS_MOUNT_PATH}/tls.key
+  ca_cert: ${TLS_MOUNT_PATH}/ca.crt
+
+cluster:
+  p2p:
+    enable_tls: true
+EOF
+  TLS_CONFIG_ARG="--config-path /tmp/tls.yaml"
+  SCHEME="https"
+  CURL_TLS="-k"
+else
+  TLS_CONFIG_ARG=""
+  SCHEME="http"
+  CURL_TLS=""
+fi
+
 if [ "$current_pod_fqdn" == "$boostrap_node_fqdn" ]; then
-  exec ./qdrant --uri "http://${current_pod_fqdn}:6335"
+  exec ./qdrant --uri "${SCHEME}://${current_pod_fqdn}:6335" $TLS_CONFIG_ARG
 else
   echo "BOOTSTRAP_HOSTNAME: ${boostrap_node_fqdn}"
-  until ./tools/curl http://${boostrap_node_fqdn}:6333/cluster; do
+  until ./tools/curl $CURL_TLS ${SCHEME}://${boostrap_node_fqdn}:6333/cluster; do
     echo "INFO: wait for bootstrap node starting..."
     sleep 1;
   done
-  exec ./qdrant --bootstrap "http://${boostrap_node_fqdn}:6335" --uri "http://${current_pod_fqdn}:6335"
+  exec ./qdrant --bootstrap "${SCHEME}://${boostrap_node_fqdn}:6335" --uri "${SCHEME}://${current_pod_fqdn}:6335" $TLS_CONFIG_ARG
 fi

--- a/addons/qdrant/templates/cmpd.yaml
+++ b/addons/qdrant/templates/cmpd.yaml
@@ -13,6 +13,12 @@ spec:
   serviceKind: qdrant
   updateStrategy: BestEffortParallel
   minReadySeconds: 10
+  tls:
+    volumeName: tls
+    mountPath: {{ .Values.tlsMountPath }}
+    caFile: ca.crt
+    certFile: tls.crt
+    keyFile: tls.key
   services:
   - name: qdrant
     serviceName: qdrant
@@ -56,6 +62,13 @@ spec:
       valueFrom:
         clusterVarRef:
           namespace: Required
+    - name: TLS_ENABLED
+      valueFrom:
+        tlsVarRef:
+          enabled: Optional
+          optional: true
+    - name: TLS_MOUNT_PATH
+      value: {{ .Values.tlsMountPath }}
   lifecycleActions:
     memberLeave:
       exec:
@@ -91,11 +104,15 @@ spec:
       securityContext:
         runAsUser: 0
       livenessProbe:
+        exec:
+          command:
+          - /bin/sh
+          - -c
+          - |
+            scheme=http; tlsArgs=""
+            [ "${TLS_ENABLED}" = "true" ] && scheme=https && tlsArgs="-k"
+            /qdrant/tools/curl -sf $tlsArgs ${scheme}://localhost:6333/ > /dev/null
         failureThreshold: 3
-        httpGet:
-          path: /
-          port: tcp-qdrant
-          scheme: HTTP
         periodSeconds: 15
         successThreshold: 1
         timeoutSeconds: 10
@@ -105,7 +122,9 @@ spec:
           - /bin/sh
           - -c
           - |
-            consensus_status=`/qdrant/tools/curl -s http://localhost:6333/cluster | /qdrant/tools/jq -r .result.consensus_thread_status.consensus_thread_status`
+            scheme=http; tlsArgs=""
+            [ "${TLS_ENABLED}" = "true" ] && scheme=https && tlsArgs="-k"
+            consensus_status=$(/qdrant/tools/curl -sf $tlsArgs ${scheme}://localhost:6333/cluster | /qdrant/tools/jq -r .result.consensus_thread_status.consensus_thread_status)
             if [ "$consensus_status" != "working" ]; then
               echo "consensus stopped"
               exit 1
@@ -116,11 +135,15 @@ spec:
         successThreshold: 1
         timeoutSeconds: 3
       startupProbe:
+        exec:
+          command:
+          - /bin/sh
+          - -c
+          - |
+            scheme=http; tlsArgs=""
+            [ "${TLS_ENABLED}" = "true" ] && scheme=https && tlsArgs="-k"
+            /qdrant/tools/curl -sf $tlsArgs ${scheme}://localhost:6333/ > /dev/null
         failureThreshold: 60
-        httpGet:
-          path: /
-          port: tcp-qdrant
-          scheme: HTTP
         periodSeconds: 30
         successThreshold: 1
         timeoutSeconds: 3
@@ -157,6 +180,10 @@ spec:
           fieldRef:
             apiVersion: v1
             fieldPath: metadata.name
+      - name: TLS_ENABLED
+        value: "$(TLS_ENABLED)"
+      - name: TLS_MOUNT_PATH
+        value: {{ .Values.tlsMountPath | quote }}
     dnsPolicy: ClusterFirst
     enableServiceLinks: true
     volumes:

--- a/addons/qdrant/values.yaml
+++ b/addons/qdrant/values.yaml
@@ -42,4 +42,6 @@ debugEnabled: true
 
 dataMountPath: /qdrant/storage
 
+tlsMountPath: /qdrant/tls
+
 clusterDomain: "cluster.local"


### PR DESCRIPTION
- Add TLS spec to ComponentDefinition (volumeName, mountPath, ca/cert/key files)
- Expose TLS_ENABLED and TLS_MOUNT_PATH env vars via tlsVarRef
- Replace httpGet liveness/startup probes with exec-based curl to support HTTPS
- Update readiness probe to use scheme/tlsArgs based on TLS_ENABLED
- Update all scripts (setup, backup, restore, member-leave) to use HTTPS and -k when TLS_ENABLED=true
- Generate /tmp/tls.yaml config for qdrant service/cluster p2p TLS in setup script
- Add tlsMountPath to values.yaml (default: /qdrant/tls)