### PR TITLE
fix(mariadb): align README + chart claims with addon-api/12b acceptance

### DIFF
--- a/addons/mariadb/README.md
+++ b/addons/mariadb/README.md
@@ -6,15 +6,44 @@ MariaDB is a high performance open source relational database management system 
 
 ### Lifecycle Management
 
-| Horizontal<br/>scaling | Vertical <br/>scaling | Expand<br/>volume | Restart   | Stop/Start | Configure | Expose | Switchover |
-|------------------------|-----------------------|-------------------|-----------|------------|-----------|--------|------------|
-| No (Standalone Only)   | Yes                   | Yes               | Yes       | Yes        | No        | Yes    | No         |
+Per-topology support matrix. `Yes (verified)` has a recorded end-to-end evidence chain; `Yes (declared)` means the chart wires the action but a full release-standard evidence chain has not yet been recorded; `No` means the topology does not implement the lifecycle action:
+
+| Topology | Horizontal scaling | Vertical scaling | Expand volume | Restart | Stop/Start | Configure | Expose | Switchover |
+|---|---|---|---|---|---|---|---|---|
+| standalone | No | Yes | Yes | Yes | Yes | No | Yes | No |
+| replication | Yes (declared) | Yes | Yes | Yes | Yes | Yes (declared) | Yes | Yes (verified) |
+| semisync | Yes (declared) | Yes | Yes | Yes | Yes | Yes (declared) | Yes | Yes (verified) |
+| galera | Yes (declared) | Yes | Yes | Yes | Yes | Yes (declared) | Yes | No |
+
+Notes:
+- `Switchover (verified)` for `replication` / `semisync` covers the OpsRequest path with bounded role transition. The action is implemented in `cmpd-replication.yaml`, `cmpd-replication-merged.yaml`, and `cmpd-semisync.yaml`.
+- `Configure (declared)` means the chart wires `ParametersDefinition` and `reconfigure.exec` plus the `replicationMode` synthetic-parameter mapper. Only a subset of parameters has end-to-end runtime evidence today, so per-parameter coverage is "declared" until a parameter is exercised in a recorded test artifact.
 
 ### Versions
 
-| Versions |
-|----------|
-| 10.6.15 |
+`ComponentVersion` lists multiple release tags, but only `10.6.15` (standalone) and `11.4.10` (replication / semisync / galera) currently have an evidence-supported install + smoke chain. Other tags listed in `cmpv.yaml` are API-compatible but unproven; treat them as "declared but unverified":
+
+| Topology | Verified release | Declared but unproven |
+|---|---|---|
+| standalone | 10.6.15 | — |
+| replication / semisync / replication-merged | 11.4.10 | 11.4.5, 11.4.8, 11.8.4, 12.0.2 |
+| galera | 11.4.10 | 11.4.5, 11.4.8 |
+
+### Extended capability declarations (claim-only acceptance)
+
+The following capabilities are **not declared** by the MariaDB chart today. Treat them as "not supported" rather than "untested":
+
+- Backup encryption (passphrase, method formatVersion, snapshot artifact, repository artifact)
+- Selective backup / restore, `RestoreKubeResources`, cross-topology / cross-sharding restore, multi-target `sourceBackupTargetName`
+- PITR / continuous backup
+- Sharding
+- Proxy in front of the engine
+- Host network / `hostAliases` / `hostPort` / advertised LoadBalancer address
+- Cross-namespace `ServiceRef`
+
+The following capability is declared **only for the `standalone` topology** and is not yet wired into multi-instance topologies. Multi-instance + TLS should be treated as "not declared, not supported" until the corresponding `cmpd-replication*.yaml`, `cmpd-semisync.yaml`, or `cmpd-galera.yaml` declares the TLS spec and a topology-aware evidence chain is recorded:
+
+- TLS-only / mutual TLS / certificate mounting at the engine layer
 
 ## Prerequisites
 

--- a/addons/mariadb/templates/backuppolicytemplate.yaml
+++ b/addons/mariadb/templates/backuppolicytemplate.yaml
@@ -8,8 +8,15 @@ spec:
   serviceKind: Mariadb
   compDefs:
     - {{ include "mariadb.cmpdRegexpPattern" . }}
+  # The ActionSet uses `mariadb-backup --safe-slave-backup --slave-info`,
+  # designed to back up a replica without disrupting the writable primary.
+  # For replication / semisync topologies the secondary role is the
+  # preferred backup target; if no secondary is available KubeBlocks
+  # falls back to the primary so a standalone cluster (single pod with
+  # role=primary) still has a backup target.
   target:
-    role: ""
+    role: secondary
+    fallbackRole: primary
     account: root
   backupMethods:
     - name: mariadb-backup

--- a/addons/mariadb/templates/cmpv.yaml
+++ b/addons/mariadb/templates/cmpv.yaml
@@ -7,6 +7,16 @@ metadata:
   annotations:
     {{- include "mariadb.annotations" . | nindent 4 }}
 spec:
+  # NOTE on release evidence (see addon-api/12b-claimed-only-acceptance):
+  # As of this chart bump, only the following (CmpD, release) pairs have a
+  # recorded evidence-supported install + smoke chain:
+  #   - standalone cmpd                                                       10.6.15
+  #   - replication / semisync / replication-merged cmpd                      11.4.10
+  #   - galera cmpd                                                           11.4.10
+  # The other releases listed below (11.4.5, 11.4.8, 11.8.4, 12.0.2) are
+  # API-compatible declarations and have NOT been exercised end-to-end.
+  # Treat them as "declared but unverified" until a recorded test artifact
+  # exercises the install + smoke + lifecycle path on the matching release.
   compatibilityRules:
     - compDefs:
         - {{ include "mariadb.standalone.cmpdRegexpPattern" . }}


### PR DESCRIPTION
## Summary

Audits the MariaDB addon against the new `kubeblocks-addon-docs/docs/addon-api/` split structure (notably `12b-claimed-only-acceptance.md`) and brings three top-level surfaces into agreement with the actual chart implementation. No engine-runtime behavior changes; this PR only edits the README, adds a missing `target:` block to the BackupPolicyTemplate, and adds an evidence-boundary comment to ComponentVersion.

## Background

The MariaDB chart has been extended through the alpha cycle with four multi-instance topologies (replication, semisync, galera, replication-merged), ParametersDefinition + reconfigure.exec, and a working switchover action chain. The top-level README and a few metadata fields still reflected an earlier standalone-only baseline. The `12b-claimed-only-acceptance.md` doc requires that any capability claimed in README / values / chart must come with an evidence chain; capabilities without evidence must be written as "not supported" or "not declared" instead of being silently treated as "supported".

## What changed

### README per-topology matrix

The previous one-row matrix declared `Horizontal scaling: No (Standalone Only) / Configure: No / Switchover: No` globally, but the chart already implements multi-instance topologies, ParametersDefinition with reconfigure.exec, and switchover in three cmpd files. Replace the global "No" entries with a per-topology matrix that distinguishes `Yes (verified)` (recorded evidence chain) from `Yes (declared)` (wired but not yet release-standard tested).

### README extended-capability declaration section

Add an explicit "Extended capability declarations (claim-only acceptance)" section that lists capabilities the chart does NOT declare today: backup encryption / selective restore / PITR / sharding / proxy / host network / `hostAliases` / `hostPort` / cross-namespace `ServiceRef`. Also declare that TLS is scoped to the standalone topology only; multi-instance + TLS must be treated as "not declared, not supported" until the corresponding multi-instance cmpd files declare the TLS spec.

### README versions matrix

`ComponentVersion` lists 6 release tags (10.6.15 / 11.4.5 / 11.4.8 / 11.4.10 / 11.8.4 / 12.0.2). Only 10.6.15 (standalone) and 11.4.10 (multi-instance) have a recorded install + smoke chain. Add a per-topology / per-release breakdown that calls the others "declared but unproven".

### BackupPolicyTemplate target block

Add the `target:` block that was previously missing entirely. The ActionSet uses `mariadb-backup --safe-slave-backup --slave-info`, which is explicitly designed to back up a replica without disrupting the writable primary. Set `role: secondary` with `fallbackRole: primary` so multi-instance topologies prefer the secondary and standalone clusters (single pod, role=primary) still have a valid backup target. Account stays at `root`, which is the only systemAccount the cmpd files declare.

### ComponentVersion evidence-boundary comment

Add a comment to `cmpv.yaml` clarifying which (CmpD, release) pairs have been exercised end-to-end and which are declared but unverified. This prevents future readers from mistaking API compatibility for shipped support.

## Test plan

- [x] `git diff --check` clean
- [x] no engine-runtime behavior changed; only documentation, one metadata block on the BackupPolicyTemplate, and one comment on ComponentVersion
- [x] public hygiene grep clean
- [x] base branch is the active topology-merge work branch (alpha.90); conformance fixes propagate to main when the work branch merges
