### PR TITLE
chore(oceanbase-ce): fix chart contract typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ KubeBlocks add-ons.
 | nebula | nebula-v3.5.0<br>nebula-v3.8.0 | NebulaGraph is a popular open-source graph database that can handle large volumes of data with milliseconds of latency, scale up quickly, and have the ability to perform fast graph analytics. | wangyelei shanshanying Xuntao Cheng |
 | neo4j | neo4j-4.4.42<br>neo4j-5.26.5 | Neo4j is a highly scalable, robust native graph database. | xuriwuyun |
 | neon | neon-broker-1.0.0<br>neon-compute-1.0.0<br>neon-pageserver-1.0.0<br>neon-safekeeper-1.0.0 | Neon is a serverless open-source alternative to AWS Aurora Postgres. It separates storage and compute and substitutes the PostgreSQL storage layer by redistributing data across a cluster of nodes. | ApeCloud |
-| oceanbase-ce | oceanbase-ce-4.3.0 | OceanBase has served over 400 customers across the globe and has been supporting all mission critical systems in Alipay. | Powerfooi shanshanying |
+| oceanbase-ce | oceanbase-ce-4.3.0 | Distribution-only addon for open-source OceanBase CE. Client connections should go through obproxy, not directly to ordinal podService. OB Enterprise is a separate private codebase outside this addon's scope. | Powerfooi shanshanying |
 | opensearch | opensearch-2.7.0<br>opensearch-dashboard-2.7.0 | Open source distributed and RESTful search engine. | ApeCloud |
 | orchestrator | orchestrator-3.2.6 | Orchestrator is a MySQL high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. | ApeCloud |
 | orioledb | orioledb-16.4.0 | OrioleDB is a new storage engine for PostgreSQL, bringing a modern approach to database capacity, capabilities and performance to the world's most-loved database platform. | ApeCloud |

--- a/addons/oceanbase-ce/Chart.yaml
+++ b/addons/oceanbase-ce/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: oceanbase-ce
-description: "OceanBase has served over 400 customers across the globe and has been supporting all mission critical systems in Alipay."
+description: "Distribution-only addon for open-source OceanBase CE. Client connections should go through obproxy, not directly to ordinal podService. OB Enterprise is a separate private codebase outside this addon's scope."
 
 type: application
 

--- a/addons/oceanbase-ce/templates/actionset.yaml
+++ b/addons/oceanbase-ce/templates/actionset.yaml
@@ -8,10 +8,6 @@ metadata:
 spec:
   backupType: Full
   env:
-    - name: REP_USER
-      value: rep_user
-    - name: REP_PASSWD
-      value: rep_user
     - name: DP_TIME_FORMAT
       value: "2006-01-02 15:04:05"
   backup:

--- a/addons/oceanbase-ce/templates/backuppolicytemplate.yaml
+++ b/addons/oceanbase-ce/templates/backuppolicytemplate.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   serviceKind: oceanbase-ce
   compDefs:
-    - oceanbase-ce-\d+
+    - {{ include "oceanbase-ce.componentDefNamePrefix" . }}
   backoffLimit: 1
   backupMethods:
     - name: full

--- a/addons/oceanbase-ce/templates/componentdefinition.yaml
+++ b/addons/oceanbase-ce/templates/componentdefinition.yaml
@@ -173,7 +173,7 @@ spec:
             mountPath: /kb_tools
           - name: metricslog
             mountPath: /home/admin/obagent/log
-        workingDir: /home/admin/obagento
+        workingDir: /home/admin/obagent
     volumes:
       - name: metricslog
         emptyDir:

--- a/addons/oceanbase-ce/values.yaml
+++ b/addons/oceanbase-ce/values.yaml
@@ -15,10 +15,5 @@ image:
     repository: apecloud/obtools
     tag: 4.2.1
 
-roleProbe:
-  failureThreshold: 3
-  periodSeconds: 2
-  timeoutSeconds: 2
-
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary
- fix the metrics container workingDir typo from `/home/admin/obagento` to `/home/admin/obagent`
- tighten the BackupPolicyTemplate `compDefs` matcher by reusing the existing `^oceanbase-ce-` helper
- remove unused `roleProbe` values that are not referenced by the chart
- remove unused `REP_USER` and `REP_PASSWD` ActionSet environment variables after confirming the backup/restore scripts do not reference them
- replace the marketing-style Chart description with the open-source CE distribution-only scope and obproxy client connection guidance

## Scope boundary
- Only touches the OB-CE chart files needed for the local fixes above.
- Does not change lifecycleActions, roles, systemAccounts, TLS, topology, or ComponentVersion.
- Does not start a live Cluster.

## Validation
- `helm template addons/oceanbase-ce`
- `helm lint addons/oceanbase-ce`
- Rendered BackupPolicyTemplate `spec.compDefs`: `^oceanbase-ce-`
- No `REP_USER` / `REP_PASSWD` references remain under `addons/oceanbase-ce` or the rendered manifest
- `kubectl create --dry-run=client --validate=false -f <rendered-oceanbase-ce-manifest>`
- `git diff --check`

## Generated file note
- The PR also contains the repository-generated README row update derived from the Chart.yaml description change. No additional chart behavior is changed by that generated file.