### PR TITLE
fix(mariadb): document BPT per-topology resolution + helper-ize galera scripts CM name

### DIFF
--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -220,6 +220,16 @@ Define versioned replication script configmap name.
 {{- end -}}
 
 {{/*
+Define galera script configmap name. Single source for the galera scripts CM
+referenced from configmap-scripts-galera.yaml and cmpd-galera.yaml. Per
+docs/addon-api/01-define-scope.md the resource name must come from one helper
+so that multiple template files do not each stitch the same literal.
+*/}}
+{{- define "mariadb.galera.scriptConfigMapName" -}}
+mariadb-galera-scripts
+{{- end -}}
+
+{{/*
 Generate reloader scripts configmap data
 */}}
 {{- define "mariadb.extend.reload.scripts" -}}

--- a/addons/mariadb/templates/backuppolicytemplate.yaml
+++ b/addons/mariadb/templates/backuppolicytemplate.yaml
@@ -10,10 +10,28 @@ spec:
     - {{ include "mariadb.cmpdRegexpPattern" . }}
   # The ActionSet uses `mariadb-backup --safe-slave-backup --slave-info`,
   # designed to back up a replica without disrupting the writable primary.
-  # For replication / semisync topologies the secondary role is the
-  # preferred backup target; if no secondary is available KubeBlocks
-  # falls back to the primary so a standalone cluster (single pod with
-  # role=primary) still has a backup target.
+  # The secondary role is the preferred backup target; KubeBlocks falls
+  # back to the primary when no pod with role=secondary exists.
+  #
+  # Per-topology resolution of target.role under this single BPT:
+  #   - replication / replication-merged / semisync: role=secondary
+  #     (avoids primary replication / write latency impact)
+  #   - galera: secondary role is not defined (all synced Galera nodes
+  #     report role=primary by design), so KubeBlocks resolves through
+  #     fallbackRole=primary; backup runs against any synced node
+  #   - standalone: single pod with role=primary, resolved through
+  #     fallbackRole=primary
+  #
+  # Method-level override is intentionally NOT used here because
+  # `mariadb-backup --safe-slave-backup` is designed for replica
+  # execution (pauses SQL_thread, takes GTID-consistent snapshot,
+  # resumes). Compare with the MySQL addon, where xtrabackup methods
+  # explicitly override `target.role: primary` because xtrabackup lacks
+  # an equivalent replica-safety flag; the MariaDB tool does not need
+  # that override. If a PITR / binlog-archive method is added later it
+  # must override `target.role: primary` at the method level (binlog
+  # only exists on the primary), matching the MySQL `mysql-pitr`
+  # pattern.
   target:
     role: secondary
     fallbackRole: primary

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -44,8 +44,8 @@ spec:
       externalManaged: true
       {{- include "mariadb.config.reconfigureAction" . | nindent 6 }}
   scripts:
-    - name: mariadb-galera-scripts
-      template: mariadb-galera-scripts
+    - name: {{ include "mariadb.galera.scriptConfigMapName" . }}
+      template: {{ include "mariadb.galera.scriptConfigMapName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: scripts
       defaultMode: 0555

--- a/addons/mariadb/templates/configmap-scripts-galera.yaml
+++ b/addons/mariadb/templates/configmap-scripts-galera.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mariadb-galera-scripts
+  name: {{ include "mariadb.galera.scriptConfigMapName" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
 data:


### PR DESCRIPTION
## Summary

Closes the two remaining source-traceability gaps from a `docs/addon-api/` conformance re-audit of the MariaDB addon. Both are anchored to specific contract sentences; the changes are doc + structural (one new helper, three literal references replaced) with no engine-runtime behavior change.

## Changes

### 1. BackupPolicyTemplate per-topology resolution comment

The single MariaDB BPT serves four topologies (standalone / replication / replication-merged / semisync / galera) but the `target` block only declared `role: secondary, fallbackRole: primary, account: root` without explaining how that resolves per topology. galera in particular has no `secondary` role defined — KubeBlocks resolves through `fallbackRole=primary` which is mechanically correct but was previously undocumented.

Per `docs/addon-api/09b-backup-extensions.md` ("每个 topology 也要单独证明 BackupPolicyTemplate 是否生效"), per-topology BPT resolution must be explicitly documented.

Extend the target block comment to record:
- per-topology role resolution (replication / replication-merged / semisync → secondary; galera and standalone → primary via fallback)
- why no method-level `target.role` override is used: `mariadb-backup --safe-slave-backup` is designed for replica execution; contrast with MySQL xtrabackup which has no equivalent flag and therefore overrides at the method level
- forward note that a future PITR / binlog-archive method must override `target.role: primary` at the method level (binlog only exists on the primary), matching the MySQL `mysql-pitr` pattern

### 2. galera scripts ConfigMap name via helper

`configmap-scripts-galera.yaml` `metadata.name` and `cmpd-galera.yaml` scripts entry (both `.name` and `.template`) hard-coded the literal `mariadb-galera-scripts` in three places. The replication path uses `mariadb.replication.scriptConfigMapName` correctly for the equivalent purpose.

Per `docs/addon-api/01-define-scope.md` ("helper 名称要带 addon 前缀，不能让多个模板文件各自拼接同一个资源名"), the resource name must come from one helper so that multiple template files do not each stitch the same literal.

Add a new helper `mariadb.galera.scriptConfigMapName` and replace the three literals with `include` calls. `helm template` render is unchanged (the helper resolves to the same `mariadb-galera-scripts` string); this is a structural cleanup, not a behavior change.

## Test plan

- [x] `helm lint addons/mariadb` clean
- [x] `helm template addons/mariadb` render diff: only the BPT comment block expanded; galera CM and cmpd scripts entry render identical strings before/after
- [x] `git diff --check` clean
- [x] public hygiene grep clean on the four changed files
- [x] base branch is the active topology-merge work branch (`helen/mariadb-topology-merge-20260519`), same as PR #2657
