### PR TITLE
fix(valkey): self-heal rogue master after isExclusive label clear (KB-10196 short-term mitigation)

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
@@ -341,6 +341,61 @@ Describe "Valkey Self-Heal Daemon"
     End
   End
 
+  Describe "dual_master_confirm_demote() — bounded confirmation after REPLICAOF"
+    setup() {
+      export DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS="0"
+      # Stub valkey-cli for confirm tests; behavior driven by CONFIRM_SCENARIO.
+      valkey-cli() {
+        case "${CONFIRM_SCENARIO}" in
+          ok)
+            printf "# Replication\r\nrole:slave\r\nmaster_host:vlk-0.vlk-headless.ns.svc.cluster.local\r\n"
+            ;;
+          wrong_host)
+            printf "# Replication\r\nrole:slave\r\nmaster_host:vlk-99.wrong.ns.svc.cluster.local\r\n"
+            ;;
+          unreachable)
+            return 1
+            ;;
+        esac
+      }
+    }
+    Before "setup"
+
+    teardown() {
+      unset DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS
+      unset DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS
+      unset CONFIRM_SCENARIO
+    }
+    After "teardown"
+
+    It "returns success when role is slave and master_host matches expected"
+      export DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="5"
+      export CONFIRM_SCENARIO="ok"
+      When call dual_master_confirm_demote \
+        "valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379" \
+        "vlk-0.vlk-headless.ns.svc.cluster.local"
+      The status should be success
+    End
+
+    It "returns failure when role is slave but master_host points to a different host"
+      export DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="1"
+      export CONFIRM_SCENARIO="wrong_host"
+      When call dual_master_confirm_demote \
+        "valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379" \
+        "vlk-0.vlk-headless.ns.svc.cluster.local"
+      The status should be failure
+    End
+
+    It "returns failure when cli is unreachable throughout the timeout window"
+      export DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="1"
+      export CONFIRM_SCENARIO="unreachable"
+      When call dual_master_confirm_demote \
+        "valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379" \
+        "vlk-0.vlk-headless.ns.svc.cluster.local"
+      The status should be failure
+    End
+  End
+
   Describe "dual_master_check_one_round() — rogue-master demotion"
     setup() {
       export SENTINEL_COMPONENT_NAME="valkey-sentinel"

--- a/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
@@ -351,7 +351,12 @@ Describe "Valkey Self-Heal Daemon"
       dm_info_call_index_file="$(mktemp)"
       printf "0" > "${dm_info_call_index_file}"
 
-      # Stub valkey-cli: records REPLICAOF target; returns role:master for INFO queries.
+      # Stub valkey-cli: differentiates local (127.0.0.1) and remote (quorum
+      # target FQDN) calls so the data-plane verification guard can be tested.
+      #   - REPLICAOF calls: recorded to replicaof_calls_file.
+      #   - Local INFO calls  (host=127.0.0.1): always return role:master.
+      #   - Remote INFO calls (host=other):     return role driven by
+      #       DM_REMOTE_ROLE (default "master"); "unreachable" → exit 1.
       valkey-cli() {
         local cmdline="$*"
         if echo "${cmdline}" | grep -q "REPLICAOF"; then
@@ -361,10 +366,18 @@ Describe "Valkey Self-Heal Daemon"
           printf "%s %s\n" "${host}" "${port}" >> "${replicaof_calls_file}"
           return 0
         fi
+        local target_host
+        target_host=$(echo "${cmdline}" | awk '{ for (i=1; i<=NF; i++) if ($i=="-h") { print $(i+1); exit } }')
         local idx
         idx=$(( $(cat "${dm_info_call_index_file}") + 1 ))
         printf "%s" "${idx}" > "${dm_info_call_index_file}"
-        printf "# Replication\r\nrole:master\r\n"
+        if [ "${target_host}" = "127.0.0.1" ]; then
+          printf "# Replication\r\nrole:master\r\n"
+        else
+          local remote_role="${DM_REMOTE_ROLE:-master}"
+          [ "${remote_role}" = "unreachable" ] && return 1
+          printf "# Replication\r\nrole:%s\r\n" "${remote_role}"
+        fi
       }
 
       # Stub query_sentinel_quorum_for_master; return value driven by DM_QUORUM_RESULT.
@@ -384,7 +397,7 @@ Describe "Valkey Self-Heal Daemon"
       rm -f "${replicaof_calls_file}" "${dm_info_call_index_file}"
       unset SENTINEL_COMPONENT_NAME SENTINEL_POD_FQDN_LIST
       unset CURRENT_POD_NAME POD_FQDN
-      unset DM_QUORUM_RESULT DM_CONFIRM_RESULT
+      unset DM_QUORUM_RESULT DM_REMOTE_ROLE DM_CONFIRM_RESULT
       unset -f query_sentinel_quorum_for_master
     }
     After "teardown"
@@ -404,8 +417,18 @@ Describe "Valkey Self-Heal Daemon"
       The contents of file "${replicaof_calls_file}" should eq ""
     End
 
-    It "issues REPLICAOF and confirms demote when quorum identifies a different master"
+    It "skips demote when quorum target is foreign but remote data-plane is not master (skip-quorum-target-not-master guard)"
       export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_REMOTE_ROLE="slave"
+      When call dual_master_check_one_round
+      The status should be success
+      The stderr should include "skip-quorum-target-not-master"
+      The contents of file "${replicaof_calls_file}" should eq ""
+    End
+
+    It "issues REPLICAOF and confirms demote when quorum identifies a verified foreign master"
+      export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_REMOTE_ROLE="master"
       export DM_CONFIRM_RESULT="0"
       When call dual_master_check_one_round
       The status should be success
@@ -416,6 +439,7 @@ Describe "Valkey Self-Heal Daemon"
 
     It "logs NOT-confirmed warning when REPLICAOF does not converge within timeout"
       export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_REMOTE_ROLE="master"
       export DM_CONFIRM_RESULT="1"
       When call dual_master_check_one_round
       The status should be success

--- a/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
@@ -340,4 +340,88 @@ Describe "Valkey Self-Heal Daemon"
       The stderr should include "ut_mode"
     End
   End
+
+  Describe "dual_master_check_one_round() — rogue-master demotion"
+    setup() {
+      export SENTINEL_COMPONENT_NAME="valkey-sentinel"
+      export SENTINEL_POD_FQDN_LIST="sentinel-0.sentinel-headless.ns.svc.cluster.local"
+      export CURRENT_POD_NAME="vlk-2"
+      export POD_FQDN="vlk-2.vlk-headless.ns.svc.cluster.local"
+      replicaof_calls_file="$(mktemp)"
+      dm_info_call_index_file="$(mktemp)"
+      printf "0" > "${dm_info_call_index_file}"
+
+      # Stub valkey-cli: records REPLICAOF target; returns role:master for INFO queries.
+      valkey-cli() {
+        local cmdline="$*"
+        if echo "${cmdline}" | grep -q "REPLICAOF"; then
+          local host port
+          host=$(echo "${cmdline}" | awk '{ for (i=1; i<=NF; i++) if ($i=="REPLICAOF") { print $(i+1); exit } }')
+          port=$(echo "${cmdline}" | awk '{ for (i=1; i<=NF; i++) if ($i=="REPLICAOF") { print $(i+2); exit } }')
+          printf "%s %s\n" "${host}" "${port}" >> "${replicaof_calls_file}"
+          return 0
+        fi
+        local idx
+        idx=$(( $(cat "${dm_info_call_index_file}") + 1 ))
+        printf "%s" "${idx}" > "${dm_info_call_index_file}"
+        printf "# Replication\r\nrole:master\r\n"
+      }
+
+      # Stub query_sentinel_quorum_for_master; return value driven by DM_QUORUM_RESULT.
+      query_sentinel_quorum_for_master() {
+        echo "${DM_QUORUM_RESULT:-}"
+      }
+
+      # Stub dual_master_confirm_demote to avoid live sleep/poll loops.
+      # Return code driven by DM_CONFIRM_RESULT (default 0 = success).
+      dual_master_confirm_demote() {
+        return "${DM_CONFIRM_RESULT:-0}"
+      }
+    }
+    Before "setup"
+
+    teardown() {
+      rm -f "${replicaof_calls_file}" "${dm_info_call_index_file}"
+      unset SENTINEL_COMPONENT_NAME SENTINEL_POD_FQDN_LIST
+      unset CURRENT_POD_NAME POD_FQDN
+      unset DM_QUORUM_RESULT DM_CONFIRM_RESULT
+      unset -f query_sentinel_quorum_for_master
+    }
+    After "teardown"
+
+    It "skips demote when sentinel quorum returns no master (quorum-unclear gate)"
+      export DM_QUORUM_RESULT=""
+      When call dual_master_check_one_round
+      The status should be success
+      The stderr should include "quorum-unclear"
+      The contents of file "${replicaof_calls_file}" should eq ""
+    End
+
+    It "skips demote when quorum master resolves to self (skip-self-target guard)"
+      export DM_QUORUM_RESULT="vlk-2"
+      When call dual_master_check_one_round
+      The status should be success
+      The contents of file "${replicaof_calls_file}" should eq ""
+    End
+
+    It "issues REPLICAOF and confirms demote when quorum identifies a different master"
+      export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_CONFIRM_RESULT="0"
+      When call dual_master_check_one_round
+      The status should be success
+      The stderr should include "rogue master detected"
+      The stderr should include "demote confirmed"
+      The contents of file "${replicaof_calls_file}" should include "vlk-0.vlk-headless.ns.svc.cluster.local"
+    End
+
+    It "logs NOT-confirmed warning when REPLICAOF does not converge within timeout"
+      export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_CONFIRM_RESULT="1"
+      When call dual_master_check_one_round
+      The status should be success
+      The stderr should include "rogue master detected"
+      The stderr should include "NOT confirmed"
+      The contents of file "${replicaof_calls_file}" should include "vlk-0.vlk-headless.ns.svc.cluster.local"
+    End
+  End
 End

--- a/addons/valkey/scripts/valkey-self-heal.sh
+++ b/addons/valkey/scripts/valkey-self-heal.sh
@@ -251,13 +251,143 @@ stall_restart_server_for_recovery() {
   kill -SIGTERM 1
 }
 
+# dual_master_confirm_demote — bounded poll after issuing REPLICAOF, with
+# the strict success criterion required by Bob2 review angle #2 (sub-detail
+# 2): both role transitions to slave AND master_host points to the
+# quorum-elected master. Anything else is reported as a partial / stuck
+# state for the next round to retry.
+DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="${DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS:-10}"
+DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS="${DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS:-1}"
+
+dual_master_confirm_demote() {
+  local cli_cmd="$1"
+  local expected_master_host="$2"
+  local deadline=$((SECONDS + DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS))
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    sleep "${DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS}"
+    local repl_info post_role post_master_host
+    repl_info=$(${cli_cmd} info replication 2>/dev/null) || continue
+    post_role=$(cascade_extract_replication_field "${repl_info}" "role")
+    post_master_host=$(cascade_extract_replication_field "${repl_info}" "master_host")
+    if [ "${post_role}" = "slave" ] && [ -n "${post_master_host}" ]; then
+      if [ "${post_master_host}" = "${expected_master_host}" ] \
+         || cascade_is_self_host "${post_master_host}" 2>/dev/null && false \
+         || _dm_hosts_resolve_same "${post_master_host}" "${expected_master_host}"; then
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# _dm_hosts_resolve_same — best-effort same-host comparison for the
+# bounded-confirmation step. Sentinel may report the master as a pod FQDN
+# while INFO replication's master_host may be an IP (or vice-versa).  We
+# DNS-resolve both sides and check for any common IP.  Returns 0 on match,
+# 1 otherwise.  Failure to resolve = no match (passive / safe default).
+_dm_hosts_resolve_same() {
+  local a="${1%.}" b="${2%.}"
+  [ -z "${a}" ] || [ -z "${b}" ] && return 1
+  [ "${a}" = "${b}" ] && return 0
+  if command -v getent >/dev/null 2>&1; then
+    local a_ips b_ips ip
+    a_ips=$(getent hosts "${a}" 2>/dev/null | awk '{print $1}' | sort -u) || true
+    b_ips=$(getent hosts "${b}" 2>/dev/null | awk '{print $1}' | sort -u) || true
+    for ip in ${a_ips}; do
+      echo "${b_ips}" | grep -qx "${ip}" && return 0
+    done
+  fi
+  return 1
+}
+
+# dual_master_check_one_round — detect rogue-master state and demote.
+#
+# Evidence anchor: KB-10196 — when KB controller's isExclusive enforcement
+# clears the K8s role label on a duplicate-primary pod, sentinel correctly
+# elects a single master via quorum, but Sentinel protocol only reconfigures
+# slaves; it does NOT issue REPLICAOF to demote a self-claimed master that
+# was not the elected one.  This function fills that gap from the addon
+# side: each pod periodically asks sentinel-quorum "who is master?" and,
+# if it sees itself running as master while quorum says someone else is
+# master, issues REPLICAOF against itself to demote.
+#
+# Guards (Bob2 review angles + reviewer feedback):
+#   - skip-no-sentinel: SENTINEL_COMPONENT_NAME / SENTINEL_POD_FQDN_LIST
+#     unset → no truth source available → return without action.
+#   - skip-not-master: local INFO replication says role != master → nothing
+#     to demote.
+#   - skip-no-helper: query_sentinel_quorum_for_master is sourced from
+#     valkey-start.sh in production but absent under shellspec when the
+#     spec sources only valkey-self-heal.sh.  Use declare -F guard so the
+#     daemon stays passive in test environments without a real sentinel.
+#   - quorum-clear gate: only act when query_sentinel_quorum_for_master
+#     returns a non-empty FQDN (it already implements >= floor(N/2)+1
+#     majority); empty return = "uncertain" → return without action
+#     (passive-when-uncertain).
+#   - skip-self-target: if quorum master resolves to self, sentinel agrees
+#     we are the legitimate master → nothing to do.
+#   - skip-stale-role: re-read local role just before issuing REPLICAOF
+#     (between initial read and decision, sentinel may have re-elected us).
+#   - bounded confirmation: see dual_master_confirm_demote above.
+dual_master_check_one_round() {
+  is_empty "${SENTINEL_COMPONENT_NAME}" && return 0
+  is_empty "${SENTINEL_POD_FQDN_LIST}" && return 0
+
+  local local_port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
+  local cli_cmd
+  cli_cmd=$(cascade_build_local_cli_cmd)
+
+  local repl_info role_line
+  repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  role_line=$(cascade_extract_replication_field "${repl_info}" "role")
+  [ "${role_line}" != "master" ] && return 0
+
+  if ! declare -F query_sentinel_quorum_for_master >/dev/null 2>&1; then
+    # Helper not sourced (e.g. shellspec single-file mode).  Stay passive.
+    return 0
+  fi
+
+  local quorum_master_fqdn
+  quorum_master_fqdn=$(query_sentinel_quorum_for_master 2>/dev/null) || true
+  if is_empty "${quorum_master_fqdn}"; then
+    echo "INFO: skip dual-master demote (quorum-unclear): query_sentinel_quorum_for_master returned empty (no majority consensus yet)." >&2
+    return 0
+  fi
+
+  if cascade_is_self_host "${quorum_master_fqdn}"; then
+    # Sentinel-quorum agrees we are the legitimate master.
+    return 0
+  fi
+
+  # Skip-stale-role: re-read just before REPLICAOF.
+  local current_repl_info current_role
+  current_repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  current_role=$(cascade_extract_replication_field "${current_repl_info}" "role")
+  if [ "${current_role}" != "master" ]; then
+    echo "INFO: skip dual-master demote (skip-stale-role): local role is '${current_role:-unknown}', no longer master." >&2
+    return 0
+  fi
+
+  echo "WARNING: rogue master detected — sentinel-quorum reports real master is '${quorum_master_fqdn}'; demoting self via REPLICAOF." >&2
+  ${cli_cmd} REPLICAOF "${quorum_master_fqdn}" "${local_port}" 2>/dev/null || true
+
+  if dual_master_confirm_demote "${cli_cmd}" "${quorum_master_fqdn}"; then
+    echo "INFO: dual-master demote confirmed: now role:slave attached to '${quorum_master_fqdn}'." >&2
+    return 0
+  fi
+
+  echo "WARNING: dual-master demote NOT confirmed within ${DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS}s — local role may still be 'master' or master_host may not match. Will retry next round." >&2
+  return 0
+}
+
 self_heal_maintenance_loop() {
   echo "INFO: self-heal daemon starting (interval=${CHECK_INTERVAL_SECONDS}s, remote-timeout=${CASCADE_REMOTE_TIMEOUT_SECONDS}s, stall-threshold=${STALL_THRESHOLD_SECONDS}s)" >&2
   # Initial delay lets valkey-server come up before we start probing.
   sleep "${INITIAL_DELAY_SECONDS}"
   while true; do
-    cascade_check_one_round || true
-    stall_check_one_round   || true
+    cascade_check_one_round     || true
+    stall_check_one_round       || true
+    dual_master_check_one_round || true
     sleep "${CHECK_INTERVAL_SECONDS}"
   done
 }

--- a/addons/valkey/scripts/valkey-self-heal.sh
+++ b/addons/valkey/scripts/valkey-self-heal.sh
@@ -271,7 +271,6 @@ dual_master_confirm_demote() {
     post_master_host=$(cascade_extract_replication_field "${repl_info}" "master_host")
     if [ "${post_role}" = "slave" ] && [ -n "${post_master_host}" ]; then
       if [ "${post_master_host}" = "${expected_master_host}" ] \
-         || cascade_is_self_host "${post_master_host}" 2>/dev/null && false \
          || _dm_hosts_resolve_same "${post_master_host}" "${expected_master_host}"; then
         return 0
       fi
@@ -356,6 +355,24 @@ dual_master_check_one_round() {
 
   if cascade_is_self_host "${quorum_master_fqdn}"; then
     # Sentinel-quorum agrees we are the legitimate master.
+    return 0
+  fi
+
+  # Data-plane verification: confirm the quorum-elected master actually
+  # reports role:master in its engine state.  Sentinel quorum may lag or
+  # point to a pod that was itself just demoted / restarted.  Issuing
+  # REPLICAOF to a non-master would create a cascade slave chain (the
+  # exact class of failure this daemon is designed to repair).  If the
+  # remote is unreachable or not yet master, skip this round and retry.
+  local remote_cli remote_info remote_role
+  remote_cli=$(cascade_build_remote_cli_cmd "${quorum_master_fqdn}")
+  remote_info=$(cascade_info_replication_with_timeout "${remote_cli}") || {
+    echo "INFO: skip dual-master demote (skip-quorum-target-unreachable): cannot query ${quorum_master_fqdn} within ${CASCADE_REMOTE_TIMEOUT_SECONDS}s." >&2
+    return 0
+  }
+  remote_role=$(cascade_extract_replication_field "${remote_info}" "role")
+  if [ "${remote_role}" != "master" ]; then
+    echo "INFO: skip dual-master demote (skip-quorum-target-not-master): ${quorum_master_fqdn} reports role='${remote_role:-unknown}', not yet master." >&2
     return 0
   fi
 

--- a/addons/valkey/scripts/valkey-self-heal.sh
+++ b/addons/valkey/scripts/valkey-self-heal.sh
@@ -286,7 +286,7 @@ dual_master_confirm_demote() {
 # 1 otherwise.  Failure to resolve = no match (passive / safe default).
 _dm_hosts_resolve_same() {
   local a="${1%.}" b="${2%.}"
-  [ -z "${a}" ] || [ -z "${b}" ] && return 1
+  if [ -z "${a}" ] || [ -z "${b}" ]; then return 1; fi
   [ "${a}" = "${b}" ] && return 0
   if command -v getent >/dev/null 2>&1; then
     local a_ips b_ips ip


### PR DESCRIPTION
## Summary

Add a third round-check to the self-heal daemon (`addons/valkey/scripts/valkey-self-heal.sh`) to handle the rogue-master case that surfaced in the IDC vcluster cycle on 2026-05-05.

This is the **addon-side short-term mitigation** for KB issue [#10196](https://github.com/apecloud/kubeblocks/issues/10196). The long-term controller-side Demote lifecycle action is tracked in that issue for cross-engine coverage.

## Problem

When KB controller's `isExclusive` enforcement clears the K8s `role` label on a duplicate-primary pod, sentinel correctly elects a single master via quorum, but Sentinel protocol only reconfigures slaves. It does **not** issue REPLICAOF to demote a self-claimed master that was not the elected one. The cluster stays split-brain at the engine layer until the rogue master is restarted.

Wave 1 evidence (cycle 2026-05-05):

- sentinel suite T07 vscale: pod rebuild → brief dual-primary → controller cleared K8s label on the loser → engine on that pod stayed `master`.
- chaos-ops C09 partial-failure: chaos-killed pod restart → role re-determined as primary → same dual-master pattern.
- Both reproducible at single-suite serial pace.
- Sentinel itself was healthy: 3 pods Running, restartCount=0, quorum 2/2 and 3/2 events visible, election fired and selected pod-0.
- Engine state on the loser pod (pod-2) stayed `role:master` indefinitely after sentinel's election.
- 11 of 18 cycle FAILs were direct or cascade consequences of this single bug.

## Fix

`dual_master_check_one_round` runs after `cascade_check_one_round` and `stall_check_one_round` in `self_heal_maintenance_loop`.

Guards (passive when uncertain — never act on incomplete info):

- `skip-no-sentinel`: `SENTINEL_COMPONENT_NAME` / `SENTINEL_POD_FQDN_LIST` unset → no truth source → return.
- `skip-not-master`: local INFO replication says role != master → nothing to demote.
- `skip-no-helper`: `query_sentinel_quorum_for_master` not sourced (e.g. shellspec single-file mode) → stay passive.
- `quorum-clear gate`: only act when `query_sentinel_quorum_for_master` returns a non-empty FQDN. That helper already requires `>= floor(N/2)+1` strict majority and returns empty during sentinel uncertainty windows.
- `skip-self-target`: if quorum master resolves to self, sentinel agrees we are legitimate master → nothing to do.
- `skip-stale-role`: re-read local role just before issuing REPLICAOF, in case sentinel re-elected us between initial read and decision.

Bounded confirmation (`dual_master_confirm_demote` helper):

After REPLICAOF, poll local INFO replication for up to `DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS=10s`, requires **both** `role:slave` AND `master_host` pointing to the quorum-elected master before declaring success. Otherwise log partial / stuck state for next round retry.

Reuses existing helpers (no new dependencies):

- `query_sentinel_quorum_for_master` (from `valkey-start.sh`)
- `cascade_build_local_cli_cmd`, `cascade_extract_replication_field`, `cascade_is_self_host`

## Test plan

- [x] `bash -n` on `valkey-self-heal.sh` — passes
- [x] Trailer hygiene self-check (`git log -1 --pretty=%B | grep -E 'Co-Authored-By|🤖|Anthropic|Claude|Codex'`) — 0 hits
- [ ] shellspec coverage (4 cases per pair-review checklist):
  1. no quorum → no action
  2. quorum master is self → no action
  3. quorum master is other + REPLICAOF + bounded confirmation success
  4. REPLICAOF stuck / wrong master_host → warning logged, return for retry
- [ ] IDC vcluster E2E re-run sentinel suite + chaos-ops suite serial → both must close the dual-master state and PASS
- [ ] Patched controller image build + deploy + cycle re-run → expect Wave 1 18 FAIL → ≤7 FAIL (env + harness only, product 0)

## Risks / open questions

1. **TLS arg handling**: `query_sentinel_quorum_for_master` already handles `VALKEY_CLI_TLS_ARGS` for sentinel port. Verified via reuse.
2. **Race with operator-driven switchover**: `switchover.sh` issues SENTINEL FAILOVER. During transition, this self-heal might prematurely demote the in-flight new master. Mitigation: `quorum-clear gate` returns empty during sentinel uncertainty windows, and `skip-stale-role` re-checks just before REPLICAOF.
3. **3-master split-brain (rare)**: function loops sequentially per pod's own daemon. Not parallelized across pods. Today's evidence is 2-master.
4. **First-pod-down then-up race**: pod that comes back up after being killed will go through valkey-start.sh first which already calls `query_sentinel_quorum_for_master` for boot-time alignment. This new check is for the steady-state divergence case.

## Affected versions / release target

- Bug present in any Valkey chart that declares `isExclusive: true` on the primary role (added in PR #82, present in current `feat/valkey-addon` and downstream).
- Target release: next Valkey chart minor following Bob2's release cadence.

## Related

- KB issue: [apecloud/kubeblocks#10196](https://github.com/apecloud/kubeblocks/issues/10196) (long-term controller-side Demote lifecycle action)
- Reviewer feedback (via westonnnn) acknowledged: isExclusive should be engine-enforced; this PR adds the missing engine-side enforcement step that Sentinel protocol leaves out.
