### PR TITLE
fix(valkey): replace check-role.sh outer pipeline with bash builtin parse to stop kbagent zombies

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -84,16 +84,30 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
-  Describe "role probe output"
+  Describe "role probe output (bash-builtin parse, no pipeline children)"
+    # Mirror production parse exactly: capture INFO output once via a
+    # single command substitution, then walk the captured string with
+    # a bash builtin while/read/case loop. No grep / tr children.
+    parse_role_line() {
+      local repl_info="$1"
+      local line role_line=""
+      while IFS= read -r line; do
+        line="${line%$'\r'}"
+        case "${line}" in
+          role:*) role_line="${line}"; break ;;
+        esac
+      done <<<"${repl_info}"
+      printf "%s" "${role_line}"
+    }
+
     Context "when server reports master"
-      It "outputs 'primary' with no trailing newline"
+      It "outputs 'primary' with no trailing newline (parsed via bash builtins)"
         valkey-cli() {
           printf "# Replication\r\nrole:master\r\nconnected_slaves:2\r\n"
         }
         cli_cmd=$(build_cli_cmd)
-        role_line=$(${cli_cmd} info replication 2>/dev/null | grep "^role:" | tr -d '\r\n')
-        # Mirror production: printf %s, no trailing byte. KubeBlocks roleProbe
-        # rejects label values containing '\n'.
+        repl_info=$(${cli_cmd} info replication 2>/dev/null)
+        role_line=$(parse_role_line "${repl_info}")
         When call bash -c "
           case \"${role_line}\" in
             \"role:master\") printf %s \"primary\" ;;
@@ -107,12 +121,13 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
 
     Context "when server reports slave"
-      It "outputs 'secondary' with no trailing newline"
+      It "outputs 'secondary' with no trailing newline (parsed via bash builtins)"
         valkey-cli() {
           printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\n"
         }
         cli_cmd=$(build_cli_cmd)
-        role_line=$(${cli_cmd} info replication 2>/dev/null | grep "^role:" | tr -d '\r\n')
+        repl_info=$(${cli_cmd} info replication 2>/dev/null)
+        role_line=$(parse_role_line "${repl_info}")
         When call bash -c "
           case \"${role_line}\" in
             \"role:master\") printf %s \"primary\" ;;
@@ -123,6 +138,54 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be success
         The stdout should eq "secondary"
       End
+    End
+
+    Context "when INFO output is empty (pod startup window)"
+      It "produces empty role_line (script will exit 1 in main)"
+        valkey-cli() { return 1; }   # cli connection fails
+        cli_cmd=$(build_cli_cmd)
+        repl_info=$(${cli_cmd} info replication 2>/dev/null) || repl_info=""
+        When call parse_role_line "${repl_info}"
+        The status should be success
+        The stdout should eq ""
+      End
+    End
+  End
+
+  Describe "fork-safety contract — no pipeline parsing of INFO replication"
+    # Background: `valkey-cli ... info replication | grep ... | tr ...`
+    # spawns three subprocess children per probe call. When kbagent
+    # SIGKILLs check-role.sh for exceeding timeoutSeconds (e.g. during a
+    # vertical-scale window when roleProbe slows down), those children are
+    # reparented to kbagent's PID 1 (Go binary, not a reaper) and
+    # accumulate as zombies. The fix replaces the pipeline with a single
+    # command substitution + bash builtin parse, eliminating two of the
+    # three children. Observed live in focused stress test T09 iter 1
+    # (see focus-kbagent-zombie summary): one (check-role.sh) Z process
+    # under PID 1 in the kbagent container.
+    check_role_script="../scripts/check-role.sh"
+
+    # Helper: count active (non-comment, non-blank) lines containing a
+    # `... | grep ` or `| tr ` token in the given file. Comment lines are
+    # `#` after optional leading whitespace.
+    active_pipeline_count() {
+      local count
+      count=$(grep -vE '^[[:space:]]*(#|$)' "${check_role_script}" \
+                | grep -cE '\|[[:space:]]+(grep|tr|awk|sed|cut)[[:space:]]' \
+                2>/dev/null || true)
+      printf "%s" "${count:-0}"
+    }
+
+    It "has no active code line piping INFO output through grep / tr / awk / sed / cut"
+      When call active_pipeline_count
+      The status should be success
+      The stdout should eq "0"
+    End
+
+    It "uses the bash builtin while/read/case parse pattern"
+      When call grep -E 'while[[:space:]]+IFS=[[:space:]]*read' "${check_role_script}"
+      The status should be success
+      The stdout should not eq ""
     End
   End
 End

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -67,10 +67,26 @@ load_common_library
 cli_cmd=$(build_cli_cmd)
 
 unset_xtrace_when_ut_mode_false
-# Strip \r\n — valkey-cli INFO output uses CRLF line endings per Redis protocol.
-# Without tr, "role:master\r" would never match the case patterns below.
-role_line=$(${cli_cmd} info replication 2>/dev/null \
-  | grep "^role:" | tr -d '\r\n')
+# Capture the full INFO replication output once via a single command
+# substitution (one valkey-cli child process), then parse it with bash
+# builtins. Pipelines like `... | grep | tr` would spawn additional
+# children (one per stage). When kbagent SIGKILLs this script for
+# exceeding probe timeoutSeconds, those pipeline children become
+# orphans and are reparented to kbagent's PID 1, which is a Go binary
+# that does not reap unrelated children — they accumulate as zombies.
+# Refer to docs/addon-probe-script-fork-and-zombie-guide.md.
+#
+# valkey-cli INFO output uses CRLF line endings per the Redis protocol;
+# the parameter expansion `${line%$'\r'}` trims the trailing CR before
+# the case match.
+repl_info=$(${cli_cmd} info replication 2>/dev/null) || repl_info=""
+role_line=""
+while IFS= read -r line; do
+  line="${line%$'\r'}"
+  case "${line}" in
+    role:*) role_line="${line}"; break ;;
+  esac
+done <<<"${repl_info}"
 set_xtrace_when_ut_mode_false
 
 # printf %s avoids the trailing newline that `echo` adds — KubeBlocks roleProbe


### PR DESCRIPTION
## What this PR fixes

Found during the focused stress test that follows PR #2618 + PR #2619: T09 stress iteration 1 produced one `(check-role.sh) Z` process under kbagent's PID 1 in a data pod's kbagent container. Live recheck confirmed the zombie persisted; correlated controller events showed a `roleProbe` timeout during the vertical-scale window (the probe had already produced `"secondary"` / `"primary"` output, but kbagent SIGKILLed the script when it exceeded probe `timeoutSeconds`, then recovered on the next probe).

Stress evidence: `valkey-focused-stress-20260502-013818/t09/01/focus-kbagent-zombie/` includes the proc snapshot, sentinel logs, and controller events.

## Root cause

PR #2618 replaced the four-stage pipeline inside `check_sync_stall` with a bash here-string + while/read/case loop, eliminating that zombie source. But the **outer** role-line capture in `check-role.sh` main was untouched and still used a three-stage pipeline:

```bash
role_line=$(${cli_cmd} info replication 2>/dev/null \
  | grep "^role:" | tr -d '\r\n')
```

Each pipeline stage spawns a child process: `valkey-cli`, `grep`, `tr`. When kbagent SIGKILLs `check-role.sh` for exceeding probe `timeoutSeconds`, the pipeline children are reparented to kbagent's PID 1, which is a Go binary that does not reap unrelated children, so they accumulate as zombies. This is the same exposure described in `docs/addon-probe-script-fork-and-zombie-guide.md`, applied to the outer parse path that PR #2618 missed.

The proc snapshot confirms `(check-role.sh) Z 1 1 1 0` — `check-role.sh` is the zombie, parent is PID 1 (kbagent). The stress runner's per-iteration sampler caught this via direct `/proc` reads, which the cycle 1/2 sampler grep patterns did not previously detect.

## Fix

Replace the three-stage pipeline with a single command substitution that captures the entire INFO output (one valkey-cli child), then walk the captured string with a bash builtin while/read/case loop. The trailing CR is removed via parameter expansion (`${line%$'\r'}`).

### Before

```bash
role_line=$(${cli_cmd} info replication 2>/dev/null \
  | grep "^role:" | tr -d '\r\n')
# 3 child processes per probe call (cli + grep + tr)
```

### After

```bash
repl_info=$(${cli_cmd} info replication 2>/dev/null) || repl_info=""
role_line=""
while IFS= read -r line; do
  line="${line%$'\r'}"
  case "${line}" in
    role:*) role_line="${line}"; break ;;
  esac
done <<<"${repl_info}"
# 1 child process per probe call (just the cli itself, returns in ~ms)
```

Reduces the worst-case orphan count under kbagent SIGKILL from three to one (only the `valkey-cli` call itself, which is local-only and typically returns within milliseconds).

## File changes

```
addons/valkey/scripts/check-role.sh                  (pipeline → bash builtin)
addons/valkey/scripts-ut-spec/check_role_spec.sh     (3 new contract assertions)
```

## Verification

- `shellspec addons/valkey/scripts-ut-spec/` → **112 examples, 0 failures**
  - 3 new assertions in `check_role_spec.sh`:
    - no active code line pipes INFO output through `grep` / `tr` / `awk` / `sed` / `cut` (regression guard)
    - the new bash builtin `while IFS= read` parse pattern is present (positive guard)
    - empty INFO output (cli connection refused at pod startup) is handled cleanly (role_line stays empty, main script's case falls through to `exit 1`)
- `bash -n addons/valkey/scripts/check-role.sh` → PASS
- Cluster validation: deferred to follow-up rerun of the focused stress test (T09 x20 + upgrade x20 + rebuild x20) after merge + helm upgrade.

## Relationship to prior PRs

- #2615 cascade-repair guards: unchanged.
- #2617 cascade self-heal entrypoint daemon refactor: unchanged.
- #2618 roleProbe newline + `check_sync_stall` pipeline fix + stall to daemon: this PR addresses the **outer** pipeline that #2618 left in place when it slimmed `check-role.sh`. Conceptually a follow-up to the same Pattern B exposure analysis.
- #2619 drop `SENTINEL RESET` from member-leave: unchanged.