### PR TITLE
chore: upgrade es cmpv customPlugins default version

### DIFF
--- a/addons/elasticsearch/values.yaml
+++ b/addons/elasticsearch/values.yaml
@@ -30,7 +30,7 @@ image:
     tag: 0.1.0
   customPlugins:
     repository: apecloud/elasticsearch-custom-plugins
-    tag: 0.1.0
+    tag: 0.1.2
   kibana:
     repository: apecloud/kibana
     tag: "8.8.2"


### PR DESCRIPTION
upgrade default customPlugins version from 0.1.0 to 0.1.2

manually pick up to 1.0