### PR TITLE
chore(mysql): wait for SQL before PITR replay

### DIFF
--- a/addons/mysql/dataprotection/mysql-pitr-restore.sh
+++ b/addons/mysql/dataprotection/mysql-pitr-restore.sh
@@ -12,7 +12,39 @@ export WALG_MYSQL_CHECK_GTIDS=true
 export MYSQL_PWD=${MYSQL_ADMIN_PASSWORD}
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 export WALG_MYSQL_BINLOG_DST=${PITR_DIR}
-export WALG_MYSQL_BINLOG_REPLAY_COMMAND="mysqlbinlog --stop-datetime=\"\$WALG_MYSQL_BINLOG_END_TS\" \"\$WALG_MYSQL_CURRENT_BINLOG\" | mysql -u ${MYSQL_ADMIN_USER} -h ${DP_DB_HOST}"
+export WALG_MYSQL_BINLOG_REPLAY_COMMAND="mysqlbinlog --stop-datetime=\"\$WALG_MYSQL_BINLOG_END_TS\" \"\$WALG_MYSQL_CURRENT_BINLOG\" | mysql -u ${MYSQL_ADMIN_USER} -h ${DP_DB_HOST} -P ${DP_DB_PORT}"
+
+mysql_pitr_wait_for_sql_ready() {
+    local timeout_seconds="${MYSQL_PITR_REPLAY_READY_TIMEOUT_SECONDS:-180}"
+    local interval_seconds="${MYSQL_PITR_REPLAY_READY_INTERVAL_SECONDS:-2}"
+    local deadline
+    local attempt=0
+    local last_error=""
+
+    deadline=$(($(date +%s) + timeout_seconds))
+    DP_log "waiting for MySQL ${DP_DB_HOST}:${DP_DB_PORT} SQL readiness before PITR replay"
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        attempt=$((attempt + 1))
+        if mysql -u "${MYSQL_ADMIN_USER}" -h "${DP_DB_HOST}" -P "${DP_DB_PORT}" -e "SELECT 1" >/tmp/mysql-pitr-ready.out 2>/tmp/mysql-pitr-ready.err; then
+            DP_log "MySQL SQL readiness confirmed before PITR replay"
+            rm -f /tmp/mysql-pitr-ready.out /tmp/mysql-pitr-ready.err
+            return 0
+        fi
+
+        if [ -s /tmp/mysql-pitr-ready.err ]; then
+            last_error=$(tail -n 1 /tmp/mysql-pitr-ready.err)
+        fi
+        if [ $((attempt % 5)) -eq 0 ]; then
+            DP_log "waiting for MySQL SQL readiness; last error: ${last_error:-unknown}"
+        fi
+        sleep "$interval_seconds"
+    done
+
+    DP_error_log "timed out waiting for MySQL SQL readiness before PITR replay; last error: ${last_error:-unknown}"
+    return 1
+}
+
+mysql_pitr_wait_for_sql_ready
 
 # If pitr logs dir exists, it may be created by previous failed restore.
 if [ -d "$WALG_MYSQL_BINLOG_DST" ]; then


### PR DESCRIPTION
## What

Add a bounded SQL readiness wait before MySQL PITR postReady binlog replay starts.

The replay script now:
- probes `${DP_DB_HOST}:${DP_DB_PORT}` with `mysql ... -e "SELECT 1"` before creating `/var/lib/mysql/pitr-logs`;
- defaults to a 180s timeout and 2s interval;
- uses `${DP_DB_PORT}` in the actual `WALG_MYSQL_BINLOG_REPLAY_COMMAND`.

## Why

idc4 MySQL 5.7.44 PITR multifile N=1 with syncer PR #160 patch crossed the previous DCS/role blocker, but PostReady still failed:

- leader CM existed and restore pod reached `role=primary`;
- first archive replay container started at `2026-05-19T08:45:52Z`;
- replay failed at `2026-05-19T08:45:53Z` with `ERROR 2003 ... Can't connect to MySQL server ... :3306 (111)`;
- retry failed because `/var/lib/mysql/pitr-logs` had already been created by the first failed attempt.

This patch prevents the observed pre-SQL-ready replay start. It keeps the existing `pitr-logs` guard fail-closed instead of blindly deleting the directory, because a directory left after replay has started may mean binlogs were partially applied.

## Validation

Static:
- `bash -n addons/mysql/dataprotection/mysql-pitr-restore.sh` passed.
- `helm template mysql addons/mysql --namespace kb-system` passed.
- Render contains the SQL readiness wait and port-aware replay command.

Runtime evidence before this patch:
- evidence dir: `evidence/mysql-tests-idc4-5.7-pitr-multifile-pr160-patch-20260519T084326Z/`
- evidence sha after adding PostReady readiness summary: `ed3fe8ec829717f8be0588c24ca962c9eac1e1553135c4cfabba7b06ff6ec90c`

## Boundary

This is a candidate fix for the observed MySQL addon ActionSet readiness race. It is not release-ready and not yet a proven PITR fix. Patch-image runtime validation still needs to prove:

- PostReady job start time;
- SQL readiness confirmation before replay;
- `wal-g binlog-replay` result;
- final PostReady phase;
- restored row count, expected `row_count=8` for the PITR window;
- retry behavior if triggered.
