### PR TITLE
fix(valkey): fan out dynamic reconfigure actions

### DIFF
--- a/addons/valkey/templates/_helpers.tpl
+++ b/addons/valkey/templates/_helpers.tpl
@@ -97,6 +97,7 @@ any future versions can include it identically.
 reconfigure:
   exec:
     container: valkey
+    targetPodSelector: All
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## What this PR does

Fans out Valkey dynamic reconfigure actions to all component pods by setting:

```yaml
reconfigure:
  exec:
    targetPodSelector: All
```

Fixes #2602.

## Why

Valkey `CONFIG SET maxmemory-policy` is process-local. It is not automatically replicated from the primary to replicas, so dynamic reconfigure needs every data pod to execute the reload action.

This addon change is intended to pair with the KubeBlocks controller-side action parameter alias fix:

- https://github.com/apecloud/kubeblocks/issues/10180
- https://github.com/apecloud/kubeblocks/pull/10181

The controller provides both `maxmemory-policy` and `MAXMEMORY_POLICY`; the addon fans the action out to every pod.

## Validation

Local chart checks:

```text
helm dependency build addons/valkey
helm lint addons/valkey
helm template valkey-pr addons/valkey
```

Rendered output includes `targetPodSelector: All` for the Valkey reconfigure action.

Repeated R08a-only validation passed 3 consecutive samples with controller-side alias plus this addon fan-out behavior, with no runtime closure check:

```text
controller image: apecloud/kubeblocks:release-1.1-controller-side-alias-20260426-195333
imageID: sha256:bc6246f747c9f7d4c42fee842e38393e28e4c9f4c177914292582e2217fcc221
addon: kb-addon-valkey revision 55
addon shape: targetPodSelector: All=yes, runtime closure check=no, rendered fallback=no
artifact root: /tmp/valkey-alias-fanout-no-runtime-closure-repeated-000106
```

| Round | Sample | OpsRequest | ComponentParameter | Pre runtime | Post-immediate runtime | Post-settle(60s) runtime |
|---|---|---|---|---|---|---|
| 1 | `valkey-178-r1-000106 / vlk-v178-r1-000106` | `Succeed` | `Finished` | `3/3 volatile-lru` | `3/3 allkeys-lru` | `3/3 allkeys-lru` |
| 2 | `valkey-178-r2-000703 / vlk-v178-r2-000703` | `Succeed` | `Finished` | `3/3 volatile-lru` | `3/3 allkeys-lru` | `3/3 allkeys-lru` |
| 3 | `valkey-178-r3-001126 / vlk-v178-r3-001126` | `Succeed` | `Finished` | `3/3 volatile-lru` | `3/3 allkeys-lru` | `3/3 allkeys-lru` |

Scope note: this validates the R08a repeated happy path. Additional switchover / pod restart / chaos coverage should remain part of broader addon regression.
