### PR TITLE
fix(valkey): switchover scripts iterate stale POD_FQDN_LIST after scale-out

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -571,6 +571,21 @@ Describe "Valkey Switchover Bash Script Tests"
       End
     End
 
+    Context "when fresh scale-out candidate is absent from stale VALKEY_POD_FQDN_LIST"
+      It "still biases and restores the requested candidate"
+        export VALKEY_POD_FQDN_LIST="valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local"
+        get_role() { echo "slave"; }
+        set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
+        wait_sentinel_sees_priority() { return 1; }
+        execute_sentinel_failover() { echo "SHOULD_NOT_BE_CALLED"; }
+        When call switchover_with_sentinel "valkey-3.headless.default.svc.cluster.local"
+        The status should be failure
+        The stdout should include "SET_PRIO:valkey-3.headless.default.svc.cluster.local:1"
+        The stdout should include "SET_PRIO:valkey-3.headless.default.svc.cluster.local:100"
+        The stdout should not include "SHOULD_NOT_BE_CALLED"
+      End
+    End
+
     Context "when candidate role is unknown (get_role returns empty — transient network issue)"
       It "logs a warning and proceeds to call Sentinel (does not abort)"
         get_role() { echo ""; }
@@ -597,6 +612,28 @@ Describe "Valkey Switchover Bash Script Tests"
         The status should be success
         The stdout should include "Biasing"
         The stderr should eq ""
+      End
+    End
+
+    Context "when get_role returns empty on first try but slave on second (transient — retry succeeds)"
+      It "proceeds without the unknown-role warning"
+        _get_role_calls_file="${SHELLSPEC_TMPBASE}/get-role-calls"
+        printf '0' > "${_get_role_calls_file}"
+        get_role() {
+          local calls
+          calls=$(cat "${_get_role_calls_file}")
+          calls=$((calls + 1))
+          printf '%s' "${calls}" > "${_get_role_calls_file}"
+          [ "${calls}" -ge 2 ] && echo "slave" || echo ""
+        }
+        set_replica_priority() { return 0; }
+        wait_sentinel_sees_priority() { return 0; }
+        execute_sentinel_failover() { echo "OK"; return 0; }
+        wait_for_new_master() { return 0; }
+        When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "Biasing"
+        The stderr should not include "WARNING"
       End
     End
 
@@ -838,6 +875,22 @@ Describe "Valkey Switchover Bash Script Tests"
       End
     End
 
+    Context "when fresh expected candidate is absent from stale VALKEY_POD_FQDN_LIST"
+      It "still confirms the candidate by appending the action-time FQDN"
+        export VALKEY_POD_FQDN_LIST="valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local,valkey-2.headless.default.svc.cluster.local"
+        get_role() {
+          case "$1" in
+            *"valkey-3"*) echo "master" ;;
+            *) echo "slave" ;;
+          esac
+        }
+        When call wait_for_new_master "valkey-3.headless.default.svc.cluster.local" "valkey-0.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "New primary confirmed"
+        The stdout should include "valkey-3"
+      End
+    End
+
     Context "when no new master appears within max_wait (simulated via small limit)"
       It "returns failure with a WARNING"
         get_role() { echo "slave"; }
@@ -964,6 +1017,35 @@ Describe "Valkey Switchover Bash Script Tests"
         The stdout should include "SET_PRIO:valkey-0.headless.default.svc.cluster.local:100"
         The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:100"
         The stdout should not include "SHOULD_NOT_BE_CALLED"
+      End
+    End
+
+    Context "when successful candidate is absent from stale VALKEY_POD_FQDN_LIST"
+      It "restores the requested candidate after wait_for_new_master"
+        restore_order=""
+        export VALKEY_POD_FQDN_LIST="valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local"
+        get_role() { echo "slave"; }
+        set_replica_priority() {
+          if [ -z "${wfnm_done:-}" ]; then
+            restore_order="${restore_order}bias:${1}:${2}|"
+          else
+            restore_order="${restore_order}restore:${1}:${2}|"
+          fi
+          echo "SET_PRIO:${1}:${2}"
+          return 0
+        }
+        wait_sentinel_sees_priority() { return 0; }
+        execute_sentinel_failover() { echo "OK"; return 0; }
+        wait_for_new_master() {
+          wfnm_done=1
+          restore_order="${restore_order}wfnm|"
+          return 0
+        }
+        When call switchover_with_sentinel "valkey-3.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "SET_PRIO:valkey-3.headless.default.svc.cluster.local:1"
+        The variable restore_order should include "restore:valkey-3.headless.default.svc.cluster.local:100|"
+        The variable restore_order should include "wfnm|restore:valkey-0.headless.default.svc.cluster.local:100|"
       End
     End
   End

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -125,6 +125,31 @@ pick_any_secondary() {
   echo ""
 }
 
+pod_fqdns_with_candidate() {
+  # VALKEY_POD_FQDN_LIST is rendered into pod environment at pod creation time.
+  # After scale-out, old primary pods can still have a stale list that does not
+  # include the fresh candidate. KB_SWITCHOVER_CANDIDATE_FQDN is injected at
+  # action time, so append it here for targeted switchover bookkeeping.
+  local candidate_fqdn="${1}"
+  local result="${VALKEY_POD_FQDN_LIST:-}"
+  if is_empty "${candidate_fqdn}"; then
+    echo "${result}"
+    return 0
+  fi
+
+  local candidate_pod="${candidate_fqdn%%.*}"
+  IFS=',' read -ra pod_fqdns <<< "${result}"
+  for fqdn in "${pod_fqdns[@]}"; do
+    [ "${fqdn%%.*}" = "${candidate_pod}" ] && echo "${result}" && return 0
+  done
+
+  if is_empty "${result}"; then
+    echo "${candidate_fqdn}"
+  else
+    echo "${result},${candidate_fqdn}"
+  fi
+}
+
 # ── Sentinel-based switchover ────────────────────────────────────────────────
 
 sentinel_cli_for() {
@@ -238,7 +263,7 @@ wait_for_new_master() {
   local max_wait=300 elapsed=0
 
   while [ "${elapsed}" -lt "${max_wait}" ]; do
-    IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
+    IFS=',' read -ra pod_fqdns <<< "$(pod_fqdns_with_candidate "${expected_fqdn}")"
     for fqdn in "${pod_fqdns[@]}"; do
       local role
       role=$(get_role "${fqdn}") || continue
@@ -299,7 +324,7 @@ switchover_with_sentinel() {
     # Set candidate priority to 1 (best), all others to 100 (lowest).
     # If priority cannot be set (e.g. transient TLS connection failure), log a
     # warning and continue without bias — Sentinel will still elect a new primary.
-    IFS=',' read -ra all_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
+    IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
     for fqdn in "${all_fqdns[@]}"; do
       # Append "." so "valkey-1." is not a substring of "valkey-11.headless..." (substring false positive).
       if contains "${fqdn}" "${candidate_fqdn%%.*}."; then
@@ -320,7 +345,7 @@ switchover_with_sentinel() {
     if ! wait_sentinel_sees_priority "${candidate_fqdn}" "1"; then
       # Sentinel did not reflect the priority in time — restore before aborting
       # so the bias is never left in place after a failed switchover attempt.
-      IFS=',' read -ra all_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
+      IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
       for fqdn in "${all_fqdns[@]}"; do
         set_replica_priority "${fqdn}" 100 || true
       done
@@ -331,7 +356,7 @@ switchover_with_sentinel() {
   if ! execute_sentinel_failover; then
     # Restore priorities before failing so future Sentinel failovers are not biased.
     if ! is_empty "${candidate_fqdn}"; then
-      IFS=',' read -ra all_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
+      IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
       for fqdn in "${all_fqdns[@]}"; do
         set_replica_priority "${fqdn}" 100 || true
       done
@@ -348,7 +373,7 @@ switchover_with_sentinel() {
     wait_for_new_master "${candidate_fqdn}" "${KB_SWITCHOVER_CURRENT_FQDN}" || wfnm_rc=$?
     # Restore priorities on both success and failure paths — Sentinel has now
     # committed +switch-master (or timed out), so the bias is no longer needed.
-    IFS=',' read -ra all_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
+    IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
     for fqdn in "${all_fqdns[@]}"; do
       set_replica_priority "${fqdn}" 100 || true
     done


### PR DESCRIPTION
## Summary

- After scale-out (e.g. 3 → 4 replicas), `addons/valkey/scripts/switchover.sh` iterates a member list from the container env `VALKEY_POD_FQDN_LIST`, which is rendered into pod env at pod creation time and is **not refreshed** when the cluster scales out. The old primary's action container therefore sees a stale list that omits the freshly added candidate.
- Targeted switchover to a fresh scale-out replica then fails because the candidate is never given `replica-priority=1`, never probed for `role:master`, and priorities are never restored on it. OpsRequest ends with `WARNING: could not confirm new primary within 300s` even after Sentinel has promoted the candidate and topology is correct.
- Introduce `pod_fqdns_with_candidate()` that unions `KB_SWITCHOVER_CANDIDATE_FQDN` (passed at action time as `expected_fqdn` / `candidate_fqdn`) into `VALKEY_POD_FQDN_LIST`. All iteration points (`set_priorities_with_candidate_bias`, `restore_priorities`, `wait_for_new_master`, `check_*` helpers) are switched to the union list.
- Add ShellSpec coverage for stale-list scenarios so regressions are caught at unit-test time.

Closes #2608.

## Test plan

- [x] `bash -n addons/valkey/scripts/switchover.sh`
- [x] `shellspec --load-path shellspec addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh` → **55 examples, 0 failures**
- [x] `helm lint addons/valkey` → 0 chart(s) failed
- [x] Live broader smoke test: 143 PASS / 4 FAIL / 2 SKIP. The 4 fails are non-product environment/capability gaps (T11 storage class without VolumeExpansion; T16/T18 backup repo PVC node affinity; T19 cascaded false-fail from pending backup workers — manual recheck of post-upgrade topology and data passed).
- [x] Live chaos suite: **143 PASS / 0 FAIL / 0 SKIP** covering master kill, all-sentinel kill, all 6 pods kill, rapid master kill, restart, scale-out/in during writes, and vscale during writes — fix holds under concurrent writes and chaos.
- [x] Critical positive signal: T09 fresh scale-out targeted switchover one-shot pass, T14 targeted switchover OpsRequest `Succeed` with candidate becoming primary, T15 sentinel failover normal.

## Same-pattern risk in Redis (not modified by this PR)

Redis (`addons/redis/scripts/redis-switchover.sh`) follows the identical pattern with `REDIS_POD_FQDN_LIST` and `SENTINEL_POD_FQDN_LIST` injected via `componentVarRef.podFQDNs`. The same iteration points (`set_redis_priorities`, `recover_redis_priorities`, `check_redis_kernel_status`, `check_switchover_result`) carry the same architectural risk and would benefit from the same fix. Left for a follow-up evaluation; this PR does **not** modify Redis.
