### PR TITLE
fix(tidb): tikv crash if RLIMIT_NOFILE not big enough

### DIFF
--- a/addons/tidb/config/tikv-config-constraint.cue
+++ b/addons/tidb/config/tikv-config-constraint.cue
@@ -480,7 +480,10 @@
 	// The size of a bucket when `enable-region-bucket` is true.
 	"coprocessor-v2.region-bucket-size": string | *"50MiB"
 
-	// rocksdb config is currently removed due to its complexity to parse
+	// most rocksdb config is currently removed due to its complexity to parse
+
+	// The total number of files that RocksDB can open
+	"rocksdb.max-open-files": int & >=-1 | *20000
 
 	// The number of background threads in RocksDB. When you modify the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 	"raftdb.max-background-jobs": int & >=2 | *4
@@ -489,7 +492,7 @@
 	"raftdb.max-sub-compactions": int & >=1 | *2
 
 	// The total number of files that RocksDB can open
-	"raftdb.max-open-files": int & >=-1 | *40960
+	"raftdb.max-open-files": int & >=-1 | *20000
 
 	// The maximum size of a RocksDB Manifest file. Unit: B|KiB|MiB|GiB
 	"raftdb.max-manifest-file-size": string | *"20MiB"

--- a/addons/tidb/config/tikv.toml.tpl
+++ b/addons/tidb/config/tikv.toml.tpl
@@ -520,10 +520,23 @@ consistency-check-method = "mvcc"
 ## If the config value is not set, the coprocessor plugin will be disabled.
 coprocessor-plugin-directory = "./coprocessors"
 
+[rocksdb]
+## Number of open files that can be used by the DB.
+## Value -1 means files opened are always kept open and RocksDB will prefetch index and filter
+## blocks into block cache at startup. So if your database has a large working set, it will take
+## several minutes to open the DB. You may need to increase this if your database has a large
+## working set. You can estimate the number of files based on `target-file-size-base` for
+## level-based compaction.
+# https://github.com/apecloud/apecloud/issues/18181
+# Some enviroments have RLIMIT_NOFILE not big enough
+max-open-files = 20000
+
 [raftdb]
 max-background-jobs = 4
 max-sub-compactions = 2
-max-open-files = 40960
+# https://github.com/apecloud/apecloud/issues/18181
+# Some enviroments have RLIMIT_NOFILE not big enough
+max-open-files = 20000
 max-manifest-file-size = "20MB"
 create-if-missing = true
 


### PR DESCRIPTION
fixes https://github.com/apecloud/apecloud/issues/18181