### PR TITLE
fix(valkey): guard cascade-repair REPLICAOF against stale-role and self-target races

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -123,4 +123,231 @@ Describe "Valkey Check-Role Bash Script Tests"
       End
     End
   End
+
+  Describe "is_self_host()"
+    Context "loopback aliases"
+      setup() {
+        export CURRENT_POD_NAME="valkey-0"
+        export KB_POD_FQDN="valkey-0.valkey-headless.ns.svc.cluster.local"
+      }
+      Before "setup"
+
+      teardown() {
+        unset CURRENT_POD_NAME
+        unset KB_POD_FQDN
+      }
+      After "teardown"
+
+      It "treats 127.0.0.1 as self"
+        When call is_self_host "127.0.0.1"
+        The status should be success
+      End
+
+      It "treats localhost as self"
+        When call is_self_host "localhost"
+        The status should be success
+      End
+    End
+
+    Context "pod identity match"
+      setup() {
+        export CURRENT_POD_NAME="valkey-0"
+        export KB_POD_FQDN="valkey-0.valkey-headless.ns.svc.cluster.local"
+      }
+      Before "setup"
+
+      teardown() {
+        unset CURRENT_POD_NAME
+        unset KB_POD_FQDN
+      }
+      After "teardown"
+
+      It "matches when host equals current pod name"
+        When call is_self_host "valkey-0"
+        The status should be success
+      End
+
+      It "matches when host begins with current pod name and a dot (FQDN form)"
+        When call is_self_host "valkey-0.valkey-headless.ns.svc.cluster.local"
+        The status should be success
+      End
+
+      It "rejects an unrelated peer pod"
+        When call is_self_host "valkey-1.valkey-headless.ns.svc.cluster.local"
+        The status should be failure
+      End
+    End
+  End
+
+  Describe "check_cascade_topology() guards"
+    # Each test uses /tmp/valkey_cli_local_calls.$$ to count local-side calls
+    # (host begins with 127.0.0.1). State across $(...) subshells survives via
+    # this file. Remote-side calls are dispatched by inspecting the -h arg of
+    # the mocked valkey-cli invocation.
+    setup() {
+      export CURRENT_POD_NAME="valkey-1"
+      export KB_POD_FQDN="valkey-1.valkey-headless.ns.svc.cluster.local"
+      unset VALKEY_DEFAULT_PASSWORD
+      unset VALKEY_CLI_TLS_ARGS
+      cli_cmd=$(build_cli_cmd)
+      LOCAL_CALL_FILE="/tmp/valkey_cli_local_calls.$$"
+      rm -f "${LOCAL_CALL_FILE}"
+    }
+    Before "setup"
+
+    teardown() {
+      unset CURRENT_POD_NAME
+      unset KB_POD_FQDN
+      rm -f "${LOCAL_CALL_FILE}"
+      unset LOCAL_CALL_FILE
+    }
+    After "teardown"
+
+    Context "when local role flips to master mid-check (stale-role race)"
+      It "skips REPLICAOF and emits the skip-stale-role marker"
+        # Local call 1 (entry):  role:slave, master_host=valkey-0
+        # Remote call (valkey-0): role:slave, master_host=valkey-2  (cascade)
+        # Local call 2 (re-read): role:master  (Sentinel promoted us mid-check)
+        # Expected: emit skip-stale-role, do NOT issue REPLICAOF.
+        valkey-cli() {
+          local host="" is_info_replication=0
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              -h) host="$2"; shift 2 ;;
+              -p|-a) shift 2 ;;
+              --no-auth-warning) shift ;;
+              info|INFO)
+                if [ "${2:-}" = "replication" ]; then
+                  is_info_replication=1
+                  shift 2
+                else
+                  shift
+                fi
+                ;;
+              *) shift ;;
+            esac
+          done
+          if [ "${is_info_replication}" -ne 1 ]; then
+            return 0
+          fi
+          if [ "${host}" = "127.0.0.1" ]; then
+            local count=0
+            [ -f "${LOCAL_CALL_FILE}" ] && count=$(cat "${LOCAL_CALL_FILE}")
+            count=$((count + 1))
+            echo "${count}" > "${LOCAL_CALL_FILE}"
+            if [ "${count}" -eq 1 ]; then
+              printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\nmaster_link_status:up\r\n"
+            else
+              printf "# Replication\r\nrole:master\r\n"
+            fi
+          else
+            printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-2\r\nmaster_port:6379\r\n"
+          fi
+        }
+        When call check_cascade_topology
+        The status should be success
+        The stderr should include "skip-stale-role"
+        The stderr should not include "Issuing REPLICAOF"
+      End
+    End
+
+    Context "when cascade chain folds back to self (self-target)"
+      It "skips REPLICAOF and emits the skip-self-target marker"
+        # Local call 1 (entry):    role:slave, master_host=valkey-0
+        # Remote call (valkey-0):  role:slave, master_host=valkey-1  (== self)
+        # Local call 2 (re-read):  role:slave  (stale-role guard passes)
+        # is_self_host("valkey-1") matches CURRENT_POD_NAME
+        # Expected: emit skip-self-target, do NOT issue REPLICAOF.
+        valkey-cli() {
+          local host="" is_info_replication=0
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              -h) host="$2"; shift 2 ;;
+              -p|-a) shift 2 ;;
+              --no-auth-warning) shift ;;
+              info|INFO)
+                if [ "${2:-}" = "replication" ]; then
+                  is_info_replication=1
+                  shift 2
+                else
+                  shift
+                fi
+                ;;
+              *) shift ;;
+            esac
+          done
+          if [ "${is_info_replication}" -ne 1 ]; then
+            return 0
+          fi
+          if [ "${host}" = "127.0.0.1" ]; then
+            local count=0
+            [ -f "${LOCAL_CALL_FILE}" ] && count=$(cat "${LOCAL_CALL_FILE}")
+            count=$((count + 1))
+            echo "${count}" > "${LOCAL_CALL_FILE}"
+            if [ "${count}" -eq 1 ]; then
+              printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\nmaster_link_status:up\r\n"
+            else
+              printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\n"
+            fi
+          else
+            printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-1\r\nmaster_port:6379\r\n"
+          fi
+        }
+        When call check_cascade_topology
+        The status should be success
+        The stderr should include "skip-self-target"
+        The stderr should not include "Issuing REPLICAOF"
+      End
+    End
+
+    Context "when chain leads to a real non-self master (sanity)"
+      It "passes both guards and issues REPLICAOF to the real master"
+        # Local call 1 (entry):    role:slave, master_host=valkey-0
+        # Remote call (valkey-0):  role:slave, master_host=valkey-2  (!= self)
+        # Local call 2 (re-read):  role:slave (stale-role guard passes)
+        # is_self_host("valkey-2") returns false (we are valkey-1)
+        # Expected: emit "Issuing REPLICAOF" with the real-master line.
+        valkey-cli() {
+          local host="" is_info_replication=0
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              -h) host="$2"; shift 2 ;;
+              -p|-a) shift 2 ;;
+              --no-auth-warning) shift ;;
+              info|INFO)
+                if [ "${2:-}" = "replication" ]; then
+                  is_info_replication=1
+                  shift 2
+                else
+                  shift
+                fi
+                ;;
+              *) shift ;;
+            esac
+          done
+          if [ "${is_info_replication}" -ne 1 ]; then
+            return 0
+          fi
+          if [ "${host}" = "127.0.0.1" ]; then
+            local count=0
+            [ -f "${LOCAL_CALL_FILE}" ] && count=$(cat "${LOCAL_CALL_FILE}")
+            count=$((count + 1))
+            echo "${count}" > "${LOCAL_CALL_FILE}"
+            if [ "${count}" -eq 1 ]; then
+              printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\nmaster_link_status:up\r\n"
+            else
+              printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\n"
+            fi
+          else
+            printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-2\r\nmaster_port:6379\r\n"
+          fi
+        }
+        When call check_cascade_topology
+        The status should be success
+        The stderr should include "Issuing REPLICAOF"
+        The stderr should not include "skip-stale-role"
+        The stderr should not include "skip-self-target"
+      End
+    End
+  End
 End

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -47,6 +47,38 @@ build_cli_cmd() {
   echo "${cmd}"
 }
 
+# is_self_host — returns 0 if the given host resolves to the current pod.
+# Used as a guard before issuing REPLICAOF so cascade-repair never points us
+# at ourselves when the chain happens to fold back (A → B → A).
+is_self_host() {
+  local host="${1%.}"
+  local current_pod="${CURRENT_POD_NAME:-}"
+  local current_fqdn="${KB_POD_FQDN%.}"
+
+  case "${host}" in
+    "127.0.0.1"|"localhost"|"::1")
+      return 0
+      ;;
+  esac
+
+  if [ -n "${current_pod}" ]; then
+    [ "${host}" = "${current_pod}" ] && return 0
+    contains "${host}" "${current_pod}." && return 0
+  fi
+  [ -n "${current_fqdn}" ] && [ "${host}" = "${current_fqdn}" ] && return 0
+
+  if command -v getent >/dev/null 2>&1 && [ -n "${current_fqdn}" ]; then
+    local host_ips current_ips ip
+    host_ips=$(getent hosts "${host}" 2>/dev/null | awk '{print $1}' | sort -u) || true
+    current_ips=$(getent hosts "${current_fqdn}" 2>/dev/null | awk '{print $1}' | sort -u) || true
+    for ip in ${host_ips}; do
+      echo "${current_ips}" | grep -qx "${ip}" && return 0
+    done
+  fi
+
+  return 1
+}
+
 # check_cascade_topology — called when this pod is a slave.
 # Detects cascading replication (slave of slave) and self-corrects by issuing
 # REPLICAOF directly to the real master.  This handles the window after a
@@ -87,6 +119,26 @@ check_cascade_topology() {
   real_master_port=$(echo "${master_repl_info}" | grep "^master_port:" | tr -d '\r\n' | cut -d: -f2)
 
   is_empty "${real_master_host}" && return 0
+
+  # Guard 1 — stale-role race: between the time we read role:slave at the start
+  # of the probe and now, Sentinel may have promoted this pod to master. Issuing
+  # REPLICAOF on a fresh master would demote it. Re-read local role and skip if
+  # we are no longer a slave.
+  local current_repl_info current_role
+  current_repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  current_role=$(echo "${current_repl_info}" | grep "^role:" | tr -d '\r\n' | cut -d: -f2)
+  if [ "${current_role}" != "slave" ]; then
+    echo "INFO: skip cascade repair (skip-stale-role): local role is '${current_role:-unknown}', not slave." >&2
+    return 0
+  fi
+
+  # Guard 2 — self-target: the chain may fold back to ourselves (A → B → A
+  # during overlapping promotions). Issuing REPLICAOF self is a no-op the
+  # server rejects, but emitting it is misleading and pollutes the log.
+  if is_self_host "${real_master_host}"; then
+    echo "WARNING: skip cascade repair (skip-self-target): target ${real_master_host}:${real_master_port:-${port}} resolves to current pod ${CURRENT_POD_NAME:-unknown}." >&2
+    return 0
+  fi
 
   echo "WARNING: cascading topology — our master ${master_host} is a slave of ${real_master_host}. Issuing REPLICAOF to reconnect directly to real master." >&2
   ${cli_cmd} REPLICAOF "${real_master_host}" "${real_master_port:-${port}}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

When this pod is a slave, `check_cascade_topology` may decide to issue `REPLICAOF` to redirect us at a real master after detecting a cascade chain. Two race conditions could cause that `REPLICAOF` to do the wrong thing:

1. **stale-role race** — Between reading `role:slave` at probe entry and the `REPLICAOF` call, Sentinel may have promoted this pod to master. Issuing `REPLICAOF` would demote a freshly-elected master back to slave, undoing the Sentinel failover.
2. **self-target** — The cascade chain (`A → B → A`) can resolve to ourselves during overlapping promotions. Issuing `REPLICAOF` self emits a misleading log line for an operation the server rejects.

This PR adds an `is_self_host` helper and two guards in `check_cascade_topology` that close both windows.

## Changes

- **`addons/valkey/scripts/check-role.sh`** (+52)
  - New `is_self_host` helper: matches `127.0.0.1` / `localhost` / `::1`, current pod name, FQDN, FQDN prefix (`valkey-1.foo`), and IP equality via `getent` if available.
  - In `check_cascade_topology`, just before issuing `REPLICAOF`:
    - **Guard 1 (stale-role)** — re-read local role; if no longer `slave`, skip with `skip-stale-role` marker.
    - **Guard 2 (self-target)** — if `real_master_host` is self, skip with `skip-self-target` marker.

- **`addons/valkey/scripts-ut-spec/check_role_spec.sh`** (+227)
  - `is_self_host` unit cases: loopback aliases, pod-name match, FQDN match, peer rejection
  - `check_cascade_topology` guard cases:
    - `when local role flips to master mid-check (stale-role race)` — skips REPLICAOF, emits `skip-stale-role` marker
    - `when cascade chain folds back to self (self-target)` — skips REPLICAOF, emits `skip-self-target` marker
    - `when chain leads to a real non-self master (sanity)` — passes both guards and issues REPLICAOF

## Scope

- **Smaller refactor previously prototyped on `alice/valkey-post-restore-fixes` is intentionally NOT in this PR.** That branch wrapped cascade/stall self-healing in an async background path with timeouts and lock dirs. There is no live signal that the inline path is too slow (chaos suite is 143/0/0 with the inline path), so that refactor is held back; only the two concrete race-condition fixes — which have ShellSpec proof — land here.
- The two guards do not change the cascade-repair contract for healthy topologies (verified by sanity test): a real non-self master still receives `REPLICAOF`.

## Validation

- [x] `bash -n addons/valkey/scripts/check-role.sh` → PASS
- [x] `bash -n addons/valkey/scripts-ut-spec/check_role_spec.sh` → PASS
- [x] `shellspec --load-path shellspec addons/valkey/scripts-ut-spec/check_role_spec.sh` → **13 examples, 0 failures**
- [x] `helm lint addons/valkey` (after `helm dep update`) → 1 chart(s) linted, **0 failed**

## Why these are real bugs (not just defensive)

ShellSpec covers the exact failure shape:
- Without Guard 1, `valkey-cli REPLICAOF <real_master>` runs while `role:master`, demoting a fresh master.
- Without Guard 2, `valkey-cli REPLICAOF <self>` is emitted with a "Issuing REPLICAOF" warning even though the cascade chain has folded.

Both have failing-without-fix / passing-with-fix coverage in the spec.