### PR TITLE
test(valkey): fix build_replicaof_config spec assertions and verify_pod_role mocking

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
@@ -212,7 +212,9 @@ Describe "Valkey Start Bash Script Tests"
       It "writes no replicaof directive (this pod is primary)"
         When call build_replicaof_config
         The status should be success
-        The stdout should include "no replicaof directive needed"
+        # build_replicaof_config logs decisions to stderr (info-level), not stdout —
+        # stdout is reserved for any captured command output (none in this path).
+        The stderr should include "no replicaof directive needed"
         The contents of file "${CONF_RUNTIME}" should not include "replicaof"
       End
     End
@@ -240,7 +242,8 @@ Describe "Valkey Start Bash Script Tests"
       It "writes replicaof directive pointing to primary"
         When call build_replicaof_config
         The status should be success
-        The stdout should include "lexicographic"
+        # Path B (no sentinel) info-logs the lexicographic election to stderr.
+        The stderr should include "lexicographic"
         The contents of file "${CONF_RUNTIME}" should include "replicaof valkey-0.valkey-headless.default.svc.cluster.local 6379"
       End
     End
@@ -270,13 +273,30 @@ Describe "Valkey Start Bash Script Tests"
       After "teardown"
 
       It "uses Sentinel-reported master as replicaof target"
-        # Mock valkey-cli: Sentinel returns valkey-0's FQDN
+        # Mock valkey-cli for the sentinel query path; production code dispatches
+        # to two different commands so the mock dispatches by argv:
+        #   - SENTINEL get-master-addr-by-name  → return master FQDN + port
+        #   - other (CONFIG SET / fallbacks)   → no-op
         valkey-cli() {
-          echo "valkey-0.valkey-headless.default.svc.cluster.local"$'\n'"6379"
+          case "$*" in
+            *"SENTINEL get-master-addr-by-name"*)
+              echo "valkey-0.valkey-headless.default.svc.cluster.local"
+              echo "6379"
+              ;;
+            *) return 0 ;;
+          esac
+        }
+        # Mock verify_pod_role directly: production code wraps the role probe in
+        # `timeout 3 valkey-cli ... info replication`, but `timeout` shell-execs
+        # the binary path and bypasses test-scope shell functions. Mocking the
+        # surrounding helper is more robust for unit tests than hooking timeout.
+        verify_pod_role() {
+          echo "master"
         }
         When call build_replicaof_config
         The status should be success
-        The stdout should include "Sentinel reports current master"
+        # Sentinel quorum + role-verified path emits this exact info line to stderr.
+        The stderr should include "sentinel quorum + role verified"
         The contents of file "${CONF_RUNTIME}" should include "replicaof valkey-0.valkey-headless.default.svc.cluster.local 6379"
       End
     End


### PR DESCRIPTION
## Summary

Fix the 3 `build_replicaof_config` test failures on the Valkey staging PR (apecloud/kubeblocks-addons#2592) which has been showing `shellspec-test FAILURE` for a while:

- `valkey_start_spec.sh:212` — `writes no replicaof directive (this pod is primary)`
- `valkey_start_spec.sh:240` — `writes replicaof directive pointing to primary`
- `valkey_start_spec.sh:272` — `uses Sentinel-reported master as replicaof target`

These are tests-only fixes; **no product code changes**.

## Root causes

Two independent drifts between `valkey-start.sh` and the tests:

### Drift A — info-log channel

`build_replicaof_config` logs decisions via `echo ... >&2` (info-level on stderr), but the tests assert via `The stdout should include`. The tests were written against an earlier revision that emitted to stdout. The expected-text fragments are still correct — only the stream is wrong.

Fix: switch the 3 assertions from `stdout` to `stderr`.

### Drift B — verify_pod_role wrapping `timeout`

Test 3 mocked `valkey-cli` to return Sentinel's response and relied on the same mock to satisfy `verify_pod_role`. The production code now wraps the role probe in:

```bash
role=$(timeout 3 ${cli_base} -h "${fqdn}" info replication 2>/dev/null | ...)
```

`timeout` shell-execs the binary path, **bypassing test-scope shell functions**, so the mock never serves the role probe. The script logs `INFO: quorum elected ... but role='<unreachable>' — retrying in 5s.` 12 times then falls through to pod scan / lexicographic bootstrap, which is why the test was looking for an obsolete `"Sentinel reports current master"` fragment that no longer exists in the success path.

Fix:
- Mock `verify_pod_role` directly (the wrapping helper) — robust to the `timeout` shell-exec barrier
- Dispatch the `valkey-cli` mock by argv: `SENTINEL get-master-addr-by-name` returns master FQDN + port, other paths no-op
- Update the expected stderr fragment to `"sentinel quorum + role verified"` (what the script emits today on the success path)

## Validation

- [x] `shellspec --load-path shellspec addons/valkey/scripts-ut-spec/valkey_start_spec.sh` → **13 examples, 0 failures**
- [x] `shellspec --load-path shellspec addons/valkey/scripts-ut-spec/` (full valkey suite) → **93 examples, 0 failures**

CI on this PR (and the rebased PR #2592) should drop from `743 examples, 3 failures` to `743 examples, 0 failures`.

## Why this is tests-only

`addons/valkey/scripts/valkey-start.sh` is unchanged. Only `addons/valkey/scripts-ut-spec/valkey_start_spec.sh` is touched, and only the 3 broken `It` blocks are touched. Other 10 examples in the file are untouched and still pass.