### PR TITLE
fix(valkey): fail closed on reload config errors

### DIFF
--- a/addons/valkey/scripts-ut-spec/reload_parameter_spec.sh
+++ b/addons/valkey/scripts-ut-spec/reload_parameter_spec.sh
@@ -1,0 +1,76 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "reload_parameter_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Valkey reload-parameter.sh"
+  setup() {
+    mkdir -p fakebin
+    cat > fakebin/timeout <<'SH'
+#!/bin/sh
+shift
+exec "$@"
+SH
+    cat > fakebin/valkey-cli <<'SH'
+#!/bin/sh
+case "${FAKE_VALKEY_OUTPUT:-OK}" in
+  OK) printf 'OK\n' ;;
+  unknown) printf 'ERR Unknown option\n' ;;
+  immutable) printf 'ERR CONFIG SET failed (possibly related to argument '\''cluster-enabled'\'') - can'\''t set immutable config\n' ;;
+  invalid) printf 'ERR invalid maxmemory policy\n' ;;
+  range) printf 'ERR value is out of range\n' ;;
+esac
+exit 0
+SH
+    chmod +x fakebin/timeout fakebin/valkey-cli
+    export PATH="./fakebin:${PATH}"
+    unset VALKEY_DEFAULT_PASSWORD
+    unset VALKEY_CLI_TLS_ARGS
+    unset SERVICE_PORT
+  }
+  Before "setup"
+
+  cleanup() {
+    rm -rf fakebin
+    unset FAKE_VALKEY_OUTPUT
+    unset VALKEY_DEFAULT_PASSWORD
+    unset VALKEY_CLI_TLS_ARGS
+    unset SERVICE_PORT
+  }
+  After "cleanup"
+
+  It "succeeds when CONFIG SET returns OK"
+    export FAKE_VALKEY_OUTPUT=OK
+    When run sh ../scripts/reload-parameter.sh MAXMEMORY_POLICY allkeys-lru
+    The status should be success
+  End
+
+  It "keeps unsupported static parameters non-fatal"
+    export FAKE_VALKEY_OUTPUT=unknown
+    When run sh ../scripts/reload-parameter.sh BIND 0.0.0.0
+    The status should be success
+  End
+
+  It "keeps immutable runtime parameters non-fatal"
+    export FAKE_VALKEY_OUTPUT=immutable
+    When run sh ../scripts/reload-parameter.sh CLUSTER_ENABLED yes
+    The status should be success
+  End
+
+  It "fails closed on invalid enum values"
+    export FAKE_VALKEY_OUTPUT=invalid
+    When run sh ../scripts/reload-parameter.sh MAXMEMORY_POLICY definitely-not-a-policy
+    The status should be failure
+    The stderr should include "ERROR: CONFIG SET maxmemory-policy failed"
+  End
+
+  It "fails closed on invalid range values"
+    export FAKE_VALKEY_OUTPUT=range
+    When run sh ../scripts/reload-parameter.sh MAXMEMORY_SAMPLES 0
+    The status should be failure
+    The stderr should include "ERROR: CONFIG SET maxmemory-samples failed"
+  End
+End

--- a/addons/valkey/scripts/reload-parameter.sh
+++ b/addons/valkey/scripts/reload-parameter.sh
@@ -9,7 +9,8 @@
 #   (maxmemory-policy) and runs CONFIG SET on the live server.
 #
 #   Not all parameters support CONFIG SET (e.g., bind, port require restart).
-#   We silently ignore errors for unsupported parameters.
+#   Unsupported/static parameters are ignored, but value validation failures
+#   must fail closed so the reconfigure action cannot report a false success.
 
 param_name="${1}"
 param_value="${2}"
@@ -29,12 +30,15 @@ if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
 fi
 
 # valkey-cli exits 0 even for protocol errors; capture output and check content.
+# Connection failures also fail closed; the caller should retry the action.
 output=$(${cli_cmd} CONFIG SET "${valkey_param}" "${param_value}" 2>&1) || true
 # Silently ignore parameters that do not support CONFIG SET (e.g. bind, port).
-# Log a warning only when the error is not "ERR Unknown option" or similar
-# (which indicate a static/unsupported param) so that invalid values are surfaced.
+# Fail closed for other CONFIG SET errors so invalid dynamic values are surfaced.
 case "${output}" in
   "OK") ;;   # success
   *"ERR Unknown option"*|*"not allowed"*|*"can't set"*) ;;
-  *) echo "WARNING: CONFIG SET ${valkey_param} failed: ${output}" >&2 ;;
+  *)
+    echo "ERROR: CONFIG SET ${valkey_param} failed: ${output}" >&2
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
## Summary

- Make `reload-parameter.sh` fail closed when `CONFIG SET` returns an unexpected non-OK response.
- Keep unsupported/static parameter errors non-fatal for the existing restart-path contract.
- Add shellspec coverage for OK, unknown option, immutable config, invalid enum, and invalid range cases.

## Validation

- `sh -n addons/valkey/scripts/reload-parameter.sh`
- `bash -n addons/valkey/scripts-ut-spec/reload_parameter_spec.sh`
- `shellspec --helperdir shellspec addons/valkey/scripts-ut-spec/reload_parameter_spec.sh` -> 5 examples, 0 failures
- `shellspec --helperdir shellspec addons/valkey/scripts-ut-spec` -> 125 examples, 0 failures
- `git diff --check`

## Live error-string check

Temporary namespace: `valkey-static-err-051551` on `valkey-fresh-0008`; cleaned up to NotFound.

- Valkey 9.0.0 image: `dockerproxy.net/valkey/valkey:9.0.0`
- Valkey 8.1.3 image: `dockerproxy.net/valkey/valkey:8.1.3`
- Evidence tar sha: `0c133c48054aa9a9d76ae6192b1f7f16c892f3e971dde23cb0781bd63c000a97`
- Valkey 9 log sha: `e496a5aad66af87223337a4876aa9fdf0c906eb6a129c1f5b38c929ec4355020`
- Valkey 8 log sha: `c8a19207dd71cda50293609e513721d8094210866c07133d47e5ea66f7eb03aa`

Observed strings:

- `CONFIG SET cluster-enabled yes` and `CONFIG SET databases 0` returned `can't set immutable config`, which matches the existing `*can't set*` branch.
- `CONFIG SET not-a-real-config 1` returned `ERR Unknown option...`, which matches the existing `*ERR Unknown option*` branch.
- `CONFIG SET appendonly maybe` returned `argument must be 'yes' or 'no'`, which now fails closed.
- `CONFIG SET bind 0.0.0.0` and `CONFIG SET port 6380` returned `OK`; those must stay on the static restart path and should not rely on the reload script whitelist.

## Boundary

This is Valkey script-layer secondary hardening. It does not replace the KubeBlocks Configure validation fix for invalid OpsRequest false-success.
