### PR TITLE
fix(mysql): match mgr backup policy template

### DIFF
--- a/addons/mysql/templates/backuppolicytemplate.yaml
+++ b/addons/mysql/templates/backuppolicytemplate.yaml
@@ -8,6 +8,7 @@ spec:
   serviceKind: MySQL
   compDefs:
     - ^mysql-\d+.*$
+    - ^mysql-mgr-\d+.*$
   target:
     role: secondary
     fallbackRole: primary


### PR DESCRIPTION
Fixes #2641

Summary:
- include mysql-mgr component definitions in the default MySQL backup policy template
- keep the existing mysql-orc backup policy template separate

Validation:
- helm lint addons/mysql
- helm template mysql addons/mysql --namespace kb-system --show-only templates/backuppolicytemplate.yaml