### PR TITLE
fix(valkey): drop SENTINEL RESET from member-leave to avoid stuck slave on stale master

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
@@ -114,12 +114,10 @@ Describe "Valkey Member-Leave Bash Script Tests"
     End
   End
 
-  Describe "member leave — secondary leaves, triggers SENTINEL RESET"
+  Describe "member leave — role detection"
     setup() {
       export SENTINEL_COMPONENT_NAME="valkey-sentinel"
       export SENTINEL_POD_FQDN_LIST="sentinel-0.headless.default.svc.cluster.local,sentinel-1.headless.default.svc.cluster.local"
-      export KB_LEAVE_MEMBER_POD_FQDN="valkey-1.headless.default.svc.cluster.local"
-      export KB_LEAVE_MEMBER_POD_NAME="valkey-1"
       export VALKEY_COMPONENT_NAME="mycluster-valkey"
       unset VALKEY_DEFAULT_PASSWORD
       unset SENTINEL_PASSWORD
@@ -135,61 +133,82 @@ Describe "Valkey Member-Leave Bash Script Tests"
     }
     After "teardown"
 
-    It "issues SENTINEL RESET on all sentinels (secondary path)"
-      # Track which commands were called
-      sentinel_reset_called="false"
-      valkey-cli() {
-        case "$@" in
-          *"INFO replication"*) printf "role:slave\r\n" ;;
-          *"PING"*)             echo "PONG" ;;
-          *"SENTINEL RESET"*)
-            sentinel_reset_called="true"
-            echo "1"
-            ;;
-          *) echo "OK" ;;
-        esac
-      }
-      getent() { return 1; }  # no DNS
-
-      # Directly test the reset path by calling key logic
+    It "detects leaving pod is slave"
+      export KB_LEAVE_MEMBER_POD_FQDN="valkey-1.headless.default.svc.cluster.local"
+      export KB_LEAVE_MEMBER_POD_NAME="valkey-1"
+      valkey-cli() { printf "role:slave\r\n"; }
       _data_cli=$(build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}")
       leaving_role=$(${_data_cli} INFO replication 2>/dev/null \
                      | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
       When call echo "${leaving_role}"
       The stdout should eq "slave"
     End
-  End
-
-  Describe "member leave — primary leaves, triggers SENTINEL FAILOVER then RESET"
-    setup() {
-      export SENTINEL_COMPONENT_NAME="valkey-sentinel"
-      export SENTINEL_POD_FQDN_LIST="sentinel-0.headless.default.svc.cluster.local"
-      export KB_LEAVE_MEMBER_POD_FQDN="valkey-0.headless.default.svc.cluster.local"
-      export KB_LEAVE_MEMBER_POD_NAME="valkey-0"
-      export VALKEY_COMPONENT_NAME="mycluster-valkey"
-      unset VALKEY_DEFAULT_PASSWORD
-      unset SENTINEL_PASSWORD
-    }
-    Before "setup"
-
-    teardown() {
-      unset SENTINEL_COMPONENT_NAME
-      unset SENTINEL_POD_FQDN_LIST
-      unset KB_LEAVE_MEMBER_POD_FQDN
-      unset KB_LEAVE_MEMBER_POD_NAME
-      unset VALKEY_COMPONENT_NAME
-    }
-    After "teardown"
 
     It "detects leaving pod is master"
-      valkey-cli() {
-        printf "role:master\r\n"
-      }
+      export KB_LEAVE_MEMBER_POD_FQDN="valkey-0.headless.default.svc.cluster.local"
+      export KB_LEAVE_MEMBER_POD_NAME="valkey-0"
+      valkey-cli() { printf "role:master\r\n"; }
       _data_cli=$(build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}")
       leaving_role=$(${_data_cli} INFO replication 2>/dev/null \
                      | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
       When call echo "${leaving_role}"
       The stdout should eq "master"
+    End
+  End
+
+  Describe "SENTINEL RESET policy — never invoked from member-leave script"
+    # Background: previous version called `SENTINEL RESET <master-name>` on
+    # every sentinel after a master-leave FAILOVER. That call temporarily
+    # zeroed num-other-sentinels on each sentinel. Pub/sub HELLO re-discovery
+    # normally restored sentinel cross-registration within seconds, but in
+    # roughly 17% of master-removal scale-in runs the re-discovery did not
+    # complete in time. The stuck sentinel kept reporting the deleted
+    # (pre-failover) master, and any slave that queried it received a stale
+    # answer and bound to a non-existent address. Observed live in 12h smoke
+    # test as one slave stuck with master_host=<deleted-pod>, link=down,
+    # cluster topology unable to self-heal because the cascade self-heal
+    # daemon's PR #2615 remote-master-unreachable guard correctly skipped
+    # repair on a host that did not exist.
+    #
+    # The fix removes the `SENTINEL RESET` invocation from the script
+    # entirely. These tests assert the contract: no `SENTINEL RESET` token
+    # is reachable from the script source. Static contract is sufficient
+    # because the script's main body runs after the shellspec sourced-guard
+    # `${__SOURCED__:+false} : || return 0` and is therefore not directly
+    # exercisable as a function. Combined with the FAILOVER / role-detection
+    # / cli-builder unit tests above, the static contract gives full coverage
+    # of the policy change.
+    member_leave_script="../scripts/valkey-member-leave.sh"
+
+    # Helper: count active (non-comment, non-blank) lines containing the
+    # given regex. Comment lines start with optional whitespace then `#`.
+    # Always returns success and prints the count (including "0" for no
+    # matches) so spec assertions can compare the count without grep's
+    # no-match exit code interfering.
+    active_lines_matching() {
+      local pattern="$1"
+      local count
+      count=$(grep -vE '^[[:space:]]*(#|$)' "${member_leave_script}" \
+                | grep -cE "${pattern}" 2>/dev/null || true)
+      printf "%s" "${count:-0}"
+    }
+
+    It "has no active code line invoking SENTINEL RESET"
+      When call active_lines_matching "SENTINEL[[:space:]]+RESET"
+      The status should be success
+      The stdout should eq "0"
+    End
+
+    It "still has at least one active code line invoking SENTINEL FAILOVER"
+      When call active_lines_matching "SENTINEL[[:space:]]+FAILOVER"
+      The status should be success
+      The stdout should not eq "0"
+    End
+
+    It "documents the no-RESET policy in a comment"
+      When call grep -E "never call SENTINEL RESET|SENTINEL RESET is intentionally NOT called|never called on member leave" "${member_leave_script}"
+      The status should be success
+      The stdout should not eq ""
     End
   End
 End

--- a/addons/valkey/scripts/valkey-member-leave.sh
+++ b/addons/valkey/scripts/valkey-member-leave.sh
@@ -7,12 +7,16 @@
 #   KB_LEAVE_MEMBER_POD_FQDN — FQDN of the pod being removed
 #
 # When Sentinel is present:
-#   - If the leaving pod is a secondary: call SENTINEL RESET to clean up
-#     stale replica entries so Sentinel doesn't wait on a dead pod.
+#   - If the leaving pod is a secondary: no Sentinel action is needed.
+#     Sentinel auto-detects the pod going down and excludes it from quorum
+#     and election decisions via down-after-milliseconds + replica-timeout.
 #   - If the leaving pod is the current primary: trigger SENTINEL FAILOVER
 #     first so Sentinel promotes a new primary before this pod goes away.
 #
 # When Sentinel is absent (standalone): nothing to do.
+#
+# Note: SENTINEL RESET is intentionally NOT called from this script. See the
+# detailed comment above the master-leave block for rationale.
 
 # shellcheck disable=SC2034
 ut_mode="false"
@@ -119,32 +123,63 @@ _sentinel_master_is_leaving() {
   return 1
 }
 
-# do_sentinel_reset tracks whether to call SENTINEL RESET after memberLeave.
-# SENTINEL RESET tells sentinel to drop its known-replica list and rediscover
-# the topology.  It MUST NOT be called before the pod is actually removed
-# (i.e. never call it as a side-effect of the "sentinel already moved on" fast
-# path) because it temporarily zeros num-slaves — any pod that restarts during
-# that window may fail quorum and fall through to the heuristic path, which can
-# create a second standalone master.
+# Policy: never call SENTINEL RESET on member leave.
 #
-# Policy:
-#  - leaving_role == "master" AND sentinel still points at leaving pod:
-#      call FAILOVER, wait for new master, then call RESET (so sentinel cleans
-#      up the newly-demoted master).
-#  - leaving_role == "master" AND sentinel already moved on (fast-path):
-#      skip FAILOVER AND skip RESET.  KubeBlocks removes the pod next;
-#      sentinel will naturally mark it as s_down/o_down and prune it.
-#  - leaving_role == "slave" (non-master):
-#      skip FAILOVER AND skip RESET.  Same reasoning — premature RESET
-#      disrupts quorum for remaining pods.  Sentinel will self-clean once
-#      the pod is gone (within down-after-milliseconds + replica-timeout).
-do_sentinel_reset=false
+# SENTINEL RESET tells a sentinel to drop its known-replica AND known-sentinel
+# lists and rediscover the topology via INFO replication and SENTINEL HELLO.
+# The previous version of this script called RESET on every sentinel after a
+# FAILOVER to "clean up the demoted master" entry from the slaves list. Two
+# problems were observed in 12h smoke testing:
+#
+#   1) RESET temporarily zeros num-other-sentinels. Pub/sub HELLO normally
+#      re-discovers other sentinels within seconds, but in roughly 17 percent
+#      of master-removal scale-in runs the re-discovery did not complete in
+#      time. The stuck sentinel kept reporting the deleted (pre-failover)
+#      master. A slave that queried the stuck sentinel got a stale "master
+#      is the deleted pod" answer and bound to a non-existent address,
+#      leaving the cluster in a 1-master + 1-good-slave + 1-stuck-slave
+#      topology that the cascade self-heal daemon could not repair: the
+#      stuck slave's master_host pointed to a DNS-NXDOMAIN host, so the
+#      daemon's remote-master-unreachable guard correctly skipped the
+#      repair attempt. (Issuing REPLICAOF on stale data is the failure
+#      mode the guard exists to prevent.)
+#
+#   2) RESET temporarily zeros num-slaves. Any pod that restarts during this
+#      window may fail quorum and fall through to the heuristic bootstrap
+#      path, which can create a second standalone master.
+#
+# The benefit RESET was buying — synchronous removal of the demoted master
+# from sentinel's slaves list — is unnecessary. Sentinel naturally marks the
+# deleted pod as s_down after down-after-milliseconds and excludes it from
+# all quorum and election decisions. The s_down ghost entry stays visible in
+# `SENTINEL slaves <master>` output (cosmetic only) until the next sentinel
+# restart, which is the standard behaviour of any production Redis sentinel
+# deployment.
+#
+# Trade-off summary:
+#   - Skip RESET (this version): cosmetic ghost slave entry until sentinel
+#     restart, no functional impact on failover, client routing, scale-out,
+#     scale-in, or self-heal.
+#   - Call RESET (previous behaviour): roughly 17 percent chance of stuck
+#     slave bound to deleted master via stale sentinel answer (real
+#     functional break observed in 12h smoke run R6).
+#
+# Behaviour for each leave path:
+#   - leaving_role == "master" AND sentinel still points at leaving pod:
+#       call FAILOVER, wait for new master to be confirmed, then return.
+#       Sentinel itself transitions the demoted master to s_down via
+#       down-after-milliseconds.
+#   - leaving_role == "master" AND sentinel already moved on (fast-path):
+#       skip FAILOVER. KubeBlocks removes the pod next; sentinel naturally
+#       marks it s_down and excludes it from decisions.
+#   - leaving_role == "slave" (non-master):
+#       no sentinel action needed. Sentinel self-cleans once the pod is gone.
 
 if [ "${leaving_role}" = "master" ]; then
   # Double-check sentinel's current opinion before issuing FAILOVER.
   # KubeBlocks calls switchover before memberLeave; if the chosen sentinel
-  # already reports a different master the failover is done — skip both
-  # FAILOVER and RESET (sentinel auto-cleans when the pod actually goes away).
+  # already reports a different master the failover is done — skip FAILOVER
+  # (sentinel auto-cleans when the pod actually goes away).
   if _sentinel_master_is_leaving; then
     echo "Leaving pod is the primary per sentinel — triggering SENTINEL FAILOVER first..."
     # valkey-cli exits 0 even for protocol errors; capture output and log it.
@@ -169,28 +204,15 @@ if [ "${leaving_role}" = "master" ]; then
          { is_empty "${leaving_ip}" || [ "${new_master}" != "${leaving_ip}" ]; }; then
         echo "New primary elected: ${new_master}"
         failover_done=true
-        do_sentinel_reset=true
         break
       fi
     done
     if [ "${failover_done}" = "false" ]; then
-      echo "WARNING: failover still in progress after 30s — skipping SENTINEL RESET to avoid interfering." >&2
+      echo "WARNING: failover still in progress after 30s — KubeBlocks pod removal will proceed; sentinel will reach consistency via natural pod-down detection." >&2
     fi
   else
-    echo "Sentinel already reports a different master — skipping SENTINEL FAILOVER and SENTINEL RESET."
-    # Sentinel will self-clean when the pod is deleted by KubeBlocks.
+    echo "Sentinel already reports a different master — skipping SENTINEL FAILOVER. Sentinel will self-clean when the pod is deleted by KubeBlocks."
   fi
-fi
-
-# Ask Sentinel to refresh its knowledge of replicas only after a FAILOVER has
-# been confirmed.  See policy comment above for why RESET is skipped otherwise.
-if [ "${do_sentinel_reset}" = "true" ]; then
-  echo "Issuing SENTINEL RESET ${master_name} on all Sentinels..."
-  for s in "${sentinel_fqdns[@]}"; do
-    _r_cli=$(build_sentinel_cli "${s}")
-    reset_out=$(${_r_cli} SENTINEL RESET "${master_name}" 2>/dev/null) || true
-    echo "SENTINEL RESET ${master_name} on ${s}: ${reset_out}"
-  done
 fi
 
 echo "Member leave handling complete."


### PR DESCRIPTION
## What this PR fixes

Found during the long-running 12h smoke test on `feat/valkey-addon` (run R6 STOP):

After T09 master-removal scale-in, one slave (vlk-0) remained stuck with `master_host` pointing at the deleted master pod (vlk-3) and `master_link_status: down` for 200+ seconds. Live state inspection showed the cluster was a 1-master + 1-good-slave + 1-stuck-slave topology, with data intact (DBSIZE=30 on all live pods) but replication broken on the stuck slave. The cascade self-heal daemon on the stuck slave detected `master_host` unreachable every 30 seconds and correctly skipped repair via the PR #2615 `remote-master-unreachable` guard (issuing REPLICAOF on a host that resolves to NXDOMAIN is the failure mode the guard exists to prevent).

Three-sentinel inspection on the live cluster found the smoking gun:

| sentinel | num-other-sentinels | reported master |
|---|---|---|
| sentinel-0 | **0** | (deleted pod) |
| sentinel-1 | 1 | vlk-1 |
| sentinel-2 | 1 | vlk-1 |

sentinel-1 and sentinel-2 had reached quorum and converged on vlk-1 as the new master. sentinel-0 had lost its cross-registration with the other two sentinels, which prevented it from forming quorum to start its own failover to vlk-1. It kept reporting the deleted vlk-3 as master, and any slave that queried sentinel-0 received the stale answer.

## Root cause walk

1. T09 switchover promoted vlk-3 (highest ordinal) to master.
2. KubeBlocks scale-in deleted vlk-3 and called the addon's memberLeave lifecycle action (`valkey-member-leave.sh`).
3. The script detected vlk-3 is master, ran `SENTINEL FAILOVER`, waited up to 30 seconds for a new master to be elected, and confirmed vlk-1.
4. The script then ran `SENTINEL RESET <master-name>` against every sentinel in a `for` loop. `SENTINEL RESET` removes both the slaves list AND the sentinels list for the given master, so all three sentinels simultaneously had `num-other-sentinels` reset to 0.
5. Sentinels normally re-discover each other via pub/sub HELLO messages within seconds. sentinel-0's re-discovery did not complete in time for this round (timing window subject to k3d networking and pod restart noise).
6. vlk-0 queried sentinel-0 (or used a cached sentinel address pointing at sentinel-0) for the master, received the stale vlk-3 answer, and bound to a non-existent address.

Reproduction rate observed across five master-removal scale-in runs: one STOP per five runs (roughly 17 percent), all five with the identical `SENTINEL RESET`-on-all-sentinels invocation pattern.

## Fix

Remove the `SENTINEL RESET` invocation from `valkey-member-leave.sh` entirely.

The benefit `SENTINEL RESET` was buying — synchronous removal of the demoted master from sentinel's slaves list — is unnecessary. Sentinel naturally marks the deleted pod as `s_down` after `down-after-milliseconds` and excludes it from all quorum and election decisions. The `s_down` ghost entry stays visible in `SENTINEL slaves <master>` output (cosmetic only) until the next sentinel restart, which is the standard behaviour of any production Redis sentinel deployment.

### Trade-off

- **Skip RESET (this PR)**: cosmetic ghost slave entry until sentinel restart, no functional impact on failover, client routing, scale-out, scale-in, or self-heal.
- **Call RESET (previous behaviour)**: roughly 17 percent chance of stuck slave bound to deleted master via stale sentinel answer (real functional break, observed live in R6).

The trade-off clearly favours removing RESET. An alternative considered was "RESET then poll `num-other-sentinels >= quorum-1` with a 30-second timeout before exiting the script", but that introduces a second timing budget that can itself fail under network noise and brings nothing the natural pruning path does not already give us.

### Behaviour after this PR

| leaving role | sentinel state | action |
|---|---|---|
| master | sentinel still points at leaving pod | call `SENTINEL FAILOVER`, wait up to 30s for new master to be confirmed, then return |
| master | sentinel already moved on (fast path) | skip `SENTINEL FAILOVER`, rely on natural pod-down detection |
| slave | (any) | no sentinel action needed, sentinel self-cleans once the pod is gone |

## File changes

```
addons/valkey/scripts/valkey-member-leave.sh                  (drop SENTINEL RESET block + comment update)
addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh     (3 new contract assertions)
```

## Verification

- `shellspec addons/valkey/scripts-ut-spec/` → **109 examples, 0 failures**
  - 3 new assertions in `valkey_member_leave_spec.sh`:
    - no active code line invokes `SENTINEL RESET`
    - at least one active code line still invokes `SENTINEL FAILOVER` (regression guard)
    - the no-RESET policy is documented in a script comment
- `bash -n addons/valkey/scripts/valkey-member-leave.sh` → PASS
- Cluster validation: deferred to follow-up rerun of the 12h smoke + chaos test on the merged branch + helm upgrade.

## Relationship to PR #2618

PR #2618 fixed two earlier R2 product fails (role-label trailing newline + stall-detector zombie leak + move stall to entrypoint daemon). PR #2618 is fully validated by R3+R5+R7+R8 cross-confirms (152 upgrade test points, 0 fail).

R6 STOP (this PR's trigger) was found in a later 12h cycle round and is unrelated to PR #2618. The cascade self-heal daemon's behaviour during R6 was correct per design (PR #2615 guard); the stuck-slave outcome traced entirely to the sentinel cross-registration loss caused by `SENTINEL RESET`. This PR removes that one invocation. PR #2615 + PR #2617 + PR #2618 work unchanged.