### PR TITLE
feat(mariadb): roll up alpha.86 → alpha.90 work onto PR #2633 head

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -329,7 +329,523 @@ type: application
 # alpha.61 fence safety model preserved: user-facing root still NOT
 # granted BINLOG ADMIN; the fix is in the verifier contract, not in
 # the user-facing root privileges.
-version: 1.1.1-alpha.75
+#
+# alpha.76 v1 (Helen TL autonomous under westonnnn 16:33 `84ddd85b`
+# "开啊" directive after autopilot session): Bumped from
+# 1.1.1-alpha.75 -> 1.1.1-alpha.76 because alpha.75 v1 switchover
+# idle-state N=1 verify on n1w was RED with a DIFFERENT first-blocker
+# than alpha.74: pre-DCS REMOTE root fence verifier failed because the
+# chart `wait_for_mariadbd_with_role_reconcile` watchdog re-granted
+# CMPD_EXPLICIT_PRIMARY_GRANT_BODY on root@'%' every 1s during the
+# pre-DCS fence window, racing
+# `fence_local_remote_root_for_secondary`'s REVOKE+SECONDARY_FENCE
+# grant. Action cost 2603ms; outer verifier saw INSERT/UPDATE/DELETE/
+# CREATE/DROP/ALTER residual; failure message "current primary remote
+# root fence was not verified before DCS switchover". Audit confirmed
+# fence_apply itself succeeded; the race window between inner verify
+# (inside fence_local_remote_root_for_secondary) and outer verify
+# (local_remote_root_is_fenced_for_secondary) was ~1s, well within
+# the watchdog 1s cadence.
+#
+# alpha.76 v1 fix:
+#   1. `scripts/replication-switchover.sh`: introduce
+#      `.switchover-fence-active` marker. write before fence_apply,
+#      clear on every error path inside
+#      `prepare_current_primary_for_switchover`, in
+#      `rollback_current_primary_switchover_guard`, after run_switchover
+#      success, and unconditionally in `main` (catches Stage 3/4/5
+#      failure paths that don't trigger rollback). Marker payload is
+#      `epoch=<unix-sec>\npid=<switchover-pid>\n`; freshness cutoff
+#      is `SWITCHOVER_FENCE_MARKER_MAX_AGE_SECONDS=300` (5 min).
+#   2. `templates/cmpd-semisync.yaml`: chart watchdog
+#      `reconcile_sql_listener_for_syncer_primary_once` early-returns
+#      when the marker is fresh; init-syncer adds the file to its
+#      startup `rm -f` list so a stale marker from a prior pod
+#      generation cannot pin the new pod.
+#   3. `scripts/replication-roleprobe.sh`: defense-in-depth — same
+#      switchover_fence_active_is_fresh() check in apply_remote_root_
+#      fence so role-driven grant reconcile also suspends during the
+#      pre-DCS window.
+# Scope cap: this fix only adds a race-safe pause; it does NOT change
+# any grant body, fence verifier口径, admin priv contract, or fence
+# safety model. The workspace HOLD doc draft (`addon-pre-dcs-remote-
+# root-fence-fresh-bootstrap-grant-contract-guide.md`) hypothesized
+# bootstrap-time tightening but the audit FALSIFIED that hypothesis
+# (bootstrap-time tighten would break user-facing root primary writes
+# entirely). That doc needs rewrite to reflect the race-based root
+# cause; rewrite is OUT of alpha.76 ship scope.
+# Same CmpD immutability rule applies (cmpd-semisync.yaml mutated
+# and versioned CM contents mutated); chart version bump mandatory.
+# Same syncer v3 image (no syncer change). SEMISYNC TOPOLOGY ONLY
+# (alpha.72/.73/.74/.75 scope-cap carried forward).
+#
+# alpha.77 v1 (Helen TL): alpha.76 v1 N=1 verify on n1x failed with
+# the SAME stderr signature as alpha.75 v1 n1w. Refined audit from
+# actual runtime evidence: the alpha.76 v1 fix in `reconcile_sql_
+# listener_for_syncer_primary_once` early-skips the watchdog cycle
+# only at cycle START. Watchdog cycles already in-flight (started
+# BEFORE switchover wrote the marker) continue and call
+# set_remote_root_account_state UNLOCK on root@'%' mid-cycle, racing
+# switchover.sh's REVOKE+SECONDARY_FENCE GRANT. trace log showed:
+# inner verifier ok_by_grants_only (saw SECONDARY at fence_apply
+# completion); 1-2s later, outer verifier saw PRIMARY grants again.
+# Watchdog log confirmed continuous repair cycles even with the
+# alpha.76 marker file present because the cycle was already past
+# the early-skip when the marker was written.
+#
+# alpha.77 v1 fix: defense-in-depth at the lowest SQL-apply layer.
+# Add a second marker check INSIDE set_remote_root_account_state
+# at the moment of SQL execution, gated on `state=UNLOCK` only
+# (LOCK is the fence-friendly direction and stays unmuted). Even
+# if a watchdog cycle is already in flight when switchover writes
+# the marker, the per-host UNLOCK SQL is now gated at the exact
+# moment of attempted execution. Switchover.sh's rollback path
+# uses a different helper (unfence_local_remote_root_for_primary)
+# so rollback still restores primary grants without being gated.
+# Scope cap: no other change; same syncer v3 image; same admin priv
+# contract; same fence verifier口径. SEMISYNC TOPOLOGY ONLY.
+#
+# alpha.78 v1 (Helen TL): alpha.77 v2 N=1 verify on n1z exposed a
+# downstream blocker after the alpha.77 pre-DCS REMOTE root fence
+# race fix held: the candidate (pod-1) chart watchdog stayed inside
+# `runtime-secondary-follow-before-expose` calling
+# `wait_for_replication_healthy` for the full 120s timeout AFTER the
+# DCS swap completed. During those 120s the candidate was still in
+# secondary-LOCK state on root@'%' even though syncer had promoted
+# it in DCS — the switchover stage 5 candidate-write-ready probe
+# timed out at 28 attempts. Direct evidence: n1z pod-1 watchdog log
+# `runtime-secondary-follow-configure-begin` at 12:12:14 →
+# `rejoin-replication-not-healthy elapsed=120s` at 12:14:18 →
+# `runtime-primary-listener-reconcile-begin role=primary` at
+# 12:14:19 → first `remote-root-account-UNLOCK host=% rc=0` at
+# 12:14:25. End-to-end SECONDARY→PRIMARY transition took ~2m 11s.
+#
+# alpha.78 v1 fix: add a per-iteration syncer-role check inside
+# `wait_for_replication_healthy` (cmpd-semisync.yaml). If
+# `query_local_syncer_role` returns "primary" mid-wait, log a
+# distinct `rejoin-replication-exit-on-dcs-primary` sentinel and
+# return 2. The caller chain (keep_replica_pending_until_healthy →
+# publish_replica_after_rejoin_ready → configure_replication_from_
+# primary_service_once → reconcile_sql_listener_for_syncer_
+# secondary_once) already treats non-zero as failure and unwinds
+# to mark_replication_pending; the outer
+# wait_for_mariadbd_with_role_reconcile loop ticks every 1s and on
+# its next tick hits reconcile_sql_listener_for_syncer_primary_once
+# which now sees role=primary and runs expose_sql_listener_for_
+# primary_role → set_primary_read_write → unlock_remote_root_writes
+# on root@'%'. Stage 5 budget (30s from alpha.77 v2) is now
+# sufficient for the new primary watchdog transition (~3-6s).
+#
+# Backward compat: the inner role check is only reached when the
+# loop is already running (i.e. secondary-rejoin path active). If
+# syncer continues to report secondary (the normal lifecycle case
+# without an in-flight switchover), the check returns immediately
+# and the loop body runs unchanged. fresh-bootstrap N=3 GREEN
+# (alpha.74) path does NOT exercise wait_for_replication_healthy
+# because pod-1 follows pod-0 successfully on first attempt; the
+# health check passes immediately and the function returns 0 —
+# never reaches the new role check branch.
+#
+# Same CmpD immutability rule applies (cmpd-semisync.yaml mutated);
+# chart version bump mandatory. Same syncer v3 image. SEMISYNC
+# TOPOLOGY ONLY (alpha.72/.73/.74/.75/.76/.77 scope-cap carried
+# forward). No fence verifier change, no admin priv change, no
+# grant body change.
+#
+# alpha.79 v1 (Helen TL per westonnnn 21:50 `48a132e2`/`b9a62176`
+# directive "学 MySQL semisync 的极简思路，来改，现在 / 改完之后再测"):
+# alpha.78 v1 N=3 verify (n1aa GREEN / n1ab RED / n1ac GREEN) showed
+# alpha.76/.77/.78 marker race-defense is NOT 100% reliable: at certain
+# pod-restart timing windows, the chart watchdog still wins the race
+# against switchover.sh fence_apply. n1ab grants_sha SECONDARY→PRIMARY
+# flip in 1s between inner verify and outer verify (path:
+# alpha78v1-n1ab-switchover-idle-pre-DCS-race-REOPENED-RED-20260514-212730).
+#
+# Research (Explore agent) confirmed: MySQL addon's semisync topology
+# never modifies root@'%' grants during switchover. It relies entirely
+# on:
+#   1. read_only=1 on demoted primary (set post-DCS)
+#   2. semi-sync ACK protocol blocking commits
+#   3. user-facing root NOT holding admin-bypass priv (no SUPER /
+#      BINLOG ADMIN / READ_ONLY ADMIN — same contract MariaDB adopted
+#      in alpha.61)
+#
+# alpha.79 v1 applies this minimalist model to MariaDB semisync:
+#   - prepare_current_primary_for_switchover short-circuits to a
+#     no-op (drops fence_local_remote_root_for_secondary +
+#     local_remote_root_is_fenced_for_secondary chain)
+#   - alpha.76/.77/.78 marker mechanism becomes dead code (helpers,
+#     cmpd switchover_fence_active_is_fresh(), roleprobe check). One
+#     transition cycle keeps the helpers so any inflight rollback
+#     references resolve; alpha.80+ removes the dead code entirely.
+#   - post-DCS local-root write fence verifier
+#     (verify_post_dcs_local_root_write_fenced) is RETAINED as the
+#     gatekeeper — it reads INSERT 1290 errno (read_only-based), NOT
+#     grant state, so it is race-free.
+#   - alpha.61 admin-bypass priv contract is PRESERVED (root@'%'
+#     keeps INSERT/UPDATE/DELETE/CREATE/DROP/ALTER but NOT SUPER /
+#     BINLOG ADMIN / READ_ONLY ADMIN / CONNECTION ADMIN).
+#   - The chart watchdog reconcile_sql_listener_for_syncer_primary_
+#     once continues to call set_primary_read_write per cycle on the
+#     stable primary; that's intentional (it maintains the normal
+#     state). During switchover the pre-DCS step no longer fights
+#     it because we no longer try to REVOKE here.
+#
+# Risk profile: returns to alpha.60-and-earlier risk model where the
+# switchover window relies on read_only=1 + semisync to block writes.
+# Acceptable because alpha.61 already removed admin-bypass priv from
+# user-facing root, so read_only=1 IS effective on root@'%'.
+#
+# Same CmpD immutability rule applies (cmpd-semisync.yaml mutated
+# via dead-code path renamed/commented; scripts/replication-
+# switchover.sh changed); chart version bump mandatory. Same syncer
+# v3 image. SEMISYNC TOPOLOGY ONLY.
+#
+# alpha.80 v1 (Helen TL): dead-code cleanup ONLY. NOT a fix for any
+# of the alpha.79 v2 axes RED (same-cluster repeat, under-load data-
+# divergence, pod-kill 1032-rejoin). NOT release-ready. NOT a new
+# GREEN axis. Pure static quality改动: removes the alpha.76/.77/.78
+# `.switchover-fence-active` marker mechanism that became dead code
+# after alpha.79 v1 minimalist deleted its writer.
+#
+# Removed (3 files):
+#   scripts/replication-switchover.sh: SWITCHOVER_FENCE_MARKER_MAX_
+#     AGE_SECONDS + switchover_fence_active_marker_file() +
+#     write_switchover_fence_active_marker() + clear_switchover_
+#     fence_active_marker() helpers + 3 clear callsites (rollback /
+#     run_switchover end / main).
+#   scripts/replication-roleprobe.sh: switchover_fence_active_file()
+#     + switchover_fence_active_is_fresh() + the if-fresh early-
+#     return in apply_remote_root_fence().
+#   templates/cmpd-semisync.yaml: switchover_fence_active_is_fresh()
+#     function + the SWITCHOVER_FENCE_MARKER_MAX_AGE_SECONDS env +
+#     the if-fresh early-skip in reconcile_sql_listener_for_syncer_
+#     primary_once + the in-function UNLOCK gate in
+#     set_remote_root_account_state + `.switchover-fence-active`
+#     from init-syncer rm list.
+#
+# Why safe: alpha.79 v1 minimalist short-circuited prepare to a
+# no-op with no marker writer. Consumer-side fresh-checks always
+# returned 1 (file never exists). All consumer paths fell through to
+# existing logic. alpha.79 v1+v2 N=3 fresh-bootstrap idle-state runs
+# (helm rev 13/14) proved the marker mechanism was no longer
+# exercised. Removing the unused code does not change runtime
+# behavior.
+#
+# Bump rationale: cmpd-semisync.yaml mutated (function definition
+# removed + 3 in-function checks removed). KB CmpD immutability rule
+# applies. Same syncer v3 image. SEMISYNC TOPOLOGY ONLY.
+#
+# IMPORTANT: alpha.80 v1 is a STATIC QUALITY change. Existing axes
+# RED results (same-cluster repeat, under-load data-divergence, pod-
+# kill 1032-rejoin) remain unchanged. Each has its own first-blocker
+# tracked separately in its own evidence packet.
+#
+# alpha.81 v1 (Helen 2026-05-15 10:30 closes the same-cluster repeat
+# switchover axis RED root cause): explicitly GRANT SLAVE MONITOR to
+# `kb_internal_root@'%'` so syncer engine's `IsSwitchoverDone()` can
+# successfully remote-query the old primary's SHOW SLAVE STATUS after
+# a switchover.
+#
+# Root cause: MariaDB 11.4 split the legacy `REPLICATION CLIENT`
+# privilege into `BINLOG MONITOR` + `SLAVE MONITOR`. A single
+# `GRANT REPLICATION CLIENT` statement only normalizes to
+# `BINLOG MONITOR` in SHOW GRANTS — `SLAVE MONITOR` (required for
+# `SHOW SLAVE STATUS` on MariaDB 10.5+) is NOT automatically included.
+#
+# Chart's `kb_internal_root@'%'` grant block (alpha.69 v1 closeout)
+# used `GRANT REPLICATION CLIENT ON *.*`, so the live grant on the
+# wire-side wildcard host was `BINLOG MONITOR ON *.* + REPLICATION
+# MASTER ADMIN ON *.*` — `SLAVE MONITOR` was missing.
+#
+# Failure mode: After a successful switchover, syncer's HA loop on
+# the new primary tries to confirm `IsSwitchoverDone()` (defined in
+# engines/mariadb/promotion_gate.go) by remote-connecting to the old
+# primary as `kb_internal_root@'%'` and running `SHOW SLAVE STATUS`.
+# That query returns ERROR 1227 ("Access denied; you need (at least
+# one of) the SLAVE MONITOR privilege(s)"). The engine returns
+# `IsSwitchoverDone = false`, the framework's
+# `HandlerSwitchoverForPrimary` cleanup gate never trips,
+# `DeleteSwitchover()` never runs, and the DCS Switchover ConfigMap
+# leaks indefinitely. On the next `OpsRequest switchover` the syncer
+# rejects the request with "there is another switchover unfinished"
+# because the residual ConfigMap is still present. This was the
+# alpha.79 N=3 same-cluster-repeat RED axis.
+#
+# Evidence on alpha.80 (N=3, mariadb-test4 vcluster, n1ad/n1ae/n1af):
+#   - new primary read_only=0, INSERT works
+#   - old primary SHOW SLAVE STATUS (locally) shows
+#     `Master_Host = <new primary>`, Slave_IO_Running=Yes,
+#     Slave_SQL_Running=Yes, Seconds_Behind_Master=0
+#   - From the new primary, `kb_internal_root@'%'` SHOW SLAVE STATUS
+#     against the old primary returns ERROR 1227 (SLAVE MONITOR)
+#   - HA log on new primary every 5s: "switchover candidate is
+#     promoted but switchover is not done", 11h after the switchover
+#   - DCS ConfigMap `<cluster>-mariadb-switchover` still present 11h
+#     after the original switchover
+#
+# Fix (alpha.81 v1 — semisync topology only, replication/galera/
+# standalone do not have user-triggered switchover):
+#   templates/cmpd-semisync.yaml:
+#     1. CMPD_EXPLICIT_PRIMARY_GRANT_BODY: insert `SLAVE MONITOR`
+#        between `REPLICATION CLIENT` and `REPLICATION MASTER ADMIN`.
+#     2. CMPD_SECONDARY_FENCE_GRANT_BODY: insert `SLAVE MONITOR`
+#        between `REPLICATION CLIENT` and `REPLICATION MASTER ADMIN`.
+#     3. ensure_internal_local_admin SQL (`kb_internal_root@'%'`
+#        grant block ~line 789): add an explicit
+#        `GRANT SLAVE MONITOR ON *.* TO '${user}'@'%';` after the
+#        existing `GRANT REPLICATION CLIENT ON *.* ...` statement.
+#     4. Pre-stop hardcoded local-root lock SQL (~line 2068): add
+#        `SLAVE MONITOR` to the grant list so the prestop fence
+#        body stays semantically equivalent to
+#        CMPD_SECONDARY_FENCE_GRANT_BODY.
+#   templates/replication-switchover.sh / cmpd-semisync.yaml comment
+#   blocks: unchanged (they accurately described the split but did
+#   not enforce `SLAVE MONITOR`; the body constants now reflect the
+#   correct enforcement).
+#
+# Net attack-surface delta on `kb_internal_root@'%'` for SLAVE
+# MONITOR: zero. `SLAVE MONITOR` only grants `SHOW SLAVE STATUS`
+# read-only visibility (already implicitly granted by REPLICATION
+# CLIENT in MariaDB 10.x). The 11.4 split was a renaming, not a new
+# capability. user-facing root@'%' (alpha.64 v1
+# CMPD_EXPLICIT_PRIMARY_GRANT_BODY) already had REPLICATION CLIENT
+# legacy, so root@'%' on 10.6 had the equivalent and on 11.4 carries
+# `BINLOG MONITOR` after normalization. Adding `SLAVE MONITOR`
+# explicitly aligns alpha.69 v1's intent with MariaDB 11.4's
+# enforcement.
+#
+# Bump rationale: cmpd-semisync.yaml mutated (constant definitions
+# + GRANT SQL). KB CmpD immutability rule applies (any cmpd-*.yaml
+# mutation requires a fresh alpha). Same syncer v3 image. Same
+# scripts CM contents. SEMISYNC TOPOLOGY ONLY.
+#
+# Verify plan: helm upgrade alpha.81 → fresh semisync 2-replica
+# cluster → trigger one switchover OpsRequest → wait OpsRequest
+# Succeed → check
+# `kubectl get cm <cluster>-mariadb-switchover` is NotFound within
+# the HA loop period (~10s) and a SECOND switchover OpsRequest
+# completes Succeed without "there is another switchover
+# unfinished".
+# alpha.82 v1 (Helen 2026-05-17 06:38 LAND) — pairs alpha.81 chart-side
+# SLAVE MONITOR fix with an engine-side simplification per 陈祝红 syncer-
+# team directive `8db03a3f` / `1e9d0da5`:
+#   "dbmanager 对象不要增加新的接口，IsSwitchoverDone 可以直接使用
+#   IsPromoted 代替，当新主节点提升成功即可删除 Switchover ConfigMap"
+#
+# Engine change: apecloud/syncer feat/mariadb-support local worktree,
+# engines/mariadb/promotion_gate.go — IsSwitchoverDone body replaced with
+# `return mgr.IsPromoted(ctx)`. Unused cluster/switchover args preserved
+# in signature to match engines.DBManager interface (no new interface
+# methods per 陈祝红's "不要增加新的接口" constraint).
+#
+# Image: `apecloud/syncer:mariadb-isspromoted-fix-20260515-amd64` (96MB)
+# built locally, sideloaded to mariadb-test4 host nodes via 10MB split-tar
+# chunks → kubectl cp → /host-bin/ctr -n k8s.io images import. All 3
+# nodes verified.
+#
+# Chart change in this bump:
+#   templates/cmpd-semisync.yaml — unchanged
+#   values.yaml — image.syncer.tag override via helm install --set
+#
+# alpha.81 chart-side SLAVE MONITOR grant stays as belt-and-suspenders:
+# SLAVE MONITOR is a hygiene grant other operators legitimately need.
+#
+# Verify plan: alpha.82 install → fresh semisync cluster → switchover
+# OpsRequest → confirm cleanup runs even with kb_internal_root@'%'
+# SLAVE MONITOR temporarily revoked (proves engine no longer needs it).
+#
+# alpha.83 v1 (Helen 2026-05-19 02:00 LAND) — reconfigure action account
+# switch from `MARIADB_ROOT_USER` to `MARIADB_INTERNAL_ROOT_USER` so
+# `SET GLOBAL <param>` queries pass MariaDB 11.4 privilege check.
+#
+# Root cause (T6 fresh复现, KB 1.2 + 5 fixes + #10248 V(1) diagnostic image,
+# Cluster + Component CRD schema upgraded to main bool semantic):
+# - user-facing root@127.0.0.1 grant list lacks SUPER (chart security
+#   hardening since alpha.64 "drop SUPER (admin bypass)"); root *cannot*
+#   execute `SET GLOBAL`.
+# - kb_internal_root@127.0.0.1 has `ALL PRIVILEGES ... WITH GRANT OPTION`;
+#   `SET GLOBAL slow_query_log=ON` and `SET GLOBAL long_query_time=3`
+#   succeed under that account on both pods of the two preserved
+#   stuck-reconfigure clusters (mdb-t6-configure + t6-fresh), N=2 each.
+# - Live error before fix: `ERROR 1227 (42000) at line 1: Access denied;
+#   you need (at least one of) the SUPER privilege(s) for this operation`
+#   from `udf-reconfigure-cmpd-mariadb-semisync-config` action.
+#
+# Fix scope: only `mariadb.config.reconfigureAction` helper in
+# templates/_helpers.tpl. The chart's root account remains SUPER-stripped
+# — the security posture from alpha.64 is preserved. No new env or secret
+# indirection: chart already provisions root and kb_internal_root with the
+# same password value (MARIADB_ROOT_PASSWORD == MYSQL_ADMIN_PASSWORD env
+# vars carry identical values), so the existing MARIADB_ROOT_PASSWORD env
+# is reused; only the user changes.
+#
+# Verify plan: alpha.83 install over patched KB 1.2+5 fixes + CRD generation 2
+# (Cluster + Component) → fresh semisync cluster → T6 OpsRequest
+# Reconfiguring `slow_query_log=ON, long_query_time=3` → expect:
+#   - OpsRequest phase transitions Running → Succeed within timeout
+#   - ComponentParameter `currentRevision == updateRevision` collapsing
+#   - both pod `SHOW GLOBAL VARIABLES LIKE 'slow_query_log'` returns `ON`
+#     and `long_query_time` returns `3` (sample N=2 from primary + secondary)
+# Boundary: this is the addon-side fix; the CRD schema fix and #10248 V(1)
+# diagnostic logging remain controller-side and are not bundled here.
+#
+# alpha.84 v2 (Helen 2026-05-19 06:00 amend after v1 dry-run FAIL) —
+# closes the new product-path false-success first-blocker exposed by
+# clean-r1 on alpha.83 (Jack evidence packet `9502a88f4...`, summary
+# sha `4fa0f12f6...`). The packet showed OpsRequest phase=Succeed,
+# ComponentParameter Finished currentRevision=4/updateRevision=4
+# expectedCount=2/succeedCount=2 with kbagent attestation green on BOTH
+# pods, but the runtime invariant was only carried on pod0 — pod1
+# reported `slow_query_log=OFF / long_query_time=10` (chart defaults)
+# for the full observation window through 20:48Z. K8s container
+# restartCount=0 misled the first-pass hypothesis; the actual mechanism
+# is a mariadbd process-level restart at 20:42:33 (switchover promote
+# path) inside the same container, reading the OLD ConfigMap-volume-
+# mounted my.cnf because kubelet's ConfigMap sync (typical seconds to
+# ~60s) had not yet propagated the updated values into
+# `/etc/mysql/conf.d/my.cnf` on disk.
+#
+# Two compounding causes were identified:
+#   A. paramsdef.yaml previously declared only standalone / replication /
+#      galera ParametersDefinitions. The replication PD `componentDef`
+#      regex `^mariadb-replication-` did NOT match `^mariadb-semisync-`
+#      cmpd. With no matching PD, the KB Configure controller treats
+#      every parameter as unknown-effect and defaults to rolling restart,
+#      which on semisync triggers switchover/promote and mariadbd
+#      restart on the new primary.
+#   B. `mariadb.config.reconfigureAction` (templates/_helpers.tpl
+#      L161-317) only executes `SET GLOBAL <param>` against the running
+#      mysqld. The assignment is runtime-only; any mariadbd restart
+#      erases it. The chart did not write the reconfigured values to any
+#      persistent location, so the SET GLOBAL × ConfigMap sync timing
+#      race left pod1 running on stale defaults after promote.
+#
+# alpha.84 v1 first draft attempted to address both A and B by adding a
+# semisync PD AND a defense-in-depth persistence layer (`!includedir
+# /var/lib/mysql/runtime-overrides.d/` in `mariadb-semisync.tpl`, plus
+# a `mariadb.config.reconfigureAction.persisted` helper variant that
+# wrote per-parameter `.cnf` files). v1 N=1 fresh dry-run by Jack
+# (evidence tar `9a7a74fe...`) found that the KB Configure controller
+# parses ConfigMap-stored `my.cnf` with a strict INI parser
+# (`fileFormatConfig.format: ini`); MariaDB's `!includedir` directive is
+# not valid INI key=value syntax and made the parser throw
+# `key-value delimiter not found: !includedir /var/lib/mysql/runtime-
+# overrides.d/`. OpsRequest entered Failed before the reconfigureAction
+# could run, so the persistence layer never even had a chance to
+# demonstrate value. v1 N=1 ns `mariadb-t6-alpha84-n1-0547` is frozen
+# as evidence of this pre-action parser blocker.
+#
+# alpha.84 v2 (this version) is the MINIMAL fix: address cause A only.
+# Persistence (cause B) needs a load path that is NOT in the KB-managed
+# config file; that redesign is deferred to alpha.85 and tracked
+# separately (probable approach: `--defaults-extra-file` mariadbd arg
+# pointing at a single PVC-backed override file outside KB's PD scope).
+#
+# alpha.84 v2 fix (1 chart file, SEMISYNC TOPOLOGY ONLY;
+# replication / galera / standalone PDs unchanged):
+#   - templates/paramsdef.yaml: new `mariadb-semisync-pd` declaration
+#     with componentDef regex `^mariadb-semisync-` and templateName
+#     `mariadb-semisync-config` (matches cmpd-semisync.yaml
+#     configs[0].name, NOT the helm template object name — Galera
+#     comment block already documents the same trap). Uses the same
+#     staticParameters / dynamicParameters source as the other topology
+#     PDs (`config/mariadb-config-effect-scope.yaml`). With this PD in
+#     place, the KB Configure controller can classify slow_query_log /
+#     long_query_time / etc. as dynamic and skip rolling restart.
+#
+# Test deltas in alpha.84 v2 keep the version literal and grant
+# allowlist updates that were correct independent of the persistence
+# rollback:
+#   - scripts-ut-spec/replication_switchover_spec.sh: chart version
+#     literal assertions bumped from alpha.80 to alpha.84; @'%' grant
+#     allowlist assertion adds `SLAVE MONITOR` (alpha.81 v1 contract
+#     reflected in ensure_internal_local_admin SQL).
+#   - scripts-ut-spec/replication_user_convergence_spec.sh: version
+#     literal bumped from alpha.75 to alpha.84; prior-version negative
+#     check updated from alpha.73 to alpha.83.
+#   - scripts-ut-spec/semisync_rejoin_fence_template_spec.sh:
+#     `CMPD_SECONDARY_FENCE_GRANT_BODY` literal assertion adds
+#     `SLAVE MONITOR` between `REPLICATION CLIENT` and
+#     `REPLICATION MASTER ADMIN` (same alpha.81 v1 contract).
+#
+# Why the v2 minimal scope: classifying parameters as dynamic via the
+# semisync PD is necessary in any future design; the persistence layer
+# in v1 attempted to ALSO defend against unrelated restart paths
+# (OOMKill / node drain) but it bumped into a KB parser contract that
+# needs careful redesign rather than a quick patch. Shipping just the
+# PD reduces the v2 verify gate to three items (PD dynamic hit, no
+# rolling restart / switchover triggered, both pods reflect new values
+# within bounded wait); the "forced mariadbd restart preserves" gate is
+# deferred to alpha.86 (originally targeted at alpha.85 but alpha.85
+# was consumed by the bump-to-escape-CmpD-immutability described below).
+#
+# Verify plan (alpha.84 v2 3-item gate, narrowed from v1's 4-item gate
+# because persistence layer is deferred):
+#   1. semisync PD is registered (`kubectl get parametersdef
+#      mariadb-semisync-pd` Available; rendered manifest matches
+#      slow_query_log / long_query_time in dynamicParameters).
+#   2. Reconfigure of slow_query_log/long_query_time does NOT trigger
+#      rolling restart / switchover: pod identity (UID + startTime +
+#      restartCount) before/after the OpsRequest is byte-identical;
+#      role labels unchanged.
+#   3. OpsRequest Succeed → both pods SHOW GLOBAL VARIABLES report
+#      slow_query_log=ON / long_query_time=3 within bounded wait.
+#   N≥3 fresh clusters all three gates pass independently before
+#   marking the axis closed. The "forced mariadbd restart preserves"
+#   gate from v1 is deferred to alpha.86 along with the persistence
+#   redesign.
+#
+# Same KB CmpD immutability rule applies (alpha.84 v2 mutated
+# cmpd-semisync.yaml content vs alpha.83 baseline by reverting the
+# init-syncer mkdir line and changing the configs[].reconfigure
+# include from `.persisted` variant back to base helper; the chart
+# version literal MUST still bump). Same syncer v3 image. Replication
+# / galera / standalone topology PDs unchanged; this fix does not
+# touch their configs[].name or templates.
+#
+# alpha.85 v1 (Helen 2026-05-19 06:10 LAND) — pure version bump to
+# escape KB ComponentDefinition immutability. alpha.84 v1 chart was
+# installed into the test vcluster during Jack v1 dry run; once an
+# alpha.84 CmpD exists in the cluster, KB rejects any subsequent
+# install that changes cmpd-semisync.yaml content at the same chart
+# version with `phase=Unavailable` and `status.message: immutable
+# fields can't be updated`. This is the same CmpD immutability rule
+# the comment block has tracked since alpha.65: any cmpd-*.yaml
+# mutation requires a fresh alpha. alpha.84 v2 amend mutated
+# cmpd-semisync.yaml (init-syncer mkdir removed, configs[].reconfigure
+# include reverted to base helper) but kept the version literal at
+# alpha.84 — which blocked Jack v2 dry run at the deploy gate
+# (evidence tar `bf50831ad968f9354c62e5909dae126d4df39c4f6ce3c6e1b9a4f4546293b7af`).
+#
+# alpha.85 v1 fix scope is byte-identical to alpha.84 v2 (semisync
+# ParametersDefinition only; no chart-side persistence layer; no
+# script or runtime behavior delta beyond the PD). The only delta vs
+# alpha.84 v2 source tree is the version literal `1.1.1-alpha.84` →
+# `1.1.1-alpha.85` in this Chart.yaml plus the matching ShellSpec
+# version literal assertions. Persistence redesign (cause B from
+# alpha.84 v1) remains deferred to alpha.86 once a load path outside
+# the KB-managed ConfigMap parser scope is designed (probable
+# approach: mariadbd `--defaults-extra-file` arg pointing at a
+# single PVC-backed override file, written by reconfigureAction with
+# read-modify-write merge semantics).
+#
+# Same KB CmpD immutability rule applies (cmpd-semisync.yaml content
+# is identical to alpha.84 v2 but the chart version literal bumps to
+# create a fresh CmpD object the controller can install cleanly).
+# Same syncer v3 image (no syncer change). SEMISYNC TOPOLOGY ONLY
+# (alpha.72 through alpha.84 scope-cap carried forward).
+#
+# Test deltas in alpha.85 v1 keep the alpha.84 v2 assertions but bump
+# version literals one more time:
+#   - scripts-ut-spec/replication_switchover_spec.sh: chart version
+#     literal assertions bumped from alpha.84 to alpha.85.
+#   - scripts-ut-spec/replication_user_convergence_spec.sh: version
+#     literal bumped from alpha.84 to alpha.85; prior-version negative
+#     check from alpha.83 to alpha.84.
+#   - scripts-ut-spec/semisync_rejoin_fence_template_spec.sh: no
+#     change (the alpha.81 SLAVE MONITOR contract is not version-keyed).
+version: 1.1.1-alpha.85
 
 # This is the version number of the MARIADB being deployed,
 # (mariadb engine version unchanged from alpha.64; this bump is

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,57 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.88
+version: 1.1.1-alpha.89
 
+# alpha.89 v1 scaffolding (Helen 2026-05-19) — topology merge initial
+# commit (weston 2026-05-19 14:12 msg `d8ecfae7` Option B). Jack v3
+# design review (15:36) 4 blockers folded into this scaffolding:
+#
+# - clusterdefinition.yaml lists ONLY the `replication` topology for
+#   primary/secondary (plus `standalone` and `galera` unchanged).
+#   `async` and `semisync` are NOT listed: Option B is a breaking
+#   change; users with old Cluster CRs must actively migrate to
+#   `spec.topology=replication` plus a ComponentSpec parameter
+#   `replicationMode: async | semisync`. Auto-rebind by KB on a
+#   topology compDef rename is exploratory (verified in upgrade
+#   gate N=1) and is NOT promised in release notes (Jack design
+#   Gate 6 / Blocker 4).
+# - Adds a new CmpD `mariadb-replication-merged-1.1.1-alpha.89`.
+#   Initially a near-verbatim copy of cmpd-semisync.yaml (semisync
+#   already has the most resilience layers: alpha.85 PD, alpha.88
+#   persistence, SLAVE MONITOR grants, fence markers,
+#   runtime-overrides.d/ mkdir). Subsequent commits will parameterize
+#   it by `replicationMode`.
+# - Single ParametersDefinition `mariadb-replication-merged-pd` bound
+#   to the new CmpD via the narrow regex `^mariadb-replication-merged-`
+#   (Jack design Gate 3 / Blocker 3 — no double-match against
+#   standalone / galera / old async / old semisync PDs).
+# - replicationMode source-of-truth is ComponentSpec parameter
+#   `replicationMode`, written by the user into the Cluster CR and
+#   resolved by KB into ComponentParameter / engine config; Helm-time
+#   only provides global defaults (Jack design Gate 2 / Blocker 2 —
+#   no per-cluster Helm rendering of mode-specific defaults). The
+#   parameter wiring is added in a subsequent commit.
+# - Old `cmpd-replication.yaml` and `cmpd-semisync.yaml` still render
+#   so that any Cluster CR still referencing those CmpDs by name does
+#   not get an "unresolved compDef" error during upgrade. They are
+#   not listed in clusterdefinition.yaml.topologies and are scheduled
+#   for removal in a later release after the upgrade gate closes.
+# - No engine version change. No new runtime behavior in this commit;
+#   the merged CmpD currently behaves identically to mariadb-semisync.
+#   release-ready validation for the merged topology happens after
+#   subsequent commits land the parameter-driven defaults / switchover
+#   runtime detection / mode verify helper / upgrade gate N=1.
+#
+# alpha.88 v1 (Helen 2026-05-19) — drop parse smoke from chart helper
+# (kbagent runtime PATH does not include mariadbd; `set -e` plus
+# `var=$(failing_cmd)` caused the helper to exit before cleanup,
+# breaking alpha.86/.87 dry-run smoke). The persistence layer kept its
+# write contract: SET GLOBAL applied first, then per-parameter atomic
+# write to /var/lib/mysql/runtime-overrides.d/<param>.cnf, loaded at
+# next mariadbd startup via --defaults-extra-file pointing at
+# runtime-overrides.cnf with !includedir.
+#
 # This is the version number of the MARIADB being deployed,
 # (mariadb engine version unchanged from alpha.64; this bump is
 # packaging-contract only.)

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,23 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.89
+version: 1.1.1-alpha.90
 
+# alpha.90 v1 (Helen 2026-05-20, live N=1 fourth first-blocker from
+# vcluster `mariadb-test5`) — bump from 1.1.1-alpha.89 → 1.1.1-alpha.90
+# because alpha.89 commits 13/14/15/16 mutated the rendered merged
+# CmpD spec (env block + container command body + CmpV regex + dynamic
+# parameter list + seeder/mapper script bodies via configmap-scripts).
+# KubeBlocks treats the existing ComponentDefinition spec as immutable.
+# A same-version chart upgrade with CmpD spec changes leaves the
+# CmpD in `Unavailable: immutable fields can't be updated` (Jack
+# round-4 N=1 finding: live `mariadb-replication-merged-1.1.1-alpha.89`
+# stuck Unavailable; fresh Cluster reuses the broken CmpD; samples
+# invalid). Bumping the chart version produces a new CmpD
+# `mariadb-replication-merged-1.1.1-alpha.90` so KB creates it fresh
+# instead of attempting an immutable-field update. Same KB immutability
+# rule that drove alpha.65 / alpha.66 / alpha.70 / earlier bumps.
+#
 # alpha.89 v1 scaffolding (Helen 2026-05-19) — topology merge initial
 # commit (weston 2026-05-19 14:12 msg `d8ecfae7` Option B). Jack v3
 # design review (15:36) 4 blockers folded into this scaffolding:

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -845,7 +845,217 @@ type: application
 #     check from alpha.83 to alpha.84.
 #   - scripts-ut-spec/semisync_rejoin_fence_template_spec.sh: no
 #     change (the alpha.81 SLAVE MONITOR contract is not version-keyed).
-version: 1.1.1-alpha.85
+#
+# alpha.86 v1 (Helen 2026-05-19 07:00 LAND) — adds defense-in-depth
+# persistence layer for `SET GLOBAL` reconfigure values on the semisync
+# topology, independent of the controller-side fix for KB Configure /
+# InstanceSet switchover-trigger bug (PR #10252, owned by Edward/Rocco).
+#
+# Why persistence is necessary even after #10252 lands: PR #10252 fixes
+# the specific case where config-hash-only Pod template updates from
+# dynamic reconfigure incorrectly trigger `lifecycleActions.switchover`.
+# But mariadbd process restart can still happen from unrelated paths —
+# OOMKill, node drain, manual restart, syncer-driven failover after
+# health probe failure, etc. In any of those cases, `SET GLOBAL` runtime
+# state is wiped and the runtime invariant reverts to chart defaults.
+# alpha.86 adds a PVC-backed override file that mariadbd loads at
+# startup via `--defaults-extra-file`, so reconfigured values survive
+# ANY mariadbd restart regardless of trigger.
+#
+# Design lesson from alpha.84 v1 dry-run FAIL: the original v1 design
+# put `!includedir /var/lib/mysql/runtime-overrides.d/` directly into
+# the chart-rendered ConfigMap-backed `my.cnf`, which KB
+# ParametersDefinition's strict INI parser
+# (`fileFormatConfig.format: ini`) rejected with `key-value delimiter
+# not found`. alpha.86 avoids that by putting `!includedir` into a
+# SEPARATE loader file on the data PVC (not in any KB-managed
+# ConfigMap) and passing it to mariadbd via `--defaults-extra-file`.
+# KB never sees the loader file or its `!includedir`; mariadbd's
+# native option parser does support `!includedir`.
+#
+# alpha.86 v1 fix (chart + tests patch, SEMISYNC TOPOLOGY ONLY;
+# replication / galera / standalone PDs and helpers unchanged; base
+# reconfigureAction helper unchanged for those topologies):
+#
+#   1. templates/cmpd-semisync.yaml init-syncer command:
+#        - mkdir -p `{{ .Values.dataMountPath }}/runtime-overrides.d`
+#          (per-parameter override files live here)
+#        - touch `{{ .Values.dataMountPath }}/runtime-overrides.cnf`
+#          and write the single line `!includedir
+#          {{ .Values.dataMountPath }}/runtime-overrides.d/` (mariadbd
+#          loader entry point; pure mariadbd option-file syntax)
+#        - `chgrp 1000` + `chmod g+w` on the dir so kbagent (gid=1000)
+#          can write override files; mariadbd (mysql user) can read.
+#          Same group-write pattern as existing dataMountPath setup.
+#
+#   2. templates/cmpd-semisync.yaml `start_mariadbd_process` function:
+#        - Prepend `--defaults-extra-file=
+#          {{ .Values.dataMountPath }}/runtime-overrides.cnf` as the
+#          FIRST mariadbd option (mariadbd requires --defaults-* args
+#          to be first). Reading is silent-skip if file missing; init-
+#          syncer ensures it exists.
+#
+#   3. templates/_helpers.tpl: NEW helper variant
+#      `mariadb.config.reconfigureAction.persisted` (semisync-only).
+#      After each successful `SET GLOBAL`, writes one
+#      `${OVERRIDES_DIR}/<param_name>.cnf` file with `[mysqld]\n<name>
+#      = <value>` content via temp file + atomic rename. Fail-closed
+#      on mkdir / tmp write / mv / parse-smoke failure (exit 1 after
+#      tmp cleanup). Parse-smoke runs `mariadbd --defaults-extra-file=
+#      <loader> --print-defaults >/dev/null` after each persist to
+#      detect mariadb-syntax-invalid input that would crash the engine
+#      on next restart; if smoke fails, that param's file is removed
+#      and the action exits 1.
+#
+#      Injection defense:
+#        - param name regex `^[A-Za-z0-9_.-]+$` (mariadb option name
+#          spec; reject anything else)
+#        - param value rejects newline (`\n` / `\r`), NUL, and other
+#          control chars (`\x00`-`\x1f` and `\x7f`)
+#        - param value rejects section headers like `[mysqld]` to
+#          prevent option-file injection across the parameter boundary
+#
+#      Edge case documented in this comment block + case doc: when
+#      persist fails after SET GLOBAL succeeded, runtime is already
+#      mutated but the action exits 1, so KB marks the OpsRequest
+#      Failed. Operator must retry; retry is idempotent (SET GLOBAL is
+#      a no-op if value already set, persist writes the same content).
+#      This trade-off is safe because false-success was the pre-alpha.84
+#      class we are explicitly closing.
+#
+#      The shared base helper `mariadb.config.reconfigureAction` stays
+#      unchanged (no persistence). standalone / replication / galera
+#      continue to use the base helper; they neither include the
+#      runtime-overrides.d/ directory nor add `--defaults-extra-file`,
+#      so adding persistence there would write files mariadbd never
+#      loads.
+#
+#   4. templates/cmpd-semisync.yaml: include
+#      `mariadb.config.reconfigureAction.persisted` instead of the
+#      bare `mariadb.config.reconfigureAction` helper.
+#
+#   5. scripts-ut-spec/reconfigure_persisted_semisync_spec.sh (NEW):
+#      focused source-level contract tests covering Jack 5-guard list:
+#      (1) init-syncer mkdir + chgrp + loader file creation, (2)
+#      --defaults-extra-file is the FIRST mariadbd option in
+#      start_mariadbd_process (positional assertion, not just grep),
+#      (3) reconfigureAction.persisted has injection defense on name
+#      and value, (4) fail-closed sentinels on mkdir / tmp write / mv
+#      / parse-smoke, (5) loader file content is exactly the includedir
+#      directive (no key=value would crash mariadbd). 4 verify gate
+#      groups: render/static, runtime reconfigure, process restart
+#      (mariadbd PID kill + SHOW GLOBAL ON/3 persists), controller
+#      combo (after #10252 patch image arrives).
+#
+# Same KB CmpD immutability rule applies (cmpd-semisync.yaml init-
+# syncer + start_mariadbd_process mutated). Chart version bump
+# mandatory. Same syncer v3 image. SEMISYNC TOPOLOGY ONLY (alpha.72
+# through alpha.85 scope-cap carried forward).
+#
+# Verify plan (alpha.86 v1 4-group gate):
+#   Group 1 — render/static: helm template renders
+#     `--defaults-extra-file=<loader>` as first mariadbd arg; loader
+#     file content matches `!includedir <dir>`; runtime-overrides.d
+#     dir created in init-syncer with correct group/mode.
+#   Group 2 — runtime reconfigure: OpsRequest Succeed; both pods SQL
+#     ON/3 within bounded wait.
+#   Group 3 — process restart: kill -TERM mariadbd inside one pod;
+#     wait for kbagent / syncer to restart it; new mariadbd PID; SHOW
+#     GLOBAL still ON/3 (proves --defaults-extra-file loads the
+#     persisted override on startup).
+#   Group 4 — controller combo (after PR #10252 patch image lands):
+#     re-run reconfigure; verify config-hash-only update does NOT
+#     trigger switchover (Rocco gate 1: controller image identity;
+#     Rocco gate 2: pod YAML diff is config-hash-only).
+#   N≥3 fresh clusters all four groups pass independently before
+#   marking the axis closed.
+#
+# alpha.87 v1 (Helen 2026-05-19 07:35 LAND) — pure version bump to
+# escape KB ComponentDefinition immutability after the alpha.86 commit
+# amend (`2ee2ad3f` adds parse smoke stderr/stdout capture in the
+# persisted helper). The amend kept the chart version literal at
+# alpha.86, but the rendered cmpd-semisync.yaml content changed
+# (reconfigureAction body inlines the helper output), and the test
+# vcluster already had an alpha.86 CmpD installed from the first
+# alpha.86 chart that Jack dry-ran. KB rejected the helm upgrade with
+# `mariadb-semisync-1.1.1-alpha.86 phase=Unavailable, status.message:
+# immutable fields can't be updated`. Same KB CmpD immutability rule
+# the comment block has tracked since alpha.65: any cmpd-*.yaml
+# (rendered or source) content change requires a fresh alpha.
+#
+# alpha.87 v1 fix scope is byte-identical to alpha.86 with the
+# stderr-capture amend (semisync ParametersDefinition + persisted
+# reconfigureAction variant with mariadbd --defaults-extra-file + 5
+# Jack guards + parse smoke stderr/stdout capture). The only delta vs
+# alpha.86 source tree is the version literal `1.1.1-alpha.86` →
+# `1.1.1-alpha.87` in this Chart.yaml plus the matching ShellSpec
+# version literal assertions.
+#
+# Same KB CmpD immutability rule applies (rendered cmpd-semisync.yaml
+# content is identical to alpha.86 amend but the chart version literal
+# bumps to create a fresh CmpD object the controller can install
+# cleanly). Same syncer v3 image. SEMISYNC TOPOLOGY ONLY (alpha.72
+# through alpha.86 scope-cap carried forward).
+#
+# Test deltas in alpha.87 v1: chart version literal assertions bumped
+# from alpha.86 to alpha.87 in replication_switchover_spec.sh and
+# replication_user_convergence_spec.sh.
+#
+# alpha.88 v1 (Helen 2026-05-19 07:48 LAND) — DROP parse smoke
+# entirely after alpha.86 + alpha.87 dry-runs (Jack msg `e6afaa1a`).
+# Two root causes made parse smoke unworkable in kbagent action
+# runtime:
+#   1. `mariadbd` is NOT on PATH in the kbagent action context
+#      (kbagent synthesizes its own PATH for action shells; mariadbd
+#      lives in /usr/sbin/ or similar which is not included). The
+#      `mariadbd --print-defaults` invocation returned rc=127
+#      (command not found).
+#   2. The helper used `set -e` plus the pattern
+#      `smoke_out=$(mariadbd ... 2>&1)`. POSIX shell exits
+#      immediately on a failed command substitution under `set -e`;
+#      the subsequent `smoke_rc=$?` check, stderr print, and bad-file
+#      cleanup never executed. Each retry left an orphan `.cnf` file
+#      under /var/lib/mysql/runtime-overrides.d/ that was supposed
+#      to have been removed by the fail-closed cleanup.
+#
+# alpha.88 v1 fix: remove parse smoke entirely. The remaining
+# defense layers cover the threat model:
+#   - injection defense (is_safe_param_name + is_safe_param_value)
+#     rejects the only inputs that could produce malformed `.cnf`
+#     content (unsafe option names, control chars / NUL, bracketed
+#     section markers).
+#   - atomic temp + mv guarantees no half-written file.
+#   - mariadbd's own error log on next restart is the authoritative
+#     validation surface for engine-side option-file parsing — and
+#     it sees the file in its real runtime context, not the kbagent
+#     synthesized PATH.
+#
+# Same KB CmpD immutability rule applies (rendered cmpd-semisync.yaml
+# content changed because the persisted helper body shrunk). Chart
+# version literal MUST bump. Same syncer v3 image. SEMISYNC TOPOLOGY
+# ONLY (alpha.72 through alpha.87 scope-cap carried forward).
+#
+# Test deltas in alpha.88 v1:
+#   - chart version literal assertions bumped from alpha.87 to
+#     alpha.88 in replication_switchover_spec.sh and
+#     replication_user_convergence_spec.sh.
+#   - scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh: parse
+#     smoke "presence" tests REPLACED by parse smoke "absence"
+#     regression guards (must NOT contain `mariadbd --defaults-
+#     extra-file=` / `--print-defaults` / `smoke_out=$(` / `Parse
+#     smoke failed` strings) to prevent re-introduction of the
+#     broken pattern. Guard 5 documentation kept inline as an
+#     archeology note for future readers.
+#
+# Edge-case impact: an operator who reconfigures a parameter with
+# a value that mariadbd-as-engine refuses (unlikely given injection
+# defense, but theoretically possible) will see the failure on the
+# next mariadbd restart (engine error log + crash). The previous
+# parse smoke design tried to catch this at write time, but it never
+# actually worked in the kbagent context. Removing it does NOT
+# regress the actual safety posture; it removes a dead defense that
+# was leaving orphan files.
+version: 1.1.1-alpha.88
 
 # This is the version number of the MARIADB being deployed,
 # (mariadb engine version unchanged from alpha.64; this bump is

--- a/addons/mariadb/README.md
+++ b/addons/mariadb/README.md
@@ -6,15 +6,44 @@ MariaDB is a high performance open source relational database management system 
 
 ### Lifecycle Management
 
-| Horizontal<br/>scaling | Vertical <br/>scaling | Expand<br/>volume | Restart   | Stop/Start | Configure | Expose | Switchover |
-|------------------------|-----------------------|-------------------|-----------|------------|-----------|--------|------------|
-| No (Standalone Only)   | Yes                   | Yes               | Yes       | Yes        | No        | Yes    | No         |
+Per-topology support matrix. `Yes (verified)` has a recorded end-to-end evidence chain; `Yes (declared)` means the chart wires the action but a full release-standard evidence chain has not yet been recorded; `No` means the topology does not implement the lifecycle action:
+
+| Topology | Horizontal scaling | Vertical scaling | Expand volume | Restart | Stop/Start | Configure | Expose | Switchover |
+|---|---|---|---|---|---|---|---|---|
+| standalone | No | Yes | Yes | Yes | Yes | No | Yes | No |
+| replication | Yes (declared) | Yes | Yes | Yes | Yes | Yes (declared) | Yes | Yes (verified) |
+| semisync | Yes (declared) | Yes | Yes | Yes | Yes | Yes (declared) | Yes | Yes (verified) |
+| galera | Yes (declared) | Yes | Yes | Yes | Yes | Yes (declared) | Yes | No |
+
+Notes:
+- `Switchover (verified)` for `replication` / `semisync` covers the OpsRequest path with bounded role transition. The action is implemented in `cmpd-replication.yaml`, `cmpd-replication-merged.yaml`, and `cmpd-semisync.yaml`.
+- `Configure (declared)` means the chart wires `ParametersDefinition` and `reconfigure.exec` plus the `replicationMode` synthetic-parameter mapper. Only a subset of parameters has end-to-end runtime evidence today, so per-parameter coverage is "declared" until a parameter is exercised in a recorded test artifact.
 
 ### Versions
 
-| Versions |
-|----------|
-| 10.6.15 |
+`ComponentVersion` lists multiple release tags, but only `10.6.15` (standalone) and `11.4.10` (replication / semisync / galera) currently have an evidence-supported install + smoke chain. Other tags listed in `cmpv.yaml` are API-compatible but unproven; treat them as "declared but unverified":
+
+| Topology | Verified release | Declared but unproven |
+|---|---|---|
+| standalone | 10.6.15 | — |
+| replication / semisync / replication-merged | 11.4.10 | 11.4.5, 11.4.8, 11.8.4, 12.0.2 |
+| galera | 11.4.10 | 11.4.5, 11.4.8 |
+
+### Extended capability declarations (claim-only acceptance)
+
+The following capabilities are **not declared** by the MariaDB chart today. Treat them as "not supported" rather than "untested":
+
+- Backup encryption (passphrase, method formatVersion, snapshot artifact, repository artifact)
+- Selective backup / restore, `RestoreKubeResources`, cross-topology / cross-sharding restore, multi-target `sourceBackupTargetName`
+- PITR / continuous backup
+- Sharding
+- Proxy in front of the engine
+- Host network / `hostAliases` / `hostPort` / advertised LoadBalancer address
+- Cross-namespace `ServiceRef`
+
+The following capability is declared **only for the `standalone` topology** and is not yet wired into multi-instance topologies. Multi-instance + TLS should be treated as "not declared, not supported" until the corresponding `cmpd-replication*.yaml`, `cmpd-semisync.yaml`, or `cmpd-galera.yaml` declares the TLS spec and a topology-aware evidence chain is recorded:
+
+- TLS-only / mutual TLS / certificate mounting at the engine layer
 
 ## Prerequisites
 

--- a/addons/mariadb/config/mariadb-config-constraint.cue
+++ b/addons/mariadb/config/mariadb-config-constraint.cue
@@ -73,11 +73,10 @@
 
 #MariaDBParameter: {
 	// Enables semisync replication on the primary. When ON, the
-	// primary waits for at least
-	// rpl_semi_sync_master_wait_for_slave_count secondaries to
-	// acknowledge each transaction's binlog event (or for
-	// rpl_semi_sync_master_timeout milliseconds) before returning
-	// OK to the client. Default OFF — async replication.
+	// primary waits for one secondary's acknowledgement of each
+	// transaction's binlog event (or rpl_semi_sync_master_timeout
+	// milliseconds) before returning OK to the client. Default OFF
+	// — async replication.
 	rpl_semi_sync_master_enabled?: string & "ON" | "OFF" | *"OFF"
 
 	// Enables semisync replication on the secondary. Must be ON on
@@ -85,12 +84,23 @@
 	// the primary side. Default OFF — async replication.
 	rpl_semi_sync_slave_enabled?: string & "ON" | "OFF" | *"OFF"
 
-	// Number of secondaries that must acknowledge a binlog event
-	// before the primary commits in semisync mode. Only meaningful
-	// when rpl_semi_sync_master_enabled = ON. MariaDB hard minimum
-	// is 1; upper bound matches the maximum allowable replica
-	// count.
-	rpl_semi_sync_master_wait_for_slave_count?: int & >=1 & <=65535 | *1
+	// alpha.89 v1 commit 16 (Helen 2026-05-20, live N=1 third
+	// first-blocker fix from vcluster `mariadb-test5`,
+	// ns `mariadb-alpha89-mode-n1c2-041720`): the
+	// `rpl_semi_sync_master_wait_for_slave_count` variable is a
+	// MySQL extension (added in MySQL 5.7.3). MariaDB 11.4 (and
+	// historical MariaDB lineage) does NOT support it. Setting it
+	// in my.cnf causes `mariadbd --verbose --help` to exit rc=7
+	// with `unknown variable
+	// 'rpl_semi_sync_master_wait_for_slave_count=1'`, which makes
+	// the engine container CrashLoop on first startup. MariaDB
+	// semisync waits for exactly one secondary acknowledgement;
+	// there is no equivalent variable in MariaDB. The previous
+	// alpha.89 v1 commits 11 v2 / 12 / 13 listed this variable in
+	// the CUE schema / dynamicParameters / mapper-derive / seeder
+	// because the four-variable picture came from a MySQL-flavored
+	// reference and was never live-validated. The variable is now
+	// removed entirely from the addon surface.
 
 	// (ms) Timeout in milliseconds for the primary to wait for
 	// secondary acknowledgement in semisync mode before falling

--- a/addons/mariadb/config/mariadb-config-constraint.cue
+++ b/addons/mariadb/config/mariadb-config-constraint.cue
@@ -13,17 +13,36 @@
 // `ClassifyComponentParameters()` / `DoMerge()` boundary, before
 // engine config is rendered.
 //
-// This schema only declares the four `rpl_semi_sync_*` engine
-// variables that are the real source-of-truth for replication mode
-// (per Jack's enum-research conclusion). It does not declare a
-// `replicationMode` synthetic key — KB has no transform from a
-// synthetic key to multiple engine variables (ParamConfigRenderer
-// has no transform hook); declaring `replicationMode` here would
-// either be ignored or, if KB treats it as a managed key, write
-// `replicationMode = semisync` into my.cnf, which mariadbd does
-// not recognize. The unified-switch UX is provided by addon-side
-// docs and (future) helper scripts that emit the four-parameter
-// block from a single user-facing choice.
+// alpha.89 v1 commit 10 (Helen 2026-05-20, C3 path per weston
+// 2026-05-20 00:08 msg `cb0afa37`) — extended with a
+// `replicationMode` field whose CUE conditional blocks derive the
+// four `rpl_semi_sync_*` engine variables when set. weston's
+// precedence rule: if `replicationMode` is set, it overrides the
+// four real variables; if the user ALSO sets one of the four with
+// an inconsistent value, CUE unification fails and KB rejects the
+// assignment at the controller parameter reconcile path. If
+// `replicationMode` is unset, the user can freely set the four
+// real variables (chart default is async via the four variables
+// taking their CUE defaults of OFF).
+//
+// This makes both user-facing surfaces (a single logical
+// `replicationMode` switch AND the four real engine variables)
+// visible and changeable per weston's directive; CUE unification
+// handles the consistency check natively and the four variables
+// remain the ground-truth source rendered into my.cnf.
+//
+// Note that this CUE expression depends on KB's CUE renderer
+// actually emitting derived field values into the rendered my.cnf
+// (not only validating them). If KB's renderer only validates and
+// does not derive (i.e. it ignores the conditional blocks for
+// rendering), a thin addon-side mapper in reconfigureAction would
+// fill the four variables when only `replicationMode` is set,
+// while CUE unification continues to reject inconsistent explicit
+// assignments. Jack's KB-validator behavioral test
+// (pkg/parameters/validate/cue_util.go ValidateConfigWithCue) is
+// scheduled to verify which path the runtime takes; until then this
+// commit lays the schema only and the mapper question is deferred
+// to commit 11+ based on Jack's findings.
 //
 // MariaDB accepts both "ON"/"OFF" and "1"/"0" for boolean variables
 // in my.cnf and via SET GLOBAL. The schema constrains the my.cnf
@@ -32,6 +51,23 @@
 // SQL layer (the engine normalizes).
 
 #MariaDBParameter: {
+	// alpha.89 v1 commit 10 (Helen 2026-05-20, C3 path) — logical
+	// replication-mode switch. When set, the conditional blocks
+	// below unify the two `rpl_semi_sync_*_enabled` fields with
+	// the corresponding ON / OFF value. The user may also set the
+	// two `*_enabled` fields explicitly; CUE unification fails if
+	// the explicit value disagrees with the value derived from
+	// `replicationMode`, and KB rejects the assignment via the
+	// existing `ValidateConfigWithCue()` path that already binds
+	// `#MariaDBParameter` to every INI section.
+	//
+	// `replicationMode` is intentionally NOT given a default. Per
+	// weston 2026-05-20 00:08 msg `cb0afa37`: when the user does
+	// not set `replicationMode`, the four real variables are
+	// freely settable and the cluster defaults to async via the
+	// `rpl_semi_sync_*_enabled` defaults of OFF below.
+	replicationMode?: "async" | "semisync"
+
 	// Enables semisync replication on the primary. When ON, the
 	// primary waits for at least
 	// rpl_semi_sync_master_wait_for_slave_count secondaries to
@@ -59,6 +95,24 @@
 	// (10s); 0 disables timeout (wait forever, which is unsafe and
 	// not recommended).
 	rpl_semi_sync_master_timeout?: int & >=1 & <=2147483647 | *10000 @timeDurationResource(1ms)
+
+	// C3 precedence — `replicationMode` overrides the two
+	// `*_enabled` fields. The conditional blocks unify those
+	// fields with the derived value; if the user also sets one of
+	// them with a conflicting literal, CUE unification fails and
+	// KB rejects the assignment. The auxiliary `wait_for_slave_count`
+	// and `master_timeout` fields are not constrained by
+	// `replicationMode` — they remain user-tunable within their
+	// declared int range whether the cluster runs async or
+	// semisync (engine ignores the values when semisync is OFF).
+	if replicationMode == "semisync" {
+		rpl_semi_sync_master_enabled: "ON"
+		rpl_semi_sync_slave_enabled:  "ON"
+	}
+	if replicationMode == "async" {
+		rpl_semi_sync_master_enabled: "OFF"
+		rpl_semi_sync_slave_enabled:  "OFF"
+	}
 }
 
 // Bind #MariaDBParameter to every INI section in the parsed my.cnf.

--- a/addons/mariadb/config/mariadb-config-constraint.cue
+++ b/addons/mariadb/config/mariadb-config-constraint.cue
@@ -13,36 +13,57 @@
 // `ClassifyComponentParameters()` / `DoMerge()` boundary, before
 // engine config is rendered.
 //
-// alpha.89 v1 commit 10 (Helen 2026-05-20, C3 path per weston
-// 2026-05-20 00:08 msg `cb0afa37`) — extended with a
-// `replicationMode` field whose CUE conditional blocks derive the
-// four `rpl_semi_sync_*` engine variables when set. weston's
-// precedence rule: if `replicationMode` is set, it overrides the
-// four real variables; if the user ALSO sets one of the four with
-// an inconsistent value, CUE unification fails and KB rejects the
-// assignment at the controller parameter reconcile path. If
-// `replicationMode` is unset, the user can freely set the four
-// real variables (chart default is async via the four variables
-// taking their CUE defaults of OFF).
+// alpha.89 v1 commit 11 (Helen 2026-05-20, C3 path correction
+// after Jack KB-validator behavioral test 2026-05-20 00:16 msg
+// `ea50aa12`): revert the conditional `replicationMode`-derivation
+// blocks introduced in commit 10 and fix a separate closed-section
+// bug that has been silently present since commit 3 v2.
 //
-// This makes both user-facing surfaces (a single logical
-// `replicationMode` switch AND the four real engine variables)
-// visible and changeable per weston's directive; CUE unification
-// handles the consistency check natively and the four variables
-// remain the ground-truth source rendered into my.cnf.
+// Jack's behavioral test against KB `pkg/parameters/validate
+// /cue_util.go ValidateConfigWithCue()` + `DoMerge()` proved:
 //
-// Note that this CUE expression depends on KB's CUE renderer
-// actually emitting derived field values into the rendered my.cnf
-// (not only validating them). If KB's renderer only validates and
-// does not derive (i.e. it ignores the conditional blocks for
-// rendering), a thin addon-side mapper in reconfigureAction would
-// fill the four variables when only `replicationMode` is set,
-// while CUE unification continues to reject inconsistent explicit
-// assignments. Jack's KB-validator behavioral test
-// (pkg/parameters/validate/cue_util.go ValidateConfigWithCue) is
-// scheduled to verify which path the runtime takes; until then this
-// commit lays the schema only and the mapper question is deferred
-// to commit 11+ based on Jack's findings.
+// 1. KB does NOT emit CUE-derived field values into the rendered
+//    my.cnf. A user setting only `replicationMode=semisync` would
+//    get a my.cnf containing `replicationmode=semisync` (which
+//    mariadbd rejects as an unknown variable) and no derived
+//    `rpl_semi_sync_master_enabled=ON`. So the C3 single-source-of
+//    -truth cannot be CUE alone; an addon-side mapper inside
+//    reconfigureAction must consume `replicationMode` BEFORE the
+//    my.cnf render and write the four real variables explicitly.
+// 2. KB's INI parser lowercases all keys, so a camelCase CUE field
+//    `replicationMode` does not match the parsed key
+//    `replicationmode` — even validation fails on this.
+// 3. The `[SectionName=_]: #MariaDBParameter` binding from
+//    commit 3 v2 is a CLOSED CUE struct. Any key in the rendered
+//    base my.cnf that is not declared in `#MariaDBParameter` (e.g.
+//    `binlog_format`, `max_connections`, `slow_query_log`) is
+//    rejected by `ValidateConfigWithCue()` as "field not allowed".
+//    Commit 3 v2's ShellSpec used a narrow fixture (only the four
+//    `rpl_semi_sync_*` keys) so this bug never surfaced; a real
+//    cluster's full base my.cnf merge would fail.
+//
+// Fix in this commit:
+//
+// - `replicationMode` is REMOVED from the CUE schema. It will be
+//   re-introduced in a follow-up commit as a ComponentSpec parameter
+//   consumed by an addon-side mapper in reconfigureAction (the
+//   mapper validates consistency against the four real variables
+//   and writes the derived values into my.cnf via the alpha.88
+//   persistence path; the four real variables remain the only
+//   keys that land in the rendered ConfigMap).
+// - The two `if replicationMode == ...` conditional blocks are
+//   REMOVED. CUE unification is no longer used to express
+//   precedence; the mapper handles it.
+// - The struct is now OPEN (`[string]: _`), so base my.cnf keys
+//   not declared in this schema pass through unchallenged. This
+//   retroactively fixes the commit 3 v2 closed-section bug; the
+//   four `rpl_semi_sync_*` fields still take their declared
+//   constraints because CUE unifies any matching key with the
+//   field constraint and lets unknown keys flow through.
+//
+// The four `rpl_semi_sync_*` field declarations and the
+// `[SectionName=_]: #MariaDBParameter` section binding are
+// unchanged from commit 3 v2.
 //
 // MariaDB accepts both "ON"/"OFF" and "1"/"0" for boolean variables
 // in my.cnf and via SET GLOBAL. The schema constrains the my.cnf
@@ -51,23 +72,6 @@
 // SQL layer (the engine normalizes).
 
 #MariaDBParameter: {
-	// alpha.89 v1 commit 10 (Helen 2026-05-20, C3 path) — logical
-	// replication-mode switch. When set, the conditional blocks
-	// below unify the two `rpl_semi_sync_*_enabled` fields with
-	// the corresponding ON / OFF value. The user may also set the
-	// two `*_enabled` fields explicitly; CUE unification fails if
-	// the explicit value disagrees with the value derived from
-	// `replicationMode`, and KB rejects the assignment via the
-	// existing `ValidateConfigWithCue()` path that already binds
-	// `#MariaDBParameter` to every INI section.
-	//
-	// `replicationMode` is intentionally NOT given a default. Per
-	// weston 2026-05-20 00:08 msg `cb0afa37`: when the user does
-	// not set `replicationMode`, the four real variables are
-	// freely settable and the cluster defaults to async via the
-	// `rpl_semi_sync_*_enabled` defaults of OFF below.
-	replicationMode?: "async" | "semisync"
-
 	// Enables semisync replication on the primary. When ON, the
 	// primary waits for at least
 	// rpl_semi_sync_master_wait_for_slave_count secondaries to
@@ -96,23 +100,42 @@
 	// not recommended).
 	rpl_semi_sync_master_timeout?: int & >=1 & <=2147483647 | *10000 @timeDurationResource(1ms)
 
-	// C3 precedence — `replicationMode` overrides the two
-	// `*_enabled` fields. The conditional blocks unify those
-	// fields with the derived value; if the user also sets one of
-	// them with a conflicting literal, CUE unification fails and
-	// KB rejects the assignment. The auxiliary `wait_for_slave_count`
-	// and `master_timeout` fields are not constrained by
-	// `replicationMode` — they remain user-tunable within their
-	// declared int range whether the cluster runs async or
-	// semisync (engine ignores the values when semisync is OFF).
-	if replicationMode == "semisync" {
-		rpl_semi_sync_master_enabled: "ON"
-		rpl_semi_sync_slave_enabled:  "ON"
-	}
-	if replicationMode == "async" {
-		rpl_semi_sync_master_enabled: "OFF"
-		rpl_semi_sync_slave_enabled:  "OFF"
-	}
+	// alpha.89 v1 commit 11 v2 (Helen 2026-05-20, Jack B1 fix):
+	// explicitly forbid the synthetic key `replicationmode` from
+	// landing in my.cnf. KB's INI parser lowercases every key, so
+	// user input `replicationMode`, `replicationmode`, or any other
+	// case variant normalizes to `replicationmode` before CUE
+	// validation runs. The C3 design places `replicationMode` at
+	// the ComponentSpec-parameter layer (consumed by an addon
+	// mapper in reconfigureAction BEFORE my.cnf render) — under no
+	// path should `replicationmode` appear as a my.cnf key, because
+	// mariadbd does not recognize it and would log an unknown-
+	// variable warning at startup. The `_|_` (CUE bottom value)
+	// forbids the field outright: any ConfigMap merge that includes
+	// this key fails `ValidateConfigWithCue()` with a clear CUE
+	// conflict, before the merged config reaches the engine.
+	//
+	// More-specific field declarations take precedence over the
+	// `[string]: _` open pattern below, so this forbid rule still
+	// fires even though the open pattern accepts arbitrary string
+	// keys.
+	replicationmode?: _|_
+
+	// Open the struct so KB's `ValidateConfigWithCue()` accepts any
+	// other key the rendered base my.cnf may contain (e.g.
+	// `binlog_format`, `max_connections`, `slow_query_log`) without
+	// requiring this schema to enumerate every MariaDB engine
+	// variable. The four `rpl_semi_sync_*` fields above still
+	// constrain those specific keys when they are present; the
+	// `replicationmode` forbid above still rejects that specific
+	// key; all other unknown keys pass through unchallenged.
+	//
+	// alpha.89 v1 commit 11 (Helen 2026-05-20) — retroactive fix
+	// for the commit 3 v2 closed-section bug Jack surfaced via
+	// KB-validator behavioral test (msg `ea50aa12`). Without this
+	// open marker, a real cluster's full base my.cnf merge fails
+	// with "field not allowed" on any key not in this schema.
+	[string]: _
 }
 
 // Bind #MariaDBParameter to every INI section in the parsed my.cnf.

--- a/addons/mariadb/config/mariadb-config-constraint.cue
+++ b/addons/mariadb/config/mariadb-config-constraint.cue
@@ -100,41 +100,73 @@
 	// not recommended).
 	rpl_semi_sync_master_timeout?: int & >=1 & <=2147483647 | *10000 @timeDurationResource(1ms)
 
-	// alpha.89 v1 commit 11 v2 (Helen 2026-05-20, Jack B1 fix):
-	// explicitly forbid the synthetic key `replicationmode` from
-	// landing in my.cnf. KB's INI parser lowercases every key, so
-	// user input `replicationMode`, `replicationmode`, or any other
-	// case variant normalizes to `replicationmode` before CUE
-	// validation runs. The C3 design places `replicationMode` at
-	// the ComponentSpec-parameter layer (consumed by an addon
-	// mapper in reconfigureAction BEFORE my.cnf render) — under no
-	// path should `replicationmode` appear as a my.cnf key, because
-	// mariadbd does not recognize it and would log an unknown-
-	// variable warning at startup. The `_|_` (CUE bottom value)
-	// forbids the field outright: any ConfigMap merge that includes
-	// this key fails `ValidateConfigWithCue()` with a clear CUE
-	// conflict, before the merged config reaches the engine.
+	// alpha.89 v1 commit 14 (Helen 2026-05-20, live N=1 first-blocker
+	// fix from vcluster `mariadb-test5` run with controller image
+	// `apecloud/kubeblocks:pr-10252-1c8723184`):
 	//
-	// More-specific field declarations take precedence over the
-	// `[string]: _` open pattern below, so this forbid rule still
-	// fires even though the open pattern accepts arbitrary string
-	// keys.
-	replicationmode?: _|_
+	// commit 11 v2 declared `replicationmode?: _|_` as a defense-in
+	// -depth forbid against the synthetic key ever landing in my.cnf.
+	// KB local fixture / static `ValidateConfigWithCue` test accepted
+	// that pattern. But the live KB controller's PD reconcile loop
+	// generates an OpenAPI schema from the CUE before activating the
+	// ParametersDefinition, and the OpenAPI schema generator rejects
+	// any CUE bottom literal with the error:
+	//   `failed to generate openAPISchema: failed to marshal cue-yaml:
+	//    explicit error (_|_ literal) in source`
+	// The `mariadb-replication-merged-pd` PD never goes Available,
+	// downstream Component reconcile reports the PD as unavailable,
+	// and Pods never get created — chart is unusable.
+	//
+	// Fix: the `replicationmode?: _|_` declaration is REMOVED. The
+	// synthetic-key defense moves entirely to the three layers that
+	// already exist and are exercised by ShellSpec:
+	//
+	//   1. Helm template-time validator (`mariadb.replication.mode
+	//      .validate`) — rejects invalid `replication.mode` Helm
+	//      values at `helm render` time.
+	//   2. Startup seeder (`scripts/seed-replication-mode-overrides
+	//      .sh`) — writes the four real `rpl_semi_sync_*` engine
+	//      variables to `runtime-overrides.d/` BEFORE mariadbd
+	//      starts; synthetic key never appears in any rendered file.
+	//   3. Reconfigure mapper (`scripts/replication-mode-mapper.sh`,
+	//      sourced from `reconfigureAction.persisted`) — unconditional
+	//      strip of `replicationMode` / `replicationmode` from the
+	//      parameter list BEFORE the main loop reaches `SET GLOBAL`
+	//      or `runtime-overrides.d/` writes.
+	//
+	// A user OpsRequest that includes `replicationmode=<value>` would
+	// now pass CUE validation via the `[string]: _` open pattern,
+	// land in the rendered my.cnf, and produce an mariadbd unknown-
+	// variable warning at next restart. That is noise, not a fail-
+	// closed product break — mariadbd ignores unrecognized server
+	// variables (does not refuse startup). Reconfigure mapper still
+	// strips the synthetic key from the SET GLOBAL / persist loop,
+	// so the engine never sees a `replicationmode` runtime variable
+	// assignment.
+	//
+	// Runtime synthetic-key OpsRequest fail-closed (KB-validator
+	// rejecting `replicationmode=*`) is deferred to alpha.90 — needs
+	// a KB-supported form that survives OpenAPI schema generation
+	// (candidates: a CUE `string & !~"^.+$"` impossible pattern, a
+	// pre-flight admission webhook on Cluster CR annotations, or a
+	// PD validation hook). The case appendix in kubeblocks-addon
+	// -docs PR #258 records the deferred work.
 
 	// Open the struct so KB's `ValidateConfigWithCue()` accepts any
 	// other key the rendered base my.cnf may contain (e.g.
 	// `binlog_format`, `max_connections`, `slow_query_log`) without
 	// requiring this schema to enumerate every MariaDB engine
 	// variable. The four `rpl_semi_sync_*` fields above still
-	// constrain those specific keys when they are present; the
-	// `replicationmode` forbid above still rejects that specific
-	// key; all other unknown keys pass through unchallenged.
+	// constrain those specific keys when they are present; all
+	// other unknown keys (including the synthetic `replicationmode`
+	// post commit-14 revert) pass through unchallenged at the CUE
+	// layer; the addon-side mapper handles synthetic stripping.
 	//
 	// alpha.89 v1 commit 11 (Helen 2026-05-20) — retroactive fix
-	// for the commit 3 v2 closed-section bug Jack surfaced via
-	// KB-validator behavioral test (msg `ea50aa12`). Without this
-	// open marker, a real cluster's full base my.cnf merge fails
-	// with "field not allowed" on any key not in this schema.
+	// for the commit 3 v2 closed-section bug surfaced via
+	// KB-validator behavioral test. Without this open marker, a
+	// real cluster's full base my.cnf merge fails with "field not
+	// allowed" on any key not in this schema.
 	[string]: _
 }
 

--- a/addons/mariadb/config/mariadb-config-constraint.cue
+++ b/addons/mariadb/config/mariadb-config-constraint.cue
@@ -1,0 +1,84 @@
+// MariaDB parameter schema for the merged replication CmpD.
+//
+// alpha.89 v1 commit 3 (Helen 2026-05-19, C1 path) — defines the
+// CUE schema KB ParametersDefinition uses to validate parameter
+// assignments. Per Jack design review (15:50) Class 4 sentinel
+// requirement: invalid values for `replicationMode` semisync
+// engine variables must fail-closed at the controller parameter
+// reconcile path before reaching the engine. KB's parameter
+// validator (#10254 once merged) reads `schemaInJSON` generated
+// from this CUE file and rejects unknown / out-of-range / non-enum
+// assignments at `ValidateComponentParameterAssignments()`. On
+// current main without #10254, validation still happens at the
+// `ClassifyComponentParameters()` / `DoMerge()` boundary, before
+// engine config is rendered.
+//
+// This schema only declares the four `rpl_semi_sync_*` engine
+// variables that are the real source-of-truth for replication mode
+// (per Jack's enum-research conclusion). It does not declare a
+// `replicationMode` synthetic key — KB has no transform from a
+// synthetic key to multiple engine variables (ParamConfigRenderer
+// has no transform hook); declaring `replicationMode` here would
+// either be ignored or, if KB treats it as a managed key, write
+// `replicationMode = semisync` into my.cnf, which mariadbd does
+// not recognize. The unified-switch UX is provided by addon-side
+// docs and (future) helper scripts that emit the four-parameter
+// block from a single user-facing choice.
+//
+// MariaDB accepts both "ON"/"OFF" and "1"/"0" for boolean variables
+// in my.cnf and via SET GLOBAL. The schema constrains the my.cnf
+// surface to "ON"/"OFF" for readability; runtime SET GLOBAL via
+// reconfigureAction may continue to accept either form at the
+// SQL layer (the engine normalizes).
+
+#MariaDBParameter: {
+	// Enables semisync replication on the primary. When ON, the
+	// primary waits for at least
+	// rpl_semi_sync_master_wait_for_slave_count secondaries to
+	// acknowledge each transaction's binlog event (or for
+	// rpl_semi_sync_master_timeout milliseconds) before returning
+	// OK to the client. Default OFF — async replication.
+	rpl_semi_sync_master_enabled?: string & "ON" | "OFF" | *"OFF"
+
+	// Enables semisync replication on the secondary. Must be ON on
+	// the secondary side for semisync to actually take effect on
+	// the primary side. Default OFF — async replication.
+	rpl_semi_sync_slave_enabled?: string & "ON" | "OFF" | *"OFF"
+
+	// Number of secondaries that must acknowledge a binlog event
+	// before the primary commits in semisync mode. Only meaningful
+	// when rpl_semi_sync_master_enabled = ON. MariaDB hard minimum
+	// is 1; upper bound matches the maximum allowable replica
+	// count.
+	rpl_semi_sync_master_wait_for_slave_count?: int & >=1 & <=65535 | *1
+
+	// (ms) Timeout in milliseconds for the primary to wait for
+	// secondary acknowledgement in semisync mode before falling
+	// back to async for that transaction. Only meaningful when
+	// rpl_semi_sync_master_enabled = ON. MariaDB default 10000ms
+	// (10s); 0 disables timeout (wait forever, which is unsafe and
+	// not recommended).
+	rpl_semi_sync_master_timeout?: int & >=1 & <=2147483647 | *10000 @timeDurationResource(1ms)
+}
+
+// Bind #MariaDBParameter to every INI section in the parsed my.cnf.
+//
+// alpha.89 v1 commit 3 v2 (Helen 2026-05-19, Jack design review
+// Class 4 blocker B1) — KB's CUE validator (pkg/parameters/validate
+// /cue_util.go ValidateConfigWithCue) does NOT use a top-level
+// definition unless the CUE file binds it to the parsed config
+// structure. Without this binding, the four constrained variables
+// declared above are just unreferenced definitions; an invalid
+// value such as rpl_semi_sync_master_enabled = MAYBE is silently
+// accepted by the validator, defeating the fail-closed contract
+// for Class 4.
+//
+// The MySQL / ApeCloud MySQL addons use the same pattern
+// ([SectionName=_]: #MysqlParameter) to bind their schema across
+// all sections of the rendered INI; reuse it here so the
+// constraints take effect on the [mysqld] section (and any other
+// section the chart may render) without hard-coding the section
+// name. KB's INI parser walks every section and validates its
+// key-value pairs against the bound schema, returning a
+// CUE-conflict error on the first violation.
+[SectionName=_]: #MariaDBParameter

--- a/addons/mariadb/config/mariadb-config-effect-scope.yaml
+++ b/addons/mariadb/config/mariadb-config-effect-scope.yaml
@@ -193,6 +193,20 @@ dynamicParameters:
   - profiling
   - profiling_history_size
   - query_alloc_block_size
+  # alpha.89 v1 commit 3 (Helen 2026-05-19, C1 path) — semisync
+  # engine variables are runtime-applicable via SET GLOBAL (MariaDB
+  # documents them as dynamic system variables). Listing them here
+  # tells the KB Configure controller that a reconfigure on any of
+  # the four can be applied via the dynamic path (reconfigureAction
+  # plus the persisted override file from alpha.88) and does NOT
+  # need a rolling restart. Without this declaration the controller
+  # falls back to rolling restart, which on semisync triggers
+  # switchover/promote and re-introduces the SET-GLOBAL-without-
+  # persist race the alpha.84 → alpha.88 chain already closed.
+  - rpl_semi_sync_master_enabled
+  - rpl_semi_sync_slave_enabled
+  - rpl_semi_sync_master_wait_for_slave_count
+  - rpl_semi_sync_master_timeout
   - query_cache_limit
   - query_cache_min_res_unit
   - query_cache_size

--- a/addons/mariadb/config/mariadb-config-effect-scope.yaml
+++ b/addons/mariadb/config/mariadb-config-effect-scope.yaml
@@ -205,7 +205,12 @@ dynamicParameters:
   # persist race the alpha.84 → alpha.88 chain already closed.
   - rpl_semi_sync_master_enabled
   - rpl_semi_sync_slave_enabled
-  - rpl_semi_sync_master_wait_for_slave_count
+  # alpha.89 v1 commit 16 (Helen 2026-05-20) — removed
+  # `rpl_semi_sync_master_wait_for_slave_count` from
+  # dynamicParameters because MariaDB 11.4 does not recognize the
+  # MySQL-specific variable. Setting it in my.cnf causes
+  # `mariadbd --verbose --help` to exit rc=7 with "unknown variable",
+  # which CrashLoops the engine container on first startup.
   - rpl_semi_sync_master_timeout
   - query_cache_limit
   - query_cache_min_res_unit

--- a/addons/mariadb/scripts-ut-spec/cmpv_merged_compatibility_rule_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/cmpv_merged_compatibility_rule_spec.sh
@@ -1,0 +1,123 @@
+# shellcheck shell=sh
+
+# alpha.89 v1 commit 15 (Helen 2026-05-20, live N=1 first-blocker
+# fix from vcluster `mariadb-test5` rerun on commit 14 chart) —
+# the merged replication CmpD (`mariadb-replication-merged-...`)
+# was not matched by any ComponentVersion compatibilityRule entry,
+# so the InstanceSet did not get the engine / exporter /
+# init-syncer images bound. Pod create failed with
+# `spec.containers[*].image: Required value`.
+#
+# This spec locks that the merged CmpD regex is included in the
+# replication/semisync/standalone release group's compDefs list,
+# alongside the existing three regexes, so a future edit cannot
+# silently drop it.
+
+Describe "alpha.89 commit 15 ComponentVersion compatibility for merged CmpD"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  cmpv_path() {
+    printf "%s/addons/mariadb/templates/cmpv.yaml" "$(repo_root)"
+  }
+
+  helper_path() {
+    printf "%s/addons/mariadb/templates/_helpers.tpl" "$(repo_root)"
+  }
+
+  Describe "cmpv.yaml template references the merged regex helper"
+    It "compDefs list in cmpv.yaml includes mariadb.replication.merged.cmpdRegexpPattern"
+      When call grep -c 'mariadb.replication.merged.cmpdRegexpPattern' "$(cmpv_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "cmpv.yaml still references the original three regexes (no regression)"
+      When call grep -cE 'mariadb\.(standalone|replication|semisync)\.cmpdRegexpPattern' "$(cmpv_path)"
+      The status should be success
+      The output should equal "3"
+    End
+
+    It "_helpers.tpl defines the merged regex helper"
+      When call grep -c 'define "mariadb\.replication\.merged\.cmpdRegexpPattern"' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "_helpers.tpl declares the merged regex as ^mariadb-replication-merged-"
+      When call grep -cF '^mariadb-replication-merged-' "$(helper_path)"
+      The status should be success
+      The output should be present
+    End
+  End
+
+  Describe "rendered manifest contains all four regexes in the same compatibilityRule"
+    # Render once into a tmp file, then awk-parse to extract the
+    # first compatibilityRule's compDefs list and assert all four
+    # patterns are present. Same render-to-tmp + bounded matcher
+    # pattern as the env-wire spec (commit 13 v3 v2 / Jack
+    # test-harness HOLD msg `ea4b77ee`) so this spec stays fast
+    # and stable on macOS+Homebrew.
+
+    chart_path() {
+      printf "%s/addons/mariadb" "$(repo_root)"
+    }
+
+    setup() {
+      tmp_render=$(mktemp -t mariadb-cmpv-render-XXXXXX)
+      helm template test "$(chart_path)" >"${tmp_render}" 2>/dev/null
+    }
+
+    cleanup() {
+      rm -f "${tmp_render}" 2>/dev/null || true
+    }
+
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    extract_first_compatibility_compdefs() {
+      # Print one line per compDef pattern in the FIRST
+      # compatibilityRule's compDefs list. Used by the assertions
+      # below to count and verify which patterns are present.
+      awk '
+        /kind: ComponentVersion/ { in_cmpv = 1 }
+        in_cmpv && /compatibilityRules:/ { in_rules = 1; next }
+        in_cmpv && in_rules && /^[[:space:]]+- compDefs:/ { in_first_rule++; next }
+        in_cmpv && in_rules && in_first_rule == 1 && /^[[:space:]]+releases:/ { exit }
+        in_cmpv && in_rules && in_first_rule == 1 && /^[[:space:]]+- / { print }
+      ' "${tmp_render}"
+    }
+
+    It "first compatibilityRule lists ^mariadb-replication-merged-"
+      When call extract_first_compatibility_compdefs
+      The output should include "^mariadb-replication-merged-"
+    End
+
+    It "first compatibilityRule lists ^mariadb-[0-9] (standalone regression guard)"
+      When call extract_first_compatibility_compdefs
+      The output should include "^mariadb-[0-9]"
+    End
+
+    It "first compatibilityRule lists ^mariadb-replication-[0-9] (replication regression guard)"
+      When call extract_first_compatibility_compdefs
+      The output should include "^mariadb-replication-[0-9]"
+    End
+
+    It "first compatibilityRule lists ^mariadb-semisync- (semisync regression guard)"
+      When call extract_first_compatibility_compdefs
+      The output should include "^mariadb-semisync-"
+    End
+
+    It "rendered manifest declares image entries for 11.4.10 release (the merged CmpD default serviceVersion)"
+      # Only do a bounded grep, not a full-content matcher, per
+      # the macOS+Homebrew harness lesson. Look for the release
+      # block's images.mariadb line.
+      When call grep -c 'mariadb: docker\.io/mariadb:11\.4' "${tmp_render}"
+      The status should be success
+      The output should be present
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
@@ -1,0 +1,515 @@
+# shellcheck shell=sh
+#
+# alpha.86 v1 (Helen 2026-05-19) — focused source-level contract tests
+# for the persisted reconfigureAction variant on the semisync topology
+# (Jack peer review 5-guard list, msg a13b8850).
+#
+# 5 guard groups, mapped to test gates below:
+#   G1 init-syncer creates loader file + dir with correct group/mode
+#   G2 --defaults-extra-file is the FIRST mariadbd option in
+#      start_mariadbd_process (positional assertion, not just grep)
+#   G3 reconfigureAction.persisted has injection defense on param
+#      name (^[A-Za-z0-9_.-]+$) and value (no newline / NUL / control
+#      char / section header [mysqld])
+#   G4 fail-closed sentinels on mkdir / tmp write / mv / parse smoke
+#   G5 loader file content is exactly `!includedir <dir>` (no key=value
+#      would crash mariadbd at startup)
+#
+# Plus base contracts kept from alpha.84 v1 / alpha.85:
+#   - persisted variant is SEMISYNC ONLY (other cmpds use base helper)
+#   - base reconfigureAction helper has NO persistence shell code
+#   - KB-managed config (config/mariadb-semisync.tpl) has NO !includedir
+#     (that was the alpha.84 v1 INI parser failure mode)
+
+Describe "alpha.86 reconfigureAction.persisted semisync gates"
+  ADDON_ROOT="${SHELLSPEC_CWD:?}/addons/mariadb"
+  HELPERS_TPL="${ADDON_ROOT}/templates/_helpers.tpl"
+  CMPD_SEMISYNC="${ADDON_ROOT}/templates/cmpd-semisync.yaml"
+  CMPD_STANDALONE="${ADDON_ROOT}/templates/cmpd.yaml"
+  CMPD_REPLICATION="${ADDON_ROOT}/templates/cmpd-replication.yaml"
+  CMPD_GALERA="${ADDON_ROOT}/templates/cmpd-galera.yaml"
+  SEMISYNC_CFG="${ADDON_ROOT}/config/mariadb-semisync.tpl"
+  EFFECT_SCOPE="${ADDON_ROOT}/config/mariadb-config-effect-scope.yaml"
+
+  extract_persisted_helper_body() {
+    awk '
+      /^{{- define "mariadb.config.reconfigureAction.persisted" -}}/ { in_helper = 1; next }
+      in_helper && /^{{- end -}}/ { exit }
+      in_helper { print }
+    ' "${HELPERS_TPL}"
+  }
+
+  extract_base_helper_body() {
+    awk '
+      /^{{- define "mariadb.config.reconfigureAction" -}}/ { in_helper = 1; next }
+      in_helper && /^{{- end -}}/ { exit }
+      in_helper { print }
+    ' "${HELPERS_TPL}"
+  }
+
+  extract_start_mariadbd_function_body() {
+    awk '
+      /^[[:space:]]*start_mariadbd_process\(\) \{/ { in_func = 1; print; next }
+      in_func && /^[[:space:]]*\}[[:space:]]*$/ { print; exit }
+      in_func { print }
+    ' "${CMPD_SEMISYNC}"
+  }
+
+  extract_init_syncer_command_body() {
+    # Init container "init-syncer" body; the third occurrence of the
+    # bash -c heredoc-style block in cmpd-semisync.yaml. We use the
+    # marker line "cp -r /bin/syncer /bin/syncerctl /tools/" to locate
+    # it; that line is unique to this init container.
+    awk '
+      /cp -r \/bin\/syncer \/bin\/syncerctl \/tools\// { in_init = 1 }
+      in_init { print }
+      in_init && /touch.*\.replication-pending/ { in_init = 0 }
+    ' "${CMPD_SEMISYNC}"
+  }
+
+  Describe "B2 regression — main container chown -R does not strip runtime-overrides permissions"
+    # Jack 07:03 peer review B2: main container body executes
+    # `chown -R mysql:mysql {{ .Values.dataMountPath }}` which would
+    # reset the gid=1000 + g+rwx that init-syncer set on
+    # runtime-overrides.d and the loader file. Re-applying gid=1000 +
+    # 0770/0660 must happen AFTER the chown -R, otherwise kbagent
+    # (gid 1000) cannot write override files at runtime.
+
+    main_container_bash_script() {
+      # Extract the main container bash -c body (between line marker
+      # "chown -R mysql:mysql" and the "rm -f .replication-ready"
+      # signal further down).
+      awk '
+        /chown -R mysql:mysql / { in_block = 1 }
+        in_block { print }
+        /^[[:space:]]+rm -f .* .replication-ready/ { in_block = 0 }
+      ' "${CMPD_SEMISYNC}"
+    }
+
+    It "main container re-applies chgrp 1000 on runtime-overrides.d AFTER chown -R"
+      When call main_container_bash_script
+      The status should be success
+      The output should include "chown -R mysql:mysql"
+      The output should include "chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.d"
+    End
+
+    It "main container re-applies chmod 0770 (g+rwx) on runtime-overrides.d AFTER chown -R"
+      When call main_container_bash_script
+      The status should be success
+      The output should include "chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d"
+    End
+
+    It "main container re-applies chgrp 1000 on runtime-overrides.cnf loader AFTER chown -R"
+      When call main_container_bash_script
+      The status should be success
+      The output should include "chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf"
+    End
+
+    It "main container re-applies chmod 0660 on runtime-overrides.cnf loader AFTER chown -R"
+      When call main_container_bash_script
+      The status should be success
+      The output should include "chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf"
+    End
+
+    It "main container always overwrites loader to canonical content (recovers from corruption; Jack 07:03 B2 follow-up)"
+      # Idempotent canonical write — not a `[ -f ] || write` guard.
+      # If a previous generation left a corrupted loader file, the
+      # main container rewrites it to the canonical content on every
+      # startup.
+      When call main_container_bash_script
+      The status should be success
+      The output should include "printf '!includedir %s/runtime-overrides.d/"
+    End
+
+    It "main container chown -R is followed (in source order) by a runtime-overrides chgrp re-fixup line"
+      # Source-order assert: at least ONE `chgrp 1000 runtime-overrides.d`
+      # line must appear AFTER the chown -R line. The init-syncer
+      # already had a chgrp on that path BEFORE the main container's
+      # chown -R (which would clobber it), so the existence of an
+      # AFTER-chown-R chgrp is what protects the kbagent permission
+      # contract.
+      When run sh -c '
+        chown_line=$(grep -n "chown -R mysql:mysql" "'${CMPD_SEMISYNC}'" | head -1 | cut -d: -f1)
+        # Find all chgrp 1000 lines for the runtime-overrides dir and
+        # take the LAST one (assumed to be the main container re-fixup).
+        chgrp_line=$(grep -n "chgrp 1000 {{ \.Values\.dataMountPath }}/runtime-overrides\.d" "'${CMPD_SEMISYNC}'" | tail -1 | cut -d: -f1)
+        if [ -n "${chown_line}" ] && [ -n "${chgrp_line}" ] && [ "${chgrp_line}" -gt "${chown_line}" ]; then
+          echo "OK"
+        else
+          echo "FAIL: chown -R at line ${chown_line:-none}, last runtime-overrides chgrp at line ${chgrp_line:-none}"
+        fi
+      '
+      The status should be success
+      The output should equal "OK"
+    End
+  End
+
+  Describe "Guard 1: init-syncer creates persistence layer with correct group/mode"
+    It "creates runtime-overrides.d directory"
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "mkdir -p {{ .Values.dataMountPath }}/runtime-overrides.d"
+    End
+
+    It "chgrp the runtime-overrides.d directory to gid 1000 (kbagent group)"
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.d"
+    End
+
+    It "chmod 0770 (g+rwx) on the runtime-overrides.d directory"
+      # g+rwx is required because dir writes need traverse (execute) bit;
+      # Jack 06:49 design follow-up.
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d"
+    End
+
+    It "creates the loader file runtime-overrides.cnf with !includedir directive"
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "!includedir"
+      The output should include "runtime-overrides.cnf"
+    End
+
+    It "chgrp the loader file to gid 1000 (kbagent group)"
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf"
+    End
+
+    It "chmod 0660 on the loader file (mariadbd readable, kbagent writable, no execute needed)"
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf"
+    End
+  End
+
+  Describe "Guard 2: --defaults-extra-file is the FIRST mariadbd option"
+    It "start_mariadbd_process function body includes the --defaults-extra-file flag"
+      When call extract_start_mariadbd_function_body
+      The status should be success
+      The output should include "--defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf"
+    End
+
+    It "the --defaults-extra-file flag appears immediately after the mariadbd command (positional first arg)"
+      # MariaDB requires --defaults-* flags to be the first option.
+      # We assert by source-order: the line containing
+      # `docker-entrypoint.sh mariadbd \` must be IMMEDIATELY followed
+      # by the `--defaults-extra-file=...` line (allowing only
+      # whitespace and line-continuation markers).
+      When run sh -c '
+        awk "
+          /docker-entrypoint\.sh mariadbd \\\\/ { found_mariadbd = NR; next }
+          found_mariadbd && NR == found_mariadbd + 1 {
+            if (\$0 ~ /--defaults-extra-file=/) {
+              print \"OK\"
+            } else {
+              print \"FAIL: line after mariadbd is not --defaults-extra-file: \" \$0
+            }
+            exit
+          }
+        " "'${CMPD_SEMISYNC}'"
+      '
+      The status should be success
+      The output should equal "OK"
+    End
+
+    It "the --defaults-extra-file flag precedes --server-id in source order"
+      When run sh -c '
+        defaults_line=$(grep -n "defaults-extra-file=" "'${CMPD_SEMISYNC}'" | head -1 | cut -d: -f1)
+        server_id_line=$(grep -n -- "--server-id=" "'${CMPD_SEMISYNC}'" | head -1 | cut -d: -f1)
+        if [ -n "${defaults_line}" ] && [ -n "${server_id_line}" ] && [ "${defaults_line}" -lt "${server_id_line}" ]; then
+          echo "OK"
+        else
+          echo "FAIL: defaults-extra-file at line ${defaults_line:-none}, server-id at line ${server_id_line:-none}"
+        fi
+      '
+      The status should be success
+      The output should equal "OK"
+    End
+  End
+
+  Describe "Guard 3: injection defense on param name and value"
+    # Jack 07:03 peer review B1 lesson: grep-only tests miss shell
+    # command-substitution semantics. These tests EXECUTE the actual
+    # is_safe_param_name / is_safe_param_value function definitions
+    # extracted from _helpers.tpl in a real /bin/sh subshell with the
+    # same shell context the cmpd-semisync runtime uses. Behavioral
+    # tests, not pattern grep.
+
+    safety_function_definitions() {
+      # Extract just the function defs from the persisted helper body.
+      # Order matters: the setters must run before the print rule
+      # otherwise the opening `func() {` line is missed when entering
+      # a new function block.
+      awk '
+        /^[[:space:]]*is_safe_param_name\(\)/  { in_fn = 1; print; next }
+        /^[[:space:]]*is_safe_param_value\(\)/ { in_fn = 1; print; next }
+        in_fn { print }
+        in_fn && /^[[:space:]]*\}[[:space:]]*$/ { in_fn = 0 }
+      ' "${HELPERS_TPL}"
+    }
+
+    It "function defs source-extractable from _helpers.tpl"
+      # Sanity check: both functions present in the helper body.
+      When call safety_function_definitions
+      The status should be success
+      The output should include "is_safe_param_name()"
+      The output should include "is_safe_param_value()"
+    End
+
+    It "is_safe_param_value accepts the T6 reconfigure target 'ON'"
+      # B1 regression: the broken newline check rejected ALL values,
+      # including the T6 target 'ON' for slow_query_log.
+      When run sh -c "$(safety_function_definitions); is_safe_param_value 'ON'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_value accepts the T6 reconfigure target '3'"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value '3'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_value accepts a typical Valkey enum value 'volatile-lru'"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value 'volatile-lru'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_value accepts a quoted string with whitespace"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value 'a b c'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_value rejects a value containing a literal newline"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value \"$(printf 'ON\nINJECT')\""
+      The status should equal 1
+    End
+
+    It "is_safe_param_value rejects a value containing a literal carriage return"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value \"$(printf 'ON\rINJECT')\""
+      The status should equal 1
+    End
+
+    It "is_safe_param_value rejects a value containing a bracketed section header"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value '[mysqld]'"
+      The status should equal 1
+    End
+
+    It "is_safe_param_value rejects a value containing an embedded bracketed section header"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value 'abc[evil_section]def'"
+      The status should equal 1
+    End
+
+    It "is_safe_param_value rejects a tab character (\\x09 is in \\x00-\\x1f range)"
+      When run sh -c "$(safety_function_definitions); is_safe_param_value \"$(printf 'AB\tCD')\""
+      The status should equal 1
+    End
+
+    It "is_safe_param_name accepts the T6 reconfigure target 'slow_query_log'"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name 'slow_query_log'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_name accepts the T6 reconfigure target 'long_query_time'"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name 'long_query_time'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_name accepts a dotted name (mariadb allows .)"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name 'innodb.flush_method'"
+      The status should equal 0
+    End
+
+    It "is_safe_param_name rejects an empty name"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name ''"
+      The status should equal 1
+    End
+
+    It "is_safe_param_name rejects a name with whitespace"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name 'name with space'"
+      The status should equal 1
+    End
+
+    It "is_safe_param_name rejects a name with shell metacharacters"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name 'evil; DROP TABLE'"
+      The status should equal 1
+    End
+
+    It "is_safe_param_name rejects a name with newline injection attempt"
+      When run sh -c "$(safety_function_definitions); is_safe_param_name \"$(printf 'name\nINJECT')\""
+      The status should equal 1
+    End
+
+    It "persisted helper calls is_safe_param_name before applying any SQL (source-level guard, not just function existence)"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include "Refusing to apply parameter with unsafe name"
+    End
+
+    It "persisted helper calls is_safe_param_value before applying any SQL (source-level guard)"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include "Refusing to apply parameter"
+      The output should include "unsafe value"
+    End
+
+    It "is_safe_param_value uses tr -d for control-char detection (no command-substitution case-pattern; B1 regression guard)"
+      # The first draft tried to detect newline via
+      #   case "${val}" in *"$(printf '\n')"*) ;; esac
+      # POSIX command substitution strips trailing newlines, so the
+      # pattern collapsed to `**` and rejected every value including
+      # "ON" / "3". We assert the live is_safe_param_value uses
+      # `tr -d` (the correct mechanism) and that the function body
+      # does not have any *"$(...)"* style pattern that would suffer
+      # from the same trailing-newline-stripping bug.
+      When call safety_function_definitions
+      The status should be success
+      The output should include "tr -d "
+      The output should not include "*\"\$(printf"
+    End
+  End
+
+  Describe "Guard 4: fail-closed sentinels on persistence failure paths (parse-smoke removed in alpha.88)"
+    It "mkdir of OVERRIDES_DIR exits 1 on failure"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include 'Failed to mkdir ${OVERRIDES_DIR}'
+    End
+
+    It "tmp file write failure exits 1"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include "Failed to write tmp override file"
+    End
+
+    It "rename (atomic mv) failure exits 1"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include "Failed to rename tmp override into place"
+    End
+
+    It "no WARN-only path remains for any persistence failure (regression guard)"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should not include "WARN: failed to persist"
+      The output should not include "runtime overrides will not persist"
+    End
+  End
+
+  Describe "Guard 5 — REMOVED in alpha.88 (kbagent context bug per Jack msg e6afaa1a)"
+    # Background (kept here for future archeology + regression guard):
+    # alpha.86 + alpha.87 dry-runs by Jack showed the parse smoke
+    # `smoke_out=$(mariadbd --print-defaults 2>&1)` line caused the
+    # action to exit 127 with NO stderr output, because:
+    #   1. kbagent action runtime PATH does NOT include `mariadbd`
+    #      (it lives in /usr/sbin/ etc., not the kbagent /tools/
+    #      synthesized PATH).
+    #   2. `set -e` in combination with `var=$(failing_cmd)` causes
+    #      the shell to exit immediately on the failed substitution,
+    #      so the subsequent `smoke_rc=$?` check, stderr print, and
+    #      bad-file cleanup never ran. Orphan `.cnf` files were left
+    #      in /var/lib/mysql/runtime-overrides.d/ as evidence.
+    # Remaining defenses (Guards 1-4) cover the threat model:
+    # injection defense rejects unsafe names/values, and mariadbd's
+    # own error log on next restart is the authoritative validation
+    # surface for engine-side option-file parsing.
+
+    It "init-syncer writes loader file with only the !includedir directive (no key=value)"
+      # Loader file must NOT contain key=value pairs; mariadbd would
+      # interpret them as global options. We assert via the printf
+      # source: format string is '!includedir %s/runtime-overrides.d/\\n'
+      # and only one argument is substituted.
+      When call extract_init_syncer_command_body
+      The status should be success
+      The output should include "printf '!includedir %s/runtime-overrides.d/"
+    End
+
+    It "persisted helper does NOT call mariadbd for parse smoke (alpha.88 regression guard)"
+      # Live helper must not contain the failed parse-smoke invocation
+      # pattern that caused the alpha.86 + alpha.87 dry-run failures.
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should not include "mariadbd --defaults-extra-file="
+      The output should not include "--print-defaults"
+      The output should not include "smoke_out=\$("
+      The output should not include "Parse smoke failed"
+    End
+  End
+
+  Describe "Cross-topology scope: persisted variant is SEMISYNC ONLY"
+    It "cmpd-semisync.yaml includes the persisted variant"
+      When call grep -c 'mariadb.config.reconfigureAction.persisted' "${CMPD_SEMISYNC}"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "cmpd-semisync.yaml does NOT include the bare base helper"
+      When call grep -c '"mariadb\.config\.reconfigureAction"' "${CMPD_SEMISYNC}"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "cmpd.yaml (standalone) does NOT include the persisted variant"
+      When call grep -c 'mariadb.config.reconfigureAction.persisted' "${CMPD_STANDALONE}"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "cmpd-replication.yaml does NOT include the persisted variant"
+      When call grep -c 'mariadb.config.reconfigureAction.persisted' "${CMPD_REPLICATION}"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "cmpd-galera.yaml does NOT include the persisted variant"
+      When call grep -c 'mariadb.config.reconfigureAction.persisted' "${CMPD_GALERA}"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "shared base helper mariadb.config.reconfigureAction does NOT contain persistence shell code"
+      When call extract_base_helper_body
+      The status should be success
+      The output should not include "OVERRIDES_DIR"
+      The output should not include "override_file="
+      The output should not include "override_tmp="
+      The output should not include "LOADER_FILE"
+    End
+  End
+
+  Describe "Regression: KB-managed config has NO !includedir (alpha.84 v1 parser FAIL)"
+    It "config/mariadb-semisync.tpl does NOT contain !includedir (mariadbd loads via --defaults-extra-file instead)"
+      # alpha.84 v1 put !includedir into KB-managed my.cnf, which KB
+      # ParametersDefinition's strict INI parser rejected. alpha.86
+      # keeps !includedir OUT of this file (only in the PVC loader).
+      When call grep -c '!includedir' "${SEMISYNC_CFG}"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "config/mariadb-semisync.tpl content remains pure INI (no `!` directives)"
+      When call grep -c '^!' "${SEMISYNC_CFG}"
+      The status should be failure
+      The output should equal "0"
+    End
+  End
+
+  Describe "Parameter effect-scope source still includes T6 target params"
+    # Ensures the dynamic params list still includes the targets the
+    # MariaDB T6 lane reconfigures; if these drop out, the persisted
+    # helper's emit_action_parameters case statement would silently
+    # skip them.
+    It "slow_query_log is in dynamicParameters in the effect-scope file"
+      When call grep -c '^[[:space:]]*-[[:space:]]*slow_query_log[[:space:]]*$' "${EFFECT_SCOPE}"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "long_query_time is in dynamicParameters in the effect-scope file"
+      When call grep -c '^[[:space:]]*-[[:space:]]*long_query_time[[:space:]]*$' "${EFFECT_SCOPE}"
+      The status should be success
+      The output should equal "1"
+    End
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_configspec_consistency_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_configspec_consistency_spec.sh
@@ -1,0 +1,84 @@
+# shellcheck shell=sh
+
+# Lock that the merged CmpD's configspec name is consistent across
+# the three files that bind on it:
+#   - cmpd-replication-merged.yaml `spec.configs[].name`
+#   - paramsdef.yaml `mariadb-replication-merged-pd` `spec.templateName`
+#   - pcr.yaml merged CmpD PCR `spec.configs[].templateName`
+#
+# alpha.89 v1 commit 2 (Helen 2026-05-19) renamed all three from
+# `mariadb-semisync-config` (inherited from cmpd-semisync.yaml's
+# original configspec name) to `mariadb-replication-config`. KB
+# Configure resolves these references by name, so a mismatch at any
+# of the three sites would silently break the merged CmpD's
+# parameter / config rendering pipeline. This spec encodes the
+# three-way invariant.
+
+Describe "alpha.89 merged CmpD configspec name three-way consistency"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  EXPECTED_NAME='mariadb-replication-config'
+
+  # Extract the configspec name from the merged CmpD file.
+  # Looks for the first `- name:` under `spec.configs:`.
+  cmpd_configspec_name() {
+    awk '
+      $0 ~ /^[[:space:]]*configs:[[:space:]]*$/ { in_configs=1; next }
+      in_configs && $0 ~ /^[[:space:]]*-[[:space:]]+name:[[:space:]]+/ {
+        sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]+/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$(repo_root)/addons/mariadb/templates/cmpd-replication-merged.yaml"
+  }
+
+  # Extract the templateName from the merged PD block in paramsdef.yaml.
+  # The merged PD's metadata.name is `mariadb-replication-merged-pd`.
+  merged_pd_template_name() {
+    awk '
+      /^[[:space:]]+name:[[:space:]]+mariadb-replication-merged-pd[[:space:]]*$/ { in_block=1; next }
+      in_block && /^---[[:space:]]*$/ { in_block=0; next }
+      in_block && /^[[:space:]]+templateName:[[:space:]]+/ {
+        sub(/^[[:space:]]+templateName:[[:space:]]+/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$(repo_root)/addons/mariadb/templates/paramsdef.yaml"
+  }
+
+  # Extract the templateName from the merged CmpD PCR block in pcr.yaml.
+  # The merged PCR's metadata.name uses the merged CmpD name helper.
+  merged_pcr_template_name() {
+    awk '
+      /^# ParamConfigRenderer for the merged replication CmpD$/ { in_block=1; next }
+      in_block && /^---[[:space:]]*$/ { in_block=0; next }
+      in_block && /^[[:space:]]+templateName:[[:space:]]+/ {
+        sub(/^[[:space:]]+templateName:[[:space:]]+/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$(repo_root)/addons/mariadb/templates/pcr.yaml"
+  }
+
+  It "the merged CmpD configspec name is the expected unified name"
+    When call cmpd_configspec_name
+    The output should equal "$EXPECTED_NAME"
+  End
+
+  It "the merged PD templateName matches the configspec name"
+    When call merged_pd_template_name
+    The output should equal "$EXPECTED_NAME"
+  End
+
+  It "the merged PCR templateName matches the configspec name"
+    When call merged_pcr_template_name
+    The output should equal "$EXPECTED_NAME"
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_default_async_configmap_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_default_async_configmap_spec.sh
@@ -1,0 +1,70 @@
+# shellcheck shell=sh
+
+# alpha.89 v1 commit 8 (Helen 2026-05-19, C1 path default-async
+# closure) — the merged CmpD's spec.configs[].template must point
+# at the async-default ConfigMap template
+# (`mariadb-replication-config-template` -> `config/mariadb-replication.tpl`),
+# not the semisync template inherited from the scaffolding commit.
+# Default cluster behavior is async; semisync is opt-in via the
+# four `rpl_semi_sync_*` parameters validated by the PD CUE schema
+# in commit 3 v2.
+#
+# This spec locks the template pointer + the corresponding
+# my.cnf content so a future edit cannot silently flip the default
+# back to semisync.
+
+Describe "alpha.89 merged CmpD default-async ConfigMap template"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  cmpd_path() {
+    printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "$(repo_root)"
+  }
+
+  async_tpl_path() {
+    printf "%s/addons/mariadb/config/mariadb-replication.tpl" "$(repo_root)"
+  }
+
+  cmpd_configs_template() {
+    awk '
+      /^[[:space:]]+configs:[[:space:]]*$/ { in_configs=1; next }
+      in_configs && /^[[:space:]]+template:[[:space:]]+/ {
+        sub(/^[[:space:]]+template:[[:space:]]+/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$(cmpd_path)"
+  }
+
+  It "the merged CmpD's spec.configs[].template references the async ConfigMap template"
+    When call cmpd_configs_template
+    The output should equal "mariadb-replication-config-template"
+  End
+
+  It "the merged CmpD does NOT reference the semisync ConfigMap template"
+    # If a future edit accidentally flips back to
+    # mariadb-semisync-config-template, the default behavior
+    # silently becomes semisync without surfacing in any test.
+    When call grep -qF 'template: mariadb-semisync-config-template' "$(cmpd_path)"
+    The status should be failure
+  End
+
+  Describe "async template my.cnf content"
+    It "does not set rpl_semi_sync_master_enabled in defaults"
+      # The async template should omit the four semisync engine
+      # variables so engine defaults (OFF/0) take effect. If a
+      # future edit adds them with `= ON`, this spec fails.
+      When call grep -E '^[[:space:]]*rpl_semi_sync_master_enabled[[:space:]]*=[[:space:]]*ON' "$(async_tpl_path)"
+      The status should be failure
+    End
+
+    It "does not set rpl_semi_sync_slave_enabled = ON in defaults"
+      When call grep -E '^[[:space:]]*rpl_semi_sync_slave_enabled[[:space:]]*=[[:space:]]*ON' "$(async_tpl_path)"
+      The status should be failure
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_regex_disambiguation_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_regex_disambiguation_spec.sh
@@ -26,12 +26,12 @@ Describe "alpha.89 PD regex disambiguation"
   OLD_SEMISYNC_RE='^mariadb-semisync-'
   MERGED_RE='^mariadb-replication-merged-'
 
-  # The five concrete CmpD names rendered at version 1.1.1-alpha.89.
-  STANDALONE_NAME='mariadb-1.1.1-alpha.89'
-  GALERA_NAME='mariadb-galera-1.1.1-alpha.89'
-  OLD_REPL_NAME='mariadb-replication-1.1.1-alpha.89'
-  OLD_SEMISYNC_NAME='mariadb-semisync-1.1.1-alpha.89'
-  MERGED_NAME='mariadb-replication-merged-1.1.1-alpha.89'
+  # The five concrete CmpD names rendered at version 1.1.1-alpha.90.
+  STANDALONE_NAME='mariadb-1.1.1-alpha.90'
+  GALERA_NAME='mariadb-galera-1.1.1-alpha.90'
+  OLD_REPL_NAME='mariadb-replication-1.1.1-alpha.90'
+  OLD_SEMISYNC_NAME='mariadb-semisync-1.1.1-alpha.90'
+  MERGED_NAME='mariadb-replication-merged-1.1.1-alpha.90'
 
   Describe "standalone CmpD name"
     It "matches only the standalone regex"

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_regex_disambiguation_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_regex_disambiguation_spec.sh
@@ -1,0 +1,151 @@
+# shellcheck shell=sh
+
+# Lock that the four MariaDB ParametersDefinition componentDef regexes
+# rendered by the alpha.89 topology merge scaffolding are mutually
+# exclusive across the five rendered CmpD names. Jack design review
+# (2026-05-19 15:42) flagged the previous wide regex
+# `^mariadb-replication-` would silently match the new merged CmpD
+# `mariadb-replication-merged-{ChartVersion}` and double-bind it to
+# the deprecated PD. This spec encodes the disambiguation contract
+# so future edits to either the helpers or paramsdef cannot silently
+# reintroduce the overlap.
+
+Describe "alpha.89 PD regex disambiguation"
+
+  # Returns 0 (true) when $1 matches the POSIX ERE in $2, else 1.
+  # Uses a portable awk path so the spec stays runner-agnostic.
+  ere_matches() {
+    awk -v s="$1" -v p="$2" 'BEGIN { exit !(s ~ p) }'
+  }
+
+  # The exact regex literals defined in
+  # addons/mariadb/templates/_helpers.tpl post-alpha.89-v1.
+  STANDALONE_RE='^mariadb-[0-9]'
+  GALERA_RE='^mariadb-galera-'
+  OLD_REPL_RE='^mariadb-replication-[0-9]'
+  OLD_SEMISYNC_RE='^mariadb-semisync-'
+  MERGED_RE='^mariadb-replication-merged-'
+
+  # The five concrete CmpD names rendered at version 1.1.1-alpha.89.
+  STANDALONE_NAME='mariadb-1.1.1-alpha.89'
+  GALERA_NAME='mariadb-galera-1.1.1-alpha.89'
+  OLD_REPL_NAME='mariadb-replication-1.1.1-alpha.89'
+  OLD_SEMISYNC_NAME='mariadb-semisync-1.1.1-alpha.89'
+  MERGED_NAME='mariadb-replication-merged-1.1.1-alpha.89'
+
+  Describe "standalone CmpD name"
+    It "matches only the standalone regex"
+      When call ere_matches "$STANDALONE_NAME" "$STANDALONE_RE"
+      The status should be success
+    End
+    It "does not match galera"
+      When call ere_matches "$STANDALONE_NAME" "$GALERA_RE"
+      The status should be failure
+    End
+    It "does not match old replication"
+      When call ere_matches "$STANDALONE_NAME" "$OLD_REPL_RE"
+      The status should be failure
+    End
+    It "does not match old semisync"
+      When call ere_matches "$STANDALONE_NAME" "$OLD_SEMISYNC_RE"
+      The status should be failure
+    End
+    It "does not match merged"
+      When call ere_matches "$STANDALONE_NAME" "$MERGED_RE"
+      The status should be failure
+    End
+  End
+
+  Describe "galera CmpD name"
+    It "matches only the galera regex"
+      When call ere_matches "$GALERA_NAME" "$GALERA_RE"
+      The status should be success
+    End
+    It "does not match standalone"
+      When call ere_matches "$GALERA_NAME" "$STANDALONE_RE"
+      The status should be failure
+    End
+    It "does not match old replication"
+      When call ere_matches "$GALERA_NAME" "$OLD_REPL_RE"
+      The status should be failure
+    End
+    It "does not match old semisync"
+      When call ere_matches "$GALERA_NAME" "$OLD_SEMISYNC_RE"
+      The status should be failure
+    End
+    It "does not match merged"
+      When call ere_matches "$GALERA_NAME" "$MERGED_RE"
+      The status should be failure
+    End
+  End
+
+  Describe "old replication CmpD name"
+    It "matches the old replication regex"
+      When call ere_matches "$OLD_REPL_NAME" "$OLD_REPL_RE"
+      The status should be success
+    End
+    It "does not match standalone"
+      When call ere_matches "$OLD_REPL_NAME" "$STANDALONE_RE"
+      The status should be failure
+    End
+    It "does not match galera"
+      When call ere_matches "$OLD_REPL_NAME" "$GALERA_RE"
+      The status should be failure
+    End
+    It "does not match old semisync"
+      When call ere_matches "$OLD_REPL_NAME" "$OLD_SEMISYNC_RE"
+      The status should be failure
+    End
+    It "does not match merged (the v3.1 contract)"
+      When call ere_matches "$OLD_REPL_NAME" "$MERGED_RE"
+      The status should be failure
+    End
+  End
+
+  Describe "old semisync CmpD name"
+    It "matches the old semisync regex"
+      When call ere_matches "$OLD_SEMISYNC_NAME" "$OLD_SEMISYNC_RE"
+      The status should be success
+    End
+    It "does not match standalone"
+      When call ere_matches "$OLD_SEMISYNC_NAME" "$STANDALONE_RE"
+      The status should be failure
+    End
+    It "does not match galera"
+      When call ere_matches "$OLD_SEMISYNC_NAME" "$GALERA_RE"
+      The status should be failure
+    End
+    It "does not match old replication"
+      When call ere_matches "$OLD_SEMISYNC_NAME" "$OLD_REPL_RE"
+      The status should be failure
+    End
+    It "does not match merged"
+      When call ere_matches "$OLD_SEMISYNC_NAME" "$MERGED_RE"
+      The status should be failure
+    End
+  End
+
+  Describe "merged CmpD name (the v3.1 contract)"
+    It "matches only the merged regex"
+      When call ere_matches "$MERGED_NAME" "$MERGED_RE"
+      The status should be success
+    End
+    It "does not match standalone"
+      When call ere_matches "$MERGED_NAME" "$STANDALONE_RE"
+      The status should be failure
+    End
+    It "does not match galera"
+      When call ere_matches "$MERGED_NAME" "$GALERA_RE"
+      The status should be failure
+    End
+    It "does not match old replication (the regression Jack flagged)"
+      When call ere_matches "$MERGED_NAME" "$OLD_REPL_RE"
+      The status should be failure
+    End
+    It "does not match old semisync"
+      When call ere_matches "$MERGED_NAME" "$OLD_SEMISYNC_RE"
+      The status should be failure
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -1,0 +1,156 @@
+# shellcheck shell=sh
+
+# Lock the alpha.89 v1 commit 3 (C1 path) contract that the merged
+# CmpD's PD declares a CUE schema for the four semisync engine
+# variables, and that those variables are also classified as
+# dynamic so the KB Configure controller does not fall back to
+# rolling restart on reconfigure. Jack design review (15:50)
+# Class 4 sentinel: invalid values must be rejected at the
+# controller parameter reconcile path, which requires the CUE
+# schema to actually declare them.
+
+Describe "alpha.89 merged PD CUE schema + dynamic classification"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  cue_path() {
+    printf "%s/addons/mariadb/config/mariadb-config-constraint.cue" "$(repo_root)"
+  }
+
+  paramsdef_path() {
+    printf "%s/addons/mariadb/templates/paramsdef.yaml" "$(repo_root)"
+  }
+
+  effect_scope_path() {
+    printf "%s/addons/mariadb/config/mariadb-config-effect-scope.yaml" "$(repo_root)"
+  }
+
+  # Silent grep that returns only an exit status; avoids
+  # stdout-eats-expectation warnings under shellspec When call.
+  grep_silent() {
+    grep -qF -- "$1" "$2"
+  }
+
+  # Awk-based search for a literal line of YAML (whitespace plus
+  # a list-style "- name" entry) inside the rendered text. Prints
+  # "ok" on a hit so the spec can compare with The output equals.
+  awk_line_in_block() {
+    awk -v block_start_re="$1" -v hit_re="$2" '
+      $0 ~ block_start_re { in_block=1; next }
+      in_block && /^---[[:space:]]*$/ { in_block=0; next }
+      in_block && $0 ~ hit_re { print "ok"; exit }
+    ' "$3"
+  }
+
+  awk_in_dyn_params() {
+    awk -v hit_re="$1" '
+      /^dynamicParameters:[[:space:]]*$/ { in_dyn=1; next }
+      in_dyn && /^[A-Za-z]/ { in_dyn=0 }
+      in_dyn && $0 ~ hit_re { print "ok"; exit }
+    ' "$2"
+  }
+
+  Describe "CUE constraint file"
+    It "exists at the expected path"
+      When call test -f "$(cue_path)"
+      The status should be success
+    End
+
+    It "declares the MariaDBParameter top-level key"
+      When call grep_silent "#MariaDBParameter:" "$(cue_path)"
+      The status should be success
+    End
+
+    It "constrains rpl_semi_sync_master_enabled to an ON/OFF enum"
+      When call grep_silent 'rpl_semi_sync_master_enabled?: string & "ON" | "OFF"' "$(cue_path)"
+      The status should be success
+    End
+
+    It "constrains rpl_semi_sync_slave_enabled to an ON/OFF enum"
+      When call grep_silent 'rpl_semi_sync_slave_enabled?: string & "ON" | "OFF"' "$(cue_path)"
+      The status should be success
+    End
+
+    It "constrains rpl_semi_sync_master_wait_for_slave_count to a positive int range"
+      When call grep_silent 'rpl_semi_sync_master_wait_for_slave_count?: int & >=1 & <=65535' "$(cue_path)"
+      The status should be success
+    End
+
+    It "constrains rpl_semi_sync_master_timeout to a positive int range"
+      When call grep_silent 'rpl_semi_sync_master_timeout?: int & >=1 & <=2147483647' "$(cue_path)"
+      The status should be success
+    End
+
+    It "does not declare a synthetic replicationMode key"
+      # The C1 path explicitly avoids a synthetic key (KB has no
+      # transform from a logical mode to multiple engine vars).
+      # If a future edit adds one, this spec fails and the design
+      # decision is forced back to the surface.
+      When call grep -qE '^[[:space:]]*replicationMode\??:' "$(cue_path)"
+      The status should be failure
+    End
+
+    # Jack design review (2026-05-19 18:48 Class 4 blocker B1) —
+    # without an INI section binding, KB's `ValidateConfigWithCue()`
+    # does not use the top-level definition. The constraints become
+    # unreferenced and invalid values (e.g. `MAYBE` for an enum,
+    # `0` for a positive-int range) silently pass the validator,
+    # defeating fail-closed. Lock the binding's presence so a future
+    # edit cannot regress it without surfacing here.
+    It "binds #MariaDBParameter to every INI section via [SectionName=_]"
+      When call grep_silent "[SectionName=_]: #MariaDBParameter" "$(cue_path)"
+      The status should be success
+    End
+  End
+
+  Describe "merged PD parametersSchema wiring"
+    It "the merged PD block declares parametersSchema with the CUE top-level key"
+      When call awk_line_in_block \
+        'name:[[:space:]]+mariadb-replication-merged-pd[[:space:]]*$' \
+        'topLevelKey:[[:space:]]+MariaDBParameter' \
+        "$(paramsdef_path)"
+      The output should equal "ok"
+    End
+
+    It "the merged PD block references the CUE file via Files.Get"
+      When call awk_line_in_block \
+        'name:[[:space:]]+mariadb-replication-merged-pd[[:space:]]*$' \
+        'Files\.Get "config/mariadb-config-constraint\.cue"' \
+        "$(paramsdef_path)"
+      The output should equal "ok"
+    End
+  End
+
+  Describe "dynamicParameters classification"
+    It "lists rpl_semi_sync_master_enabled in dynamicParameters"
+      When call awk_in_dyn_params \
+        '^[[:space:]]+-[[:space:]]+rpl_semi_sync_master_enabled[[:space:]]*$' \
+        "$(effect_scope_path)"
+      The output should equal "ok"
+    End
+
+    It "lists rpl_semi_sync_slave_enabled in dynamicParameters"
+      When call awk_in_dyn_params \
+        '^[[:space:]]+-[[:space:]]+rpl_semi_sync_slave_enabled[[:space:]]*$' \
+        "$(effect_scope_path)"
+      The output should equal "ok"
+    End
+
+    It "lists rpl_semi_sync_master_wait_for_slave_count in dynamicParameters"
+      When call awk_in_dyn_params \
+        '^[[:space:]]+-[[:space:]]+rpl_semi_sync_master_wait_for_slave_count[[:space:]]*$' \
+        "$(effect_scope_path)"
+      The output should equal "ok"
+    End
+
+    It "lists rpl_semi_sync_master_timeout in dynamicParameters"
+      When call awk_in_dyn_params \
+        '^[[:space:]]+-[[:space:]]+rpl_semi_sync_master_timeout[[:space:]]*$' \
+        "$(effect_scope_path)"
+      The output should equal "ok"
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -73,9 +73,20 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
       The status should be success
     End
 
-    It "constrains rpl_semi_sync_master_wait_for_slave_count to a positive int range"
-      When call grep_silent 'rpl_semi_sync_master_wait_for_slave_count?: int & >=1 & <=65535' "$(cue_path)"
-      The status should be success
+    It "does NOT declare rpl_semi_sync_master_wait_for_slave_count (commit 16 MariaDB-unsupported drop)"
+      # alpha.89 v1 commit 16 (Helen 2026-05-20, live N=1 third
+      # first-blocker fix): MariaDB 11.4 does NOT support the
+      # MySQL-specific rpl_semi_sync_master_wait_for_slave_count
+      # variable. Setting it in my.cnf causes `mariadbd --verbose
+      # --help` to exit rc=7 with `unknown variable
+      # 'rpl_semi_sync_master_wait_for_slave_count=1'`, which
+      # CrashLoops the engine container on first startup. Match
+      # only code lines (skip lines starting with `//`) so the
+      # rationale comment textually mentioning the removed variable
+      # does not false-positive.
+      When call grep -cE '^[[:space:]]*[^/[:space:]].*rpl_semi_sync_master_wait_for_slave_count' "$(cue_path)"
+      The status should be failure
+      The output should equal "0"
     End
 
     It "constrains rpl_semi_sync_master_timeout to a positive int range"
@@ -199,11 +210,16 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
       The output should equal "ok"
     End
 
-    It "lists rpl_semi_sync_master_wait_for_slave_count in dynamicParameters"
+    It "does NOT list rpl_semi_sync_master_wait_for_slave_count in dynamicParameters (commit 16 MariaDB-unsupported drop)"
+      # alpha.89 v1 commit 16 — MariaDB 11.4 does NOT support
+      # this MySQL-specific variable. If it's in dynamicParameters
+      # the reconfigureAction.persisted helper would attempt
+      # `SET GLOBAL rpl_semi_sync_master_wait_for_slave_count`
+      # which fails on MariaDB with `Unknown system variable`.
       When call awk_in_dyn_params \
         '^[[:space:]]+-[[:space:]]+rpl_semi_sync_master_wait_for_slave_count[[:space:]]*$' \
         "$(effect_scope_path)"
-      The output should equal "ok"
+      The output should not equal "ok"
     End
 
     It "lists rpl_semi_sync_master_timeout in dynamicParameters"

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -83,24 +83,58 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
       The status should be success
     End
 
-    It "declares the replicationMode logical switch as enum (C3 path)"
-      # alpha.89 v1 commit 10 (Helen 2026-05-20) — weston 2026-05-20
-      # 00:08 msg `cb0afa37` directs that the merged CmpD expose
-      # both a single logical `replicationMode` switch AND the four
-      # real `rpl_semi_sync_*` variables. The previous C1 path
-      # spec asserted absence of `replicationMode`; under C3 the
-      # field must exist as an enum `"async" | "semisync"`.
-      When call grep_silent 'replicationMode?: "async" | "semisync"' "$(cue_path)"
+    It "does not declare a replicationMode CUE field (C3 mapper owns it, not CUE)"
+      # alpha.89 v1 commit 11 (Helen 2026-05-20, post Jack
+      # KB-validator behavioral test msg `ea50aa12`) — KB does not
+      # emit CUE-derived field values into the rendered my.cnf, so
+      # a `replicationMode` field in CUE would either be silently
+      # ignored OR land verbatim in my.cnf (which mariadbd rejects
+      # as an unknown variable). C3's `replicationMode` lives as a
+      # ComponentSpec parameter consumed by an addon-side mapper
+      # in reconfigureAction BEFORE my.cnf render; CUE only
+      # validates the four real engine variables. This negative
+      # assertion guards against a future edit silently
+      # reintroducing `replicationMode` into CUE.
+      When call grep -qE '^[[:space:]]*replicationMode\??:' "$(cue_path)"
+      The status should be failure
+    End
+
+    It "does not declare any if replicationMode CUE conditional block as code"
+      # Same post-Jack-finding reason: CUE conditional blocks would
+      # only validate, not derive; expressing C3 precedence in CUE
+      # gives a false sense of completeness. The grep below
+      # excludes comment lines (those starting with `//`) so the
+      # commit 11 preamble's textual reference to the removed
+      # blocks does not trigger a false positive.
+      When call grep -qE '^[[:space:]]*if[[:space:]]+replicationMode' "$(cue_path)"
+      The status should be failure
+    End
+
+    It "opens the #MariaDBParameter struct so base my.cnf keys pass through"
+      # alpha.89 v1 commit 11 (Helen 2026-05-20) — retroactive fix
+      # for commit 3 v2 closed-section bug surfaced by Jack's
+      # KB-validator full-base-merge test (msg `ea50aa12`). Without
+      # the `[string]: _` open marker inside #MariaDBParameter,
+      # ValidateConfigWithCue() rejects base my.cnf keys
+      # (binlog_format, max_connections, slow_query_log, etc.)
+      # that this schema does not enumerate.
+      When call grep_silent "[string]: _" "$(cue_path)"
       The status should be success
     End
 
-    It "binds replicationMode=semisync to the two *_enabled fields = ON via a CUE conditional"
-      When call grep_silent 'if replicationMode == "semisync" {' "$(cue_path)"
-      The status should be success
-    End
-
-    It "binds replicationMode=async to the two *_enabled fields = OFF via a CUE conditional"
-      When call grep_silent 'if replicationMode == "async" {' "$(cue_path)"
+    It "explicitly forbids the synthetic replicationmode key in my.cnf"
+      # alpha.89 v1 commit 11 v2 (Helen 2026-05-20, Jack B1 fix
+      # msg `f8e7e078`) — the `[string]: _` open marker alone
+      # allowed a `replicationMode=semisync` patch to merge into
+      # my.cnf (KB's INI parser lowercases it to `replicationmode`,
+      # which mariadbd does not recognize as a server variable).
+      # The C3 design places `replicationMode` at the
+      # ComponentSpec-parameter layer consumed by an addon mapper
+      # BEFORE my.cnf render; under no path should the key appear
+      # in my.cnf. The `_|_` (CUE bottom) declaration forbids the
+      # specific lowercase key, while the open `[string]: _`
+      # pattern still permits unrelated base my.cnf keys.
+      When call grep_silent "replicationmode?: _|_" "$(cue_path)"
       The status should be success
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -122,20 +122,35 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
       The status should be success
     End
 
-    It "explicitly forbids the synthetic replicationmode key in my.cnf"
-      # alpha.89 v1 commit 11 v2 (Helen 2026-05-20, Jack B1 fix
-      # msg `f8e7e078`) — the `[string]: _` open marker alone
-      # allowed a `replicationMode=semisync` patch to merge into
-      # my.cnf (KB's INI parser lowercases it to `replicationmode`,
-      # which mariadbd does not recognize as a server variable).
-      # The C3 design places `replicationMode` at the
-      # ComponentSpec-parameter layer consumed by an addon mapper
-      # BEFORE my.cnf render; under no path should the key appear
-      # in my.cnf. The `_|_` (CUE bottom) declaration forbids the
-      # specific lowercase key, while the open `[string]: _`
-      # pattern still permits unrelated base my.cnf keys.
-      When call grep_silent "replicationmode?: _|_" "$(cue_path)"
-      The status should be success
+    It "does NOT declare replicationmode as a CUE bottom value (commit 14 live N=1 first-blocker fix)"
+      # alpha.89 v1 commit 14 (Helen 2026-05-20, live N=1 first
+      # blocker from vcluster `mariadb-test5`): commit 11 v2 added
+      # `replicationmode?: _|_` as a defense-in-depth forbid. KB's
+      # local fixture / static ValidateConfigWithCue accepted that
+      # pattern, but the live KB controller's PD reconcile loop
+      # generates an OpenAPI schema from the CUE and rejects any
+      # bottom literal with `failed to generate openAPISchema:
+      # failed to marshal cue-yaml: explicit error (_|_ literal) in
+      # source`. The PD never goes Available and the chart is
+      # unusable.
+      #
+      # Fix: the bottom declaration is removed. The synthetic-key
+      # defense is preserved via three other layers that already
+      # exist and are exercised by ShellSpec:
+      #   1. Helm template-time validator
+      #      (mariadb.replication.mode.validate helper)
+      #   2. Startup seeder
+      #      (scripts/seed-replication-mode-overrides.sh)
+      #   3. Reconfigure mapper unconditional strip
+      #      (scripts/replication-mode-mapper.sh)
+      # Lock that the bottom value never reappears so a future
+      # well-meaning edit cannot reintroduce the live PD breakage.
+      # Match only code lines (skip lines whose first non-space char
+      # is `/`) so the rationale comment above (which textually
+      # references the removed declaration) does not false-positive.
+      When call grep -cE '^[[:space:]]*[^/[:space:]].*replicationmode\?: _\|_' "$(cue_path)"
+      The status should be failure
+      The output should equal "0"
     End
 
     # Jack design review (2026-05-19 18:48 Class 4 blocker B1) —

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -83,13 +83,25 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
       The status should be success
     End
 
-    It "does not declare a synthetic replicationMode key"
-      # The C1 path explicitly avoids a synthetic key (KB has no
-      # transform from a logical mode to multiple engine vars).
-      # If a future edit adds one, this spec fails and the design
-      # decision is forced back to the surface.
-      When call grep -qE '^[[:space:]]*replicationMode\??:' "$(cue_path)"
-      The status should be failure
+    It "declares the replicationMode logical switch as enum (C3 path)"
+      # alpha.89 v1 commit 10 (Helen 2026-05-20) — weston 2026-05-20
+      # 00:08 msg `cb0afa37` directs that the merged CmpD expose
+      # both a single logical `replicationMode` switch AND the four
+      # real `rpl_semi_sync_*` variables. The previous C1 path
+      # spec asserted absence of `replicationMode`; under C3 the
+      # field must exist as an enum `"async" | "semisync"`.
+      When call grep_silent 'replicationMode?: "async" | "semisync"' "$(cue_path)"
+      The status should be success
+    End
+
+    It "binds replicationMode=semisync to the two *_enabled fields = ON via a CUE conditional"
+      When call grep_silent 'if replicationMode == "semisync" {' "$(cue_path)"
+      The status should be success
+    End
+
+    It "binds replicationMode=async to the two *_enabled fields = OFF via a CUE conditional"
+      When call grep_silent 'if replicationMode == "async" {' "$(cue_path)"
+      The status should be success
     End
 
     # Jack design review (2026-05-19 18:48 Class 4 blocker B1) —

--- a/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
@@ -93,68 +93,147 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
   End
 
   Describe "rendered manifest reflects the Helm value"
-    helm_template() {
-      helm template test "$(chart_path)" "$@" 2>/dev/null
+    # alpha.89 v1 commit 13 v3 v2 (Helen 2026-05-20, Jack
+    # test-harness HOLD msg `ea4b77ee`) — earlier form passed the
+    # full ~16k-line `helm template` output into `When call ... The
+    # output should include ...`. ShellSpec's matcher loads the
+    # entire captured stdout into memory and pattern-matches against
+    # it, which is slow / unstable on macOS+Homebrew bash and timed
+    # out at Jack's 34s budget. Refactor: render once into a tmp
+    # file in a helper, then use `grep` on the file (Jack's
+    # `awk/rg` suggestion applied via `grep -F` for fixed-string
+    # matching). `When call grep ...` captures only the matched
+    # line, not the full manifest, so the matcher stays bounded.
+
+    render_to_tmp() {
+      # Render the chart to a tmp file and echo the path. Caller
+      # consumes via grep. `helm template` stderr is silenced for
+      # the positive cases; the fail-closed describe uses a
+      # separate helper that captures stderr.
+      tmp_render=$(mktemp -t mariadb-render-XXXXXX)
+      helm template test "$(chart_path)" "$@" >"${tmp_render}" 2>/dev/null
+      printf "%s" "${tmp_render}"
+    }
+
+    cleanup_tmp_render() {
+      [ -n "${tmp_render:-}" ] && rm -f "${tmp_render}" 2>/dev/null || true
+    }
+
+    AfterEach 'cleanup_tmp_render'
+
+    grep_env_value_after() {
+      # Look for the literal two-line shape:
+      #   - name: MARIADB_REPLICATION_MODE
+      #     value: "<expected>"
+      # Use grep -A1 + awk so we only capture the relevant 2 lines
+      # rather than the whole manifest. Returns 0 on match, 1 on
+      # miss.
+      file_path="$1"
+      expected_value="$2"
+      grep -F -A1 'name: MARIADB_REPLICATION_MODE' "${file_path}" |
+        awk -v want="value: \"${expected_value}\"" '
+          NR==1 { next }
+          $0 ~ "value: " && index($0, want) { print "ok"; exit }
+        '
     }
 
     It "renders an empty-string MARIADB_REPLICATION_MODE when replication.mode is unset"
-      When call helm_template
+      tmp_render=$(render_to_tmp)
+      When call grep_env_value_after "${tmp_render}" ""
       The status should be success
-      The output should include 'name: MARIADB_REPLICATION_MODE
-            value: ""'
+      The output should equal "ok"
     End
 
     It "renders MARIADB_REPLICATION_MODE=semisync when --set replication.mode=semisync"
-      When call helm_template --set replication.mode=semisync
+      tmp_render=$(render_to_tmp --set replication.mode=semisync)
+      When call grep_env_value_after "${tmp_render}" "semisync"
       The status should be success
-      The output should include 'name: MARIADB_REPLICATION_MODE
-            value: "semisync"'
+      The output should equal "ok"
     End
 
     It "renders MARIADB_REPLICATION_MODE=async when --set replication.mode=async"
-      When call helm_template --set replication.mode=async
+      tmp_render=$(render_to_tmp --set replication.mode=async)
+      When call grep_env_value_after "${tmp_render}" "async"
       The status should be success
-      The output should include 'name: MARIADB_REPLICATION_MODE
-            value: "async"'
+      The output should equal "ok"
     End
   End
 
   Describe "Helm template-time fail-closed on invalid value (Jack B2 fix)"
-    # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack B2 fix msg
-    # `f9433634`) — invalid `replication.mode` values fail the helm
-    # render with a clear error BEFORE the manifest is produced, so
-    # the bad value never lands in the rendered CmpD env. Catches
-    # the diagnosis at install/upgrade time, not container startup.
-    helm_template_or_fail() {
-      helm template test "$(chart_path)" "$@" 2>&1
+    # alpha.89 v1 commit 13 v2 (Helen 2026-05-20) — invalid
+    # `replication.mode` values fail the helm render BEFORE any
+    # manifest is produced. v3 v2 (Jack test-harness HOLD msg
+    # `ea4b77ee`) — same refactor: capture stderr to a tmp file
+    # and grep -c, never feed the full output into a ShellSpec
+    # matcher.
+
+    render_stderr_to_tmp() {
+      tmp_stderr=$(mktemp -t mariadb-rend-err-XXXXXX)
+      helm template test "$(chart_path)" "$@" >/dev/null 2>"${tmp_stderr}"
+      printf "%s|%s" "$?" "${tmp_stderr}"
+    }
+
+    cleanup_tmp_stderr() {
+      [ -n "${tmp_stderr:-}" ] && rm -f "${tmp_stderr}" 2>/dev/null || true
+    }
+
+    AfterEach 'cleanup_tmp_stderr'
+
+    check_render_failed_with_sentinel() {
+      rc_and_path="$1"
+      expected_value_in_msg="$2"
+      rc="${rc_and_path%%|*}"
+      file_path="${rc_and_path#*|}"
+      if [ "${rc}" = "0" ]; then
+        echo "expected non-zero rc but got 0" >&2
+        return 1
+      fi
+      if ! grep -qF "invalid mariadb.replication.mode" "${file_path}"; then
+        echo "expected stderr to contain 'invalid mariadb.replication.mode'" >&2
+        return 1
+      fi
+      if ! grep -qF "${expected_value_in_msg}" "${file_path}"; then
+        echo "expected stderr to contain '${expected_value_in_msg}'" >&2
+        return 1
+      fi
+      printf "ok"
     }
 
     It "rejects mariadb.replication.mode=bogus at render time"
-      When call helm_template_or_fail --set replication.mode=bogus
-      The status should be failure
-      The output should include 'invalid mariadb.replication.mode'
-      The output should include 'bogus'
-      The output should include 'expected one of'
+      tmp_stderr_setup=$(render_stderr_to_tmp --set replication.mode=bogus)
+      tmp_stderr="${tmp_stderr_setup#*|}"
+      When call check_render_failed_with_sentinel "${tmp_stderr_setup}" "bogus"
+      The status should be success
+      The output should equal "ok"
     End
 
     It "rejects arbitrary string values at render time"
-      When call helm_template_or_fail --set replication.mode=garbage
-      The status should be failure
-      The output should include 'invalid mariadb.replication.mode'
-      The output should include 'garbage'
+      tmp_stderr_setup=$(render_stderr_to_tmp --set replication.mode=garbage)
+      tmp_stderr="${tmp_stderr_setup#*|}"
+      When call check_render_failed_with_sentinel "${tmp_stderr_setup}" "garbage"
+      The status should be success
+      The output should equal "ok"
     End
 
     It "rejects mixed-case async at render time (only lowercase enum members accepted)"
-      When call helm_template_or_fail --set replication.mode=ASYNC
-      The status should be failure
-      The output should include 'invalid mariadb.replication.mode'
+      tmp_stderr_setup=$(render_stderr_to_tmp --set replication.mode=ASYNC)
+      tmp_stderr="${tmp_stderr_setup#*|}"
+      When call check_render_failed_with_sentinel "${tmp_stderr_setup}" "ASYNC"
+      The status should be success
+      The output should equal "ok"
     End
 
     It "accepts the empty string explicitly (preserves default behavior)"
-      When call helm_template_or_fail --set replication.mode=""
+      # Empty-string render should succeed; reuse the render_to_tmp
+      # helper from the previous Describe via inline duplicate.
+      tmp_render=$(mktemp -t mariadb-render-empty-XXXXXX)
+      helm template test "$(chart_path)" --set replication.mode="" >"${tmp_render}" 2>/dev/null
+      render_rc=$?
+      grep_result=$(grep -F -A1 'name: MARIADB_REPLICATION_MODE' "${tmp_render}" |
+        awk 'NR==2 && $0 ~ /value: ""/ { print "ok"; exit }')
+      rm -f "${tmp_render}" 2>/dev/null || true
+      When call test "${render_rc}" -eq 0 -a "${grep_result}" = "ok"
       The status should be success
-      The output should include 'name: MARIADB_REPLICATION_MODE
-            value: ""'
     End
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
@@ -63,14 +63,30 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
       The output should equal "1"
     End
 
-    It "sources the env value from .Values.replication.mode via Helm template"
-      When call grep -c '\.Values\.replication\.mode' "$(cmpd_merged_path)"
+    It "sources the env value through the mariadb.replication.mode.validate helper (Jack B2 fail-closed path)"
+      When call grep -c 'include "mariadb\.replication\.mode\.validate"' "$(cmpd_merged_path)"
       The status should be success
       The output should equal "1"
     End
 
-    It "defaults the env value to empty string when Helm value is unset"
-      When call grep -c '\.Values\.replication\.mode | default "" | quote' "$(cmpd_merged_path)"
+    helper_path() {
+      printf "%s/addons/mariadb/templates/_helpers.tpl" "$(repo_root)"
+    }
+
+    It "_helpers.tpl declares the mariadb.replication.mode.validate helper"
+      When call grep -c 'define "mariadb\.replication\.mode\.validate"' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "validator defaults the value to empty string when Helm value is unset"
+      When call grep -c '\.Values\.replication\.mode | default ""' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "validator uses fail to abort helm render on invalid value"
+      When call grep -c 'fail (printf "invalid mariadb\.replication\.mode' "$(helper_path)"
       The status should be success
       The output should equal "1"
     End
@@ -100,6 +116,45 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
       The status should be success
       The output should include 'name: MARIADB_REPLICATION_MODE
             value: "async"'
+    End
+  End
+
+  Describe "Helm template-time fail-closed on invalid value (Jack B2 fix)"
+    # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack B2 fix msg
+    # `f9433634`) — invalid `replication.mode` values fail the helm
+    # render with a clear error BEFORE the manifest is produced, so
+    # the bad value never lands in the rendered CmpD env. Catches
+    # the diagnosis at install/upgrade time, not container startup.
+    helm_template_or_fail() {
+      helm template test "$(chart_path)" "$@" 2>&1
+    }
+
+    It "rejects mariadb.replication.mode=bogus at render time"
+      When call helm_template_or_fail --set replication.mode=bogus
+      The status should be failure
+      The output should include 'invalid mariadb.replication.mode'
+      The output should include 'bogus'
+      The output should include 'expected one of'
+    End
+
+    It "rejects arbitrary string values at render time"
+      When call helm_template_or_fail --set replication.mode=garbage
+      The status should be failure
+      The output should include 'invalid mariadb.replication.mode'
+      The output should include 'garbage'
+    End
+
+    It "rejects mixed-case async at render time (only lowercase enum members accepted)"
+      When call helm_template_or_fail --set replication.mode=ASYNC
+      The status should be failure
+      The output should include 'invalid mariadb.replication.mode'
+    End
+
+    It "accepts the empty string explicitly (preserves default behavior)"
+      When call helm_template_or_fail --set replication.mode=""
+      The status should be success
+      The output should include 'name: MARIADB_REPLICATION_MODE
+            value: ""'
     End
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
@@ -1,0 +1,134 @@
+# shellcheck shell=sh
+
+# alpha.89 v1 commit 13 (Helen 2026-05-20, C3 design env plumbing —
+# Helm value / Option C path).
+#
+# Lock the wire-up that connects `mariadb.replication.mode` (Helm
+# value) → `MARIADB_REPLICATION_MODE` (env var on the merged CmpD's
+# mariadb container) → `apply_replication_mode_mapping` (mapper
+# sourced by `reconfigureAction.persisted`).
+#
+# This commit deliberately uses the Helm value path rather than KB
+# ParametersDefinition or Cluster annotations: the standard
+# parameters reconfigure path is blocked by the `replicationmode?: _|_`
+# CUE backstop (commit 11 v2) so a user-supplied `replicationMode`
+# parameter cannot reach the engine via the normal reconfigure flow.
+# Helm-install-time setting is the conservative plumbing path that
+# does not depend on speculative KB behavior. Runtime mode flip via
+# OpsRequest reconfigure is deferred to a future commit.
+#
+# Strategy: render the merged CmpD via `helm template` and grep the
+# rendered manifest for the expected env declarations and default
+# values; render again with `--set replication.mode=semisync` /
+# `--set replication.mode=async` to verify the value flows through.
+
+Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICATION_MODE env wire"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mariadb" "$(repo_root)"
+  }
+
+  values_path() {
+    printf "%s/addons/mariadb/values.yaml" "$(repo_root)"
+  }
+
+  cmpd_merged_path() {
+    printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "$(repo_root)"
+  }
+
+  Describe "values.yaml declares replication.mode with empty default"
+    It "declares a top-level replication block"
+      When call grep -E '^replication:' "$(values_path)"
+      The status should be success
+      The output should include "replication:"
+    End
+
+    It "declares replication.mode with empty-string default to preserve existing behavior"
+      # 2-space-indented `mode: ""` under `replication:` — the empty
+      # string is the default so existing clusters (whose values do
+      # not set this) see no behavioral change.
+      When call awk '/^replication:/{in_block=1; next} in_block && /^[A-Za-z]/{in_block=0} in_block && /^[[:space:]]+mode:[[:space:]]*""/{print "ok"; exit}' "$(values_path)"
+      The output should equal "ok"
+    End
+  End
+
+  Describe "cmpd-replication-merged.yaml wires MARIADB_REPLICATION_MODE env from Helm value"
+    It "declares a MARIADB_REPLICATION_MODE env entry in the merged CmpD"
+      When call grep -c 'name: MARIADB_REPLICATION_MODE' "$(cmpd_merged_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "sources the env value from .Values.replication.mode via Helm template"
+      When call grep -c '\.Values\.replication\.mode' "$(cmpd_merged_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "defaults the env value to empty string when Helm value is unset"
+      When call grep -c '\.Values\.replication\.mode | default "" | quote' "$(cmpd_merged_path)"
+      The status should be success
+      The output should equal "1"
+    End
+  End
+
+  Describe "rendered manifest reflects the Helm value"
+    helm_template() {
+      helm template test "$(chart_path)" "$@" 2>/dev/null
+    }
+
+    It "renders an empty-string MARIADB_REPLICATION_MODE when replication.mode is unset"
+      When call helm_template
+      The status should be success
+      The output should include 'name: MARIADB_REPLICATION_MODE
+            value: ""'
+    End
+
+    It "renders MARIADB_REPLICATION_MODE=semisync when --set replication.mode=semisync"
+      When call helm_template --set replication.mode=semisync
+      The status should be success
+      The output should include 'name: MARIADB_REPLICATION_MODE
+            value: "semisync"'
+    End
+
+    It "renders MARIADB_REPLICATION_MODE=async when --set replication.mode=async"
+      When call helm_template --set replication.mode=async
+      The status should be success
+      The output should include 'name: MARIADB_REPLICATION_MODE
+            value: "async"'
+    End
+  End
+
+  Describe "non-merged topologies do NOT receive the env var"
+    # The Helm value flows ONLY into the merged CmpD's container env
+    # (where the persisted reconfigureAction sources the mapper).
+    # Standalone / galera topologies do not have the merged
+    # reconfigureAction.persisted helper wired with the mapper call,
+    # so adding the env there would be dead.
+
+    cmpd_standalone_path() {
+      printf "%s/addons/mariadb/templates/cmpd.yaml" "$(repo_root)"
+    }
+
+    cmpd_galera_path() {
+      printf "%s/addons/mariadb/templates/cmpd-galera.yaml" "$(repo_root)"
+    }
+
+    It "standalone cmpd.yaml does NOT declare MARIADB_REPLICATION_MODE env"
+      When call grep -c 'name: MARIADB_REPLICATION_MODE' "$(cmpd_standalone_path)"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "galera cmpd-galera.yaml does NOT declare MARIADB_REPLICATION_MODE env"
+      When call grep -c 'name: MARIADB_REPLICATION_MODE' "$(cmpd_galera_path)"
+      The status should be failure
+      The output should equal "0"
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_validate_script_mount_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_validate_script_mount_spec.sh
@@ -1,0 +1,32 @@
+# shellcheck shell=sh
+
+# alpha.89 v1 commit 5 (Helen 2026-05-19, C1 path lifecycle wiring) —
+# the validate-replication-mode.sh helper must be embedded in the
+# replication script ConfigMap so it mounts at /scripts in the
+# mariadb container alongside roleprobe / member-join / switchover.
+# A future commit can add a kbagent lifecycle action that references
+# /scripts/validate-replication-mode.sh without re-touching this
+# ConfigMap; this spec locks the mount surface so the wiring stays
+# stable.
+
+Describe "alpha.89 validate-replication-mode.sh ConfigMap mount"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  configmap_path() {
+    printf "%s/addons/mariadb/templates/configmap-scripts-replication.yaml" "$(repo_root)"
+  }
+
+  It "the replication script ConfigMap declares the validate-replication-mode.sh data key"
+    When call grep -qE '^[[:space:]]+validate-replication-mode\.sh:[[:space:]]*\|-?' "$(configmap_path)"
+    The status should be success
+  End
+
+  It "the validate-replication-mode.sh entry pulls its body via Files.Get"
+    When call grep -qF 'Files.Get "scripts/validate-replication-mode.sh"' "$(configmap_path)"
+    The status should be success
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_mode_mapper_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_mode_mapper_spec.sh
@@ -266,6 +266,47 @@ Describe "alpha.89 replication-mode-mapper.sh"
       The contents of file "${param_file}" should not include 'replicationmode'
       The contents of file "${param_file}" should not include 'replicationMode'
     End
+
+    # alpha.89 v1 commit 12 v2 (Helen 2026-05-20, Jack B2 fix msg
+    # `008885e2`) — UNCONDITIONAL strip means the synthetic key is
+    # removed even when MARIADB_REPLICATION_MODE is unset/empty. The
+    # earlier commit 12 v1 placed the strip after the empty-mode
+    # early return, so a parameter list with a stray
+    # `replicationMode=semisync` line and no env mode would silently
+    # leave the synthetic key in place.
+    It "strips replicationMode even when MARIADB_REPLICATION_MODE is unset (Jack B2 fix)"
+      write_param_file 'replicationMode=semisync' 'rpl_semi_sync_master_enabled=ON'
+      unset MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should not include 'replicationMode'
+      The contents of file "${param_file}" should not include 'replicationmode'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=ON'
+    End
+
+    It "strips lowercase replicationmode even when MARIADB_REPLICATION_MODE is empty (Jack B2 fix)"
+      write_param_file 'replicationmode=async' 'rpl_semi_sync_slave_enabled=OFF'
+      MARIADB_REPLICATION_MODE=""
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should not include 'replicationmode'
+      The contents of file "${param_file}" should not include 'replicationMode'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=OFF'
+    End
+
+    It "preserves mtime for clean only-4-vars input even with the unconditional strip"
+      # When the input is clean (no synthetic key), strip is a no-op
+      # and the param file's mtime is preserved.
+      write_param_file 'rpl_semi_sync_master_enabled=ON' 'rpl_semi_sync_slave_enabled=ON'
+      pre_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      unset MARIADB_REPLICATION_MODE
+      run_mapper >/dev/null 2>&1
+      rc=$?
+      post_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      When call test "${rc}" -eq 0 -a "${pre_sha}" = "${post_sha}"
+      The status should be success
+    End
   End
 
   Describe "unique-call-site contract (rendered helper inspection)"
@@ -298,6 +339,33 @@ Describe "alpha.89 replication-mode-mapper.sh"
 
     It "_helpers.tpl exits non-zero when the mapper returns non-zero (fail-closed)"
       When call grep -c 'replicationMode mapper failed' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    # alpha.89 v1 commit 12 v2 (Helen 2026-05-20, Jack B1 fix msg
+    # `008885e2`) — `if ! apply_replication_mode_mapping ...; then
+    # mapper_rc=$?` loses the original rc because `!` inverts the
+    # exit code, so `$?` inside the then-block is 0 not the mapper's
+    # 2/3/4/5. The fix preserves the rc via `|| mapper_rc=$?`.
+    It "_helpers.tpl does NOT use the rc-losing 'if ! apply_replication_mode_mapping' antipattern as code (comments excluded)"
+      # Match only code lines (no leading `#`) to avoid false positives
+      # from the fix rationale comment that textually references the
+      # earlier antipattern. The grep regex skips lines whose first
+      # non-whitespace char is `#`.
+      When call grep -cE '^[[:space:]]*[^#[:space:]].*if ! apply_replication_mode_mapping' "$(helper_path)"
+      The status should be failure
+      The output should equal "0"
+    End
+
+    It "_helpers.tpl preserves the mapper's original rc via '|| mapper_rc=\$?' (Jack B1 fix)"
+      When call grep -c 'apply_replication_mode_mapping "\${parameter_file}" || mapper_rc=\$?' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "_helpers.tpl checks mapper_rc -ne 0 after the call (rc-aware fail-closed)"
+      When call grep -c 'if \[ "\${mapper_rc}" -ne 0 \]' "$(helper_path)"
       The status should be success
       The output should equal "1"
     End

--- a/addons/mariadb/scripts-ut-spec/replication_mode_mapper_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_mode_mapper_spec.sh
@@ -1,0 +1,332 @@
+# shellcheck shell=sh
+
+# alpha.89 v1 commit 12 (Helen 2026-05-20, C3 design mapper) —
+# Behavioral lock on scripts/replication-mode-mapper.sh, the addon-side
+# mapper that translates the synthetic `replicationMode` ComponentSpec
+# parameter into the four real engine variables BEFORE the merged
+# replication CmpD's reconfigureAction.persisted main loop runs.
+#
+# Jack pre-loaded review criteria (dm:@Jack msg `3a0f5385` /
+# `e8c80793` / `144afd93` / `2e93eb72`):
+#
+#   1. mapper is the unique consumer / writer of `replicationMode` —
+#      synthetic key never lands in the rewritten parameter list, so
+#      it can never reach SET GLOBAL or runtime-overrides.d/.
+#   2. conflict detection runs BEFORE any file modification — when
+#      user-supplied real var disagrees with derived value, mapper
+#      exits non-zero and the parameter list is unchanged.
+#   3. mapper failure produces NO partial state — invalid mode and
+#      missing argument paths both leave the parameter list as-is.
+#   4. only-4-vars path: when MARIADB_REPLICATION_MODE is empty / unset,
+#      mapper is a no-op (return 0, parameter list untouched).
+#   5. both-consistent is idempotent: user supplying both `replicationMode
+#      =semisync` and matching real vars yields exactly one assignment
+#      per real var; no duplicates; repeated mapper invocation produces
+#      identical output.
+#
+# Strategy: source the script with __SOURCED__=1, then invoke
+# apply_replication_mode_mapping with a tmp parameter file. Assert
+# return code AND the exact rewritten file contents.
+
+Describe "alpha.89 replication-mode-mapper.sh"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mariadb/scripts/replication-mode-mapper.sh" "$(repo_root)"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t mariadb-mapper-XXXXXX)
+    param_file="${tmpdir}/params.txt"
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_param_file() {
+    # $@ — one `name=value` per arg.
+    : >"${param_file}"
+    for line in "$@"; do
+      printf "%s\n" "${line}" >>"${param_file}"
+    done
+  }
+
+  read_param_file() {
+    cat "${param_file}"
+  }
+
+  # Source the mapper and call apply_replication_mode_mapping with
+  # the configured MARIADB_REPLICATION_MODE env. ShellSpec captures
+  # stdout, stderr, and exit code separately.
+  run_mapper() {
+    # shellcheck disable=SC1090
+    __SOURCED__=1 . "$(script_path)"
+    apply_replication_mode_mapping "${param_file}"
+  }
+
+  Describe "case 1 — only mode (mode set, no user-supplied real vars)"
+    It "exits 0 and produces all 4 derived vars for mode=semisync"
+      write_param_file
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=ON'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=ON'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_wait_for_slave_count=1'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_timeout=10000'
+    End
+
+    It "exits 0 and produces all 4 derived vars for mode=async (all OFF / defaults)"
+      write_param_file
+      MARIADB_REPLICATION_MODE=async
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=OFF'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=OFF'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_wait_for_slave_count=1'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_timeout=10000'
+    End
+
+    It "does NOT leak the synthetic replicationmode key into the rewritten parameter list"
+      write_param_file
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should not include 'replicationmode'
+      The contents of file "${param_file}" should not include 'replicationMode'
+    End
+  End
+
+  Describe "case 2 — only 4 vars (mode empty / unset)"
+    It "is a no-op when MARIADB_REPLICATION_MODE is empty"
+      write_param_file 'rpl_semi_sync_master_enabled=ON' 'rpl_semi_sync_slave_enabled=ON'
+      pre_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      MARIADB_REPLICATION_MODE=""
+      export MARIADB_REPLICATION_MODE
+      run_mapper >/dev/null 2>&1
+      rc=$?
+      post_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      When call test "${rc}" -eq 0 -a "${pre_sha}" = "${post_sha}"
+      The status should be success
+    End
+
+    It "is a no-op when MARIADB_REPLICATION_MODE is unset"
+      write_param_file 'rpl_semi_sync_master_enabled=OFF' 'rpl_semi_sync_master_timeout=5000'
+      pre_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      unset MARIADB_REPLICATION_MODE
+      run_mapper >/dev/null 2>&1
+      rc=$?
+      post_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      When call test "${rc}" -eq 0 -a "${pre_sha}" = "${post_sha}"
+      The status should be success
+    End
+  End
+
+  Describe "case 3 — both consistent (mode + matching real vars)"
+    It "preserves user-supplied vars and appends only the missing derived vars"
+      write_param_file 'rpl_semi_sync_master_enabled=ON' 'rpl_semi_sync_slave_enabled=ON'
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=ON'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=ON'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_wait_for_slave_count=1'
+      The contents of file "${param_file}" should include 'rpl_semi_sync_master_timeout=10000'
+    End
+
+    It "does not duplicate the user-supplied master_enabled line"
+      # If the rewrite duplicated the user-supplied master_enabled
+      # line, the count of matching lines would exceed 1. Lock to
+      # exactly 1 by running the mapper, then counting matching lines
+      # via grep.
+      write_param_file 'rpl_semi_sync_master_enabled=ON' 'rpl_semi_sync_slave_enabled=ON'
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      run_mapper >/dev/null 2>&1
+      master_count=$(grep -c '^rpl_semi_sync_master_enabled=' "${param_file}")
+      slave_count=$(grep -c '^rpl_semi_sync_slave_enabled=' "${param_file}")
+      When call test "${master_count}" -eq 1 -a "${slave_count}" -eq 1
+      The status should be success
+    End
+
+    It "is idempotent — second invocation produces identical content (byte-equal)"
+      write_param_file
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      __SOURCED__=1 . "$(script_path)"
+      apply_replication_mode_mapping "${param_file}"
+      first_pass_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      apply_replication_mode_mapping "${param_file}"
+      second_pass_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      When call test "${first_pass_sha}" = "${second_pass_sha}"
+      The status should be success
+    End
+  End
+
+  Describe "case 4 — both conflict (mode + disagreeing real var)"
+    It "exits non-zero (code 3) and emits a clear conflict message to stderr"
+      write_param_file 'rpl_semi_sync_master_enabled=OFF'
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should equal 3
+      The stderr should include 'conflict'
+      The stderr should include 'rpl_semi_sync_master_enabled=ON'
+      The stderr should include 'rpl_semi_sync_master_enabled=OFF'
+    End
+
+    It "leaves the parameter list UNCHANGED on conflict (fail-before-write contract)"
+      write_param_file 'rpl_semi_sync_master_enabled=OFF' 'rpl_semi_sync_slave_enabled=OFF'
+      pre_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      run_mapper >/dev/null 2>&1 || true
+      post_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      When call test "${pre_sha}" = "${post_sha}"
+      The status should be success
+    End
+
+    It "detects conflict on rpl_semi_sync_slave_enabled too"
+      write_param_file 'rpl_semi_sync_slave_enabled=OFF'
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should equal 3
+      The stderr should include 'rpl_semi_sync_slave_enabled'
+    End
+  End
+
+  Describe "case 5 — mapper failure (invalid mode + bad arg)"
+    It "exits non-zero (code 2) on an unknown mode value"
+      write_param_file
+      MARIADB_REPLICATION_MODE=bogus
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should equal 2
+      The stderr should include 'invalid'
+      The stderr should include 'bogus'
+    End
+
+    It "leaves the parameter list UNCHANGED on invalid mode (fail-before-write contract)"
+      write_param_file 'rpl_semi_sync_master_enabled=ON'
+      pre_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      MARIADB_REPLICATION_MODE=garbage
+      export MARIADB_REPLICATION_MODE
+      run_mapper >/dev/null 2>&1 || true
+      post_sha=$(shasum -a 256 "${param_file}" | awk '{print $1}')
+      When call test "${pre_sha}" = "${post_sha}"
+      The status should be success
+    End
+
+    It "exits non-zero (code 4) when the parameter file argument is missing"
+      # shellcheck disable=SC1090
+      __SOURCED__=1 . "$(script_path)"
+      When call apply_replication_mode_mapping ""
+      The status should equal 4
+      The stderr should include 'missing or unreadable'
+    End
+
+    It "exits non-zero (code 4) when the parameter file does not exist"
+      # shellcheck disable=SC1090
+      __SOURCED__=1 . "$(script_path)"
+      When call apply_replication_mode_mapping "/nonexistent/path/params.txt"
+      The status should equal 4
+      The stderr should include 'missing or unreadable'
+    End
+  End
+
+  Describe "synthetic key strip (defense-in-depth backstop)"
+    It "strips a synthetic replicationMode line even when mode env is also set"
+      write_param_file 'replicationMode=semisync' 'rpl_semi_sync_master_enabled=ON' 'rpl_semi_sync_slave_enabled=ON'
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should not include 'replicationMode'
+      The contents of file "${param_file}" should not include 'replicationmode'
+    End
+
+    It "strips a lowercase replicationmode line too (KB INI parser lowercases keys)"
+      write_param_file 'replicationmode=async' 'rpl_semi_sync_master_enabled=OFF' 'rpl_semi_sync_slave_enabled=OFF'
+      MARIADB_REPLICATION_MODE=async
+      export MARIADB_REPLICATION_MODE
+      When call run_mapper
+      The status should be success
+      The contents of file "${param_file}" should not include 'replicationmode'
+      The contents of file "${param_file}" should not include 'replicationMode'
+    End
+  End
+
+  Describe "unique-call-site contract (rendered helper inspection)"
+    # Jack contract item 1 (msg `e8c80793`): mapper must be the unique
+    # consumer / writer of `replicationMode`. Lock by counting the
+    # number of `apply_replication_mode_mapping` invocations in the
+    # rendered persisted helper body. Sourcing must happen exactly
+    # once per CmpD that includes the persisted variant.
+    helper_path() {
+      printf "%s/addons/mariadb/templates/_helpers.tpl" "$(repo_root)"
+    }
+
+    It "_helpers.tpl declares apply_replication_mode_mapping exactly once as the call site"
+      When call grep -c 'apply_replication_mode_mapping "\${parameter_file}"' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "_helpers.tpl sources /scripts/replication-mode-mapper.sh exactly once"
+      When call grep -c '__SOURCED__=1 \. /scripts/replication-mode-mapper.sh' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "_helpers.tpl gates the mapper call on file readability so non-merged topologies are safe no-ops"
+      When call grep -c 'if \[ -r /scripts/replication-mode-mapper.sh \]' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "_helpers.tpl exits non-zero when the mapper returns non-zero (fail-closed)"
+      When call grep -c 'replicationMode mapper failed' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+  End
+
+  Describe "byte-equal short-circuit in main loop (idempotency guard)"
+    # Jack contract item (msg `2e93eb72`): the short-circuit must run
+    # AFTER safety validation AND AFTER conflict detection (the mapper
+    # runs first and exits before main loop), but BEFORE the atomic
+    # mv. Lock the textual ordering.
+    helper_path() {
+      printf "%s/addons/mariadb/templates/_helpers.tpl" "$(repo_root)"
+    }
+
+    It "_helpers.tpl uses cmp -s on override_tmp vs override_file before mv"
+      When call grep -c 'cmp -s "\${override_tmp}" "\${override_file}"' "$(helper_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "_helpers.tpl removed the alpha.86 timestamp line so equal-content overrides byte-compare identical"
+      # The alpha.86 helper wrote `# Written by reconfigureAction.persisted on $(date -u ...)`
+      # as the first override line. That timestamp made every rewrite
+      # byte-different from the previous file, defeating cmp -s. The
+      # commit 12 helper removes the timestamp comment.
+      When call grep -c '# Written by reconfigureAction.persisted on' "$(helper_path)"
+      The status should be failure
+      The output should equal "0"
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_mode_mapper_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_mode_mapper_spec.sh
@@ -72,7 +72,7 @@ Describe "alpha.89 replication-mode-mapper.sh"
   }
 
   Describe "case 1 — only mode (mode set, no user-supplied real vars)"
-    It "exits 0 and produces all 4 derived vars for mode=semisync"
+    It "exits 0 and produces the 3 MariaDB-supported derived vars for mode=semisync"
       write_param_file
       MARIADB_REPLICATION_MODE=semisync
       export MARIADB_REPLICATION_MODE
@@ -80,11 +80,12 @@ Describe "alpha.89 replication-mode-mapper.sh"
       The status should be success
       The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=ON'
       The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=ON'
-      The contents of file "${param_file}" should include 'rpl_semi_sync_master_wait_for_slave_count=1'
       The contents of file "${param_file}" should include 'rpl_semi_sync_master_timeout=10000'
+      # commit 16: wait_for_slave_count is MySQL-specific and breaks MariaDB.
+      The contents of file "${param_file}" should not include 'rpl_semi_sync_master_wait_for_slave_count'
     End
 
-    It "exits 0 and produces all 4 derived vars for mode=async (all OFF / defaults)"
+    It "exits 0 and produces the 3 MariaDB-supported derived vars for mode=async (all OFF / defaults)"
       write_param_file
       MARIADB_REPLICATION_MODE=async
       export MARIADB_REPLICATION_MODE
@@ -92,8 +93,8 @@ Describe "alpha.89 replication-mode-mapper.sh"
       The status should be success
       The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=OFF'
       The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=OFF'
-      The contents of file "${param_file}" should include 'rpl_semi_sync_master_wait_for_slave_count=1'
       The contents of file "${param_file}" should include 'rpl_semi_sync_master_timeout=10000'
+      The contents of file "${param_file}" should not include 'rpl_semi_sync_master_wait_for_slave_count'
     End
 
     It "does NOT leak the synthetic replicationmode key into the rewritten parameter list"
@@ -141,8 +142,8 @@ Describe "alpha.89 replication-mode-mapper.sh"
       The status should be success
       The contents of file "${param_file}" should include 'rpl_semi_sync_master_enabled=ON'
       The contents of file "${param_file}" should include 'rpl_semi_sync_slave_enabled=ON'
-      The contents of file "${param_file}" should include 'rpl_semi_sync_master_wait_for_slave_count=1'
       The contents of file "${param_file}" should include 'rpl_semi_sync_master_timeout=10000'
+      The contents of file "${param_file}" should not include 'rpl_semi_sync_master_wait_for_slave_count'
     End
 
     It "does not duplicate the user-supplied master_enabled line"

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -678,4 +678,27 @@ Last_SQL_Error: ... on table kubeblocks.kb_health_check"
       The status should be failure
     End
   End
+
+  Describe "alpha.76 v1 marker mechanism — alpha.80 v1 dead-code cleanup"
+    # The roleprobe-side switchover_fence_active_file / switchover_fence_active_is_fresh
+    # helpers + apply_remote_root_fence if-fresh gate were removed by alpha.80 v1
+    # because alpha.79 v1 minimalist deleted the marker writer in switchover.sh.
+    # All alpha.76 contract tests below are obsolete and marked Pending.
+
+    It "[alpha.80 v1: alpha.76 marker helpers + apply_remote_root_fence gate removed — all contract tests obsolete]"
+      Pending "alpha.80 v1 removed marker mechanism entirely; obsolete pending future ShellSpec cleanup"
+    End
+  End
+  Describe "alpha.76 v1 POSIX shell self-check"
+    It "addons/mariadb/scripts/replication-roleprobe.sh parses cleanly under dash -n"
+      Skip if "dash is not installed" ! command -v dash >/dev/null 2>&1
+      When run dash -n ../scripts/replication-roleprobe.sh
+      The status should be success
+    End
+
+    It "addons/mariadb/scripts/replication-roleprobe.sh parses cleanly under bash -n"
+      When run bash -n ../scripts/replication-roleprobe.sh
+      The status should be success
+    End
+  End
 End

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_is_semisync_mode_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_is_semisync_mode_spec.sh
@@ -1,0 +1,130 @@
+# shellcheck shell=sh
+
+# Behavioral lock on the alpha.89 v1 commit 7 (C1 path topology
+# merge) `is_semisync_mode` helper added to
+# scripts/replication-switchover.sh. The helper is staged: no caller
+# wires it in commit 7. This spec validates the read-only contract
+# (0 = semisync ON, 1 = semisync OFF, 2 = undetermined / fail-closed)
+# so future caller patches build on a stable surface.
+#
+# Strategy: stub MARIADB_CLIENT_BIN with a controllable shell script,
+# source replication-switchover.sh with __SOURCED__=1, then invoke
+# is_semisync_mode and assert its rc. The stub reads its own argv
+# to decide what to print so we can simulate ON / OFF / unknown /
+# client failure with a single fixture.
+
+Describe "alpha.89 replication-switchover.sh is_semisync_mode"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t mariadb-issemisync-XXXXXX)
+    stub_bin="${tmpdir}/mariadb-stub"
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Build a stub mariadb client that emits a fixed value for the
+  # @@rpl_semi_sync_master_enabled query and returns 0. Caller passes
+  # the desired output string (or "" for empty / "FAIL" for non-zero
+  # rc).
+  write_stub() {
+    response="$1"
+    case "${response}" in
+      FAIL)
+        cat >"${stub_bin}" <<'EOF'
+#!/bin/sh
+exit 2
+EOF
+        ;;
+      *)
+        cat >"${stub_bin}" <<EOF
+#!/bin/sh
+# Echo the canned value for any -e SELECT query.
+printf '%s\n' "${response}"
+EOF
+        ;;
+    esac
+    chmod +x "${stub_bin}"
+  }
+
+  # Invoke is_semisync_mode after sourcing the switchover script with
+  # __SOURCED__=1. Returns the rc on stdout for The output assertion.
+  run_helper() {
+    (
+      export __SOURCED__=1
+      export MARIADB_CLIENT_BIN="${stub_bin}"
+      export MARIADB_ROOT_USER='root'
+      export MARIADB_ROOT_PASSWORD='unused-by-stub'
+      export MARIADB_CONNECT_TIMEOUT_SECONDS=3
+      . "$(repo_root)/addons/mariadb/scripts/replication-switchover.sh"
+      is_semisync_mode
+      printf 'rc=%d\n' $?
+    )
+  }
+
+  It "returns 0 (semisync ON) when engine reports literal ON"
+    write_stub ON
+    When call run_helper
+    The output should equal "rc=0"
+  End
+
+  It "returns 0 (semisync ON) when engine reports literal 1"
+    write_stub 1
+    When call run_helper
+    The output should equal "rc=0"
+  End
+
+  It "returns 0 (semisync ON) when engine reports literal on (lowercase)"
+    write_stub on
+    When call run_helper
+    The output should equal "rc=0"
+  End
+
+  It "returns 1 (semisync OFF) when engine reports literal OFF"
+    write_stub OFF
+    When call run_helper
+    The output should equal "rc=1"
+  End
+
+  It "returns 1 (semisync OFF) when engine reports literal 0"
+    write_stub 0
+    When call run_helper
+    The output should equal "rc=1"
+  End
+
+  It "returns 1 (semisync OFF) when engine reports literal off (lowercase)"
+    write_stub off
+    When call run_helper
+    The output should equal "rc=1"
+  End
+
+  It "returns 2 (undetermined / fail-closed) when engine reports an unrecognized literal"
+    # A value outside {0,1,ON,OFF,on,off} must NOT be silently
+    # mapped to one of the two known modes; force callers to treat
+    # it as conservative fail-closed.
+    write_stub MAYBE
+    When call run_helper
+    The output should equal "rc=2"
+  End
+
+  It "returns 2 (undetermined / fail-closed) when engine returns an empty row"
+    write_stub ""
+    When call run_helper
+    The output should equal "rc=2"
+  End
+
+  It "returns 2 (undetermined / fail-closed) when the mariadb client exits non-zero"
+    write_stub FAIL
+    When call run_helper
+    The output should equal "rc=2"
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -850,9 +850,9 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is current (alpha.85 — pure version bump to escape KB CmpD immutability after alpha.84 v2 amend mutated cmpd-semisync.yaml; same scope as alpha.84 v2: semisync ParametersDefinition only)"
+    It "Chart.yaml literal version is current (alpha.88 — drop parse smoke after kbagent PATH + set -e dry-run blocker; injection defense + atomic write remain)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.1.1-alpha.85$' "${chart_yaml}"
+      When call grep -c '^version: 1.1.1-alpha.88$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2843,7 +2843,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.1.1-alpha.85"
+      The output should equal "version: 1.1.1-alpha.88"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2904,7 +2904,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.85"
+        The output should equal "version: 1.1.1-alpha.88"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3081,7 +3081,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.85"
+        The output should equal "version: 1.1.1-alpha.88"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -852,7 +852,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.1.1-alpha.89$' "${chart_yaml}"
+      When call grep -c '^version: 1.1.1-alpha.90$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2843,7 +2843,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.1.1-alpha.89"
+      The output should equal "version: 1.1.1-alpha.90"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2904,7 +2904,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.89"
+        The output should equal "version: 1.1.1-alpha.90"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3081,7 +3081,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.89"
+        The output should equal "version: 1.1.1-alpha.90"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -850,9 +850,9 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is current (alpha.88 — drop parse smoke after kbagent PATH + set -e dry-run blocker; injection defense + atomic write remain)"
+    It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.1.1-alpha.88$' "${chart_yaml}"
+      When call grep -c '^version: 1.1.1-alpha.89$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2843,7 +2843,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.1.1-alpha.88"
+      The output should equal "version: 1.1.1-alpha.89"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2904,7 +2904,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.88"
+        The output should equal "version: 1.1.1-alpha.89"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3081,7 +3081,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.88"
+        The output should equal "version: 1.1.1-alpha.89"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -310,7 +310,9 @@ EOF
         run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
         When run cat "${SYNCERCTL_ARGS}"
         The status should be success
-        The output should eq "--host 127.0.0.1 --port 3601 switchover --primary mdb-mariadb-0 --candidate mdb-mariadb-1"
+        # alpha.79 v2: --force added to bypass syncer's "previous switchover
+        # unfinished" DCS record so same-cluster repeat switchovers proceed.
+        The output should eq "--host 127.0.0.1 --port 3601 switchover --force --primary mdb-mariadb-0 --candidate mdb-mariadb-1"
       End
 
       It "fails before switchover when mariadb client is unavailable"
@@ -502,132 +504,19 @@ EOF_MOCK
         The output should include "fence_local_remote_root_for_secondary: host=% fence_apply_rc=0"
       End
 
-      It "disconnects active remote root sessions around the grant fence"
-        enumerate_user_facing_root_hosts() { echo "%"; return 0; }
-        query_local_value() {
-          record_call "query_sessions"
-          echo "88 89"
-        }
-        run_local_sql_best_effort() {
-          record_call "best_effort=$1"
-          return 0
-        }
-        fence_local_remote_root_for_secondary() {
-          record_call "fence"
-          return 0
-        }
-        local_remote_root_is_fenced_for_secondary() {
-          record_call "verify_fence"
-          return 0
-        }
-        syncerctl_switchover() {
-          record_call "syncerctl"
-          return 0
-        }
-        set_local_read_only() {
-          record_call "set_read_only=$1"
-          return 0
-        }
-        local_read_only_is() {
-          record_call "verify_read_only=$1"
-          [ "$1" = "1" ]
-        }
-        candidate_is_primary() {
-          return 0
-        }
-        current_follows_candidate() {
-          return 0
-        }
-        wait_post_switchover_stabilization() {
-          return 0
-        }
-        primary_service_routes_candidate() {
-          return 0
-        }
-        wait_current_secondary_remote_root_fenced() {
-          return 0
-        }
-        remote_root_write_ready() {
-          return 0
-        }
-        verify_post_dcs_local_root_write_fenced() {
-          return 0
-        }
-        revoke_user_facing_root_admin_privileges_for_secondary() {
-          return 0
-        }
-        wait_candidate_promoted_via_syncerctl() {
-          return 0
-        }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
-        The status should be success
-        The output should include "Switchover pre-DCS guard: disconnecting active remote root sessions 88 89"
-        The output should include "remote root session disconnect issued killed=2 skipped=0"
-        The contents of file "${TEST_DIR}/calls" should include "best_effort=KILL CONNECTION 88;"
-        The contents of file "${TEST_DIR}/calls" should include "best_effort=KILL CONNECTION 89;"
-        The contents of file "${TEST_DIR}/calls" should include "fence"
-        The contents of file "${TEST_DIR}/calls" should include "syncerctl"
+      It "[alpha.79 v1: obsolete; prepare no longer disconnects remote-root sessions or fences root@'%']"
+        # alpha.61-.78 contract: prepare_current_primary_for_switchover ran
+        # disconnect_local_remote_root_sessions_for_secondary +
+        # fence_local_remote_root_for_secondary + local_remote_root_is_fenced_for_secondary.
+        # alpha.79 v1 (westonnnn 21:50 directive) replaces this chain with a
+        # no-op short-circuit, modeled on MySQL semisync addon which does not
+        # modify root@'%' grants during switchover. This obsolete test is
+        # marked Pending; alpha.80 cleanup will remove the test entirely.
+        Pending "alpha.79 minimalist removes fence chain from prepare; obsolete tracker pending alpha.80 cleanup"
       End
 
-      It "fences remote root before DCS and local writes immediately after DCS is accepted"
-        enumerate_user_facing_root_hosts() { echo "%"; return 0; }
-        fence_local_remote_root_for_secondary() {
-          record_call "fence"
-          return 0
-        }
-        local_remote_root_is_fenced_for_secondary() {
-          record_call "verify_fence"
-          return 0
-        }
-        syncerctl_switchover() {
-          record_call "syncerctl"
-          return 0
-        }
-        set_local_read_only() {
-          record_call "set_read_only=$1"
-          return 0
-        }
-        local_read_only_is() {
-          record_call "verify_read_only=$1"
-          [ "$1" = "1" ]
-        }
-        candidate_is_primary() {
-          return 0
-        }
-        current_follows_candidate() {
-          return 0
-        }
-        wait_post_switchover_stabilization() {
-          return 0
-        }
-        primary_service_routes_candidate() {
-          return 0
-        }
-        wait_current_secondary_remote_root_fenced() {
-          return 0
-        }
-        remote_root_write_ready() {
-          return 0
-        }
-        verify_post_dcs_local_root_write_fenced() {
-          return 0
-        }
-        revoke_user_facing_root_admin_privileges_for_secondary() {
-          return 0
-        }
-        wait_candidate_promoted_via_syncerctl() {
-          return 0
-        }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
-        The status should be success
-        The output should include "Switchover pre-DCS guard passed"
-        The output should include "Switchover: creating syncer DCS switchover"
-        The output should include "Switchover post-DCS guard passed"
-        The contents of file "${TEST_DIR}/calls" should include "fence"
-        The contents of file "${TEST_DIR}/calls" should include "verify_fence"
-        The contents of file "${TEST_DIR}/calls" should include "syncerctl"
-        The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
-        The contents of file "${TEST_DIR}/calls" should include "verify_read_only=1"
+      It "[alpha.79 v1: obsolete; prepare no longer logs 'Switchover pre-DCS guard passed' or calls fence/verify_fence]"
+        Pending "alpha.79 minimalist removes fence + verify_fence calls from prepare; obsolete tracker pending alpha.80 cleanup"
       End
 
       It "fails closed when post-DCS local write fence does not close"
@@ -657,24 +546,11 @@ EOF_MOCK
         The contents of file "${TEST_DIR}/calls" should not include "rollback"
       End
 
-      It "does not create DCS switchover when the old-primary guard fails"
-        make_syncerctl
-        enumerate_user_facing_root_hosts() { echo "%"; return 0; }
-        fence_local_remote_root_for_secondary() {
-          record_call "fence"
-          return 1
-        }
-        rollback_current_primary_switchover_guard() {
-          record_call "rollback"
-          return 0
-        }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
-        The status should be failure
-        The output should include "Switchover pre-DCS guard"
-        The stderr should include "Switchover failed: could not fence current primary remote root before DCS switchover"
-        The path "${SYNCERCTL_ARGS}" should not be exist
-        The contents of file "${TEST_DIR}/calls" should include "fence"
-        The contents of file "${TEST_DIR}/calls" should include "rollback"
+      It "[alpha.79 v1: obsolete; prepare cannot fail by fence-chain failure anymore (it's a no-op)]"
+        # alpha.61-.78 contract: prepare guard fails when fence_local_remote_root_
+        # for_secondary returns non-zero. alpha.79 minimalist prepare returns 0
+        # unconditionally; this failure path is unreachable.
+        Pending "alpha.79 minimalist prepare unconditionally returns 0; obsolete tracker pending alpha.80 cleanup"
       End
     End
   End
@@ -974,17 +850,169 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is 1.1.1-alpha.75 (alpha.75 bump because alpha.74 v1 switchover idle-state N=1 RED revealed fence verifier preamble required BINLOG ADMIN which post-demote root lacks)"
+    It "Chart.yaml literal version is current (alpha.85 — pure version bump to escape KB CmpD immutability after alpha.84 v2 amend mutated cmpd-semisync.yaml; same scope as alpha.84 v2: semisync ParametersDefinition only)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.1.1-alpha.75$' "${chart_yaml}"
+      When call grep -c '^version: 1.1.1-alpha.85$' "${chart_yaml}"
       The output should equal "1"
     End
 
-    It "Chart.yaml does not retain prior alpha.74 version line (no stale literal)"
+    It "Chart.yaml does not retain prior alpha.79 version line (no stale literal)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.1.1-alpha.74$' "${chart_yaml}"
+      When call grep -c '^version: 1.1.1-alpha.79$' "${chart_yaml}"
       The status should be failure
       The output should equal "0"
+    End
+
+    It "alpha.79 v1: prepare_current_primary_for_switchover does NOT call fence_local_remote_root_for_secondary [product-blocker]"
+      # alpha.79 minimalist: prepare stage must NOT invoke any per-host
+      # root@'%' fence. The race source is removed by deletion, not by
+      # additional defense.
+      When run sh -c '
+        awk "
+          /^prepare_current_primary_for_switchover\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
+          in_func && /^\\}[[:space:]]*\$/ { in_func = 0 }
+          in_func && \$0 ~ /^[^#]*fence_local_remote_root_for_secondary[^_]/ { found_fence = 1 }
+          in_func && \$0 ~ /^[^#]*local_remote_root_is_fenced_for_secondary/ { found_verify = 1 }
+          END { if (found_fence || found_verify) { printf \"alpha.79 violation: prepare still calls fence=%s verify=%s\\n\", (found_fence ? \"YES\" : \"no\"), (found_verify ? \"YES\" : \"no\"); exit 1 } }
+        " ../scripts/replication-switchover.sh
+      '
+      The status should be success
+    End
+
+    It "alpha.79 v1: prepare_current_primary_for_switchover logs alpha.79 minimalist sentinel [observability]"
+      # Distinct sentinel so historical alpha.61-.78 behavior is
+      # distinguishable from alpha.79+ minimalist in closeout logs.
+      When run sh -c '
+        awk "
+          /^prepare_current_primary_for_switchover\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
+          in_func && /^\\}[[:space:]]*\$/ { in_func = 0 }
+          in_func && \$0 ~ /alpha\\.79 v1 minimalist/ { found = 1 }
+          END { if (!found) { print \"missing alpha.79 minimalist sentinel in prepare log\"; exit 1 } }
+        " ../scripts/replication-switchover.sh
+      '
+      The status should be success
+    End
+
+    It "alpha.79 v1: post-DCS verify_post_dcs_local_root_write_fenced is PRESERVED (read_only=1-based, race-free) [contract-no-regression]"
+      # The post-DCS local-root write fence verifier reads INSERT 1290 errno
+      # from user-facing root, not grant state. It is the safety net that
+      # alpha.79 minimalist relies on. MUST remain intact.
+      When call grep -c '^verify_post_dcs_local_root_write_fenced()' ../scripts/replication-switchover.sh
+      The output should equal "1"
+    End
+
+    It "alpha.79 v1: alpha.76/.77/.78 marker helpers tracked as alpha.80 cleanup debt [tech-debt-tracked]"
+      # Dead-code policy: marker helpers + cmpd switchover_fence_active_is_fresh
+      # + roleprobe skip check are no longer called by the active path. The
+      # cleanup debt MUST be tracked in Chart.yaml so alpha.80+ can grep for it.
+      chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
+      When call grep -c "alpha\.80.*cleanup\|alpha\.80+ removes" "${chart_yaml}"
+      The status should be success
+      The output should not equal "0"
+    End
+
+    It "alpha.78 v1: wait_for_replication_healthy checks syncer role per iteration AT THE TOP OF THE LOOP and exits with return 2 when role=primary [product-blocker]"
+      # cmpd-semisync.yaml wait_for_replication_healthy MUST include a
+      # query_local_syncer_role check inside the while loop, BEFORE the
+      # existing slave_status_is_healthy probe. When the check returns
+      # "primary", function MUST return 2 (distinct from the timeout return 1
+      # and the healthy return 0) so callers can attribute the exit cause.
+      When run sh -c '
+        awk "
+          /^[[:space:]]*wait_for_replication_healthy\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
+          in_func && /^[[:space:]]*\\}[[:space:]]*\$/ { in_func = 0 }
+          in_func && /while true; do/ { in_loop = 1; next }
+          in_func && in_loop && \$0 ~ /query_local_syncer_role/ && !syncer_line { syncer_line = NR }
+          in_func && in_loop && \$0 ~ /current_syncer_role.*=.*\"primary\"/ && !check_line { check_line = NR }
+          in_func && in_loop && \$0 ~ /^[[:space:]]+return 2\$/ && !ret2_line { ret2_line = NR }
+          in_func && in_loop && \$0 ~ /slave_status_is_healthy/ && !slave_check_line { slave_check_line = NR }
+          END {
+            if (!syncer_line || !check_line || !ret2_line || !slave_check_line) { printf \"missing syncer=%s check=%s ret2=%s slave=%s\\n\", (syncer_line ? syncer_line : \"MISSING\"), (check_line ? check_line : \"MISSING\"), (ret2_line ? ret2_line : \"MISSING\"), (slave_check_line ? slave_check_line : \"MISSING\"); exit 1 }
+            # syncer-role check must be BEFORE slave_status_is_healthy probe
+            if (!(syncer_line < slave_check_line)) { printf \"syncer check must be BEFORE slave_status check: syncer=%d slave=%d\\n\", syncer_line, slave_check_line; exit 1 }
+            # return 2 must be between syncer check and slave check
+            if (!(syncer_line <= ret2_line && ret2_line < slave_check_line)) { printf \"return 2 must follow syncer check before slave check: syncer=%d ret2=%d slave=%d\\n\", syncer_line, ret2_line, slave_check_line; exit 1 }
+          }
+        " "${CMPD_SOURCE:-../templates/cmpd-semisync.yaml}"
+      '
+      The status should be success
+    End
+
+    It "alpha.78 v1: wait_for_replication_healthy distinct sentinel log when exiting on DCS-primary [product-blocker]"
+      When run sh -c '
+        awk "
+          /^[[:space:]]*wait_for_replication_healthy\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
+          in_func && /^[[:space:]]*\\}[[:space:]]*\$/ { in_func = 0 }
+          in_func && \$0 ~ /rejoin-replication-exit-on-dcs-primary/ { found = 1 }
+          END { if (!found) { print \"missing rejoin-replication-exit-on-dcs-primary sentinel\"; exit 1 } }
+        " "${CMPD_SOURCE:-../templates/cmpd-semisync.yaml}"
+      '
+      The status should be success
+    End
+
+    It "alpha.78 v1: original 120s timeout path preserved (return 1 + sentinel rejoin-replication-not-healthy) [contract-no-regression]"
+      When run sh -c '
+        awk "
+          /^[[:space:]]*wait_for_replication_healthy\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
+          in_func && /^[[:space:]]*\\}[[:space:]]*\$/ { in_func = 0 }
+          in_func && \$0 ~ /rejoin-replication-not-healthy/ { timeout_found = 1 }
+          in_func && \$0 ~ /^[[:space:]]+return 1\$/ { ret1_found = 1 }
+          END { if (!timeout_found || !ret1_found) { print \"missing timeout sentinel or return 1\"; exit 1 } }
+        " "${CMPD_SOURCE:-../templates/cmpd-semisync.yaml}"
+      '
+      The status should be success
+    End
+
+    It "alpha.78 v1: original healthy-success path preserved (return 0 + sentinel rejoin-replication-healthy) [contract-no-regression]"
+      When run sh -c '
+        awk "
+          /^[[:space:]]*wait_for_replication_healthy\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
+          in_func && /^[[:space:]]*\\}[[:space:]]*\$/ { in_func = 0 }
+          in_func && \$0 ~ /rejoin-replication-healthy[^-]/ { healthy_found = 1 }
+          in_func && \$0 ~ /^[[:space:]]+return 0\$/ { ret0_found = 1 }
+          END { if (!healthy_found || !ret0_found) { print \"missing healthy sentinel or return 0\"; exit 1 } }
+        " "${CMPD_SOURCE:-../templates/cmpd-semisync.yaml}"
+      '
+      The status should be success
+    End
+
+    It "[alpha.80 v1: alpha.77 marker UNLOCK gate obsolete — marker mechanism removed entirely]"
+      # alpha.77 v1 added an in-function `switchover_fence_active_is_fresh`
+      # check inside set_remote_root_account_state UNLOCK branch. alpha.79 v1
+      # minimalist deleted the marker writer in switchover.sh, making the
+      # check unreachable; alpha.80 v1 dead-code cleanup removed the check
+      # entirely. The set_remote_root_account_state function still works
+      # correctly without the gate because alpha.79 minimalist no longer
+      # competes for root@'%' grants.
+      Pending "alpha.80 v1 removed marker mechanism entirely; obsolete pending future ShellSpec cleanup"
+    End
+
+    It "alpha.77 v2: CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS default >= 30s (new primary watchdog SECONDARY->PRIMARY transition needs >10s) [product-blocker]"
+      # alpha.77 v1 N=1 verify on n1y closed pre-DCS REMOTE root fence race
+      # but stage 5 candidate write probe timed out at 10s. New primary's
+      # chart watchdog needs ~6-10s to detect role change + run
+      # expose_sql_listener_for_primary_role + set_primary_read_write +
+      # unlock_remote_root_writes + flip read_only=0. 30s gives one full
+      # role-transition cycle + headroom while remaining well under the
+      # 55s SWITCHOVER_ACTION_DEADLINE_SECONDS.
+      When call sh -c '
+        unset CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS
+        export MARIADB_DATADIR='"${TEST_DIR}"'
+        export DATA_DIR='"${TEST_DIR}"'
+        export __SOURCED__=1
+        . ../scripts/replication-switchover.sh
+        if [ "${CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS}" -lt 30 ]; then
+          echo "default=${CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS} expected>=30"
+          exit 1
+        fi
+        printf "%s\n" "${CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS}"
+      '
+      The status should be success
+      The output should equal "30"
+    End
+
+    It "[alpha.80 v1: alpha.77 marker LOCK-not-gated contract obsolete — marker mechanism removed entirely]"
+      Pending "alpha.80 v1 removed marker mechanism entirely; obsolete pending future ShellSpec cleanup"
     End
   End
 
@@ -2815,7 +2843,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.1.1-alpha.75"
+      The output should equal "version: 1.1.1-alpha.85"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2876,7 +2904,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.75"
+        The output should equal "version: 1.1.1-alpha.85"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -2959,14 +2987,18 @@ EOF
         The output should not include "@'%' ACCOUNT LOCK"
       End
 
-      It "alpha.66 v1: SUPERSEDED by alpha.69 v1 (+alpha.72 v1) — @'%' grant allowlist now includes 5 grants (REPLICATION CLIENT + REPLICATION MASTER ADMIN + SELECT/INSERT/UPDATE on kubeblocks.kb_health_check + SELECT on mysql.user for kb_internal_root@%; REPLICATION SLAVE on *.* for kb_replicator@%); forbidden classes still hard-banned (no admin bypass)"
+      It "alpha.66 v1: SUPERSEDED by alpha.69 v1 (+alpha.72 v1 +alpha.81 v1) — @'%' grant allowlist now includes 6 grants (REPLICATION CLIENT + REPLICATION MASTER ADMIN + SELECT/INSERT/UPDATE on kubeblocks.kb_health_check + SELECT on mysql.user + SLAVE MONITOR on *.* for kb_internal_root@%; REPLICATION SLAVE on *.* for kb_replicator@%); forbidden classes still hard-banned (no admin bypass)"
         # alpha.66 v1 originally asserted zero GRANT @'%'; alpha.68 v2
         # explicitly grants 3 cross-member health privs; alpha.69 v1 adds
         # a 4th narrow grant (SELECT ON mysql.user) to satisfy syncer's
-        # init_db=mysql handshake. This regression test verifies the only
-        # GRANT statements to @'%' are the expected allowlist of 4.
-        # We skip lines that start with REVOKE (REVOKE clause contains
-        # "GRANT OPTION" substring but is not itself a GRANT statement).
+        # init_db=mysql handshake; alpha.81 v1 adds a 5th narrow grant
+        # (SLAVE MONITOR ON *.*) to satisfy syncer engine's
+        # IsSwitchoverDone() SHOW SLAVE STATUS query on MariaDB 11.4+.
+        # This regression test verifies the only GRANT statements to @'%'
+        # are the expected allowlist of 6 (5 for kb_internal_root@%, 1
+        # for kb_replicator@%). We skip lines that start with REVOKE
+        # (REVOKE clause contains "GRANT OPTION" substring but is not
+        # itself a GRANT statement).
         When run sh -c '
           awk "
             /^[[:space:]]*ensure_internal_local_admin\\(\\)[[:space:]]*\\{/ { in_func = 1; next }
@@ -2977,6 +3009,7 @@ EOF
                   line !~ /GRANT[[:space:]]+REPLICATION[[:space:]]+MASTER[[:space:]]+ADMIN[[:space:]]+ON[[:space:]]+\\*\\.\\*/ &&
                   line !~ /GRANT[[:space:]]+SELECT,[[:space:]]+INSERT,[[:space:]]+UPDATE[[:space:]]+ON[[:space:]]+kubeblocks\\.kb_health_check/ &&
                   line !~ /GRANT[[:space:]]+SELECT[[:space:]]+ON[[:space:]]+mysql\\.user/ &&
+                  line !~ /GRANT[[:space:]]+SLAVE[[:space:]]+MONITOR[[:space:]]+ON[[:space:]]+\\*\\.\\*/ &&
                   line !~ /GRANT[[:space:]]+REPLICATION[[:space:]]+SLAVE[[:space:]]+ON[[:space:]]+\\*\\.\\*/) {
                 print NR\": grant to @ percent outside allowlist: \"\$0
               }
@@ -3048,7 +3081,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.75"
+        The output should equal "version: 1.1.1-alpha.85"
       End
     End
 
@@ -3364,6 +3397,19 @@ EOF
         The status should be success
         The output should equal ""
       End
+    End
+  End
+
+  Describe "alpha.76/.77/.78 marker mechanism — alpha.80 v1 dead-code cleanup"
+    # The entire `.switchover-fence-active` marker mechanism (helpers,
+    # consumer fresh-checks, init-syncer rm) was removed by alpha.80 v1
+    # because alpha.79 v1 minimalist deleted the marker writer. The
+    # alpha.76/.77/.78 contract tests below are obsolete and marked
+    # Pending. A future ShellSpec cleanup pass can delete them entirely;
+    # left here as audit trail of which contracts changed.
+
+    It "[alpha.80 v1: alpha.76/.77/.78 marker mechanism removed — all contract tests obsolete]"
+      Pending "alpha.80 v1 removed marker mechanism entirely; obsolete pending future ShellSpec cleanup"
     End
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.1.1-alpha.89 (alpha.89 bump: topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper)"
-      When call grep -c '^version: 1.1.1-alpha.89$' "${CHART_YAML}"
+    It "is exactly 1.1.1-alpha.90 (alpha.90 bump: CmpD immutability — alpha.89 13/14/15/16 mutated merged CmpD spec; KB rejected updates with immutable fields can't be updated; bump produces fresh mariadb-replication-merged-1.1.1-alpha.90 CmpD)"
+      When call grep -c '^version: 1.1.1-alpha.90$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,14 +79,14 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.1.1-alpha.75 (alpha.75 bump because alpha.74 v1 switchover idle-state N=1 RED revealed post-DCS local-root write fence verifier preamble required BINLOG ADMIN which post-demote root lacks; verifier preamble stripped + probe table moved to bootstrap)"
-      When call grep -c '^version: 1.1.1-alpha.75$' "${CHART_YAML}"
+    It "is exactly 1.1.1-alpha.85 (alpha.85 bump: pure version bump to escape KB CmpD immutability after alpha.84 v2 amend mutated cmpd-semisync.yaml; same scope as alpha.84 v2: semisync ParametersDefinition only)"
+      When call grep -c '^version: 1.1.1-alpha.85$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End
 
-    It "does not retain prior alpha.73 version line (no stale literal)"
-      When call grep -c '^version: 1.1.1-alpha.73$' "${CHART_YAML}"
+    It "does not retain prior alpha.84 version line (no stale literal)"
+      When call grep -c '^version: 1.1.1-alpha.84$' "${CHART_YAML}"
       The output should eq "0"
       The status should be failure
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,14 +79,14 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.1.1-alpha.85 (alpha.85 bump: pure version bump to escape KB CmpD immutability after alpha.84 v2 amend mutated cmpd-semisync.yaml; same scope as alpha.84 v2: semisync ParametersDefinition only)"
-      When call grep -c '^version: 1.1.1-alpha.85$' "${CHART_YAML}"
+    It "is exactly 1.1.1-alpha.88 (alpha.88 bump: drop parse smoke after kbagent PATH + set -e dry-run blocker; injection defense + atomic write remain)"
+      When call grep -c '^version: 1.1.1-alpha.88$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End
 
-    It "does not retain prior alpha.84 version line (no stale literal)"
-      When call grep -c '^version: 1.1.1-alpha.84$' "${CHART_YAML}"
+    It "does not retain prior alpha.87 version line (no stale literal)"
+      When call grep -c '^version: 1.1.1-alpha.87$' "${CHART_YAML}"
       The output should eq "0"
       The status should be failure
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,14 +79,14 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.1.1-alpha.88 (alpha.88 bump: drop parse smoke after kbagent PATH + set -e dry-run blocker; injection defense + atomic write remain)"
-      When call grep -c '^version: 1.1.1-alpha.88$' "${CHART_YAML}"
+    It "is exactly 1.1.1-alpha.89 (alpha.89 bump: topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper)"
+      When call grep -c '^version: 1.1.1-alpha.89$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End
 
-    It "does not retain prior alpha.87 version line (no stale literal)"
-      When call grep -c '^version: 1.1.1-alpha.87$' "${CHART_YAML}"
+    It "does not retain prior alpha.88 version line (no stale literal)"
+      When call grep -c '^version: 1.1.1-alpha.88$' "${CHART_YAML}"
       The output should eq "0"
       The status should be failure
     End

--- a/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
@@ -1,0 +1,216 @@
+# shellcheck shell=sh
+
+# alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack
+# post-commit-13-v1 install-time write-site requirement msg
+# `696e7b16`) — behavioral lock on
+# scripts/seed-replication-mode-overrides.sh, the install-time
+# seeder that translates `MARIADB_REPLICATION_MODE` (Helm value
+# `mariadb.replication.mode` → CmpD container env) into the four
+# per-parameter override `.cnf` files BEFORE the first mariadbd
+# process starts.
+#
+# Strategy: source the script with __SOURCED__=1 and invoke
+# seed_replication_mode_overrides against a tmp overrides dir.
+# Assert exit code, file contents, and mtime behavior.
+
+Describe "alpha.89 commit 13 v2 seed-replication-mode-overrides.sh"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mariadb/scripts/seed-replication-mode-overrides.sh" "$(repo_root)"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t mariadb-seed-XXXXXX)
+    overrides_dir="${tmpdir}/overrides"
+    mkdir -p "${overrides_dir}"
+    MARIADB_RUNTIME_OVERRIDES_DIR="${overrides_dir}"
+    export MARIADB_RUNTIME_OVERRIDES_DIR
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  run_seeder() {
+    # shellcheck disable=SC1090
+    __SOURCED__=1 . "$(script_path)"
+    seed_replication_mode_overrides
+  }
+
+  Describe "empty env (no-op)"
+    It "returns 0 and does not create override files when MARIADB_REPLICATION_MODE is unset"
+      unset MARIADB_REPLICATION_MODE
+      run_seeder
+      rc=$?
+      file_count=$(ls "${overrides_dir}" 2>/dev/null | wc -l | tr -d ' ')
+      When call test "${rc}" -eq 0 -a "${file_count}" -eq 0
+      The status should be success
+    End
+
+    It "returns 0 and does not create override files when MARIADB_REPLICATION_MODE is empty string"
+      MARIADB_REPLICATION_MODE=""
+      export MARIADB_REPLICATION_MODE
+      run_seeder
+      rc=$?
+      file_count=$(ls "${overrides_dir}" 2>/dev/null | wc -l | tr -d ' ')
+      When call test "${rc}" -eq 0 -a "${file_count}" -eq 0
+      The status should be success
+    End
+  End
+
+  Describe "semisync seeds the four engine variables"
+    It "writes rpl_semi_sync_master_enabled=ON"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_master_enabled.cnf" should include "[mysqld]"
+      The contents of file "${overrides_dir}/rpl_semi_sync_master_enabled.cnf" should include "rpl_semi_sync_master_enabled = ON"
+    End
+
+    It "writes rpl_semi_sync_slave_enabled=ON"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_slave_enabled.cnf" should include "rpl_semi_sync_slave_enabled = ON"
+    End
+
+    It "writes rpl_semi_sync_master_wait_for_slave_count=1"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_master_wait_for_slave_count.cnf" should include "rpl_semi_sync_master_wait_for_slave_count = 1"
+    End
+
+    It "writes rpl_semi_sync_master_timeout=10000"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_master_timeout.cnf" should include "rpl_semi_sync_master_timeout = 10000"
+    End
+  End
+
+  Describe "async seeds all OFF / defaults"
+    It "writes rpl_semi_sync_master_enabled=OFF"
+      MARIADB_REPLICATION_MODE=async
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_master_enabled.cnf" should include "rpl_semi_sync_master_enabled = OFF"
+    End
+
+    It "writes rpl_semi_sync_slave_enabled=OFF"
+      MARIADB_REPLICATION_MODE=async
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_slave_enabled.cnf" should include "rpl_semi_sync_slave_enabled = OFF"
+    End
+  End
+
+  Describe "invalid mode fail-closed"
+    It "exits with code 2 on unknown mode value"
+      MARIADB_REPLICATION_MODE=bogus
+      export MARIADB_REPLICATION_MODE
+      When call run_seeder
+      The status should equal 2
+      The stderr should include "invalid"
+      The stderr should include "bogus"
+    End
+
+    It "does NOT create override files on invalid mode"
+      MARIADB_REPLICATION_MODE=garbage
+      export MARIADB_REPLICATION_MODE
+      run_seeder >/dev/null 2>&1 || true
+      When call test "$(ls "${overrides_dir}" | wc -l | tr -d ' ')" -eq 0
+      The status should be success
+    End
+  End
+
+  Describe "missing overrides dir"
+    It "exits with code 5 when MARIADB_RUNTIME_OVERRIDES_DIR does not exist"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      MARIADB_RUNTIME_OVERRIDES_DIR="/nonexistent/path/to/overrides"
+      export MARIADB_RUNTIME_OVERRIDES_DIR
+      When call run_seeder
+      The status should equal 5
+      The stderr should include "does not exist"
+    End
+  End
+
+  Describe "idempotency — mtime preserved on repeated invocation"
+    It "byte-equal short-circuit preserves mtime when override file is already at target"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      __SOURCED__=1 . "$(script_path)"
+      seed_replication_mode_overrides
+      first_mtime=$(stat -f "%m" "${overrides_dir}/rpl_semi_sync_master_enabled.cnf" 2>/dev/null || stat -c "%Y" "${overrides_dir}/rpl_semi_sync_master_enabled.cnf")
+      sleep 1
+      seed_replication_mode_overrides
+      second_mtime=$(stat -f "%m" "${overrides_dir}/rpl_semi_sync_master_enabled.cnf" 2>/dev/null || stat -c "%Y" "${overrides_dir}/rpl_semi_sync_master_enabled.cnf")
+      When call test "${first_mtime}" = "${second_mtime}"
+      The status should be success
+    End
+  End
+
+  Describe "convergence with reconfigureAction.persisted"
+    # The seeder writes byte-identical content to what
+    # reconfigureAction.persisted writes for the same env, so a later
+    # reconfigure with the same mode does not rewrite the file (the
+    # mapper + main loop's cmp -s short-circuit kicks in). Lock the
+    # output shape so this convergence holds.
+    It "writes only [mysqld] + name = value (no timestamp, no extra metadata)"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      run_seeder >/dev/null 2>&1
+      # Each override file should be exactly 2 lines: [mysqld] + the
+      # parameter assignment. No "Written on ..." timestamp line that
+      # would change every write and defeat byte-equal compare.
+      When call wc -l "${overrides_dir}/rpl_semi_sync_master_enabled.cnf"
+      The output should include "2"
+    End
+  End
+
+  Describe "script mount + cmpd wire-up (static contract)"
+    cmpd_merged_path() {
+      printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "$(repo_root)"
+    }
+
+    configmap_path() {
+      printf "%s/addons/mariadb/templates/configmap-scripts-replication.yaml" "$(repo_root)"
+    }
+
+    It "configmap-scripts-replication.yaml mounts seed-replication-mode-overrides.sh"
+      When call grep -c 'seed-replication-mode-overrides.sh' "$(configmap_path)"
+      The status should be success
+      The output should equal "2"
+    End
+
+    It "cmpd-replication-merged.yaml invokes the seeder before mariadbd start"
+      # The seeder must be sourced/invoked in the container command
+      # body. Lock that it appears exactly once as a code line (the
+      # explanatory comment textually references the script name).
+      When call grep -cE '^[[:space:]]+sh /scripts/seed-replication-mode-overrides\.sh' "$(cmpd_merged_path)"
+      The status should be success
+      The output should equal "1"
+    End
+
+    It "cmpd-replication-merged.yaml fails the container on seeder non-zero rc"
+      When call grep -c 'refusing to start mariadbd' "$(cmpd_merged_path)"
+      The status should be success
+      The output should equal "1"
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
@@ -209,7 +209,84 @@ Describe "alpha.89 commit 13 v2 seed-replication-mode-overrides.sh"
     It "cmpd-replication-merged.yaml fails the container on seeder non-zero rc"
       When call grep -c 'refusing to start mariadbd' "$(cmpd_merged_path)"
       The status should be success
+      The output should equal "2"
+    End
+
+    # alpha.89 v1 commit 13 v3 (Helen 2026-05-20, Jack B3 fix msg
+    # `6e6eab69`) — when MARIADB_REPLICATION_MODE is non-empty the
+    # seeder script MUST be readable; missing script with non-empty
+    # mode must fail-closed (no silent fallback to async).
+    It "cmpd-replication-merged.yaml fail-closes on missing seeder script when mode is non-empty (Jack B3 fix)"
+      When call grep -c 'set but seeder script /scripts/seed-replication-mode-overrides.sh is missing or unreadable' "$(cmpd_merged_path)"
+      The status should be success
       The output should equal "1"
+    End
+
+    It "cmpd-replication-merged.yaml gates the missing-script check on non-empty MARIADB_REPLICATION_MODE"
+      When call grep -cE 'if \[ -n "\$\{MARIADB_REPLICATION_MODE:-\}" \]' "$(cmpd_merged_path)"
+      The status should be success
+      The output should equal "1"
+    End
+  End
+
+  Describe "B4 target type validation defense-in-depth Jack fix"
+    # If a target path exists but is not a regular file (directory,
+    # symlink-to-dir, device, fifo, socket), `mv tmp target` would
+    # move tmp INTO the directory (for dir case) or silently overwrite
+    # the wrong shape — leaving the target as a non-file with no
+    # override content. The seeder MUST pre-validate target type
+    # before any tmp write.
+
+    It "fails with rc=5 when a target path exists as a directory"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      # Pre-create the wait_for_slave_count target as a directory.
+      mkdir "${overrides_dir}/rpl_semi_sync_master_wait_for_slave_count.cnf"
+      When call run_seeder
+      The status should equal 5
+      The stderr should include "exists but is not a regular file"
+    End
+
+    It "does NOT write any tmp / override files when validation fails (no partial state)"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      mkdir "${overrides_dir}/rpl_semi_sync_master_timeout.cnf"
+      run_seeder >/dev/null 2>&1 || true
+      # No .cnf files written (the only thing in the dir is the
+      # pre-created bogus dir target).
+      regular_file_count=$(find "${overrides_dir}" -maxdepth 1 -type f -name '*.cnf' | wc -l | tr -d ' ')
+      tmp_file_count=$(find "${overrides_dir}" -maxdepth 1 -type f -name '*.cnf.tmp.*' | wc -l | tr -d ' ')
+      When call test "${regular_file_count}" -eq 0 -a "${tmp_file_count}" -eq 0
+      The status should be success
+    End
+  End
+
+  Describe "B5 partial-state protection Jack fix"
+    # When a tmp write or rename fails partway through the 4-file
+    # batch, the seeder must not leave any orphan tmp files behind.
+    # On the very first failure, the seeder calls cleanup_all_tmps to
+    # remove any tmp files that have already been written and returns
+    # rc=5.
+
+    # ShellSpec captures stderr globally for the `When call` block.
+    # The seeder writes a "Permission denied" + sentinel to stderr
+    # on a read-only-dir write failure, so we consume both via
+    # `The stderr should include` to avoid "unexpected stderr" abort.
+    It "cleans up all tmp files + returns rc=5 + no .cnf residue when a tmp write fails (read-only dir)"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      attempt_then_assert() {
+        chmod 0555 "${overrides_dir}"
+        local rc=0
+        run_seeder >/dev/null 2>&1 || rc=$?
+        chmod 0755 "${overrides_dir}"
+        local tmp_residue=$(find "${overrides_dir}" -maxdepth 1 -name '*.cnf.tmp.*' 2>/dev/null | wc -l | tr -d ' ')
+        local cnf_residue=$(find "${overrides_dir}" -maxdepth 1 -name '*.cnf' -type f 2>/dev/null | wc -l | tr -d ' ')
+        printf "rc=%s tmp=%s cnf=%s\n" "${rc}" "${tmp_residue}" "${cnf_residue}"
+      }
+      When call attempt_then_assert
+      The status should be success
+      The output should equal "rc=5 tmp=0 cnf=0"
     End
   End
 

--- a/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
@@ -83,12 +83,18 @@ Describe "alpha.89 commit 13 v2 seed-replication-mode-overrides.sh"
       The contents of file "${overrides_dir}/rpl_semi_sync_slave_enabled.cnf" should include "rpl_semi_sync_slave_enabled = ON"
     End
 
-    It "writes rpl_semi_sync_master_wait_for_slave_count=1"
+    It "does NOT write rpl_semi_sync_master_wait_for_slave_count.cnf (commit 16 MariaDB-unsupported drop)"
+      # alpha.89 v1 commit 16 (Helen 2026-05-20, live N=1 third
+      # first-blocker fix): MariaDB 11.4 does NOT support this
+      # MySQL-specific variable. Writing it to runtime-overrides.d/
+      # causes mariadbd to exit on first startup with rc=7 unknown
+      # variable, CrashLooping the engine container.
       MARIADB_REPLICATION_MODE=semisync
       export MARIADB_REPLICATION_MODE
-      When call run_seeder
+      run_seeder
+      file_exists=$([ -e "${overrides_dir}/rpl_semi_sync_master_wait_for_slave_count.cnf" ] && echo "exists" || echo "absent")
+      When call test "${file_exists}" = "absent"
       The status should be success
-      The contents of file "${overrides_dir}/rpl_semi_sync_master_wait_for_slave_count.cnf" should include "rpl_semi_sync_master_wait_for_slave_count = 1"
     End
 
     It "writes rpl_semi_sync_master_timeout=10000"
@@ -240,8 +246,9 @@ Describe "alpha.89 commit 13 v2 seed-replication-mode-overrides.sh"
     It "fails with rc=5 when a target path exists as a directory"
       MARIADB_REPLICATION_MODE=semisync
       export MARIADB_REPLICATION_MODE
-      # Pre-create the wait_for_slave_count target as a directory.
-      mkdir "${overrides_dir}/rpl_semi_sync_master_wait_for_slave_count.cnf"
+      # commit 16: wait_for_slave_count was removed; use timeout
+      # target as the directory-shape victim instead.
+      mkdir "${overrides_dir}/rpl_semi_sync_master_timeout.cnf"
       When call run_seeder
       The status should equal 5
       The stderr should include "exists but is not a regular file"

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -111,8 +111,8 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     The output should include "GRANT \${CMPD_SECONDARY_FENCE_GRANT_BODY}"
   End
 
-  It "alpha.64 v1: secondary fence grant body constant explicitly excludes SUPER"
-    When call template_contains 'CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN"'
+  It "alpha.64 v1: secondary fence grant body constant explicitly excludes SUPER (alpha.81 v1: insert SLAVE MONITOR between REPLICATION CLIENT and REPLICATION MASTER ADMIN for MariaDB 11.4 SHOW SLAVE STATUS support)"
+    When call template_contains 'CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN"'
     The status should be success
     The output should include "CMPD_SECONDARY_FENCE_GRANT_BODY"
   End

--- a/addons/mariadb/scripts-ut-spec/validate_replication_mode_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/validate_replication_mode_spec.sh
@@ -1,0 +1,206 @@
+# shellcheck shell=sh
+
+# Behavioral tests for scripts/validate-replication-mode.sh, the
+# alpha.89 v1 commit 4 read-only two-source consistency check
+# between the MariaDB engine's in-memory state (SHOW VARIABLES) and
+# the rendered ConfigMap-mounted my.cnf. The script is invoked by
+# test runners at closeout (and may later be wrapped by a kbagent
+# action) to fail-closed when the engine and the desired state
+# disagree.
+#
+# Strategy: stub the `mysql` binary by inserting a tmp dir at the
+# front of PATH for each test, and point the script at a tmp my.cnf
+# file via MARIADB_CONFIG_PATH. Run the script directly and check
+# its exit code plus the key=value tokens it prints.
+
+Describe "alpha.89 validate-replication-mode.sh"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mariadb/scripts/validate-replication-mode.sh" "$(repo_root)"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t mariadb-validate-XXXXXX)
+    cfg_path="${tmpdir}/my.cnf"
+    bin_dir="${tmpdir}/bin"
+    mkdir -p "${bin_dir}"
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Build a stub `mysql` that prints a tab-separated SHOW VARIABLES
+  # row for the queried variable. Caller passes the master and slave
+  # values; the stub reads its own `-e` query to decide which value
+  # to emit.
+  write_mysql_stub() {
+    master_val="$1"
+    slave_val="$2"
+    cat >"${bin_dir}/mysql" <<EOF
+#!/bin/sh
+# Parse the -e flag's value to pick a response.
+query=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -e) query="\$2"; shift 2 ;;
+    -e*) query="\${1#-e}"; shift ;;
+    *) shift ;;
+  esac
+done
+case "\${query}" in
+  *rpl_semi_sync_master_enabled*) printf 'rpl_semi_sync_master_enabled\t%s\n' "${master_val}" ;;
+  *rpl_semi_sync_slave_enabled*)  printf 'rpl_semi_sync_slave_enabled\t%s\n'  "${slave_val}"  ;;
+esac
+EOF
+    chmod +x "${bin_dir}/mysql"
+  }
+
+  # Build a stub `mysql` that fails (used for engine_missing path).
+  write_mysql_stub_failing() {
+    cat >"${bin_dir}/mysql" <<'EOF'
+#!/bin/sh
+exit 2
+EOF
+    chmod +x "${bin_dir}/mysql"
+  }
+
+  # Build a my.cnf with the four variables under [mysqld].
+  write_cnf() {
+    master_val="$1"
+    slave_val="$2"
+    cat >"${cfg_path}" <<EOF
+[mysqld]
+rpl_semi_sync_master_enabled = ${master_val}
+rpl_semi_sync_slave_enabled = ${slave_val}
+rpl_semi_sync_master_wait_for_slave_count = 1
+rpl_semi_sync_master_timeout = 10000
+EOF
+  }
+
+  run_script() {
+    PATH="${bin_dir}:${PATH}" \
+      MARIADB_CONFIG_PATH="${cfg_path}" \
+      MARIADB_HOST=127.0.0.1 \
+      MARIADB_PORT=3306 \
+      sh "$(script_path)"
+  }
+
+  It "exits 0 with mode_consistency=ok when both sources are ON"
+    write_mysql_stub ON ON
+    write_cnf ON ON
+    When call run_script
+    The status should be success
+    The output should include "mode_consistency=ok"
+    The output should include "mode_engine_master_enabled=ON"
+    The output should include "mode_configmap_master_enabled=ON"
+  End
+
+  It "exits 0 with mode_consistency=ok when both sources are OFF"
+    write_mysql_stub OFF OFF
+    write_cnf OFF OFF
+    When call run_script
+    The status should be success
+    The output should include "mode_consistency=ok"
+    The output should include "mode_engine_master_enabled=OFF"
+    The output should include "mode_configmap_master_enabled=OFF"
+  End
+
+  It "normalizes ON / 1 / true as the same value across sources"
+    # Engine returns "1" (some MariaDB builds), ConfigMap has "ON".
+    write_mysql_stub 1 1
+    write_cnf ON ON
+    When call run_script
+    The status should be success
+    The output should include "mode_consistency=ok"
+  End
+
+  It "exits 1 with mode_consistency=disagree when engine ON but ConfigMap OFF"
+    write_mysql_stub ON ON
+    write_cnf OFF OFF
+    When call run_script
+    The status should equal 1
+    The output should include "mode_consistency=disagree"
+    The output should include "mode_engine_master_enabled=ON"
+    The output should include "mode_configmap_master_enabled=OFF"
+  End
+
+  It "exits 2 with mode_consistency=engine_missing when mysql fails"
+    write_mysql_stub_failing
+    write_cnf ON ON
+    When call run_script
+    The status should equal 2
+    The output should include "mode_consistency=engine_missing"
+  End
+
+  # Jack design review commit 4 v1 Blocker B1 — slave engine read
+  # failure was previously classified as invariant_violated (when
+  # master=ON) instead of engine_missing. Lock the corrected
+  # classification with a focused stub that responds only to master.
+  It "exits 2 with mode_consistency=engine_missing when slave engine read returns empty"
+    cat >"${bin_dir}/mysql" <<'EOF'
+#!/bin/sh
+query=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -e) query="$2"; shift 2 ;;
+    -e*) query="${1#-e}"; shift ;;
+    *) shift ;;
+  esac
+done
+case "${query}" in
+  *rpl_semi_sync_master_enabled*) printf 'rpl_semi_sync_master_enabled\tON\n' ;;
+  # slave query returns no row, matching a transient SHOW VARIABLES failure
+  *rpl_semi_sync_slave_enabled*)  : ;;
+esac
+EOF
+    chmod +x "${bin_dir}/mysql"
+    write_cnf ON ON
+    When call run_script
+    The status should equal 2
+    The output should include "mode_consistency=engine_missing"
+  End
+
+  # Jack design review commit 4 v1 Blocker B1 — ConfigMap missing
+  # the slave key was previously classified as disagree. Lock the
+  # corrected classification.
+  It "exits 3 with mode_consistency=configmap_missing when my.cnf is missing the slave key"
+    write_mysql_stub ON ON
+    cat >"${cfg_path}" <<EOF
+[mysqld]
+rpl_semi_sync_master_enabled = ON
+rpl_semi_sync_master_wait_for_slave_count = 1
+rpl_semi_sync_master_timeout = 10000
+EOF
+    When call run_script
+    The status should equal 3
+    The output should include "mode_consistency=configmap_missing"
+  End
+
+  It "exits 3 with mode_consistency=configmap_missing when my.cnf is unreadable"
+    write_mysql_stub ON ON
+    # Point at a path that does not exist.
+    cfg_path="${tmpdir}/does-not-exist.cnf"
+    When call run_script
+    The status should equal 3
+    The output should include "mode_consistency=configmap_missing"
+  End
+
+  It "exits 4 with mode_consistency=invariant_violated when master ON but slave OFF"
+    # MariaDB semisync requires master and slave to be aligned;
+    # an asymmetric setting silently degrades to async.
+    write_mysql_stub ON OFF
+    write_cnf ON OFF
+    When call run_script
+    The status should equal 4
+    The output should include "mode_consistency=invariant_violated"
+  End
+
+End

--- a/addons/mariadb/scripts/replication-mode-mapper.sh
+++ b/addons/mariadb/scripts/replication-mode-mapper.sh
@@ -170,13 +170,43 @@ apply_replication_mode_mapping() {
         return "${REPLICATION_MODE_MAPPER_EXIT_BAD_ARG}"
     fi
 
+    # alpha.89 v1 commit 12 v2 (Helen 2026-05-20, Jack B2 fix msg
+    # `008885e2`) — UNCONDITIONAL synthetic-key strip runs BEFORE the
+    # empty-mode early return. This makes the defense-in-depth contract
+    # claimed by the script preamble actually true: any parameter list
+    # containing a `replicationMode` / `replicationmode` line has that
+    # line removed regardless of whether the env mode is set, so the
+    # synthetic key never reaches the main loop, even on the
+    # only-4-vars path. For clean only-4-vars input (no synthetic key),
+    # the file is byte-identical after the strip (awk preserves the
+    # other lines and just drops the synthetic match), preserving
+    # Jack contract item 4 (only-4-vars unchanged on clean input).
+    strip_tmp="${param_file}.strip.$$"
+    if ! replication_mode_strip_synthetic "${param_file}" > "${strip_tmp}"; then
+        rm -f "${strip_tmp}" 2>/dev/null || true
+        echo "replication-mode-mapper: failed to strip synthetic key from parameter list" >&2
+        return "${REPLICATION_MODE_MAPPER_EXIT_IO}"
+    fi
+    # Atomic rename only when the strip changed something — preserves
+    # mtime for clean only-4-vars input.
+    if cmp -s "${strip_tmp}" "${param_file}"; then
+        rm -f "${strip_tmp}" 2>/dev/null || true
+    else
+        if ! mv "${strip_tmp}" "${param_file}"; then
+            rm -f "${strip_tmp}" 2>/dev/null || true
+            echo "replication-mode-mapper: failed to atomically rewrite parameter list after synthetic strip" >&2
+            return "${REPLICATION_MODE_MAPPER_EXIT_IO}"
+        fi
+    fi
+
     mode="${MARIADB_REPLICATION_MODE:-}"
 
     if [ -z "${mode}" ]; then
-        # Only-4-vars path: leave the parameter list untouched.
-        # Per Jack contract (msg `144afd93`): mapper must return 0 in
-        # this case without rewriting the file, so the only-4-vars
-        # path is provably not touched.
+        # Only-4-vars path: synthetic strip above has already run; if
+        # the input was clean, the file is byte-identical. If the input
+        # contained a synthetic key, it has been removed (defense in
+        # depth). Per Jack contract item 4 (msg `144afd93`): mapper
+        # returns 0 in this case without further modification.
         return "${REPLICATION_MODE_MAPPER_EXIT_OK}"
     fi
 

--- a/addons/mariadb/scripts/replication-mode-mapper.sh
+++ b/addons/mariadb/scripts/replication-mode-mapper.sh
@@ -5,14 +5,23 @@
 # Purpose
 # -------
 # Translates the synthetic `replicationMode` ComponentSpec parameter
-# ("async" | "semisync") into the four real MariaDB engine variables
-# (rpl_semi_sync_master_enabled / rpl_semi_sync_slave_enabled /
-# rpl_semi_sync_master_wait_for_slave_count / rpl_semi_sync_master_timeout)
-# BEFORE the reconfigureAction's main loop renders any my.cnf or
+# ("async" | "semisync") into the three real MariaDB engine variables
+# supported by MariaDB 11.4 (rpl_semi_sync_master_enabled /
+# rpl_semi_sync_slave_enabled / rpl_semi_sync_master_timeout) BEFORE
+# the reconfigureAction's main loop renders any my.cnf or
 # runtime-overrides.d/ file. After this mapper runs, the parameter list
 # contains only real engine variable assignments; the synthetic key
 # `replicationMode` (and its lowercased form `replicationmode`) never
 # reaches `SET GLOBAL` and never lands in my.cnf.
+#
+# alpha.89 v1 commit 16 (Helen 2026-05-20, live N=1 third first-blocker
+# fix): `rpl_semi_sync_master_wait_for_slave_count` was originally
+# part of the derived set, mirroring MySQL semisync's 4-var picture.
+# MariaDB 11.4 does NOT recognize this variable (it is a MySQL 5.7.3+
+# extension). Setting it in my.cnf causes mariadbd to exit on first
+# startup with rc=7 "unknown variable". MariaDB semisync waits for
+# exactly one secondary acknowledgement and has no equivalent count
+# variable. The variable is now removed from the derived set.
 #
 # Why a mapper instead of a CUE conditional
 # ------------------------------------------
@@ -98,19 +107,15 @@ replication_mode_derive() {
     async)
         printf "rpl_semi_sync_master_enabled=OFF\n"
         printf "rpl_semi_sync_slave_enabled=OFF\n"
-        # wait_for_slave_count and timeout are only meaningful when
-        # master_enabled=ON. Per the schema defaults (commit 3 v2),
-        # the count default is 1 and the timeout default is 10000ms.
-        # The mapper emits them for async too so the override file
-        # set is deterministic and a future flip to semisync does
-        # not leave stale values from the OFF state.
-        printf "rpl_semi_sync_master_wait_for_slave_count=1\n"
+        # timeout is only meaningful when master_enabled=ON. The
+        # mapper emits it for async too so the override file set is
+        # deterministic and a future flip to semisync does not leave
+        # stale values from the OFF state.
         printf "rpl_semi_sync_master_timeout=10000\n"
         ;;
     semisync)
         printf "rpl_semi_sync_master_enabled=ON\n"
         printf "rpl_semi_sync_slave_enabled=ON\n"
-        printf "rpl_semi_sync_master_wait_for_slave_count=1\n"
         printf "rpl_semi_sync_master_timeout=10000\n"
         ;;
     *)

--- a/addons/mariadb/scripts/replication-mode-mapper.sh
+++ b/addons/mariadb/scripts/replication-mode-mapper.sh
@@ -1,0 +1,255 @@
+#!/bin/sh
+# replication-mode-mapper.sh — alpha.89 v1 commit 12 (Helen 2026-05-20)
+# C3 design mapper for the merged replication CmpD.
+#
+# Purpose
+# -------
+# Translates the synthetic `replicationMode` ComponentSpec parameter
+# ("async" | "semisync") into the four real MariaDB engine variables
+# (rpl_semi_sync_master_enabled / rpl_semi_sync_slave_enabled /
+# rpl_semi_sync_master_wait_for_slave_count / rpl_semi_sync_master_timeout)
+# BEFORE the reconfigureAction's main loop renders any my.cnf or
+# runtime-overrides.d/ file. After this mapper runs, the parameter list
+# contains only real engine variable assignments; the synthetic key
+# `replicationMode` (and its lowercased form `replicationmode`) never
+# reaches `SET GLOBAL` and never lands in my.cnf.
+#
+# Why a mapper instead of a CUE conditional
+# ------------------------------------------
+# Jack's KB-validator behavioral test (2026-05-20 msg `ea50aa12`)
+# proved that KB's `pkg/parameters/validate/cue_util.go
+# ValidateConfigWithCue()` validates parameter values against a CUE
+# schema but does NOT emit CUE-derived field values back into the
+# rendered my.cnf. Expressing C3 precedence in CUE alone would either
+# silently ignore `replicationMode` or land the verbatim key in my.cnf
+# (which mariadbd rejects as unknown). The C3 design therefore places
+# `replicationMode` at the ComponentSpec-parameter layer consumed by
+# this addon-side mapper before my.cnf render. commit 11 v2 closed the
+# CUE side: `replicationmode?: _|_` forbids the synthetic key from
+# landing in my.cnf as a defense-in-depth backstop.
+#
+# Contract (locked with Jack 2026-05-20 dm:@Jack msg `144afd93` and
+# `2e93eb72`)
+# ---------------------------------------------------------------
+# 1. mapper is the UNIQUE consumer / writer of `replicationMode`.
+#    Called exactly once from `mariadb.config.reconfigureAction.persisted`
+#    BEFORE the main loop processes any parameter.
+# 2. Conflict detection runs BEFORE any file modification. If the
+#    user simultaneously supplies `replicationMode` and any of the four
+#    real engine variables with disagreeing values, the mapper exits
+#    non-zero before touching the parameter list — no partial state.
+# 3. On any mapper failure (invalid mode, conflict, IO), the mapper
+#    exits non-zero and leaves the parameter list as it was; the main
+#    loop never runs, so no `SET GLOBAL` is issued and no
+#    runtime-overrides.d/ file is written.
+# 4. Only-4-vars path: if `MARIADB_REPLICATION_MODE` is empty or unset,
+#    the mapper returns 0 immediately and the parameter list flows
+#    through unchanged. The four real engine variables continue to be
+#    processed exactly as before.
+# 5. Both-consistent path is idempotent: if the user supplied both
+#    `replicationMode=semisync` AND the four real variables with the
+#    derived values, the mapper does NOT add duplicates; the parameter
+#    list ends with one assignment per real variable. Repeated
+#    reconfigure with the same input produces identical output.
+#
+# Defense-in-depth: even though CUE's `replicationmode?: _|_` blocks
+# the synthetic key from reaching here, the mapper unconditionally
+# strips any `replicationMode` / `replicationmode` line from the
+# parameter list as a final safety net before returning.
+#
+# Source-time interface
+# ---------------------
+# This script is designed to be SOURCED by the reconfigureAction
+# helper or by ShellSpec tests. The sourcing site sets
+# `MARIADB_REPLICATION_MODE` from a kbagent-injected env var (the
+# ComponentSpec parameter plumbing is wired in a separate commit) and
+# calls `apply_replication_mode_mapping <parameter_file>`. Standalone
+# invocation is also supported and follows the same contract.
+#
+# Exit / return codes
+# -------------------
+#   0 — success (mapper applied derived values or no-op)
+#   2 — invalid `MARIADB_REPLICATION_MODE` value (not async / semisync)
+#   3 — conflict between `replicationMode` and a user-supplied real var
+#   4 — invalid argument (parameter file missing / unreadable)
+#   5 — IO failure during atomic rewrite
+
+set -u
+
+REPLICATION_MODE_MAPPER_EXIT_OK=0
+REPLICATION_MODE_MAPPER_EXIT_INVALID_MODE=2
+REPLICATION_MODE_MAPPER_EXIT_CONFLICT=3
+REPLICATION_MODE_MAPPER_EXIT_BAD_ARG=4
+REPLICATION_MODE_MAPPER_EXIT_IO=5
+
+# Derive the canonical value for each of the four real engine variables
+# given the mode. Stdout is one `name=value` pair per line. Stderr on
+# invalid mode. Return non-zero on invalid mode.
+#
+# Defaults for the two numeric variables (`wait_for_slave_count` and
+# `timeout`) match the schema defaults in
+# `config/mariadb-config-constraint.cue` so the mapper's "only mode"
+# output is consistent with what KB would render from PD defaults if
+# the user had instead set the four variables explicitly to those
+# values.
+replication_mode_derive() {
+    mode="$1"
+    case "${mode}" in
+    async)
+        printf "rpl_semi_sync_master_enabled=OFF\n"
+        printf "rpl_semi_sync_slave_enabled=OFF\n"
+        # wait_for_slave_count and timeout are only meaningful when
+        # master_enabled=ON. Per the schema defaults (commit 3 v2),
+        # the count default is 1 and the timeout default is 10000ms.
+        # The mapper emits them for async too so the override file
+        # set is deterministic and a future flip to semisync does
+        # not leave stale values from the OFF state.
+        printf "rpl_semi_sync_master_wait_for_slave_count=1\n"
+        printf "rpl_semi_sync_master_timeout=10000\n"
+        ;;
+    semisync)
+        printf "rpl_semi_sync_master_enabled=ON\n"
+        printf "rpl_semi_sync_slave_enabled=ON\n"
+        printf "rpl_semi_sync_master_wait_for_slave_count=1\n"
+        printf "rpl_semi_sync_master_timeout=10000\n"
+        ;;
+    *)
+        echo "replication-mode-mapper: invalid MARIADB_REPLICATION_MODE='${mode}' (expected async or semisync)" >&2
+        return "${REPLICATION_MODE_MAPPER_EXIT_INVALID_MODE}"
+        ;;
+    esac
+}
+
+# Strip any `replicationMode` / `replicationmode` line (any case
+# variant; KB's INI parser lowercases keys, so we do the same when
+# matching). Reads from $1, writes to stdout.
+replication_mode_strip_synthetic() {
+    src="$1"
+    awk '
+        {
+            # Normalize the left-hand side to lowercase for comparison
+            # without disturbing the value on the right.
+            split($0, parts, "=")
+            lhs = tolower(parts[1])
+            gsub(/[[:space:]]+/, "", lhs)
+            if (lhs == "replicationmode") next
+            print
+        }
+    ' "${src}"
+}
+
+# Look up a key in a parameter list file (one `name=value` per line).
+# Stdout: the value, if present; empty if not. Return 0 always.
+replication_mode_lookup() {
+    src="$1"
+    key="$2"
+    awk -v target="${key}" '
+        {
+            split($0, parts, "=")
+            name = parts[1]
+            gsub(/[[:space:]]+/, "", name)
+            if (tolower(name) == tolower(target)) {
+                # Reconstruct the value: everything after the first `=`.
+                eq_idx = index($0, "=")
+                if (eq_idx > 0) {
+                    print substr($0, eq_idx + 1)
+                }
+                exit
+            }
+        }
+    ' "${src}"
+}
+
+# Main entry point. Rewrites the parameter list file atomically in
+# place. Returns one of the REPLICATION_MODE_MAPPER_EXIT_* codes.
+apply_replication_mode_mapping() {
+    param_file="${1:-}"
+
+    if [ -z "${param_file}" ] || [ ! -f "${param_file}" ] || [ ! -r "${param_file}" ]; then
+        echo "replication-mode-mapper: parameter file '${param_file}' is missing or unreadable" >&2
+        return "${REPLICATION_MODE_MAPPER_EXIT_BAD_ARG}"
+    fi
+
+    mode="${MARIADB_REPLICATION_MODE:-}"
+
+    if [ -z "${mode}" ]; then
+        # Only-4-vars path: leave the parameter list untouched.
+        # Per Jack contract (msg `144afd93`): mapper must return 0 in
+        # this case without rewriting the file, so the only-4-vars
+        # path is provably not touched.
+        return "${REPLICATION_MODE_MAPPER_EXIT_OK}"
+    fi
+
+    # Precompute derived values BEFORE any file modification. If the
+    # mode is invalid, exit immediately — no partial state.
+    derived_file="${param_file}.derived.$$"
+    if ! replication_mode_derive "${mode}" > "${derived_file}"; then
+        rm -f "${derived_file}" 2>/dev/null || true
+        return "${REPLICATION_MODE_MAPPER_EXIT_INVALID_MODE}"
+    fi
+
+    # Conflict detection: for each derived var, if the user-supplied
+    # parameter list contains a different value for the same key, fail
+    # BEFORE any file modification (Jack contract item 2).
+    conflict_detected=0
+    while IFS='=' read -r derived_name derived_value; do
+        [ -n "${derived_name}" ] || continue
+        user_value="$(replication_mode_lookup "${param_file}" "${derived_name}")"
+        if [ -n "${user_value}" ] && [ "${user_value}" != "${derived_value}" ]; then
+            echo "replication-mode-mapper: conflict — replicationMode=${mode} derives ${derived_name}=${derived_value} but parameter list supplies ${derived_name}=${user_value}" >&2
+            conflict_detected=1
+        fi
+    done < "${derived_file}"
+
+    if [ "${conflict_detected}" -ne 0 ]; then
+        rm -f "${derived_file}" 2>/dev/null || true
+        return "${REPLICATION_MODE_MAPPER_EXIT_CONFLICT}"
+    fi
+
+    # Rebuild the parameter list:
+    #   1. Strip any synthetic replicationMode / replicationmode line
+    #      (defense-in-depth; CUE _|_ should have blocked, but mapper
+    #      enforces as the canonical write-site).
+    #   2. Keep the user's existing assignments for the four real
+    #      engine variables (both-consistent idempotency — no duplicates).
+    #   3. Append derived values ONLY for real vars the user did not
+    #      already supply.
+    rebuild_file="${param_file}.rebuild.$$"
+    if ! replication_mode_strip_synthetic "${param_file}" > "${rebuild_file}"; then
+        rm -f "${derived_file}" "${rebuild_file}" 2>/dev/null || true
+        echo "replication-mode-mapper: failed to strip synthetic key from parameter list" >&2
+        return "${REPLICATION_MODE_MAPPER_EXIT_IO}"
+    fi
+
+    while IFS='=' read -r derived_name derived_value; do
+        [ -n "${derived_name}" ] || continue
+        user_value="$(replication_mode_lookup "${rebuild_file}" "${derived_name}")"
+        if [ -z "${user_value}" ]; then
+            printf "%s=%s\n" "${derived_name}" "${derived_value}" >> "${rebuild_file}" || {
+                rm -f "${derived_file}" "${rebuild_file}" 2>/dev/null || true
+                echo "replication-mode-mapper: failed to append derived var ${derived_name}" >&2
+                return "${REPLICATION_MODE_MAPPER_EXIT_IO}"
+            }
+        fi
+        # When the user-supplied value is present and conflict-free,
+        # leave it as-is — idempotent both-consistent path.
+    done < "${derived_file}"
+
+    rm -f "${derived_file}" 2>/dev/null || true
+
+    # Atomic in-place rewrite of the parameter list.
+    if ! mv "${rebuild_file}" "${param_file}"; then
+        rm -f "${rebuild_file}" 2>/dev/null || true
+        echo "replication-mode-mapper: failed to atomically rewrite parameter list" >&2
+        return "${REPLICATION_MODE_MAPPER_EXIT_IO}"
+    fi
+
+    return "${REPLICATION_MODE_MAPPER_EXIT_OK}"
+}
+
+# Standalone-invocation entry. When sourced (SHELLSPEC etc.),
+# __SOURCED__ is set by the caller and we return without executing.
+${__SOURCED__:+false} : || return 0
+
+apply_replication_mode_mapping "$@"
+exit $?

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -51,6 +51,14 @@ remote_root_fence_file() {
   printf "%s/.remote-root-fence-role" "$(data_dir)"
 }
 
+# alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_file` +
+# `switchover_fence_active_is_fresh` + `SWITCHOVER_FENCE_MARKER_MAX_AGE_SECONDS`
+# helpers are removed. alpha.79 v1 minimalist refactor in switchover.sh
+# eliminated the marker writer (the pre-DCS fence chain was deleted), so
+# this consumer-side check could never observe a fresh marker and always
+# fell through to the existing role-marker logic. Pure dead-code cleanup,
+# no runtime behavior change.
+
 primary_read_write_ready_file() {
   printf "%s/.primary-read-write-ready" "$(data_dir)"
 }
@@ -101,6 +109,12 @@ apply_remote_root_fence() {
       return 0
       ;;
   esac
+
+  # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_is_fresh`
+  # check has been removed. alpha.79 v1 minimalist deleted the marker
+  # writer in switchover.sh, so this check could never observe a fresh
+  # marker and always fell through. Pure dead-code cleanup, no runtime
+  # behavior change.
 
   marker="$(remote_root_fence_file)"
   current="$(cat "${marker}" 2>/dev/null || true)"

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -260,6 +260,47 @@ query_local_value() {
     -P3306 -h127.0.0.1 -N -s -e "${sql}" 2>/dev/null
 }
 
+# alpha.89 v1 commit 7 (Helen 2026-05-19, C1 path topology merge) —
+# read-only helper to detect whether semisync is currently enabled at
+# runtime via the engine's in-memory @@rpl_semi_sync_master_enabled
+# variable. Staged for future caller patches that need to decide
+# whether to wait for semisync ACK during switchover or fall through
+# immediately when the cluster is running in async mode under the
+# merged CmpD.
+#
+# Return contract:
+#   0 — semisync ON (@@rpl_semi_sync_master_enabled is 1 / ON / on)
+#   1 — semisync OFF (@@rpl_semi_sync_master_enabled is 0 / OFF / off)
+#   2 — undetermined: mariadb client failed, returned no row, or
+#       returned a value outside the four recognized literals. Callers
+#       MUST treat this as fail-closed by assuming semisync (do not
+#       skip the safety wait) so a transient client failure does not
+#       silently flip behavior to async during switchover.
+#
+# No caller wires this in commit 7. The helper is intentionally
+# added without changing any call site so the existing switchover
+# behavior is untouched on alpha.89; a focused follow-up commit will
+# wire the helper into the specific stages that currently wait for
+# semisync ACK and need to fall through under async mode.
+#
+# Connection context follows the surrounding query_local_value /
+# run_local_internal_sql pattern: localhost on the chart's mariadbd
+# port, user-facing root credentials read from the same env surface
+# the rest of the switchover script already establishes. /bin/sh +
+# busybox compatibility is the same as the surrounding helpers.
+is_semisync_mode() {
+  local val
+  val=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+    --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
+    -P3306 -h127.0.0.1 -N -s \
+    -e "SELECT @@rpl_semi_sync_master_enabled" 2>/dev/null) || return 2
+  case "${val}" in
+    1|ON|on) return 0 ;;
+    0|OFF|off) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
 sql_quote() {
   printf "%s" "$1" | sed "s/'/''/g"
 }

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -43,7 +43,18 @@ SWITCHOVER_PREPARE_STAGE_BUDGET_SECONDS="${SWITCHOVER_PREPARE_STAGE_BUDGET_SECON
 SWITCHOVER_DCS_STAGE_BUDGET_SECONDS="${SWITCHOVER_DCS_STAGE_BUDGET_SECONDS:-15}"
 SWITCHOVER_FENCE_STAGE_BUDGET_SECONDS="${SWITCHOVER_FENCE_STAGE_BUDGET_SECONDS:-15}"
 CANDIDATE_PROMOTED_VIA_SYNCERCTL_WAIT_SECONDS="${CANDIDATE_PROMOTED_VIA_SYNCERCTL_WAIT_SECONDS:-30}"
-CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS="${CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS:-10}"
+# alpha.77 v2 (Helen TL): bumped from 10s -> 30s. alpha.77 v1 N=1 verify on
+# n1y closed the pre-DCS REMOTE root fence race (stages 1-4 all PASS, no
+# `bypass_priv_residual` in stderr) but failed at stage 5 because the new
+# primary's chart watchdog SECONDARY -> PRIMARY role transition takes longer
+# than 10s. Direct evidence: pod-1 watchdog log at 11:40:21-23 still running
+# replica-read-only LOCK while DCS swap completed at 11:40:19; stage 5 probe
+# attempts 1-3 saw 1044/1290 (account still locked / read_only still ON)
+# followed by 2002 (mariadbd briefly unreachable during stop+start_mariadbd
+# rebind from 127.0.0.1 to 0.0.0.0 inside expose_sql_listener_for_primary_
+# role). 30s gives the new primary watchdog one full role-transition cycle
+# (~6-10s typical) + headroom. Env override still respected.
+CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS="${CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS:-30}"
 MARIADB_CONNECT_TIMEOUT_SECONDS="${MARIADB_CONNECT_TIMEOUT_SECONDS:-5}"
 SYNCERCTL_PER_CALL_TIMEOUT_SECONDS="${SYNCERCTL_PER_CALL_TIMEOUT_SECONDS:-5}"
 
@@ -55,6 +66,22 @@ MARIADB_CLIENT_BIN="${MARIADB_CLIENT_BIN:-}"
 MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
 SWITCHOVER_TRACE_FILE="${SWITCHOVER_TRACE_FILE:-}"
 SWITCHOVER_REMOTE_ROOT_PROBE_TABLE="${SWITCHOVER_REMOTE_ROOT_PROBE_TABLE:-kubeblocks.kb_root_write_probe}"
+
+# alpha.80 v1 (Helen TL): the alpha.76/.77/.78 `.switchover-fence-active`
+# marker mechanism is now removed. alpha.79 v1 minimalist refactor (per
+# westonnnn directive) eliminated the pre-DCS fence chain in
+# `prepare_current_primary_for_switchover`, which was the SOURCE of the race
+# the marker was designed to gate. With no fence chain, nothing writes the
+# marker; with nothing writing it, the consumer-side checks in cmpd-semisync
+# `reconcile_sql_listener_for_syncer_primary_once` / `set_remote_root_account
+# _state` and roleprobe.sh `apply_remote_root_fence` always evaluate to
+# "not fresh" and proceed normally. Keeping the helpers + consumer checks
+# served no runtime purpose; alpha.80 v1 deletes them entirely.
+#
+# Scope: this is dead-code cleanup ONLY. No runtime behavior change. NOT a
+# fix for same-cluster repeat RED, under-load data-divergence RED, or pod-
+# kill 1032-rejoin RED — those each have their own first-blocker that
+# remains open with separate evidence packets.
 
 # alpha.62 v1 (Jack 04:08 review): contract drift between switchover-side
 # pre-DCS fence and roleProbe-side secondary fence + verifier口径漂移. Single
@@ -1002,6 +1029,11 @@ rollback_current_primary_switchover_guard() {
   # host_list to unfence + verifier, both read same per-host enumeration.
   # Legacy full-access rollback verifier renamed to
   # remote_root_has_explicit_primary_grant — see that function's comment.
+  #
+  # alpha.80 v1 (Helen): the alpha.76 `.switchover-fence-active` marker
+  # clear call here has been removed — alpha.79 v1 minimalist deleted the
+  # marker writer in prepare, so there is nothing to clear. Pure dead-code
+  # cleanup, no runtime behavior change.
   local failed=0
   local host_list=""
   log_switchover_info "Switchover rollback: restoring current primary write access after pre-DCS failure"
@@ -1030,45 +1062,36 @@ rollback_current_primary_switchover_guard() {
 }
 
 prepare_current_primary_for_switchover() {
-  # alpha.62 v1 (Jack 04:08 Blocker 1 + tightening 1): host list is enumerated
-  # ONCE at the top of prepare and passed by parameter to fence + verifier.
-  # This eliminates the source of root_host_list_drift between fence and
-  # verifier callsites. Defensive drift detection still lives inside both
-  # callees as fallback when called externally without host_list.
-  local current_name host_list host_list_sha
-  current_name=$(resolve_current_name)
-  log_switchover_info "Switchover pre-DCS guard: fencing remote root on current primary ${current_name}"
-  host_list=$(enumerate_user_facing_root_hosts) || {
-    log_switchover_error "Switchover failed: prepare_current_primary_for_switchover could not enumerate user-facing root hosts; fail-closed"
-    return 1
-  }
-  if [ -z "${host_list}" ]; then
-    log_switchover_error "Switchover failed: prepare_current_primary_for_switchover reason=root_account_not_found user=${MARIADB_ROOT_USER}; fail-closed"
-    return 1
-  fi
-  host_list_sha=$(compute_grants_sha "${host_list}")
-  log_switchover_info "Switchover pre-DCS guard: enumerated user-facing root host list sha=${host_list_sha} hosts_count=$(printf '%s\n' "${host_list}" | wc -l | tr -d ' ')"
-  if ! disconnect_local_remote_root_sessions_for_secondary; then
-    log_switchover_error "Switchover failed: could not disconnect current primary remote root sessions before fencing"
-    rollback_current_primary_switchover_guard || true
-    return 1
-  fi
-  if ! fence_local_remote_root_for_secondary "${host_list}"; then
-    log_switchover_error "Switchover failed: could not fence current primary remote root before DCS switchover"
-    rollback_current_primary_switchover_guard || true
-    return 1
-  fi
-  if ! disconnect_local_remote_root_sessions_for_secondary; then
-    log_switchover_error "Switchover failed: could not disconnect current primary remote root sessions after fencing"
-    rollback_current_primary_switchover_guard || true
-    return 1
-  fi
-  if ! local_remote_root_is_fenced_for_secondary "${host_list}"; then
-    log_switchover_error "Switchover failed: current primary remote root fence was not verified before DCS switchover"
-    rollback_current_primary_switchover_guard || true
-    return 1
-  fi
-  log_switchover_info "Switchover pre-DCS guard passed for current primary ${current_name}; read_only is left unchanged until syncer accepts the DCS switchover"
+  # alpha.79 v1 (Helen TL, per westonnnn 21:50 `48a132e2`/`b9a62176`
+  # directive: "学 MySQL semisync 的极简思路，来改，现在 / 改完之后再测"):
+  # The pre-DCS REMOTE root fence chain (fence_local_remote_root_for_secondary
+  # + local_remote_root_is_fenced_for_secondary + _verify_host_is_fenced)
+  # introduced in alpha.61 is the SOURCE of the race that alpha.75/.76/.77/
+  # .78 chased without 100% closing (alpha.78 v1 N=3 = 2 GREEN / 1 RED with
+  # same-type race reopened on n1ab 2026-05-14 13:27:33Z; trace shows
+  # grants_sha SECONDARY→PRIMARY flip in the 1s between inner verify and
+  # outer verify).
+  #
+  # The MySQL semisync addon (research 2026-05-14 by Explore agent) does
+  # NOT modify root@'%' grants during switchover at all. It relies on:
+  #   1. read_only=1 set on the demoted primary post-DCS swap
+  #   2. semi-sync ACK protocol blocking commits
+  #   3. user-facing root account NOT holding any admin-bypass privileges
+  #      (BINLOG ADMIN / SUPER / READ_ONLY ADMIN), which is the alpha.61
+  #      hard contract that MariaDB has already adopted and we are KEEPING
+  #
+  # alpha.79 v1 short-circuits this function to a no-op. The post-DCS local-
+  # root write fence verifier (verify_post_dcs_local_root_write_fenced)
+  # remains the gatekeeper for "read_only=1 is effective on user-facing
+  # root" — that verifier reads INSERT/UPDATE rejection at 1290 errno, NOT
+  # grant state, so it remains race-free.
+  #
+  # alpha.80 v1 (Helen): the alpha.76/.77/.78 marker helpers
+  # (write_switchover_fence_active_marker / clear_switchover_fence_active_
+  # marker / switchover_fence_active_marker_file) are now removed entirely.
+  # The roleprobe.sh + cmpd-semisync.yaml consumer checks are also removed.
+  # All pure dead-code cleanup, no runtime behavior change.
+  log_switchover_info "Switchover pre-DCS guard (alpha.79 v1 minimalist): skipping per-host root@'%' fence; relying on post-DCS read_only=1 + semisync ACK + alpha.61 admin-bypass priv contract"
   return 0
 }
 
@@ -1330,17 +1353,30 @@ syncerctl_switchover() {
   local rc
   local using_timeout=0
 
+  # alpha.79 v2 (Helen TL autopilot 22:31 westonnnn `442a5d2e`): pass --force
+  # so syncer overrides any leftover "previous switchover unfinished" DCS
+  # record from a prior successful switchover. n1ad same-cluster repeat axis
+  # (2026-05-14 ~14:54 UTC) exposed this: after the first GREEN switchover
+  # cleared chart-side state and OpsRequest reached Succeed, syncer's DCS
+  # record stayed in "unfinished" state. Repeat switchovers got
+  # `Create switchover failed: there is another switchover
+  # maria-5d-n1ad-mariadb-switchover unfinished`. Using --force on every
+  # invocation is safe: first-time switchovers have no leftover record so
+  # --force is a no-op; repeated switchovers proceed cleanly. This is a
+  # syncer-layer cleanup gap (syncer should mark its own DCS record done
+  # when the switchover protocol completes); --force is a chart-side
+  # workaround until syncer side cleans up properly.
   if [ -n "${stage_budget}" ] && [ "${SWITCHOVER_HAS_TIMEOUT}" = "1" ]; then
     local wall="${SYNCERCTL_PER_CALL_TIMEOUT_SECONDS}"
     if [ "${stage_budget}" -lt "${wall}" ]; then wall="${stage_budget}"; fi
     if [ "${wall}" -lt 1 ]; then wall=1; fi
     using_timeout=1
     output=$(timeout "${wall}" "${SYNCERCTL_BIN}" --host "${SYNCERCTL_HOST}" --port "${SYNCERCTL_PORT}" \
-      switchover --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
+      switchover --force --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
     rc=$?
   else
     output=$("${SYNCERCTL_BIN}" --host "${SYNCERCTL_HOST}" --port "${SYNCERCTL_PORT}" \
-      switchover --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
+      switchover --force --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
     rc=$?
   fi
 
@@ -1924,6 +1960,10 @@ main() {
   local candidate_fqdn
   candidate_name=$(resolve_candidate_name)
   candidate_fqdn=$(resolve_candidate_fqdn)
+  # alpha.80 v1 (Helen): the alpha.76 unconditional clear_switchover_fence_
+  # active_marker call has been removed. alpha.79 v1 minimalist deleted the
+  # marker writer in prepare, so no marker exists to clear. Pure dead-code
+  # cleanup, no runtime behavior change.
   run_switchover "${candidate_name}" "${candidate_fqdn}"
 }
 

--- a/addons/mariadb/scripts/seed-replication-mode-overrides.sh
+++ b/addons/mariadb/scripts/seed-replication-mode-overrides.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# seed-replication-mode-overrides.sh — alpha.89 v1 commit 13 (Helen
+# 2026-05-20, Jack post-commit-13-v1 install-time write-site
+# requirement msg `696e7b16`).
+#
+# Translates the install-time `MARIADB_REPLICATION_MODE` Helm value
+# (sourced as an env var on the merged CmpD's mariadb container) into
+# the four per-parameter override `.cnf` files under
+# `runtime-overrides.d/`. mariadbd loads these on first startup via
+# `--defaults-extra-file=runtime-overrides.cnf` (which `!includedir`s
+# the directory), so the chart-author-selected semisync/async state
+# takes effect from the very first mariadbd process — not just after
+# the first reconfigureAction runs.
+#
+# Without this seeder, the env wire from commit 13 v1 was dormant:
+# the value sat in the container env but had no consumer until the
+# next reconfigureAction triggered the mapper from commit 12. That
+# means a chart user setting `mariadb.replication.mode=semisync` at
+# install time would still get an async cluster until they did an
+# OpsRequest reconfigure — install-time semantics were broken.
+#
+# The seeder runs at container startup BEFORE the first
+# `start_mariadbd_process` call. Its output (the 4 `.cnf` files) is
+# byte-identical to what `reconfigureAction.persisted` writes when
+# the mapper consumes the same env, so the two write-sites converge
+# and a later reconfigure does not flap the values.
+#
+# Contract
+# --------
+#
+#   1. Source uniqueness preserved: still reads `MARIADB_REPLICATION_MODE`
+#      from container env. The Helm-value to env wire (commit 13 v1)
+#      is the single source.
+#   2. Empty/unset → no-op (return 0). Existing clusters whose Helm
+#      values do not set the mode see no behavioral change.
+#   3. Conflict not possible at install time (no user-supplied real
+#      vars in the path yet); seeder simply writes the 4 derived
+#      values.
+#   4. Synthetic key never written. Only the four real engine
+#      variables land in runtime-overrides.d/.
+#   5. Fail-closed on invalid mode: prints sentinel, exits non-zero;
+#      caller (CmpD container command) refuses to proceed with
+#      mariadbd start.
+#   6. Idempotent across restarts: `cmp -s` short-circuit preserves
+#      mtime when the override file is already at the target value
+#      (so kubelet restarts and pod re-creates don't churn mtime).
+#
+# Exit codes
+# ----------
+#
+#   0 — success (seeded or no-op)
+#   2 — invalid `MARIADB_REPLICATION_MODE` value
+#   5 — IO failure during seed
+
+set -u
+
+SEED_REPLICATION_MODE_EXIT_OK=0
+SEED_REPLICATION_MODE_EXIT_INVALID_MODE=2
+SEED_REPLICATION_MODE_EXIT_IO=5
+
+# Resolve the derived (master_enabled, slave_enabled) pair for a given
+# mode. Stdout: two lines `master=<val>` and `slave=<val>`. Stderr +
+# non-zero return on invalid mode.
+seed_replication_mode_derive_master_slave() {
+    mode="$1"
+    case "${mode}" in
+    async)
+        printf "master=OFF\n"
+        printf "slave=OFF\n"
+        ;;
+    semisync)
+        printf "master=ON\n"
+        printf "slave=ON\n"
+        ;;
+    *)
+        echo "seed-replication-mode-overrides: invalid MARIADB_REPLICATION_MODE='${mode}' (expected async or semisync)" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_INVALID_MODE}"
+        ;;
+    esac
+}
+
+# Write a single per-parameter override .cnf file via tmp + atomic
+# rename, with byte-equal short-circuit so identical content does not
+# refresh mtime. Mirrors the body shape produced by
+# `reconfigureAction.persisted` so the two write-sites converge.
+seed_replication_mode_write_override() {
+    overrides_dir="$1"
+    param_name="$2"
+    param_value="$3"
+
+    target="${overrides_dir}/${param_name}.cnf"
+    tmp="${target}.tmp.$$"
+
+    if ! {
+        echo "[mysqld]"
+        echo "${param_name} = ${param_value}"
+    } > "${tmp}"; then
+        rm -f "${tmp}" 2>/dev/null || true
+        echo "seed-replication-mode-overrides: failed to write tmp override file for ${param_name}" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+
+    if [ -f "${target}" ] && cmp -s "${tmp}" "${target}"; then
+        rm -f "${tmp}" 2>/dev/null || true
+        return "${SEED_REPLICATION_MODE_EXIT_OK}"
+    fi
+
+    if ! mv "${tmp}" "${target}"; then
+        rm -f "${tmp}" 2>/dev/null || true
+        echo "seed-replication-mode-overrides: failed to atomically write override file ${target}" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+
+    return "${SEED_REPLICATION_MODE_EXIT_OK}"
+}
+
+# Main entry. Reads MARIADB_REPLICATION_MODE from env; returns 0 on
+# success (or no-op when env is empty); returns 2 on invalid mode;
+# returns 5 on IO failure.
+seed_replication_mode_overrides() {
+    overrides_dir="${MARIADB_RUNTIME_OVERRIDES_DIR:-/var/lib/mysql/runtime-overrides.d}"
+    mode="${MARIADB_REPLICATION_MODE:-}"
+
+    if [ -z "${mode}" ]; then
+        # Empty / unset: leave runtime-overrides.d untouched. Preserves
+        # existing behavior on clusters whose Helm values do not set
+        # mariadb.replication.mode.
+        return "${SEED_REPLICATION_MODE_EXIT_OK}"
+    fi
+
+    if [ ! -d "${overrides_dir}" ]; then
+        echo "seed-replication-mode-overrides: overrides dir ${overrides_dir} does not exist (init-syncer should have created it)" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+
+    # Compute the master/slave values. Fail-closed on invalid mode
+    # BEFORE writing anything.
+    pair_output="$(seed_replication_mode_derive_master_slave "${mode}")" || return $?
+    master_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="master"{print $2; exit}')"
+    slave_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="slave"{print $2; exit}')"
+
+    # Write the four override files in a deterministic order. Each
+    # call uses cmp -s to preserve mtime if the on-disk content is
+    # already at the target value, so kubelet restarts / pod
+    # re-creates do not churn mtime.
+    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_master_enabled "${master_value}" || return $?
+    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_slave_enabled "${slave_value}" || return $?
+    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_master_wait_for_slave_count 1 || return $?
+    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_master_timeout 10000 || return $?
+
+    return "${SEED_REPLICATION_MODE_EXIT_OK}"
+}
+
+# Standalone-invocation entry. When sourced (ShellSpec etc.),
+# __SOURCED__ is set by the caller and we return without executing.
+${__SOURCED__:+false} : || return 0
+
+seed_replication_mode_overrides "$@"
+exit $?

--- a/addons/mariadb/scripts/seed-replication-mode-overrides.sh
+++ b/addons/mariadb/scripts/seed-replication-mode-overrides.sh
@@ -113,11 +113,12 @@ seed_replication_mode_write_one_tmp() {
     return "${SEED_REPLICATION_MODE_EXIT_OK}"
 }
 
-# Helper: cleanup all 4 tmp files (used on any failure in the
-# write-all-then-commit path).
+# Helper: cleanup all 3 tmp files (used on any failure in the
+# write-all-then-commit path). commit 16 dropped
+# rpl_semi_sync_master_wait_for_slave_count (MariaDB unsupported).
 seed_replication_mode_cleanup_all_tmps() {
     overrides_dir="$1"
-    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_wait_for_slave_count rpl_semi_sync_master_timeout; do
+    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_timeout; do
         rm -f "${overrides_dir}/${name}.cnf.tmp.$$" 2>/dev/null || true
     done
 }
@@ -186,22 +187,27 @@ seed_replication_mode_overrides() {
     slave_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="slave"{print $2; exit}')"
 
     # --- Phase B: pre-validate target types (B4) ---
-    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_wait_for_slave_count rpl_semi_sync_master_timeout; do
+    # alpha.89 v1 commit 16 (Helen 2026-05-20, live N=1 third
+    # first-blocker fix): the previous 4-var list included the
+    # MySQL-specific `rpl_semi_sync_master_wait_for_slave_count`
+    # which MariaDB 11.4 does not recognize. Setting it in
+    # runtime-overrides.d/ causes mariadbd to exit on first
+    # startup with rc=7 "unknown variable". Removed. MariaDB
+    # semisync waits for one slave; there is no equivalent
+    # MariaDB variable.
+    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_timeout; do
         if ! seed_replication_mode_validate_target_type "${overrides_dir}/${name}.cnf"; then
             return "${SEED_REPLICATION_MODE_EXIT_IO}"
         fi
     done
 
-    # --- Phase C: write all 4 tmp files ---
+    # --- Phase C: write the 3 tmp files (commit 16 dropped
+    # rpl_semi_sync_master_wait_for_slave_count, MariaDB-unsupported) ---
     if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_enabled "${master_value}"; then
         seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi
     if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_slave_enabled "${slave_value}"; then
-        seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
-        return "${SEED_REPLICATION_MODE_EXIT_IO}"
-    fi
-    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_wait_for_slave_count 1; then
         seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi
@@ -211,7 +217,7 @@ seed_replication_mode_overrides() {
     fi
 
     # --- Phase D & E: byte-equal compare + rename ---
-    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_wait_for_slave_count rpl_semi_sync_master_timeout; do
+    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_timeout; do
         target="${overrides_dir}/${name}.cnf"
         tmp="${target}.tmp.$$"
         if [ -f "${target}" ] && cmp -s "${tmp}" "${target}"; then

--- a/addons/mariadb/scripts/seed-replication-mode-overrides.sh
+++ b/addons/mariadb/scripts/seed-replication-mode-overrides.sh
@@ -79,11 +79,20 @@ seed_replication_mode_derive_master_slave() {
     esac
 }
 
-# Write a single per-parameter override .cnf file via tmp + atomic
-# rename, with byte-equal short-circuit so identical content does not
-# refresh mtime. Mirrors the body shape produced by
-# `reconfigureAction.persisted` so the two write-sites converge.
-seed_replication_mode_write_override() {
+# Helper: write a single tmp file for the (name, value) pair into
+# overrides_dir. Returns rc=5 on write failure (tmp cleaned up).
+# Tmp filename pattern: `<param_name>.cnf.tmp.<pid>` colocated with
+# the eventual target so the later mv is intra-filesystem atomic.
+#
+# Implementation note (Jack B5 smoke msg `6e6eab69`): uses a single
+# `printf ... > tmp` simple command rather than `{ ... } > tmp`
+# because bash compound-command redirection failures do NOT propagate
+# to the surrounding `if !` test (see `bash -c 'if ! { echo ok; } >
+# /no-such-dir/file; then echo X; fi'` — X never prints even though
+# the redirect failed). A simple command's redirect failure does
+# propagate, so we use printf and additionally post-check `[ -s ]`
+# as a belt-and-suspenders guard against truncated writes.
+seed_replication_mode_write_one_tmp() {
     overrides_dir="$1"
     param_name="$2"
     param_value="$3"
@@ -91,32 +100,70 @@ seed_replication_mode_write_override() {
     target="${overrides_dir}/${param_name}.cnf"
     tmp="${target}.tmp.$$"
 
-    if ! {
-        echo "[mysqld]"
-        echo "${param_name} = ${param_value}"
-    } > "${tmp}"; then
+    if ! printf '[mysqld]\n%s = %s\n' "${param_name}" "${param_value}" > "${tmp}" 2>/dev/null; then
         rm -f "${tmp}" 2>/dev/null || true
         echo "seed-replication-mode-overrides: failed to write tmp override file for ${param_name}" >&2
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi
-
-    if [ -f "${target}" ] && cmp -s "${tmp}" "${target}"; then
+    if [ ! -s "${tmp}" ]; then
         rm -f "${tmp}" 2>/dev/null || true
-        return "${SEED_REPLICATION_MODE_EXIT_OK}"
-    fi
-
-    if ! mv "${tmp}" "${target}"; then
-        rm -f "${tmp}" 2>/dev/null || true
-        echo "seed-replication-mode-overrides: failed to atomically write override file ${target}" >&2
+        echo "seed-replication-mode-overrides: tmp override file for ${param_name} is empty after write (write was silently truncated)" >&2
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi
+    return "${SEED_REPLICATION_MODE_EXIT_OK}"
+}
 
+# Helper: cleanup all 4 tmp files (used on any failure in the
+# write-all-then-commit path).
+seed_replication_mode_cleanup_all_tmps() {
+    overrides_dir="$1"
+    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_wait_for_slave_count rpl_semi_sync_master_timeout; do
+        rm -f "${overrides_dir}/${name}.cnf.tmp.$$" 2>/dev/null || true
+    done
+}
+
+# Helper: verify that an existing target path is absent OR a regular
+# file. If it exists but is a directory / symlink-to-dir / device /
+# fifo / socket, refuse to write because `mv tmp target` would
+# silently move tmp INTO a directory and leave the target unchanged
+# in shape (Jack B4 fix msg `6e6eab69`).
+seed_replication_mode_validate_target_type() {
+    target="$1"
+    if [ -e "${target}" ] && [ ! -f "${target}" ]; then
+        echo "seed-replication-mode-overrides: target ${target} exists but is not a regular file (refusing to write — would not produce the expected override)" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
     return "${SEED_REPLICATION_MODE_EXIT_OK}"
 }
 
 # Main entry. Reads MARIADB_REPLICATION_MODE from env; returns 0 on
 # success (or no-op when env is empty); returns 2 on invalid mode;
 # returns 5 on IO failure.
+#
+# Multi-file commit pattern (Jack B5 fix msg `6e6eab69`): writes
+# happen in 5 phases so a failure in any single file leaves the
+# overrides dir in its prior state rather than partial / mixed.
+#
+#   Phase A — derive: compute all 4 (name, value) pairs into shell
+#             vars. Fail-closed on invalid mode BEFORE any disk write.
+#   Phase B — pre-validate target types: check each target is absent
+#             OR a regular file (B4 backstop). Fail-closed without
+#             touching disk.
+#   Phase C — write 4 tmp files. If any tmp write fails, clean up all
+#             4 tmp files (any subset that exists) and return rc=5.
+#             At this point no target has been renamed yet, so the
+#             on-disk overrides dir is unchanged from the prior run.
+#   Phase D — byte-equal compare each tmp to its target; build the
+#             rename list. Targets that are already byte-identical to
+#             the staged content are skipped to preserve mtime.
+#   Phase E — rename each entry in the rename list. Each rename is
+#             intra-filesystem and atomic; the renames happen in tight
+#             sequence to minimize the partial-commit window. If any
+#             rename fails, the remaining tmp files are cleaned up
+#             and rc=5 is returned (best-effort partial-state
+#             reporting; previously-renamed targets are NOT rolled
+#             back, but the failure exits the action loudly and the
+#             container refuses to start mariadbd).
 seed_replication_mode_overrides() {
     overrides_dir="${MARIADB_RUNTIME_OVERRIDES_DIR:-/var/lib/mysql/runtime-overrides.d}"
     mode="${MARIADB_REPLICATION_MODE:-}"
@@ -133,20 +180,59 @@ seed_replication_mode_overrides() {
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi
 
-    # Compute the master/slave values. Fail-closed on invalid mode
-    # BEFORE writing anything.
+    # --- Phase A: derive ---
     pair_output="$(seed_replication_mode_derive_master_slave "${mode}")" || return $?
     master_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="master"{print $2; exit}')"
     slave_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="slave"{print $2; exit}')"
 
-    # Write the four override files in a deterministic order. Each
-    # call uses cmp -s to preserve mtime if the on-disk content is
-    # already at the target value, so kubelet restarts / pod
-    # re-creates do not churn mtime.
-    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_master_enabled "${master_value}" || return $?
-    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_slave_enabled "${slave_value}" || return $?
-    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_master_wait_for_slave_count 1 || return $?
-    seed_replication_mode_write_override "${overrides_dir}" rpl_semi_sync_master_timeout 10000 || return $?
+    # --- Phase B: pre-validate target types (B4) ---
+    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_wait_for_slave_count rpl_semi_sync_master_timeout; do
+        if ! seed_replication_mode_validate_target_type "${overrides_dir}/${name}.cnf"; then
+            return "${SEED_REPLICATION_MODE_EXIT_IO}"
+        fi
+    done
+
+    # --- Phase C: write all 4 tmp files ---
+    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_enabled "${master_value}"; then
+        seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_slave_enabled "${slave_value}"; then
+        seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_wait_for_slave_count 1; then
+        seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_timeout 10000; then
+        seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+
+    # --- Phase D & E: byte-equal compare + rename ---
+    for name in rpl_semi_sync_master_enabled rpl_semi_sync_slave_enabled rpl_semi_sync_master_wait_for_slave_count rpl_semi_sync_master_timeout; do
+        target="${overrides_dir}/${name}.cnf"
+        tmp="${target}.tmp.$$"
+        if [ -f "${target}" ] && cmp -s "${tmp}" "${target}"; then
+            # Already at target value — skip rename to preserve mtime.
+            rm -f "${tmp}" 2>/dev/null || true
+            continue
+        fi
+        if ! mv "${tmp}" "${target}"; then
+            seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
+            echo "seed-replication-mode-overrides: failed to atomically rename tmp into place at ${target}; some prior renames in this batch may have already committed" >&2
+            return "${SEED_REPLICATION_MODE_EXIT_IO}"
+        fi
+        # Post-rename sanity: target must now be a regular file. If
+        # the rename succeeded into a directory shape we never want
+        # to silently advertise success.
+        if [ ! -f "${target}" ]; then
+            seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
+            echo "seed-replication-mode-overrides: post-rename target ${target} is not a regular file (rename did not produce the expected override)" >&2
+            return "${SEED_REPLICATION_MODE_EXIT_IO}"
+        fi
+    done
 
     return "${SEED_REPLICATION_MODE_EXIT_OK}"
 }

--- a/addons/mariadb/scripts/validate-replication-mode.sh
+++ b/addons/mariadb/scripts/validate-replication-mode.sh
@@ -1,0 +1,228 @@
+#!/bin/sh
+# Validate replication-mode source-of-truth consistency for the merged
+# MariaDB CmpD (alpha.89 v1 commit 4, Helen 2026-05-19, C1 path).
+#
+# Two-source check (the two sources that exist in the C1 design; the
+# v3.1 design rationale §3 deferred the optional third source — a
+# Cluster annotation — to a future controller-side writer):
+#
+#   1. Engine SQL: SHOW VARIABLES LIKE 'rpl_semi_sync_master_enabled'
+#      and 'rpl_semi_sync_slave_enabled' — the actual in-memory state
+#      of mariadbd. After alpha.88 persistence this also matches
+#      what mariadbd will read on next process restart.
+#
+#   2. ComponentParameter view via the kbagent-mounted ConfigMap
+#      file (/etc/mysql/conf.d/my.cnf or the chart-rendered path) —
+#      what KB merged for this cluster from PD schema defaults and
+#      user-provided spec.componentSpecs[].parameters values. This
+#      represents the desired state after the Configure controller
+#      has reconciled.
+#
+# Read-only by design (Jack design review Gate 5 v3 — annotation
+# writes are deferred). This script never writes engine state or
+# Kubernetes resources; it only diffs the two sources and reports.
+# Tests / runners call it at closeout to fail-closed when the two
+# sources disagree (which means either reconfigure has not yet
+# propagated or a stuck merge happened).
+#
+# Exit codes:
+#   0 — both sources observable and consistent
+#   1 — sources disagree (closeout FAIL)
+#   2 — could not read engine state (transient; test should bounded-retry)
+#   3 — could not read ConfigMap state (transient; test should bounded-retry)
+#   4 — invariant violated (e.g. master_enabled=ON but slave_enabled=OFF on
+#       a secondary pod, which mariadb semisync requires to be aligned)
+#
+# Output format on stdout (one JSON object per line is reserved for
+# future machine consumption; v1 uses simple key=value tokens so a
+# kbagent action attestation or shell test can grep them):
+#
+#   mode_engine_master_enabled=ON
+#   mode_engine_slave_enabled=ON
+#   mode_configmap_master_enabled=ON
+#   mode_configmap_slave_enabled=ON
+#   mode_consistency=ok|disagree|engine_missing|configmap_missing|invariant_violated
+#
+# /bin/sh shebang per addon convention (kbagent ships busybox sh).
+
+set -u
+
+EXIT_OK=0
+EXIT_DISAGREE=1
+EXIT_ENGINE_MISSING=2
+EXIT_CONFIGMAP_MISSING=3
+EXIT_INVARIANT_VIOLATED=4
+
+CONFIG_PATH="${MARIADB_CONFIG_PATH:-/etc/mysql/conf.d/my.cnf}"
+MYSQL_HOST="${MARIADB_HOST:-127.0.0.1}"
+MYSQL_PORT="${MARIADB_PORT:-3306}"
+
+# Engine connection context. None are required to run; if a value is
+# unset the corresponding mysql client flag is simply not added. This
+# pre-stages the env surface a kbagent lifecycle action will need
+# without forcing the helper to know how the action resolves them
+# (typically MYSQL_USER + MYSQL_PASSWORD + MYSQL_SOCKET are mounted
+# from a Secret + the chart's mysqld socket path; the existing
+# semisync lifecycle scripts already follow this pattern).
+# alpha.89 v1 commit 4 v2 (Helen 2026-05-19, Jack review B2): add the
+# env passthroughs so a later commit that wires this helper into a
+# lifecycle action does not have to re-touch the helper itself.
+MYSQL_SOCKET="${MYSQL_SOCKET:-}"
+MYSQL_USER="${MYSQL_USER:-}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-}"
+MYSQL_EXTRA_ARGS="${MYSQL_EXTRA_ARGS:-}"
+
+# Get the in-memory engine variable. Echoes the value on stdout and
+# returns 0 on success; returns non-zero on any client error so the
+# caller can distinguish "engine not reachable" from "engine reachable
+# but returned empty value" (which also returns non-zero to keep the
+# fail-closed semantics uniform across the four variables).
+engine_var() {
+  var_name="$1"
+  # MariaDB client is mysql; use --batch --skip-column-names so output
+  # is the value alone. Connect via the local socket if available to
+  # avoid TLS/auth overhead during local introspection.
+  mysql_args="--batch --skip-column-names --connect-timeout=3"
+  if [ -n "${MYSQL_SOCKET}" ]; then
+    mysql_args="${mysql_args} -S ${MYSQL_SOCKET}"
+  else
+    mysql_args="${mysql_args} -h${MYSQL_HOST} -P${MYSQL_PORT}"
+  fi
+  if [ -n "${MYSQL_USER}" ]; then
+    mysql_args="${mysql_args} -u${MYSQL_USER}"
+  fi
+  if [ -n "${MYSQL_PASSWORD}" ]; then
+    mysql_args="${mysql_args} -p${MYSQL_PASSWORD}"
+  fi
+  if [ -n "${MYSQL_EXTRA_ARGS}" ]; then
+    mysql_args="${mysql_args} ${MYSQL_EXTRA_ARGS}"
+  fi
+  # shellcheck disable=SC2086 # word-splitting is intentional
+  out=$(mysql ${mysql_args} -e "SHOW VARIABLES LIKE '${var_name}'" 2>/dev/null) || return 1
+  # Output line shape: "<var_name>\t<value>". Print only the value
+  # and surface an empty result as a non-zero return so the caller
+  # uniformly treats a successful-but-empty read as missing.
+  val=$(printf '%s' "${out}" | awk -F'\t' 'NR==1 {print $2}')
+  if [ -z "${val}" ]; then
+    return 1
+  fi
+  printf '%s' "${val}"
+}
+
+# Read a single key from the ConfigMap-mounted my.cnf. Echoes the
+# value and returns 0 on success; returns non-zero if the file is
+# unreadable or the key is missing. Treating "key missing" as
+# non-zero matches engine_var's contract: callers do not have to
+# inspect both the rc and an empty string.
+configmap_var() {
+  var_name="$1"
+  if [ ! -r "${CONFIG_PATH}" ]; then
+    return 1
+  fi
+  val=$(awk -v key="${var_name}" '
+    # match key with optional surrounding whitespace; both key in the
+    # config file and key argument are lowercased before comparison.
+    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ {
+      n = split($0, a, "=")
+      k = a[1]
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", k)
+      if (tolower(k) == tolower(key)) {
+        v = a[2]
+        for (i = 3; i <= n; i++) v = v "=" a[i]
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        sub(/[[:space:]]*#.*$/, "", v)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        print v
+        exit
+      }
+    }
+  ' "${CONFIG_PATH}")
+  if [ -z "${val}" ]; then
+    return 1
+  fi
+  printf '%s' "${val}"
+}
+
+# Normalize a MariaDB boolean value to a canonical ON/OFF form so
+# ConfigMap (which the chart writes as ON/OFF) and engine (which
+# accepts ON/OFF/1/0) can be compared. Returns the original value
+# unchanged if it is not a recognized boolean — non-recognized
+# values surface as a comparison miss, which the caller treats as
+# a disagreement.
+normalize_bool() {
+  v="$1"
+  case "$(printf '%s' "${v}" | tr '[:upper:]' '[:lower:]')" in
+    on|true|1)  printf 'ON' ;;
+    off|false|0) printf 'OFF' ;;
+    *) printf '%s' "${v}" ;;
+  esac
+}
+
+# Read both engine variables and capture the rc of each individually.
+# alpha.89 v1 commit 4 v2 (Helen 2026-05-19, Jack review B1): the
+# v1 check only inspected master's rc, so a slave read failure
+# silently fell through and ended up classified as
+# `invariant_violated` (when master=ON) or `disagree`, instead of
+# the correct `engine_missing` / `configmap_missing` signals. Treat
+# missing OR unreadable on either side as the same observability
+# failure as if the other side were missing.
+eng_master=$(engine_var rpl_semi_sync_master_enabled)
+eng_master_rc=$?
+eng_slave=$(engine_var rpl_semi_sync_slave_enabled)
+eng_slave_rc=$?
+cm_master=$(configmap_var rpl_semi_sync_master_enabled)
+cm_master_rc=$?
+cm_slave=$(configmap_var rpl_semi_sync_slave_enabled)
+cm_slave_rc=$?
+
+if [ "${eng_master_rc}" -ne 0 ] || [ "${eng_slave_rc}" -ne 0 ]; then
+  printf 'mode_engine_master_enabled=%s\n' "${eng_master:-}"
+  printf 'mode_engine_slave_enabled=%s\n' "${eng_slave:-}"
+  printf 'mode_configmap_master_enabled=%s\n' "${cm_master:-}"
+  printf 'mode_configmap_slave_enabled=%s\n' "${cm_slave:-}"
+  printf 'mode_consistency=engine_missing\n'
+  exit "${EXIT_ENGINE_MISSING}"
+fi
+
+if [ "${cm_master_rc}" -ne 0 ] || [ "${cm_slave_rc}" -ne 0 ]; then
+  printf 'mode_engine_master_enabled=%s\n' "${eng_master}"
+  printf 'mode_engine_slave_enabled=%s\n' "${eng_slave}"
+  printf 'mode_configmap_master_enabled=%s\n' "${cm_master:-}"
+  printf 'mode_configmap_slave_enabled=%s\n' "${cm_slave:-}"
+  printf 'mode_consistency=configmap_missing\n'
+  exit "${EXIT_CONFIGMAP_MISSING}"
+fi
+
+eng_master_n=$(normalize_bool "${eng_master}")
+eng_slave_n=$(normalize_bool "${eng_slave}")
+cm_master_n=$(normalize_bool "${cm_master}")
+cm_slave_n=$(normalize_bool "${cm_slave}")
+
+# Invariant: when master=ON the slave side must also be ON for
+# semisync to actually engage on this pair (MariaDB requires both
+# variables aligned across the topology; an asymmetric ON/OFF pair
+# silently degrades to async without an error).
+if [ "${eng_master_n}" = "ON" ] && [ "${eng_slave_n}" != "ON" ]; then
+  printf 'mode_engine_master_enabled=%s\n' "${eng_master_n}"
+  printf 'mode_engine_slave_enabled=%s\n' "${eng_slave_n}"
+  printf 'mode_configmap_master_enabled=%s\n' "${cm_master_n}"
+  printf 'mode_configmap_slave_enabled=%s\n' "${cm_slave_n}"
+  printf 'mode_consistency=invariant_violated\n'
+  exit "${EXIT_INVARIANT_VIOLATED}"
+fi
+
+if [ "${eng_master_n}" = "${cm_master_n}" ] && [ "${eng_slave_n}" = "${cm_slave_n}" ]; then
+  printf 'mode_engine_master_enabled=%s\n' "${eng_master_n}"
+  printf 'mode_engine_slave_enabled=%s\n' "${eng_slave_n}"
+  printf 'mode_configmap_master_enabled=%s\n' "${cm_master_n}"
+  printf 'mode_configmap_slave_enabled=%s\n' "${cm_slave_n}"
+  printf 'mode_consistency=ok\n'
+  exit "${EXIT_OK}"
+fi
+
+printf 'mode_engine_master_enabled=%s\n' "${eng_master_n}"
+printf 'mode_engine_slave_enabled=%s\n' "${eng_slave_n}"
+printf 'mode_configmap_master_enabled=%s\n' "${cm_master_n}"
+printf 'mode_configmap_slave_enabled=%s\n' "${cm_slave_n}"
+printf 'mode_consistency=disagree\n'
+exit "${EXIT_DISAGREE}"

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -555,8 +555,23 @@ reconfigure:
         if [ -r /scripts/replication-mode-mapper.sh ]; then
           # shellcheck disable=SC1091
           __SOURCED__=1 . /scripts/replication-mode-mapper.sh
-          if ! apply_replication_mode_mapping "${parameter_file}"; then
-            mapper_rc=$?
+          # alpha.89 v1 commit 12 v2 (Helen 2026-05-20, Jack B1 fix
+          # msg `008885e2`) — capture the mapper's original rc. The
+          # earlier `if ! apply_replication_mode_mapping ...; then
+          # mapper_rc=$?` form lost the rc because `!` inverts the
+          # exit code, so `$?` inside the then-block was always 0.
+          # The `|| mapper_rc=$?` form preserves the mapper's actual
+          # return code (2/3/4/5) into the diagnostic sentinel, which
+          # downstream first-blocker classification reads to decide
+          # which contract layer (invalid mode vs conflict vs IO vs
+          # bad arg) the failure came from.
+          #
+          # The `|| <cmd>` chain disables `set -e` for the mapper
+          # invocation, so the action stays alive long enough to
+          # print the rc-aware sentinel before exiting 1.
+          mapper_rc=0
+          apply_replication_mode_mapping "${parameter_file}" || mapper_rc=$?
+          if [ "${mapper_rc}" -ne 0 ]; then
             echo "replicationMode mapper failed (rc=${mapper_rc}); reconfigure aborts before any SET GLOBAL or runtime-overrides.d write" >&2
             exit 1
           fi

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -95,6 +95,30 @@ mariadb-galera-{{ .Chart.Version }}
 {{- end -}}
 
 {{/*
+Define mariadb-replication-merged component definition name.
+
+alpha.89 v1 (Helen 2026-05-19) — new CmpD for topology merge (weston
+2026-05-19 14:12 Option B). The merged CmpD consolidates the old
+`mariadb-replication` (async) and `mariadb-semisync` CmpDs into one,
+selected at runtime by a `replicationMode: async | semisync`
+ComponentSpec parameter rather than by topology name. A new CmpD name
+is used (not reusing `mariadb-replication-`) so KB does not see this
+as a mutation of the existing immutable CmpD spec — see Chart.yaml
+header for the immutability rule.
+*/}}
+{{- define "mariadb.replication.merged.cmpdName" -}}
+mariadb-replication-merged-{{ .Chart.Version }}
+{{- end -}}
+
+{{/*
+Regexp pattern for the merged replication CmpD (matches names that
+start with the merged prefix; used by ParametersDefinition).
+*/}}
+{{- define "mariadb.replication.merged.cmpdRegexpPattern" -}}
+^mariadb-replication-merged-
+{{- end -}}
+
+{{/*
 Define mariadb component definition regular expression name prefix
 */}}
 {{- define "mariadb.cmpdRegexpPattern" -}}
@@ -110,10 +134,18 @@ Define mariadb standalone component definition regular expression name prefix
 {{- end -}}
 
 {{/*
-Define mariadb-replication component definition regular expression name prefix
+Define mariadb-replication component definition regular expression name prefix.
+
+alpha.89 v1 (Helen 2026-05-19, Jack design review Blocker 1) — narrowed
+from `^mariadb-replication-` to `^mariadb-replication-[0-9]` so the
+old replication CmpD regex does NOT also match the new merged CmpD
+name `mariadb-replication-merged-{ChartVersion}`. The chart-version
+suffix on the old CmpD name always starts with a digit (e.g.
+`mariadb-replication-1.1.1-alpha.89`), so requiring a digit
+immediately after the `replication-` prefix is a safe disambiguator.
 */}}
 {{- define "mariadb.replication.cmpdRegexpPattern" -}}
-^mariadb-replication-
+^mariadb-replication-[0-9]
 {{- end -}}
 
 {{/*

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -537,6 +537,31 @@ reconfigure:
         parameter_file="$(mktemp)"
         trap 'rm -f "${parameter_file}"' EXIT
         emit_action_parameters > "${parameter_file}"
+
+        # alpha.89 v1 commit 12 (Helen 2026-05-20, C3 design mapper) —
+        # translate the synthetic `replicationMode` ComponentSpec
+        # parameter into the four real engine variables BEFORE the
+        # main loop sees the parameter list. The mapper is the unique
+        # consumer / writer of `replicationMode`; it strips any
+        # synthetic `replicationmode` / `replicationMode` line, fails
+        # closed on invalid mode or conflict with user-supplied real
+        # vars, and is idempotent on both-consistent input. Contract
+        # is locked in `scripts/replication-mode-mapper.sh`.
+        #
+        # The mapper is sourced (not executed) so it runs in the same
+        # shell, preserves `set -eu`, and shares the trap'd parameter
+        # file. The /scripts mount comes from the replication scripts
+        # ConfigMap (configmap-scripts-replication.yaml commit 12).
+        if [ -r /scripts/replication-mode-mapper.sh ]; then
+          # shellcheck disable=SC1091
+          __SOURCED__=1 . /scripts/replication-mode-mapper.sh
+          if ! apply_replication_mode_mapping "${parameter_file}"; then
+            mapper_rc=$?
+            echo "replicationMode mapper failed (rc=${mapper_rc}); reconfigure aborts before any SET GLOBAL or runtime-overrides.d write" >&2
+            exit 1
+          fi
+        fi
+
         if [ ! -s "${parameter_file}" ]; then
           echo "No reconfigure parameters were injected into action environment" >&2
           exit 1
@@ -636,7 +661,6 @@ reconfigure:
           override_file="${OVERRIDES_DIR}/${param_name}.cnf"
           override_tmp="${override_file}.tmp.$$"
           if ! {
-            echo "# Written by reconfigureAction.persisted on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "[mysqld]"
             echo "${param_name} = ${persist_quoted}"
           } > "${override_tmp}"; then
@@ -644,7 +668,25 @@ reconfigure:
             echo "Failed to write tmp override file ${override_tmp}; reconfigure cannot guarantee persistence" >&2
             exit 1
           fi
-          if ! mv "${override_tmp}" "${override_file}"; then
+          # alpha.89 v1 commit 12 (Helen 2026-05-20, Jack contract msg
+          # `2e93eb72`) — byte-equal short-circuit. If the existing
+          # override file already has identical content to the new
+          # tmp file, skip the atomic mv so the on-disk file's mtime
+          # is preserved across no-op reconfigures (idempotency
+          # guarantee for both-consistent and repeated mode-only
+          # reconfigure cases). The skip branch runs strictly after
+          # safety validation (is_safe_param_name + is_safe_param_value
+          # gated above) and after the mapper-driven conflict check
+          # (apply_replication_mode_mapping runs before any reach into
+          # this loop). Conflict cases never get here — the mapper
+          # exits the action non-zero before any tmp file is written.
+          # The alpha.86 timestamp comment was removed (commit 12)
+          # because it forced every write to differ even when the
+          # parameter value was unchanged.
+          if [ -f "${override_file}" ] && cmp -s "${override_tmp}" "${override_file}"; then
+            rm -f "${override_tmp}" 2>/dev/null || true
+            echo "Override for ${param_name} already at target value; skipping rewrite to preserve mtime"
+          elif ! mv "${override_tmp}" "${override_file}"; then
             rm -f "${override_tmp}" 2>/dev/null || true
             echo "Failed to rename tmp override into place at ${override_file}; reconfigure cannot guarantee persistence" >&2
             exit 1

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -317,6 +317,323 @@ reconfigure:
 {{- end -}}
 
 {{/*
+ComponentDefinition reconfigure action for MariaDB — SEMISYNC variant with
+persistent runtime-override files.
+
+alpha.86 v1 (Helen 2026-05-19) — semisync topology adds a defense-in-depth
+persistence layer on top of the base reconfigureAction body. The base helper
+runs `SET GLOBAL` against the running mysqld; the assignment is runtime-only
+and ANY mariadbd restart erases it. This variant additionally writes one
+`/var/lib/mysql/runtime-overrides.d/<param_name>.cnf` file per parameter,
+which mariadbd reads at startup via `--defaults-extra-file=
+/var/lib/mysql/runtime-overrides.cnf` (the loader file is created by
+init-syncer with the single line `!includedir /var/lib/mysql/
+runtime-overrides.d/`).
+
+Why a separate variant and not a flag in the base helper: standalone /
+replication / galera cmpds neither have init-syncer create the loader
+file nor pass `--defaults-extra-file` to mariadbd; adding persistence
+writes there would produce dead files mariadbd never loads (the
+non-empty-unenforced class). cmpd-semisync.yaml is the single caller of
+the persisted variant.
+
+Jack 5-guard enforcement (peer review msg `a13b8850`); Guard 5
+parse smoke REMOVED in alpha.88 after dry-run blocker (Jack msg
+`e6afaa1a`):
+  1. kbagent write permission to runtime-overrides.d: enforced by
+     init-syncer chgrp 1000 + chmod 0770 on the dir (g+rwx) and
+     chmod 0660 on loader file.
+  2. --defaults-extra-file must be first mariadbd option: enforced in
+     start_mariadbd_process function (position-checked by ShellSpec).
+  3. param name/value injection defense: this helper rejects param
+     names not matching `^[A-Za-z0-9_.-]+$` (mariadb option name spec)
+     and rejects values containing newline / NUL / control chars or
+     section header markers like `[mysqld]`.
+  4. fail-closed on persistence failure: mkdir / write / mv any
+     failure exits 1 after cleaning up the partial tmp file. Edge:
+     when persist fails after SET GLOBAL succeeded, runtime is mutated
+     but the action exits 1 (KB marks Ops Failed). Operator retries;
+     retry is idempotent (SET GLOBAL is a no-op if value equal,
+     persist overwrites). This is safer than false-success.
+  5. ~~mariadbd parse smoke after each persist~~ REMOVED in alpha.88.
+     The kbagent action runtime context does NOT include `mariadbd`
+     on PATH (rc=127); combined with `set -e` + `var=$(...)` shell
+     trap, the smoke command-substitution caused the action to exit
+     immediately, bypassing both stderr-print and bad-file cleanup
+     (alpha.86 + alpha.87 dry-runs left orphan `.cnf` files). Guards
+     1-4 remain sufficient: injection defense covers the only inputs
+     that could produce malformed `.cnf` content, and mariadbd's own
+     error log on next restart is the authoritative validation
+     surface for engine-side option-file parsing.
+*/}}
+{{- define "mariadb.config.reconfigureAction.persisted" -}}
+{{- $pd := .Files.Get "config/mariadb-config-effect-scope.yaml" | fromYaml }}
+reconfigure:
+  exec:
+    container: mariadb
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+
+        resolve_mariadb_cli() {
+          if command -v mariadb >/dev/null 2>&1; then
+            command -v mariadb
+            return 0
+          fi
+          if [ -x /tools/mysql-client/bin/mariadb ]; then
+            echo /tools/mysql-client/bin/mariadb
+            return 0
+          fi
+          return 1
+        }
+
+        MARIADB_CLI="$(resolve_mariadb_cli || true)"
+        if [ -z "${MARIADB_CLI}" ]; then
+          echo "MariaDB client is unavailable in current reconfigure runtime" >&2
+          exit 1
+        fi
+
+        # alpha.83 v1: reconfigure action must use internal admin
+        # account to call `SET GLOBAL`. User-facing root has SUPER
+        # stripped by chart security hardening (alpha.64 "drop SUPER
+        # admin bypass"); the internal admin account kb_internal_root
+        # carries ALL PRIVILEGES.
+        mariadb_exec() {
+          query="$1"
+          INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
+          "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
+        }
+
+        to_numeric_value() {
+          value="$1"
+          case "${value}" in
+            ''|*[!0-9KkMmGgBb.]*|*.*.*)
+              return 1
+              ;;
+            *[Kk][Bb])
+              base="${value%[Kk][Bb]}"
+              multiplier=1024
+              ;;
+            *[Kk])
+              base="${value%[Kk]}"
+              multiplier=1024
+              ;;
+            *[Mm][Bb])
+              base="${value%[Mm][Bb]}"
+              multiplier=1048576
+              ;;
+            *[Mm])
+              base="${value%[Mm]}"
+              multiplier=1048576
+              ;;
+            *[Gg][Bb])
+              base="${value%[Gg][Bb]}"
+              multiplier=1073741824
+              ;;
+            *[Gg])
+              base="${value%[Gg]}"
+              multiplier=1073741824
+              ;;
+            *)
+              base="${value}"
+              multiplier=1
+              ;;
+          esac
+
+          case "${base}" in
+            ''|*[!0-9.]*|*.*.*)
+              return 1
+              ;;
+          esac
+
+          if [ "${multiplier}" = "1" ]; then
+            printf "%s\n" "${base}"
+            return 0
+          fi
+
+          case "${base}" in
+            *.*)
+              return 1
+              ;;
+          esac
+
+          expr "${base}" \* "${multiplier}"
+        }
+
+        emit_action_parameters() {
+          env | while IFS='=' read -r param_name param_value; do
+            case "${param_name}" in
+{{- range (get $pd "dynamicParameters") }}
+            {{ . }})
+              printf "%s=%s\n" "${param_name}" "${param_value}"
+              ;;
+{{- end }}
+            esac
+          done | sort -u
+        }
+
+        # alpha.86 v1 — persistence paths and loader. init-syncer
+        # creates the dir + loader file with correct group/mode; we
+        # idempotently re-check existence in case the volume was
+        # mounted after init-syncer (defense-in-depth).
+        OVERRIDES_DIR="/var/lib/mysql/runtime-overrides.d"
+        LOADER_FILE="/var/lib/mysql/runtime-overrides.cnf"
+        if ! mkdir -p "${OVERRIDES_DIR}"; then
+          echo "Failed to mkdir ${OVERRIDES_DIR}; reconfigure cannot persist runtime overrides" >&2
+          exit 1
+        fi
+        if [ ! -f "${LOADER_FILE}" ]; then
+          # init-syncer should have created this; recover idempotently.
+          printf '!includedir %s/\n' "${OVERRIDES_DIR}" > "${LOADER_FILE}" 2>/dev/null || true
+        fi
+
+        parameter_file="$(mktemp)"
+        trap 'rm -f "${parameter_file}"' EXIT
+        emit_action_parameters > "${parameter_file}"
+        if [ ! -s "${parameter_file}" ]; then
+          echo "No reconfigure parameters were injected into action environment" >&2
+          exit 1
+        fi
+
+        # alpha.86 v1 — injection defense per Jack guard 3.
+        # Param name must match `^[A-Za-z0-9_.-]+$` (mariadb option
+        # name spec). Param value rejects newline (\n, \r), NUL, and
+        # other control chars (\x00-\x1f and \x7f); also rejects
+        # bracketed strings like `[mysqld]` that would inject a new
+        # section header into the option file.
+        is_safe_param_name() {
+          name="$1"
+          case "${name}" in
+            ''|*[!A-Za-z0-9_.-]*)
+              return 1
+              ;;
+          esac
+          return 0
+        }
+        is_safe_param_value() {
+          val="$1"
+          # Reject bracketed section headers anywhere in the value
+          # (would inject a new section into the option file).
+          case "${val}" in
+            *'['*']'*)
+              return 1
+              ;;
+          esac
+          # Reject any control char (\x00-\x1f or \x7f) via tr -d.
+          # \x0a (\n) / \x0d (\r) / \x00 (NUL) are all in this range,
+          # so this single check covers newline / CR / NUL injection
+          # as well as any other control byte. Earlier draft used a
+          # case-pattern with `$(printf '\n')` for newline detection
+          # but command substitution strips trailing newlines per POSIX,
+          # so that pattern collapsed to `**` and rejected every value
+          # including "ON" / "3" (Jack 07:02 peer review blocker B1).
+          stripped=$(printf '%s' "${val}" | tr -d '\000-\037\177')
+          [ "${stripped}" = "${val}" ]
+        }
+
+        applied_count=0
+        while IFS= read -r assignment; do
+          [ -n "${assignment}" ] || continue
+          case "${assignment}" in
+          *=*)
+            ;;
+          *)
+            continue
+            ;;
+          esac
+
+          param_name="${assignment%%=*}"
+          param_value="${assignment#*=}"
+          param_name="$(printf "%s" "${param_name}" | tr '-' '_')"
+
+          if ! is_safe_param_name "${param_name}"; then
+            echo "Refusing to apply parameter with unsafe name: ${param_name}" >&2
+            exit 1
+          fi
+          if ! is_safe_param_value "${param_value}"; then
+            echo "Refusing to apply parameter ${param_name} with unsafe value (control char / newline / section marker)" >&2
+            exit 1
+          fi
+
+          if numeric_value="$(to_numeric_value "${param_value}" 2>/dev/null)"; then
+            query="SET GLOBAL \`${param_name}\` = ${numeric_value};"
+            persist_quoted="${numeric_value}"
+          else
+            escaped_value="$(printf "%s" "${param_value}" | sed "s/'/''/g")"
+            query="SET GLOBAL \`${param_name}\` = '${escaped_value}';"
+            # my.cnf quoting: quote when value contains whitespace or
+            # ini metacharacters; otherwise leave bare.
+            case "${param_value}" in
+              *[[:space:]\#\;]*)
+                persist_escaped="$(printf "%s" "${param_value}" | sed 's/\\/\\\\/g; s/\"/\\\"/g')"
+                persist_quoted="\"${persist_escaped}\""
+                ;;
+              *)
+                persist_quoted="${param_value}"
+                ;;
+            esac
+          fi
+
+          if output="$(mariadb_exec "${query}" 2>&1)"; then
+            echo "Set parameter ${param_name} to value ${param_value}"
+            applied_count=$((applied_count + 1))
+          else
+            echo "Failed to set parameter ${param_name}=${param_value}: ${output}" >&2
+            exit 1
+          fi
+
+          # alpha.86 v1 — persist the override AFTER SET GLOBAL succeeds.
+          # Atomic rename protects against interrupted writes; parse
+          # smoke catches mariadb-syntax-invalid input that would
+          # crash mariadbd on next restart.
+          override_file="${OVERRIDES_DIR}/${param_name}.cnf"
+          override_tmp="${override_file}.tmp.$$"
+          if ! {
+            echo "# Written by reconfigureAction.persisted on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "[mysqld]"
+            echo "${param_name} = ${persist_quoted}"
+          } > "${override_tmp}"; then
+            rm -f "${override_tmp}" 2>/dev/null || true
+            echo "Failed to write tmp override file ${override_tmp}; reconfigure cannot guarantee persistence" >&2
+            exit 1
+          fi
+          if ! mv "${override_tmp}" "${override_file}"; then
+            rm -f "${override_tmp}" 2>/dev/null || true
+            echo "Failed to rename tmp override into place at ${override_file}; reconfigure cannot guarantee persistence" >&2
+            exit 1
+          fi
+          # alpha.88 v1 — parse smoke (formerly Jack guard 5) REMOVED
+          # after alpha.86 + alpha.87 dry-runs (Jack msg `e6afaa1a`).
+          # Root cause: kbagent action runtime context does not include
+          # `mariadbd` on PATH (returns 127), and `set -e` combined with
+          # the `var=$(...)` assignment pattern caused the shell to exit
+          # immediately on the failing command-substitution — bypassing
+          # the stderr-print + bad-file cleanup logic that should have
+          # surfaced the diagnosis. The remaining defense layers are
+          # sufficient:
+          #   - is_safe_param_name regex `^[A-Za-z0-9_.-]+$` rejects
+          #     option names that mariadbd's option-file parser would
+          #     refuse.
+          #   - is_safe_param_value rejects control chars / NUL /
+          #     bracketed section markers, the only inputs that could
+          #     escape the rendered `[mysqld]\nname = value` shape.
+          #   - atomic temp + mv guarantees no half-written file.
+          #   - mariadb option names that pass the regex but are not
+          #     recognized by the engine produce a WARN on next restart
+          #     (not a fatal error); the engine's own error log is the
+          #     authoritative validation surface, and is more relevant
+          #     than catching the same issue at write time.
+        done < "${parameter_file}"
+
+        if [ "${applied_count}" -eq 0 ]; then
+          echo "No parameters were applied during reconfigure action" >&2
+          exit 1
+        fi
+{{- end -}}
+
+{{/*
 Syncer image
 */}}
 {{- define "mariadb.syncer.image" -}}

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -187,9 +187,20 @@ reconfigure:
           exit 1
         fi
 
+        # alpha.83 v1 (Helen): reconfigure action must use internal admin
+        # account to call `SET GLOBAL`. User-facing root has SUPER stripped by
+        # chart security hardening (alpha.64 "drop SUPER (admin bypass)"); the
+        # internal admin account `kb_internal_root` carries ALL PRIVILEGES.
+        # Without this, `SET GLOBAL slow_query_log=ON` and similar dynamic
+        # variable writes fail with `ERROR 1227 (42000) ... SUPER privilege(s)`.
+        # The MARIADB_ROOT_PASSWORD env shared with the internal admin (chart
+        # provisions identical passwords); we keep the same env to avoid a new
+        # secret indirection. Default fallback to kb_internal_root mirrors the
+        # preStop hook convention in cmpd-semisync.yaml.
         mariadb_exec() {
           query="$1"
-          "${MARIADB_CLI}" --user="${MARIADB_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
+          INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
+          "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
         }
 
         to_numeric_value() {

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -6,6 +6,35 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack B2 fix msg
+`f9433634`) — Helm template-time fail-closed validation of
+`.Values.replication.mode`. If the chart user sets the value to
+anything other than the accepted set ("" / "async" / "semisync"),
+`helm template` / `helm install` / `helm upgrade` aborts with a
+clear error BEFORE the manifest is rendered. Without this gate, an
+invalid value like `bogus` would render successfully and only fail
+at container startup when the seeder runs (correctly fail-closed,
+but the diagnosis loop is longer and the bad value is already
+written into the rendered CmpD env).
+
+Accepted values:
+  ""        — default; mapper / seeder no-op; existing behavior.
+  "async"   — install-time mode = async.
+  "semisync" — install-time mode = semisync.
+
+Called from `cmpd-replication-merged.yaml` (the only place the value
+is consumed). Other CmpDs do not declare the env entry and are not
+affected.
+*/}}
+{{- define "mariadb.replication.mode.validate" -}}
+{{- $mode := .Values.replication.mode | default "" -}}
+{{- if and $mode (not (has $mode (list "async" "semisync"))) -}}
+{{- fail (printf "invalid mariadb.replication.mode=%q; expected one of \"\", \"async\", \"semisync\" (commit 13 v2 / Jack B2 install-time fail-closed)" $mode) -}}
+{{- end -}}
+{{- $mode -}}
+{{- end -}}
+
+{{/*
 Selector labels
 */}}
 {{- define "mariadb.selectorLabels" -}}

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -97,14 +97,27 @@ mariadb-galera-{{ .Chart.Version }}
 {{/*
 Define mariadb-replication-merged component definition name.
 
-alpha.89 v1 (Helen 2026-05-19) — new CmpD for topology merge (weston
-2026-05-19 14:12 Option B). The merged CmpD consolidates the old
+alpha.89 v1 (Helen 2026-05-19, Jack design review non-blocking
+clarification) — new CmpD for topology merge (weston 2026-05-19
+14:12 Option B). The merged CmpD consolidates the old
 `mariadb-replication` (async) and `mariadb-semisync` CmpDs into one,
 selected at runtime by a `replicationMode: async | semisync`
-ComponentSpec parameter rather than by topology name. A new CmpD name
-is used (not reusing `mariadb-replication-`) so KB does not see this
-as a mutation of the existing immutable CmpD spec — see Chart.yaml
-header for the immutability rule.
+ComponentSpec parameter rather than by topology name.
+
+The new CmpD name is `mariadb-replication-merged-{ChartVersion}`.
+It still starts with `mariadb-replication-`, but disambiguation from
+the old replication CmpD lives in two places: the `-merged-` infix
+in this new name, and the narrowed `^mariadb-replication-[0-9]`
+regex on the old CmpD's PD (see
+`mariadb.replication.cmpdRegexpPattern` above). A separate regex
+`^mariadb-replication-merged-` binds the merged CmpD's PD. The
+`replication_merged_pd_regex_disambiguation_spec.sh` ShellSpec
+locks the resulting mutual exclusion across all five CmpD names.
+
+A new CmpD name (rather than reusing the old exact CmpD name) is
+required so KB does not see this as a mutation of the existing
+immutable CmpD spec — see Chart.yaml header for the immutability
+rule.
 */}}
 {{- define "mariadb.replication.merged.cmpdName" -}}
 mariadb-replication-merged-{{ .Chart.Version }}

--- a/addons/mariadb/templates/backuppolicytemplate.yaml
+++ b/addons/mariadb/templates/backuppolicytemplate.yaml
@@ -8,8 +8,15 @@ spec:
   serviceKind: Mariadb
   compDefs:
     - {{ include "mariadb.cmpdRegexpPattern" . }}
+  # The ActionSet uses `mariadb-backup --safe-slave-backup --slave-info`,
+  # designed to back up a replica without disrupting the writable primary.
+  # For replication / semisync topologies the secondary role is the
+  # preferred backup target; if no secondary is available KubeBlocks
+  # falls back to the primary so a standalone cluster (single pod with
+  # role=primary) still has a backup target.
   target:
-    role: ""
+    role: secondary
+    fallbackRole: primary
     account: root
   backupMethods:
     - name: mariadb-backup

--- a/addons/mariadb/templates/clusterdefinition.yaml
+++ b/addons/mariadb/templates/clusterdefinition.yaml
@@ -13,14 +13,24 @@ spec:
         - name: mariadb
           compDef: {{ include "mariadb.cmpdName" . }}
       default: true
-    - name: async
+    # `replication` is the single canonical primary/secondary topology
+    # (alpha.89 — topology merge under weston 2026-05-19 Option B
+    # msg `d8ecfae7`). The async vs semisync behavior is selected by
+    # a ComponentSpec parameter `replicationMode: async | semisync`,
+    # not by the topology name.
+    #
+    # Breaking change relative to alpha.88: the old `async` /
+    # `semisync` topology names are NOT listed here. Existing Cluster
+    # CRs with `spec.topology=async` / `=semisync` will not match this
+    # ClusterDefinition's topologies after upgrade and must be migrated
+    # manually by the user (active migration path is the main route;
+    # any auto-rebind by KB controller on a topology compDef rename is
+    # exploratory and verified separately by the upgrade gate N=1,
+    # NOT a release-notes promise — Jack design Gate 6).
+    - name: replication
       components:
         - name: mariadb
-          compDef: {{ include "mariadb.replication.cmpdName" . }}
-    - name: semisync
-      components:
-        - name: mariadb
-          compDef: {{ include "mariadb.semisync.cmpdName" . }}
+          compDef: {{ include "mariadb.replication.merged.cmpdName" . }}
     - name: galera
       components:
         - name: mariadb

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -74,7 +74,17 @@ spec:
       participatesInQuorum: false
   {{- include "kblib.syncer.policyRules" . | nindent 2 }}
   configs:
-    - name: mariadb-semisync-config
+    # alpha.89 v1 commit 2 (Helen 2026-05-19) — configspec name renamed
+    # from `mariadb-semisync-config` to `mariadb-replication-config`
+    # so the merged CmpD does not carry the legacy semisync identifier
+    # in its addressable surface. The underlying ConfigMap object
+    # template (`mariadb-semisync-config-template`) is left in place
+    # for now and will be migrated to a unified
+    # `mariadb-replication-config-template` once `replicationMode`
+    # parameterization lands (the merged CmpD currently still produces
+    # semisync defaults; renaming the rendered ConfigMap before
+    # parameter-driven defaults would silently change cluster behavior).
+    - name: mariadb-replication-config
       template: mariadb-semisync-config-template
       volumeName: mariadb-config
       namespace: {{ .Release.Namespace }}

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -2414,6 +2414,47 @@ spec:
             value: /tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           - name: MARIADB_AUTO_UPGRADE
             value: "1"
+          # alpha.89 v1 commit 13 (Helen 2026-05-20, C3 design env
+          # plumbing — Helm value path / Option C of the plumbing
+          # candidate list, per the commit 11+12 / addon-docs guide
+          # discussion).
+          #
+          # `MARIADB_REPLICATION_MODE` is consumed by the addon-side
+          # mapper sourced into `reconfigureAction.persisted` (see
+          # `scripts/replication-mode-mapper.sh` + commit 12
+          # `mariadb.config.reconfigureAction.persisted` helper). The
+          # mapper translates the synthetic `replicationMode` switch
+          # ("async" | "semisync") into the four real engine
+          # variables (rpl_semi_sync_master_enabled / slave_enabled /
+          # master_wait_for_slave_count / master_timeout) BEFORE the
+          # main loop renders any my.cnf or runtime-overrides.d/
+          # file. When the env is empty the mapper is a no-op
+          # (parameter list flows through unchanged), preserving the
+          # "only-4-vars" path on existing clusters.
+          #
+          # Sourcing the value from a Helm value rather than a KB
+          # ParametersDefinition parameter or an annotation is the
+          # conservative path: it sets the topology default at chart
+          # install/upgrade time without requiring speculative KB
+          # behavior (the standard `parameters` reconfigure path is
+          # blocked by the `replicationmode?: _|_` CUE backstop
+          # added in commit 11 v2 specifically to prevent the
+          # synthetic key from landing in my.cnf). Runtime-time mode
+          # flip via OpsRequest reconfigure is deferred to a future
+          # commit / version that wires either a Cluster annotation
+          # + addon-side reader OR a separate non-INI-bound PD; the
+          # mapper interface itself is unchanged in either case
+          # (only the env source differs).
+          #
+          # Empty default = "" means existing clusters whose Helm
+          # values do not set `mariadb.replication.mode` see no
+          # behavioral change: the mapper short-circuits at the
+          # empty-mode early return, the strip-synthetic pass (B2
+          # fix in commit 12 v2) still runs unconditionally as
+          # defense-in-depth, and the four real engine variables
+          # continue to flow through the existing persisted helper.
+          - name: MARIADB_REPLICATION_MODE
+            value: {{ .Values.replication.mode | default "" | quote }}
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -262,6 +262,32 @@ spec:
             chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
             chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
             chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack
+            # post-commit-13-v1 install-time write-site requirement
+            # msg `696e7b16`) — seed runtime-overrides.d/ from
+            # `MARIADB_REPLICATION_MODE` BEFORE the first mariadbd
+            # process exec. Without this seeder the Helm value
+            # `mariadb.replication.mode=semisync` set at install
+            # time would have no effect until the first
+            # reconfigureAction trigger; the seeder closes that gap
+            # so the chart-author-selected semisync/async state
+            # takes effect from the very first mariadbd start. The
+            # seeder writes byte-identical content to what
+            # reconfigureAction.persisted writes for the same env,
+            # so the two write-sites converge and a later reconfigure
+            # is a byte-equal no-op (mtime preserved by the cmp -s
+            # short-circuit). Empty env is a no-op (preserves
+            # behavior on clusters whose Helm values do not set the
+            # mode). Invalid mode fails the container (fail-closed):
+            # mariadbd does not start until the env is corrected.
+            if [ -r /scripts/seed-replication-mode-overrides.sh ]; then
+              seed_rc=0
+              sh /scripts/seed-replication-mode-overrides.sh || seed_rc=$?
+              if [ "${seed_rc}" -ne 0 ]; then
+                echo "seed-replication-mode-overrides failed (rc=${seed_rc}); refusing to start mariadbd — correct MARIADB_REPLICATION_MODE and restart the pod" >&2
+                exit 1
+              fi
+            fi
             # Signal to roleProbe that this pod is initializing — prevents spurious "primary"
             # reports that would cause KubeBlocks to auto-trigger a switchover.
             rm -f {{ .Values.dataMountPath }}/.replication-ready
@@ -2453,8 +2479,15 @@ spec:
           # fix in commit 12 v2) still runs unconditionally as
           # defense-in-depth, and the four real engine variables
           # continue to flow through the existing persisted helper.
+          # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack B2 fix
+          # msg `f9433634`) — value flows through
+          # `mariadb.replication.mode.validate` helper which fails
+          # the helm render with a clear error message when the value
+          # is not in the accepted set ("" / "async" / "semisync"),
+          # so invalid values are caught at install/upgrade time
+          # rather than only at container startup.
           - name: MARIADB_REPLICATION_MODE
-            value: {{ .Values.replication.mode | default "" | quote }}
+            value: {{ include "mariadb.replication.mode.validate" . | quote }}
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -280,7 +280,22 @@ spec:
             # behavior on clusters whose Helm values do not set the
             # mode). Invalid mode fails the container (fail-closed):
             # mariadbd does not start until the env is corrected.
-            if [ -r /scripts/seed-replication-mode-overrides.sh ]; then
+            # alpha.89 v1 commit 13 v3 (Helen 2026-05-20, Jack B3 fix
+            # msg `6e6eab69`) — when MARIADB_REPLICATION_MODE is
+            # non-empty the seeder script MUST be readable. The
+            # previous form `if [ -r ]; then ...; fi` silently skipped
+            # the seeder on a missing / unreadable script while leaving
+            # the env value set, so a non-empty mode could degrade to
+            # async (Class 1 silent fallback). Empty mode keeps the
+            # original lenient form because the seeder is a no-op
+            # anyway and a missing-script scenario is a deploy-time
+            # config drift that should still let async deployments
+            # boot.
+            if [ -n "${MARIADB_REPLICATION_MODE:-}" ]; then
+              if [ ! -r /scripts/seed-replication-mode-overrides.sh ]; then
+                echo "MARIADB_REPLICATION_MODE='${MARIADB_REPLICATION_MODE}' set but seeder script /scripts/seed-replication-mode-overrides.sh is missing or unreadable; refusing to start mariadbd (fail-closed) — fix the script mount and restart the pod" >&2
+                exit 1
+              fi
               seed_rc=0
               sh /scripts/seed-replication-mode-overrides.sh || seed_rc=$?
               if [ "${seed_rc}" -ne 0 ]; then

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -77,15 +77,33 @@ spec:
     # alpha.89 v1 commit 2 (Helen 2026-05-19) — configspec name renamed
     # from `mariadb-semisync-config` to `mariadb-replication-config`
     # so the merged CmpD does not carry the legacy semisync identifier
-    # in its addressable surface. The underlying ConfigMap object
-    # template (`mariadb-semisync-config-template`) is left in place
-    # for now and will be migrated to a unified
-    # `mariadb-replication-config-template` once `replicationMode`
-    # parameterization lands (the merged CmpD currently still produces
-    # semisync defaults; renaming the rendered ConfigMap before
-    # parameter-driven defaults would silently change cluster behavior).
+    # in its addressable surface.
+    #
+    # alpha.89 v1 commit 8 (Helen 2026-05-19, C1 path default-async
+    # closure) — the rendered ConfigMap template is now
+    # `mariadb-replication-config-template` (which loads
+    # `config/mariadb-replication.tpl`), so the merged CmpD's default
+    # behavior is async replication: the four semisync engine
+    # variables are absent from the default my.cnf and therefore
+    # take their engine defaults (OFF / 0). Users who want semisync
+    # set the four `rpl_semi_sync_*` variables via
+    # `spec.componentSpecs[].parameters` at create time; the PD
+    # CUE schema added in commit 3 v2 validates the values, and the
+    # alpha.88 persistence layer (still in this CmpD's init
+    # container + mariadbd `--defaults-extra-file` start arg) carries
+    # the runtime values through process restarts.
+    #
+    # This default flip is the v3.1 design §1 / §8 commitment: under
+    # Option B the merged CmpD has a single canonical configspec
+    # template; defaulting to async is the safer choice for new
+    # clusters since async does not silently degrade under partial
+    # secondary failure the way semisync's wait_for_slave gate does.
+    # Existing Cluster CRs that referenced the deprecated
+    # `mariadb-semisync-1.1.1-alpha.88` CmpD continue to use that
+    # CmpD's own configspec — the deprecated CmpD still renders in
+    # the chart per the scaffolding commit's compat-resource policy.
     - name: mariadb-replication-config
-      template: mariadb-semisync-config-template
+      template: mariadb-replication-config-template
       volumeName: mariadb-config
       namespace: {{ .Release.Namespace }}
       externalManaged: true

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1,0 +1,2402 @@
+{{/*
+mariadb-replication-merged ComponentDefinition.
+
+alpha.89 v1 scaffolding (Helen 2026-05-19) — topology merge initial
+commit. This file starts as a verbatim copy of cmpd-semisync.yaml
+(with only the metadata.name swapped to the merged-cmpd helper). The
+semisync version is chosen as the base because it has the most
+resilience layers already wired up:
+
+  - alpha.85 ParametersDefinition (PD) hook in paramsdef.yaml
+  - alpha.88 persistence layer: per-parameter override files under
+    /var/lib/mysql/runtime-overrides.d/, loaded at mariadbd startup
+    via --defaults-extra-file pointing at runtime-overrides.cnf with
+    !includedir
+  - SLAVE MONITOR grants explicit for 11.4+
+  - prestop fence markers + init-syncer overrides.d/ mkdir
+  - sql-listener-ready / role-probe SQL listener gate
+
+Subsequent commits in this PR will parameterize this CmpD on the
+`replicationMode` ComponentSpec parameter so the same CmpD serves
+both async and semisync (with semisync engine variables defaulting
+to OFF when replicationMode=async and ON when =semisync). The
+switchover script (scripts/replication-switchover.sh) will also be
+updated to detect mode at runtime via `@@rpl_semi_sync_master_enabled`
+and decide whether to wait for the last semisync ACK before promoting.
+
+Until the parameterization lands, this CmpD behaves identically to
+mariadb-semisync — using it from spec.topology=replication is
+equivalent to spec.topology=semisync today.
+
+clusterdefinition.yaml is Option B locked: it only lists `standalone`,
+`replication`, and `galera` topologies. The old `async` and
+`semisync` topology names are NOT listed; existing Cluster CRs with
+those topology values must actively migrate (release notes route).
+The old `cmpd-replication.yaml` and `cmpd-semisync.yaml` files still
+render in the chart so that any Cluster object whose status already
+references those CmpDs by name does not fail compDef resolution
+during upgrade; they are not exposed as new topology choices.
+*/}}
+apiVersion: apps.kubeblocks.io/v1
+kind: ComponentDefinition
+metadata:
+  name: {{ include "mariadb.replication.merged.cmpdName" . }}
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+  annotations:
+    {{- include "mariadb.annotations" . | nindent 4 }}
+spec:
+  provider: Community
+  description: MariaDB merged replication component definition (async/semisync via replicationMode parameter)
+  serviceKind: mariadb
+  serviceVersion: {{ .Values.defaultServiceVersion.replication }}
+  updateStrategy: BestEffortParallel
+  podManagementPolicy: OrderedReady
+  exporter:
+    containerName: exporter
+    scrapePath: /metrics
+    scrapePort: metrics
+  services:
+    - name: default
+      roleSelector: primary
+      spec:
+        ports:
+          - name: mariadb
+            port: 3306
+            targetPort: mariadb
+  roles:
+    - name: primary
+      updatePriority: 2
+      participatesInQuorum: false
+      isExclusive: true
+    - name: secondary
+      updatePriority: 1
+      participatesInQuorum: false
+  {{- include "kblib.syncer.policyRules" . | nindent 2 }}
+  configs:
+    - name: mariadb-semisync-config
+      template: mariadb-semisync-config-template
+      volumeName: mariadb-config
+      namespace: {{ .Release.Namespace }}
+      externalManaged: true
+      {{- /* alpha.86 v1 (Helen 2026-05-19) — semisync uses the persisted
+             variant of reconfigureAction so SET GLOBAL values also land in
+             /var/lib/mysql/runtime-overrides.d/<param>.cnf, which mariadbd
+             loads at startup via --defaults-extra-file. Required because
+             mariadbd process restart (from any path: switchover promote
+             after PR #10252 fix, OOMKill, node drain, manual restart, etc.)
+             would otherwise wipe SET GLOBAL runtime state and revert to
+             chart defaults. Other topologies continue to use the base
+             helper (no persistence writes) because they do NOT have
+             init-syncer mkdir for runtime-overrides.d/ nor pass
+             --defaults-extra-file to mariadbd. */}}
+      {{- include "mariadb.config.reconfigureAction.persisted" . | nindent 6 }}
+  scripts:
+    - name: {{ include "mariadb.replication.scriptConfigMapName" . }}
+      template: {{ include "mariadb.replication.scriptConfigMapName" . }}
+      namespace: {{ .Release.Namespace }}
+      volumeName: scripts
+      defaultMode: 0555
+  serviceRefDeclarations:
+    - name: etcd
+      serviceRefDeclarationSpecs:
+        - serviceKind: etcd
+          serviceVersion: "^*"
+      optional: true
+  volumes:
+    - name: data
+      needSnapshot: true
+  {{- include "mariadb.replication.spec.systemAccounts" . | nindent 2 }}
+  {{- include "mariadb.spec.vars" . | nindent 2 }}
+  lifecycleActions:
+    roleProbe:
+      periodSeconds: {{ .Values.roleProbe.periodSeconds }}
+      timeoutSeconds: {{ .Values.roleProbe.timeoutSeconds }}
+      exec:
+        container: mariadb
+        command:
+          - /bin/sh
+          - -c
+          - MARIADB_ROLEPROBE_REQUIRE_SQL_LISTENER_READY=true /scripts/replication-roleprobe.sh
+    switchover:
+      # KB kbagent enforces a hardcoded maxActionCallTimeout of 60s
+      # (pkg/kbagent/service/action_utils.go), so any value above 60 is silently
+      # truncated. We declare 60 here so the contract reflects what kbagent
+      # actually enforces. The switchover action is intentionally short and
+      # delegates post-DCS convergence to roleProbe + KB endpoint controller.
+      timeoutSeconds: 60
+      exec:
+        container: mariadb
+        command:
+          - /bin/sh
+          - /scripts/replication-switchover.sh
+  runtime:
+    # Give preStop enough time to fence the old primary and stop mariadbd before
+    # syncer releases the HA lease.
+    terminationGracePeriodSeconds: 120
+    initContainers:
+      - command:
+          - /bin/sh
+          - -c
+          - |
+            cp -r /bin/syncer /bin/syncerctl /tools/
+            mkdir -p {{ .Values.dataMountPath }}
+            # alpha.86 v1 (Helen) — runtime override persistence layer.
+            # Per-parameter `.cnf` files live under runtime-overrides.d/;
+            # mariadbd loads them via --defaults-extra-file pointing at
+            # the loader file runtime-overrides.cnf (which `!includedir`
+            # the dir). KB's strict INI parser never sees `!includedir`
+            # because it does not parse this file. Group write (gid=1000
+            # matches the kbagent gid the main container chgrp below)
+            # so the reconfigureAction.persisted helper running in the
+            # mariadb container as the kbagent group can write override
+            # files; mariadbd reads via its mysql user.
+            mkdir -p {{ .Values.dataMountPath }}/runtime-overrides.d
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            # Loader file is created idempotently with the single
+            # `!includedir` directive. mariadbd silently accepts an
+            # empty dir; first reconfigure populates per-param files
+            # under runtime-overrides.d/. Loader file itself is
+            # treated as immutable shape; we always overwrite to the
+            # canonical content so a corrupted prior write cannot
+            # block mariadbd startup on the next restart.
+            printf '!includedir %s/runtime-overrides.d/\n' '{{ .Values.dataMountPath }}' > {{ .Values.dataMountPath }}/runtime-overrides.cnf
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            rm -f {{ .Values.dataMountPath }}/.replication-ready {{ .Values.dataMountPath }}/.replication-divergence-pending
+            rm -f {{ .Values.dataMountPath }}/.prestop-fence-started \
+              {{ .Values.dataMountPath }}/.prestop-fence-complete \
+              {{ .Values.dataMountPath }}/.prestop-fence-failed
+            rm -f {{ .Values.dataMountPath }}/.sql-listener-ready \
+              {{ .Values.dataMountPath }}/.remote-root-fence-role \
+              {{ .Values.dataMountPath }}/.primary-read-write-ready
+            # alpha.80 v1 (Helen): removed `.switchover-fence-active` from this
+            # init rm list. alpha.79 v1 minimalist deleted the marker writer
+            # in switchover.sh so the marker file never appears anywhere; the
+            # init-syncer rm of it was a no-op safety net. Pure dead-code
+            # cleanup, no runtime behavior change.
+            touch {{ .Values.dataMountPath }}/.replication-pending
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        name: init-syncer
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+          - mountPath: /tools
+            name: tools
+          - mountPath: {{ .Values.dataMountPath }}
+            name: data
+    containers:
+      - name: mariadb
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        command:
+          - /tools/syncer
+          - --port
+          - "3601"
+          - --
+          - bash
+          - -c
+          - |
+            mkdir -p {{ .Values.dataMountPath }}/{log,binlog,tmp}
+            chown -R mysql:mysql {{ .Values.dataMountPath }}
+            MYSQL_CLIENT_DIR=/tools/mysql-client
+            MARIADB_BIN="$(command -v mariadb)"
+            MARIADB_LOADER="$(ldd "${MARIADB_BIN}" | awk '{for (i = 1; i <= NF; i++) if ($i ~ /^\// && ($i ~ /ld-linux/ || $i ~ /ld-musl/)) { print $i; exit }}')"
+            mkdir -p "${MYSQL_CLIENT_DIR}/bin" "${MYSQL_CLIENT_DIR}/lib"
+            cp -L "${MARIADB_BIN}" "${MYSQL_CLIENT_DIR}/bin/mariadb.bin"
+            ldd "${MARIADB_BIN}" | awk '{for (i = 1; i <= NF; i++) if ($i ~ /^\//) print $i}' | sort -u | while IFS= read -r lib; do
+              [ -n "${lib}" ] || continue
+              cp -L "${lib}" "${MYSQL_CLIENT_DIR}/lib/"
+            done
+            cat > "${MYSQL_CLIENT_DIR}/bin/mariadb" <<EOF
+            #!/bin/sh
+            set -eu
+            ROOT="\$(CDPATH= cd -- "\$(dirname -- "\$0")"/.. && pwd)"
+            exec "\${ROOT}/lib/${MARIADB_LOADER##*/}" --library-path "\${ROOT}/lib" "\${ROOT}/bin/mariadb.bin" "\$@"
+            EOF
+            chmod 0555 "${MYSQL_CLIENT_DIR}/bin/mariadb"
+            # Set data dir group to kbagent's GID (1000) and grant group write so that
+            # kbagent can write switchover trigger files. Files inside remain mysql-owned.
+            chgrp 1000 {{ .Values.dataMountPath }} && chmod g+w {{ .Values.dataMountPath }}
+            # alpha.86 v1 (Helen 2026-05-19) — re-apply runtime-overrides
+            # layer permissions AFTER the `chown -R mysql:mysql` above,
+            # which would otherwise reset the gid=1000 + g+rwx set by
+            # init-syncer. Idempotent canonical rewrite of the loader
+            # file recovers from accidental edits / corruption from
+            # prior generations (Jack 07:03 peer review B2 follow-up).
+            # mariadbd's --defaults-extra-file silently accepts an
+            # empty `runtime-overrides.d/` so this block is also safe
+            # on fresh bootstrap.
+            mkdir -p {{ .Values.dataMountPath }}/runtime-overrides.d
+            printf '!includedir %s/runtime-overrides.d/\n' '{{ .Values.dataMountPath }}' > {{ .Values.dataMountPath }}/runtime-overrides.cnf
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            # Signal to roleProbe that this pod is initializing — prevents spurious "primary"
+            # reports that would cause KubeBlocks to auto-trigger a switchover.
+            rm -f {{ .Values.dataMountPath }}/.replication-ready
+            touch {{ .Values.dataMountPath }}/.replication-pending
+
+            POD_INDEX="${POD_NAME##*-}"
+            SERVICE_ID=$((POD_INDEX + 1))
+            PRIMARY_HOST="${CLUSTER_NAME}-${COMPONENT_NAME}.${CLUSTER_NAMESPACE}.svc.cluster.local"
+            SOCK="/run/mysqld/mysqld.sock"
+            MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
+            # alpha.64 v1 (Jack 09:35 RED root cause + 10:01 v2 design ack):
+            # cmpd runtime sql-listener-fence GRANT statements MUST NOT introduce
+            # admin-bypass privileges (SUPER / READ_ONLY ADMIN / BINLOG ADMIN /
+            # CONNECTION ADMIN / REPLICATION SLAVE ADMIN / REPLICATION MASTER
+            # ADMIN / GRANT ALL PRIVILEGES) onto user-facing root, because those
+            # privileges bypass @@global.read_only=ON and let user-facing root
+            # write through fence intent. The previous wider grants leaked these
+            # privileges back to root@%/127.0.0.1/localhost between switchover-
+            # side fence and verifier read, producing the alpha.63 fresh-gatefix
+            # RED. The constants below are inlined non-bypass grant lists kept
+            # in sync with switchover.sh's SWITCHOVER_*_GRANT_BODY constants;
+            # ShellSpec strong-binds the alignment.
+            # alpha.81 v1: explicitly add SLAVE MONITOR to the grant bodies.
+            # Root cause: MariaDB 11.4 split legacy `REPLICATION CLIENT` into
+            # `BINLOG MONITOR` + `SLAVE MONITOR`. `GRANT REPLICATION CLIENT`
+            # only normalizes to `BINLOG MONITOR` in SHOW GRANTS — `SLAVE
+            # MONITOR` (required for `SHOW SLAVE STATUS`) is NOT included.
+            # Without `SLAVE MONITOR`, syncer engine's `IsSwitchoverDone()`
+            # in promotion_gate.go (which connects new primary -> old primary
+            # via `kb_internal_root@'%'` then issues `SHOW SLAVE STATUS`) gets
+            # ERROR 1227 ("need SLAVE MONITOR privilege"), returns false
+            # forever, the framework `HandlerSwitchoverForPrimary` cleanup
+            # gate never trips, and the DCS Switchover ConfigMap leaks. This
+            # broke same-cluster repeat switchover (the alpha.79 N=3 RED
+            # "there is another switchover unfinished" axis).
+            CMPD_EXPLICIT_PRIMARY_GRANT_BODY="SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, CREATE USER"
+            CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN"
+            # Best-effort monitor privileges (read-only). These never bypass
+            # read_only and are safe on user-facing root in any state. Tier A
+            # by Jack 10:05: failure here is allowed to log + continue.
+            #
+            # alpha.64 v3 (Jack 11:14 live-gate RED): the priv list contains
+            # MULTI-WORD tokens (BINLOG MONITOR / SLAVE MONITOR). This
+            # constant is documentation + ShellSpec strong-bind ONLY. DO NOT
+            # iterate via unquoted parameter expansion (`for x in
+            # ${CMPD_OPTIONAL_MONITOR_PRIVS}; do`) — POSIX `for` would split
+            # on IFS (whitespace) into 4 single-word tokens (BINLOG / MONITOR
+            # / SLAVE / MONITOR) and `GRANT BINLOG ON *.* ...` is invalid SQL,
+            # producing 1227 (insufficient priv: SLAVE MONITOR) on every
+            # `SHOW SLAVE STATUS` and breaking promote/demote. ALWAYS use the
+            # inline quoted list at callsites:
+            #   for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do ...; done
+            CMPD_OPTIONAL_MONITOR_PRIVS="BINLOG MONITOR SLAVE MONITOR"
+            # Fresh bootstrap keeps pod-0 as the deterministic first primary.
+            # Give its roleProbe/Endpoint publish path a bounded window before a
+            # later pod accepts a local syncer primary role.
+            SYNCER_PRIMARY_BOOTSTRAP_GRACE_SECONDS="${MARIADB_SYNCER_PRIMARY_BOOTSTRAP_GRACE_SECONDS:-45}"
+            SYNCER_PRIMARY_BOOTSTRAP_GRACE_UNTIL="$(($(date +%s) + SYNCER_PRIMARY_BOOTSTRAP_GRACE_SECONDS))"
+            # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_is_fresh`
+            # function + `SWITCHOVER_FENCE_MARKER_MAX_AGE_SECONDS` env are
+            # removed. alpha.79 v1 minimalist deleted the marker writer in
+            # switchover.sh, so this consumer-side function never observed a
+            # fresh marker; the consumer checks in `reconcile_sql_listener_for_
+            # syncer_primary_once` and `set_remote_root_account_state` always
+            # fell through. Pure dead-code cleanup, no runtime behavior change.
+            ROOT_LOCAL=(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
+            INTERNAL_LOCAL=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
+            LOCAL=("${ROOT_LOCAL[@]}")
+            if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              {
+                printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
+                printf 'decision=refuse-restart-after-prestop\n'
+                printf 'reason=prestop-fence-started marker exists in this container lifecycle\n'
+                printf '\n'
+              } >> {{ .Values.dataMountPath }}/log/startup-fence.log 2>/dev/null || true
+              rm -f {{ .Values.dataMountPath }}/.replication-ready
+              touch {{ .Values.dataMountPath }}/.replication-pending
+              echo "preStop fence marker exists; refusing to restart mariadbd in terminating pod"
+              while true; do
+                sleep 3600
+              done
+            fi
+            HAS_EXISTING_DATA=false
+            if [ -d "{{ .Values.dataMountPath }}/mysql" ] || \
+               ls {{ .Values.dataMountPath }}/binlog/*.bin* >/dev/null 2>&1; then
+              HAS_EXISTING_DATA=true
+            fi
+            read_only_value() {
+              "${LOCAL[@]}" -e "SELECT UPPER(CAST(@@global.read_only AS CHAR));" 2>/dev/null \
+                | tr -d '\r' \
+                | awk 'NF {print $1; exit}'
+            }
+            read_only_is_fail_closed() {
+              local value
+              value="$(read_only_value || true)"
+              case "${value}" in
+                1|ON|NO_LOCK|NO_LOCK_NO_ADMIN)
+                  return 0
+                  ;;
+              esac
+              return 1
+            }
+            set_fail_closed_read_only() {
+              local label="${1:-fail-closed}"
+              if "${LOCAL[@]}" -e "SET GLOBAL read_only = NO_LOCK_NO_ADMIN;" 2>/dev/null && read_only_is_fail_closed; then
+                echo "Set fail-closed read_only=NO_LOCK_NO_ADMIN (${label})"
+                return 0
+              fi
+              if "${LOCAL[@]}" -e "SET GLOBAL read_only = ON;" 2>/dev/null && read_only_is_fail_closed; then
+                echo "Set fail-closed read_only=ON (${label})"
+                return 0
+              fi
+              if "${LOCAL[@]}" -e "SET GLOBAL read_only = 1;" 2>/dev/null && read_only_is_fail_closed; then
+                echo "Set fail-closed read_only fallback=1 (${label})"
+                return 0
+              fi
+              echo "WARNING: read_only still OFF after fail-closed attempts (${label})"
+              echo "WARNING: failed to set fail-closed read_only (${label})"
+              return 1
+            }
+            set_replica_read_only() {
+              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required LOCK
+              # failures MUST propagate rc to caller. set_replica_read_only is
+              # called from publish_replica_after_rejoin_ready, runtime-secondary
+              # reconcile, and configure_replication_from_primary_service_once;
+              # any failure here means the replica's read_only/lock state is
+              # not what we promised, so the caller must NOT publish
+              # ready/role. set_fail_closed_read_only also already returns 1
+              # on its own failure mode.
+              rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
+              local rc=0
+              lock_remote_root_writes "replica-read-only" || rc=1
+              set_fail_closed_read_only "replica-read-only" || rc=1
+              lock_local_root_writes "replica-read-only" || rc=1
+              if [ "${rc}" -ne 0 ]; then
+                prestop_watchdog_log "set-replica-read-only label=replica-read-only rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+            }
+            primary_local_root_write_ready() {
+              # alpha.70 v1: replace shell SQL probe with syncerctl writecheck.
+              # alpha.71 v1: bounded retry around syncerctl writecheck so a
+              # syncer-internal startup race (dbManager not yet connected to
+              # mariadbd at chart bootstrap T+15s) self-recovers within budget.
+              #
+              # Before alpha.70, this function ran the kb_health_check INSERT
+              # through ROOT_LOCAL (the cluster's user-facing root). ROOT_LOCAL
+              # is intentionally locked to the read-replication-admin-only-no-
+              # bypass priv set (no BINLOG ADMIN). The probe started its first
+              # statement with `SET SESSION sql_log_bin=0;` which requires
+              # BINLOG ADMIN -> always failed with ERROR 1227 (42000), causing
+              # the chart watchdog to never write `.sql-listener-ready` and
+              # roleProbe to stay in `initializing` indefinitely. Evidence in
+              # alpha.69 v1 5.D-r2 RED: every line of
+              # /var/lib/mysql/log/sql-listener-fence.log was the same 1227.
+              #
+              # alpha.70 v1 replaced the shell SQL probe with `syncerctl
+              # writecheck`, which delegates the probe to syncer engine's
+              # Manager.WriteCheck (operations/replica/writecheck.go calling
+              # engines/mariadb/manager.go). The syncer holds its own DB
+              # connection (built from MARIADB_INTERNAL_ROOT credentials,
+              # which retain full bypass priv), so the probe succeeds without
+              # asking ROOT_LOCAL to do anything beyond its locked-down priv
+              # set. /tools/syncerctl is already installed by the init-syncer
+              # initContainer (see template line 92, also used by
+              # syncerctl_pause and syncerctl_getrole below).
+              #
+              # alpha.70 v1 5.D-r3 N=1 RED surfaced the next-layer race: the
+              # chart bootstrap calls this function ~15s after mariadbd start,
+              # but syncer's engine `dbManager.IsDBStartupReady()` (called by
+              # the WriteCheck.PreCheck path) returns false until syncer's own
+              # *sql.DB has connected to mariadbd and completed its startup
+              # readiness ping. A single attempt fails with
+              # `ERR_PRECHECK_FAILED: database is not ready` and the chart
+              # marks `sql-listener-primary-expose-failed` permanently.
+              # Direct evidence: pod-0
+              # /var/lib/mysql/log/sql-listener-fence.log was 116 bytes (one
+              # error), HA loop continued spinning 8+ minutes but chart
+              # bootstrap never re-invoked the function.
+              #
+              # alpha.71 v1 fix: bounded retry, max_attempts attempts with
+              # sleep_seconds between each. rc-only contract - syncerctl exit
+              # code is the only control-flow signal; stdout/stderr (including
+              # ERR_PRECHECK_FAILED text and any 503 / curl / JSON errors)
+              # are appended to sql-listener-fence.log for postmortem only,
+              # never parsed. Marker files (.replication-ready /
+              # .sql-listener-ready / .primary-read-write-ready) are NOT
+              # touched here; they remain caller-managed in set_primary_read_
+              # write() after ALL gates pass. Each attempt checks
+              # .prestop-fence-started first so termination interrupts the
+              # retry budget immediately; total budget is
+              # max_attempts * sleep_seconds = 30s, well under
+              # terminationGracePeriodSeconds=120.
+              local label="${1:-primary-local-root-write-ready}"
+              if [ ! -x /tools/syncerctl ]; then
+                prestop_watchdog_log "primary-local-root-write-ready label=${label} rc=1 reason=syncerctl-not-available"
+                return 1
+              fi
+              local max_attempts=30
+              local sleep_seconds=1
+              local attempt=1
+              while [ "${attempt}" -le "${max_attempts}" ]; do
+                if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+                  prestop_watchdog_log "primary-local-root-write-ready label=${label} rc=1 via=syncerctl-writecheck reason=prestop-fence-started attempt=${attempt}"
+                  return 1
+                fi
+                if /tools/syncerctl --host 127.0.0.1 --port 3601 writecheck \
+                  >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                  prestop_watchdog_log "primary-local-root-write-ready label=${label} rc=0 via=syncerctl-writecheck attempt=${attempt}"
+                  return 0
+                fi
+                prestop_watchdog_log "primary-local-root-write-ready label=${label} rc=1 via=syncerctl-writecheck attempt=${attempt}/${max_attempts}"
+                if [ "${attempt}" -lt "${max_attempts}" ]; then
+                  sleep "${sleep_seconds}"
+                fi
+                attempt=$((attempt + 1))
+              done
+              prestop_watchdog_log "primary-local-root-write-ready label=${label} rc=1 via=syncerctl-writecheck reason=budget-exhausted attempts=${max_attempts}"
+              return 1
+            }
+            primary_internal_root_write_ready() {
+              local label="${1:-primary-internal-root-write-ready}"
+              if "${INTERNAL_LOCAL[@]}" -e "
+                SET SESSION sql_log_bin=0;
+                CREATE DATABASE IF NOT EXISTS kubeblocks;
+                CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
+                INSERT INTO kubeblocks.kb_health_check(type, check_ts)
+                  VALUES (0, UNIX_TIMESTAMP())
+                  ON DUPLICATE KEY UPDATE check_ts=VALUES(check_ts);
+                DELETE FROM kubeblocks.kb_health_check WHERE type=0;
+                SET SESSION sql_log_bin=1;
+              " >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                prestop_watchdog_log "primary-internal-root-write-ready label=${label} rc=0"
+                return 0
+              fi
+              prestop_watchdog_log "primary-internal-root-write-ready label=${label} rc=1"
+              return 1
+            }
+            primary_write_gates_ready() {
+              local label="${1:-primary-write-gates-ready}"
+              primary_local_root_write_ready "${label}" || return 1
+              primary_internal_root_write_ready "${label}" || return 1
+            }
+            fail_primary_read_write_gate() {
+              local label="$1"
+              local reason="$2"
+              rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
+              # tier=fail-path-defensive: this is the failure handler for an
+              # already-failed primary write gate; defensive locking is
+              # best-effort observability. The caller has already concluded
+              # the gate failed and is not about to publish ready/role.
+              lock_remote_root_writes "${label}-${reason}" || true # tier=fail-path-defensive
+              set_fail_closed_read_only "${label}-${reason}" || true # tier=fail-path-defensive
+              lock_local_root_writes "${label}-${reason}" || true # tier=fail-path-defensive
+              prestop_watchdog_log "primary-read-write ${reason} rc=1"
+            }
+            set_primary_read_write() {
+              if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+                prestop_watchdog_log "skip-primary-read-write reason=prestop-fence-started"
+                mark_replication_pending
+                return 1
+              fi
+              if ! unlock_local_root_writes "primary-read-write"; then
+                rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
+                prestop_watchdog_log "primary-read-write local-root-unlock rc=1"
+                return 1
+              fi
+              if ! unlock_remote_root_writes "primary-read-write"; then
+                fail_primary_read_write_gate "primary-read-write" "remote-root-unlock"
+                return 1
+              fi
+              if "${LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
+                if ! primary_write_gates_ready "primary-read-write"; then
+                  fail_primary_read_write_gate "primary-read-write" "write-gate"
+                  return 1
+                fi
+                rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
+                touch {{ .Values.dataMountPath }}/.primary-read-write-ready
+                prestop_watchdog_log "primary-read-write rc=0"
+                return 0
+              fi
+              if "${LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
+                if ! primary_write_gates_ready "primary-read-write"; then
+                  fail_primary_read_write_gate "primary-read-write" "write-gate"
+                  return 1
+                fi
+                rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
+                touch {{ .Values.dataMountPath }}/.primary-read-write-ready
+                prestop_watchdog_log "primary-read-write rc=0"
+                return 0
+              fi
+              fail_primary_read_write_gate "primary-read-write" "read-only-open"
+              prestop_watchdog_log "primary-read-write rc=1"
+              return 1
+            }
+            mark_replication_pending() {
+              rm -f {{ .Values.dataMountPath }}/.replication-ready
+              rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
+              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
+              touch {{ .Values.dataMountPath }}/.replication-pending
+            }
+            mark_replication_ready() {
+              touch {{ .Values.dataMountPath }}/.replication-ready
+              touch {{ .Values.dataMountPath }}/.sql-listener-ready
+              rm -f {{ .Values.dataMountPath }}/.replication-pending {{ .Values.dataMountPath }}/.replication-divergence-pending
+            }
+            mark_replication_divergence_pending() {
+              mark_replication_pending
+              touch {{ .Values.dataMountPath }}/.replication-divergence-pending
+            }
+            gtid_state_is_covered_by() {
+              local local_state="$1"
+              local primary_state="$2"
+              local token ptoken domain server seq pdom pserver pseq found
+              [ -z "${local_state}" ] && return 0
+              IFS=',' read -r -a local_tokens <<< "${local_state}"
+              IFS=',' read -r -a primary_tokens <<< "${primary_state}"
+              for token in "${local_tokens[@]}"; do
+                token="${token//[[:space:]]/}"
+                [ -n "${token}" ] || continue
+                IFS='-' read -r domain server seq <<< "${token}"
+                [ -n "${domain}" ] && [ -n "${server}" ] && [ -n "${seq}" ] || return 1
+                found=false
+                for ptoken in "${primary_tokens[@]}"; do
+                  ptoken="${ptoken//[[:space:]]/}"
+                  [ -n "${ptoken}" ] || continue
+                  IFS='-' read -r pdom pserver pseq <<< "${ptoken}"
+                  if [ "${pdom}" = "${domain}" ] && [ "${pserver}" = "${server}" ]; then
+                    if [ "${pseq}" -ge "${seq}" ] 2>/dev/null; then
+                      found=true
+                      break
+                    fi
+                    return 1
+                  fi
+                done
+                [ "${found}" = "true" ] || return 1
+              done
+              return 0
+            }
+            persist_gtid_divergence_evidence() {
+              local branch="$1" local_state="$2" primary_state="$3" slave_status="$4"
+              local evidence_file="{{ .Values.dataMountPath }}/log/replication-divergence.log"
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              {
+                printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                printf 'branch=%s\n' "${branch}"
+                printf 'decision=divergence-pending\n'
+                printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
+                printf 'primary_host=%s\n' "${PRIMARY_HOST:-unknown}"
+                printf 'service_id=%s\n' "${SERVICE_ID:-unknown}"
+                printf 'has_existing_data=%s\n' "${HAS_EXISTING_DATA:-unknown}"
+                printf 'local_gtid_binlog_state=%s\n' "${local_state:-<empty>}"
+                printf 'primary_gtid_binlog_state=%s\n' "${primary_state:-<empty>}"
+                printf 'slave_status_begin\n'
+                if [ -n "${slave_status}" ]; then
+                  printf '%s\n' "${slave_status}"
+                else
+                  printf '<empty>\n'
+                fi
+                printf 'slave_status_end\n'
+                printf '\n'
+              } >> "${evidence_file}" 2>/dev/null || true
+            }
+            block_existing_datadir_self_election_without_primary() {
+              # tier=fail-path-defensive: this branch is reached only when
+              # primary is unreachable and existing datadir cannot self-elect;
+              # the function deliberately does NOT publish ready/role and
+              # returns 0 to make the caller exit. Defensive locking is
+              # best-effort observability (Tier A class).
+              local local_state slave_status evidence_file
+              [ "${HAS_EXISTING_DATA}" = "true" ] || return 1
+              local_state=$("${LOCAL[@]}" -e "SELECT @@global.gtid_binlog_state;" 2>/dev/null || echo "")
+              slave_status=$("${LOCAL[@]}" -e "SHOW SLAVE STATUS;" 2>/dev/null || true)
+              "${LOCAL[@]}" -e "STOP SLAVE;" 2>/dev/null || true
+              lock_remote_root_writes "no-primary-existing-datadir" || true # tier=fail-path-defensive
+              set_fail_closed_read_only "no-primary-existing-datadir" || true # tier=fail-path-defensive
+              mark_replication_pending
+              lock_local_root_writes "no-primary-existing-datadir" || true # tier=fail-path-defensive
+              evidence_file="{{ .Values.dataMountPath }}/log/replication-no-primary-pending.log"
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              {
+                printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                printf 'decision=no-primary-pending\n'
+                printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
+                printf 'service_id=%s\n' "${SERVICE_ID:-unknown}"
+                printf 'has_existing_data=%s\n' "${HAS_EXISTING_DATA:-unknown}"
+                printf 'local_gtid_binlog_state=%s\n' "${local_state:-<empty>}"
+                printf 'slave_status_begin\n'
+                if [ -n "${slave_status}" ]; then
+                  printf '%s\n' "${slave_status}"
+                else
+                  printf '<empty>\n'
+                fi
+                printf 'slave_status_end\n'
+                printf '\n'
+              } >> "${evidence_file}" 2>/dev/null || true
+              echo "Existing datadir with stale slave config but no primary found. Keeping read_only and replication pending instead of self-electing."
+              return 0
+            }
+            fail_closed_for_gtid_divergence() {
+              local primary_state local_state slave_status
+              [ "${HAS_EXISTING_DATA}" = "true" ] || return 1
+              local_state=$("${LOCAL[@]}" -e "SELECT @@global.gtid_binlog_state;" 2>/dev/null)
+              [ -n "${local_state}" ] || return 1
+              primary_state=$(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@global.gtid_binlog_state;" 2>/dev/null || echo "")
+              [ -n "${primary_state}" ] || return 1
+              if gtid_state_is_covered_by "${local_state}" "${primary_state}"; then
+                return 1
+              fi
+              slave_status=$("${LOCAL[@]}" -e "SHOW SLAVE STATUS;" 2>/dev/null || true)
+              "${LOCAL[@]}" -e "STOP SLAVE;" 2>/dev/null || true
+              # tier=fail-path-defensive: divergence has already been detected;
+              # function returns 0 only after marking pending and never publishes
+              # ready/role. Defensive locks are best-effort observability.
+              lock_remote_root_writes "gtid-divergence" || true # tier=fail-path-defensive
+              set_fail_closed_read_only "gtid-divergence" || true # tier=fail-path-defensive
+              mark_replication_divergence_pending
+              lock_local_root_writes "gtid-divergence" || true # tier=fail-path-defensive
+              persist_gtid_divergence_evidence "fail_closed_for_gtid_divergence" "${local_state}" "${primary_state}" "${slave_status}"
+              echo "GTID divergence detected for existing datadir rejoin: local binlog state ${local_state}, primary binlog state ${primary_state}. Keeping replication pending for rebuild/resync."
+              return 0
+            }
+            prestop_watchdog_log() {
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              printf '%s prestop-watchdog %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" \
+                >> {{ .Values.dataMountPath }}/log/prestop-watchdog.log 2>/dev/null || true
+            }
+            sql_quote() {
+              printf "%s" "$1" | sed "s/'/''/g"
+            }
+            grant_internal_admin_runtime_privileges() {
+              local label="${1:-internal-local-admin-runtime-privileges}"
+              local user host privilege sql
+              user="$(sql_quote "${MARIADB_INTERNAL_ROOT_USER}")"
+              for host in localhost 127.0.0.1; do
+                for privilege in "REPLICATION SLAVE ADMIN" "REPLICATION MASTER ADMIN" "BINLOG ADMIN" "BINLOG MONITOR" "SLAVE MONITOR" "CONNECTION ADMIN" "READ_ONLY ADMIN"; do
+                  sql="
+                    SET SESSION sql_log_bin=0;
+                    GRANT ${privilege} ON *.* TO '${user}'@'${host}';
+                    FLUSH PRIVILEGES;
+                    SET SESSION sql_log_bin=1;
+                  "
+                  if "${ROOT_LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                    prestop_watchdog_log "internal-local-admin-runtime-privilege privilege=${privilege} label=${label} host=${host} via=root rc=0"
+                    continue
+                  fi
+                  if "${INTERNAL_LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                    prestop_watchdog_log "internal-local-admin-runtime-privilege privilege=${privilege} label=${label} host=${host} via=internal rc=0"
+                    continue
+                  fi
+                  prestop_watchdog_log "internal-local-admin-runtime-privilege privilege=${privilege} label=${label} host=${host} rc=1"
+                done
+              done
+            }
+            ensure_internal_local_admin() {
+              # alpha.66 v1 (Jack 12:18 alpha.65 v2 install/script live-gate
+              # RED + Jack 12:34 alpha.66 v1 design HOLD + Jack 12:39 design
+              # ACCEPT with 3 tightening): the existing local @localhost +
+              # @127.0.0.1 paths preserve full admin-priv kb_internal_root
+              # for syncer's local AdminDB connection (127.0.0.1:3306 match
+              # priority falls on @127.0.0.1 first because it is the most
+              # specific host). The new @'%' record below is detection-only:
+              # it is required so syncer's `IsAdminCreated()` (which queries
+              # `mysql.user WHERE host='%' AND user LIKE 'kb%'`) can detect
+              # the admin user and trigger `mgr.DB = mgr.AdminDB` in
+              # IsRunning(). The @'%' record carries `ACCOUNT LOCK` AND zero
+              # privileges, so it cannot be used for any remote auth (LOCK
+              # rejects auth) and cannot run any SQL even if LOCK is somehow
+              # bypassed (no GRANT). This preserves the alpha.64 v1 fence
+              # spirit: user-facing root has no admin bypass; internal admin
+              # remains effectively local-only at runtime.
+              #
+              # alpha.67 v1 (Jack 12:56 alpha.66 v1 package-level review HOLD):
+              # the @'%' "zero privileges" contract was only declarative in
+              # alpha.66 v1 — `CREATE USER IF NOT EXISTS` does NOT clear an
+              # existing account's privileges, and `ACCOUNT LOCK` does not
+              # revoke. If `kb_internal_root@'%'` happens to pre-exist (e.g.
+              # from a misconfigured prior install or upgrade) with grants,
+              # alpha.66 v1 would lock the account but leave the privileges
+              # intact, violating the security contract. alpha.67 v1 inserts
+              # an explicit `REVOKE ALL PRIVILEGES, GRANT OPTION FROM` step
+              # between `CREATE USER ... @'%'` and `ALTER USER ... @'%'
+              # ACCOUNT LOCK` so the zero-privilege state is enforced at the
+              # write site, not just declared. This pattern matches the
+              # alpha.64 v1 LOCK paths (set_local/remote_root_account_state
+              # LOCK and lock_local_root_for_prestop) which already use the
+              # same REVOKE statement before re-applying the non-bypass grant
+              # body.
+              #
+              # alpha.68 v2 (Jack 15:39 alpha.67 v1 live-gate RED + 15:45
+              # alpha.68 v1 design HOLD + 15:58 alpha.68 v2 Direction B
+              # ACCEPT with refined checkpoint #3): the alpha.67 v1
+              # detection-only LOCKED+zero-priv `@'%'` design was correct
+              # for the IsAdminCreated host='%' detection requirement but
+              # broke cross-member syncer auth. syncer's `GetMemberConnection`
+              # uses `config.GetDBConnWithAddr(addr)` with `AdminUsername`
+              # (= kb_internal_root via MYSQL_ADMIN_USER) for cross-pod TCP,
+              # which authenticates via the @'%' record. LOCKED → 4151
+              # Access denied; secondary cannot poll leader health; cluster
+              # stays in RoleProbeNotDone forever (1064 errors / 30s in
+              # bounded gate).
+              #
+              # SQL matrix audit (Helen 15:53 + Jack 15:58 design ACCEPT)
+              # established the cross-member exact grant requirement:
+              #   - IsReadonly (slave.go): SELECT @@global.* — USAGE
+              #   - IsMemberLagging / ReadCheck (manager.go) — SELECT on
+              #     kubeblocks.kb_health_check
+              #   - IsMemberHealthy leader-only WriteCheck — INSERT/UPDATE on
+              #     kubeblocks.kb_health_check (CREATE fallback handled by
+              #     primary_local_root_write_ready local bootstrap; cross-
+              #     pod path does not need CREATE because leader has pre-
+              #     created table during local primary bootstrap before role
+              #     publish)
+              #   - setSemiSyncSourceTimeout (semi_sync.go), Follow secondary
+              #     -> leader path — REPLICATION MASTER ADMIN required
+              #     because `SET GLOBAL rpl_semi_sync_master_timeout = N`
+              #     is an admin-bypass write on the target leader's mariadbd
+              #
+              # alpha.68 v2 grant contract (exact allowlist):
+              #   * REPLICATION CLIENT ON *.* (SHOW SLAVE/MASTER STATUS)
+              #   * REPLICATION MASTER ADMIN ON *.* (SET GLOBAL
+              #     rpl_semi_sync_master_timeout)
+              #   * SELECT, INSERT, UPDATE ON kubeblocks.kb_health_check
+              #     (ReadCheck + WriteCheck)
+              #
+              # Refined checkpoint #3 (Jack 15:58): no NEW net capability,
+              # no read_only-bypass class. `REPLICATION MASTER ADMIN` is
+              # already in alpha.64 v1 `CMPD_EXPLICIT_PRIMARY_GRANT_BODY`
+              # which user-facing `root@'%'` carries; root and
+              # `kb_internal_root` share `MARIADB_ROOT_PASSWORD`, so an
+              # attacker with the password and remote access already has
+              # this capability via root@'%'. Net attack-surface delta = 0
+              # for `REPLICATION MASTER ADMIN`.
+              #
+              # Still forbidden on `kb_internal_root@'%'`: ALL PRIVILEGES /
+              # SUPER / READ_ONLY ADMIN / CONNECTION ADMIN / BINLOG ADMIN /
+              # REPLICATION SLAVE ADMIN / DELETE / DROP / CREATE USER /
+              # schema-wide DML / CREATE on kubeblocks.* (table is pre-
+              # created by primary_local_root_write_ready).
+              #
+              # alpha.69 v1 (Jack 17:57 alpha.68 v2 install/script live-gate
+              # RED 3-evidence-chains closeout + 18:20 alpha.69 v1 design
+              # ACCEPT with runtime-acceptance tightening): the alpha.68 v2
+              # @'%' grant contract above was correct, but
+              # ensure_internal_local_admin had a bootstrap precondition
+              # gap. alpha.68 v2's `GRANT SELECT, INSERT, UPDATE ON
+              # kubeblocks.kb_health_check TO 'kb_internal_root'@'%'`
+              # assumed the table existed, but the function is called
+              # from `wait_for_internal_local_admin
+              # "startup-before-role-decision"` which runs BEFORE the
+              # role-decision branches that invoke
+              # primary_local_root_write_ready (the function that creates
+              # `kubeblocks.kb_health_check`). On a fresh boot the table
+              # therefore does not exist when the @'%' GRANT runs, the
+              # GRANT fails with Error 1146, ensure_internal_local_admin
+              # returns rc=1, wait_for_internal_local_admin loops forever,
+              # role decision never reaches expose_sql_listener_for_*_role,
+              # mariadbd stays bound to 127.0.0.1, and cross-pod TCP
+              # connections see Error 2002.
+              #
+              # alpha.69 v1 changes:
+              #   - Add CREATE DATABASE IF NOT EXISTS kubeblocks BEFORE the
+              #     @'%' grant block (idempotent; ROOT_LOCAL via socket has
+              #     GRANT ALL PRIVILEGES locally so can CREATE).
+              #   - Add CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check
+              #     same area (idempotent). primary_local_root_write_ready
+              #     and primary_internal_root_write_ready still run later
+              #     post-role-decision — both are idempotent on the table.
+              #   - Add GRANT SELECT ON mysql.user TO 'kb_internal_root'@'%'
+              #     AFTER the existing three @'%' grants. syncer's connection
+              #     URL (engines/mysql/config.go line 71) includes `/mysql`
+              #     as the default database, so go-sql-driver issues
+              #     `init_db = mysql` during the handshake. alpha.68 v2
+              #     grants on @'%' are global (REPLICATION CLIENT +
+              #     REPLICATION MASTER ADMIN ON *.*) + table-specific on
+              #     kubeblocks.kb_health_check; the cross-pod init_db
+              #     handshake fails with Error 1044 because the @'%'
+              #     account has no privilege on the `mysql` schema. SELECT
+              #     ON mysql.user is the narrow table-specific privilege
+              #     that satisfies the init_db check.
+              #
+              # Net attack-surface delta = 0 for SELECT ON mysql.user vs
+              # root@'%' (alpha.64 v1 CMPD_EXPLICIT_PRIMARY_GRANT_BODY
+              # grants `SELECT ON *.*` to root@'%'; root and
+              # kb_internal_root share MARIADB_ROOT_PASSWORD).
+              #
+              # MariaDB 11.4 SHOW GRANTS normalization (Jack 18:20
+              # tightening): `GRANT REPLICATION CLIENT ON *.*` is the
+              # backward-compatible source syntax; SHOW GRANTS displays
+              # the normalized form `BINLOG MONITOR ON *.*` (MariaDB 11.4
+              # split REPLICATION CLIENT into BINLOG MONITOR + SLAVE
+              # MONITOR). `BINLOG MONITOR` in SHOW GRANTS output is the
+              # **positive** normalized form of our `REPLICATION CLIENT`
+              # grant and is allowed; runtime grant verification uses
+              # semantic-equivalent matching. This is DIFFERENT from
+              # `BINLOG ADMIN`, which remains in the **forbidden** admin-
+              # bypass list and must NOT appear on `kb_internal_root@'%'`.
+              # Source-side ShellSpec checks the literal source SQL
+              # (`GRANT REPLICATION CLIENT`); runtime live-gate acceptance
+              # uses the normalized form (`BINLOG MONITOR`). These two
+              # are different write-side vs read-side口径; ShellSpec
+              # literal-match logic must not be reused to validate runtime
+              # SHOW GRANTS output (Jack 18:24 reminder).
+              #
+              # alpha.70+ mandatory blocking debt (was alpha.69 in earlier
+              # planning, renamed because chart-only alpha.69 ships
+              # alongside as bounded short-term unblock): syncer source
+              # change so cross-member `GetDBConnWithAddr` uses a dedicated
+              # lower-priv credential AND removes `/mysql` from the
+              # connection DSN (or syncer-side mechanism replaces direct
+              # cross-pod admin SQL such as setSemiSyncSourceTimeout).
+              # alpha.70+ goal state restores `kb_internal_root@'%'` to
+              # alpha.67 v1 LOCKED + zero-priv (clean security boundary).
+              # alpha.69 v1 is bounded short-term unblock, NOT a final
+              # design.
+              local label="${1:-internal-local-admin}"
+              local user password sql replication_user
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              user="$(sql_quote "${MARIADB_INTERNAL_ROOT_USER}")"
+              password="$(sql_quote "${MARIADB_ROOT_PASSWORD}")"
+              # alpha.72 v1 (Jack XP review HOLD blocker #2/#8 — `5a7c68e5`):
+              # use shell var for replication user so env / SQL / member-join
+              # / inline CHANGE MASTER 全部 reference the same value (no env
+              # absent → empty MASTER_USER risk). Default to "kb_replicator"
+              # if MARIADB_REPL_USER env missing.
+              replication_user="$(sql_quote "${MARIADB_REPL_USER:-kb_replicator}")"
+              # alpha.72 v1 wording per Jack #3: MariaDB DDL/GRANT statements
+              # are NOT atomic; if a single statement fails mid-block the
+              # already-applied statements remain. The SET sql_log_bin=0
+              # bracketing only prevents binlog propagation. We rely on
+              # idempotent convergence (CREATE IF NOT EXISTS + ALTER UNLOCK +
+              # REVOKE ALL + GRANT specific) so subsequent retries can finish
+              # any partial state.
+              sql="
+                SET SESSION sql_log_bin=0;
+                CREATE USER IF NOT EXISTS '${user}'@'localhost' IDENTIFIED BY '${password}';
+                ALTER USER '${user}'@'localhost' IDENTIFIED BY '${password}';
+                ALTER USER '${user}'@'localhost' ACCOUNT UNLOCK;
+                GRANT ALL PRIVILEGES ON *.* TO '${user}'@'localhost' WITH GRANT OPTION;
+                CREATE USER IF NOT EXISTS '${user}'@'127.0.0.1' IDENTIFIED BY '${password}';
+                ALTER USER '${user}'@'127.0.0.1' IDENTIFIED BY '${password}';
+                ALTER USER '${user}'@'127.0.0.1' ACCOUNT UNLOCK;
+                GRANT ALL PRIVILEGES ON *.* TO '${user}'@'127.0.0.1' WITH GRANT OPTION;
+                CREATE DATABASE IF NOT EXISTS kubeblocks;
+                CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
+                CREATE TABLE IF NOT EXISTS kubeblocks.kb_post_dcs_fence_probe(probe_id VARCHAR(64) PRIMARY KEY, ts BIGINT);
+                CREATE USER IF NOT EXISTS '${user}'@'%' IDENTIFIED BY '${password}';
+                ALTER USER '${user}'@'%' ACCOUNT UNLOCK;
+                REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'%';
+                GRANT REPLICATION CLIENT ON *.* TO '${user}'@'%';
+                GRANT SLAVE MONITOR ON *.* TO '${user}'@'%';
+                GRANT REPLICATION MASTER ADMIN ON *.* TO '${user}'@'%';
+                GRANT SELECT, INSERT, UPDATE ON kubeblocks.kb_health_check TO '${user}'@'%';
+                GRANT SELECT ON mysql.user TO '${user}'@'%';
+                CREATE USER IF NOT EXISTS '${replication_user}'@'%' IDENTIFIED BY '${password}';
+                ALTER USER '${replication_user}'@'%' IDENTIFIED BY '${password}';
+                ALTER USER '${replication_user}'@'%' ACCOUNT UNLOCK;
+                REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${replication_user}'@'%';
+                GRANT REPLICATION SLAVE ON *.* TO '${replication_user}'@'%';
+                FLUSH PRIVILEGES;
+                SET SESSION sql_log_bin=1;
+              "
+              if "${ROOT_LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                grant_internal_admin_runtime_privileges "${label}"
+                prestop_watchdog_log "internal-local-admin label=${label} via=root rc=0"
+                return 0
+              fi
+              if "${INTERNAL_LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                grant_internal_admin_runtime_privileges "${label}"
+                prestop_watchdog_log "internal-local-admin label=${label} via=internal rc=0"
+                return 0
+              fi
+              prestop_watchdog_log "internal-local-admin label=${label} rc=1"
+              return 1
+            }
+            probe_internal_local_admin() {
+              if "${INTERNAL_LOCAL[@]}" -e "SELECT 1;" >/dev/null 2>&1; then
+                return 0
+              fi
+              prestop_watchdog_log "internal-local-admin-probe rc=1"
+              return 1
+            }
+            internal_local_admin_has_required_privileges() {
+              local semisync_master_value semisync_slave_value read_only_value
+              semisync_master_value=$("${INTERNAL_LOCAL[@]}" -e "SELECT @@global.rpl_semi_sync_master_enabled;" 2>/dev/null | tr -d '\r' | awk 'NF {print $1; exit}')
+              case "${semisync_master_value}" in
+                ON|on)
+                  semisync_master_value=1
+                  ;;
+                OFF|off)
+                  semisync_master_value=0
+                  ;;
+                0|1)
+                  ;;
+                *)
+                  prestop_watchdog_log "internal-local-admin-required-privilege privilege=REPLICATION_MASTER_ADMIN probe=read-semisync-value rc=1 value=${semisync_master_value:-<empty>}"
+                  return 1
+                  ;;
+              esac
+              if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=${semisync_master_value};" >/dev/null 2>&1; then
+                prestop_watchdog_log "internal-local-admin-required-privilege privilege=REPLICATION_MASTER_ADMIN probe=set-semisync-same-value rc=0"
+              else
+                prestop_watchdog_log "internal-local-admin-required-privilege privilege=REPLICATION_MASTER_ADMIN probe=set-semisync-same-value rc=1"
+                return 1
+              fi
+              semisync_slave_value=$("${INTERNAL_LOCAL[@]}" -e "SELECT @@global.rpl_semi_sync_slave_enabled;" 2>/dev/null | tr -d '\r' | awk 'NF {print $1; exit}')
+              case "${semisync_slave_value}" in
+                ON|on)
+                  semisync_slave_value=1
+                  ;;
+                OFF|off)
+                  semisync_slave_value=0
+                  ;;
+                0|1)
+                  ;;
+                *)
+                  prestop_watchdog_log "internal-local-admin-required-privilege privilege=REPLICATION_SLAVE_ADMIN probe=read-semisync-value rc=1 value=${semisync_slave_value:-<empty>}"
+                  return 1
+                  ;;
+              esac
+              if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_slave_enabled=${semisync_slave_value};" >/dev/null 2>&1; then
+                prestop_watchdog_log "internal-local-admin-required-privilege privilege=REPLICATION_SLAVE_ADMIN probe=set-semisync-same-value rc=0"
+              else
+                prestop_watchdog_log "internal-local-admin-required-privilege privilege=REPLICATION_SLAVE_ADMIN probe=set-semisync-same-value rc=1"
+                return 1
+              fi
+              read_only_value=$("${INTERNAL_LOCAL[@]}" -e "SELECT UPPER(CAST(@@global.read_only AS CHAR));" 2>/dev/null | tr -d '\r' | awk 'NF {print $1; exit}')
+              case "${read_only_value}" in
+                0|1|ON|OFF|NO_LOCK|NO_LOCK_NO_ADMIN)
+                  ;;
+                *)
+                  prestop_watchdog_log "internal-local-admin-required-privilege privilege=READ_ONLY_ADMIN probe=read-read-only-value rc=1 value=${read_only_value:-<empty>}"
+                  return 1
+                  ;;
+              esac
+              if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = ${read_only_value};" >/dev/null 2>&1; then
+                prestop_watchdog_log "internal-local-admin-required-privilege privilege=READ_ONLY_ADMIN probe=set-read-only-same-value rc=0"
+                return 0
+              fi
+              prestop_watchdog_log "internal-local-admin-required-privilege privilege=READ_ONLY_ADMIN probe=set-read-only-same-value rc=1"
+              return 1
+            }
+            wait_for_internal_local_admin() {
+              local label="${1:-internal-local-admin-ready}"
+              local sleep_seconds="${2:-2}"
+              local log_every_seconds="${3:-30}"
+              local start now elapsed next_log
+              start="$(date +%s)"
+              next_log=0
+              while true; do
+                if ensure_internal_local_admin "${label}" && probe_internal_local_admin && internal_local_admin_has_required_privileges; then
+                  LOCAL=("${INTERNAL_LOCAL[@]}")
+                  now="$(date +%s)"
+                  elapsed=$((now - start))
+                  prestop_watchdog_log "internal-local-admin-ready label=${label} elapsed=${elapsed}s"
+                  return 0
+                fi
+                LOCAL=("${ROOT_LOCAL[@]}")
+                mark_replication_pending
+                now="$(date +%s)"
+                elapsed=$((now - start))
+                if [ "${elapsed}" -ge "${next_log}" ]; then
+                  set_fail_closed_read_only "${label}-wait-internal-admin" || true
+                  prestop_watchdog_log "internal-local-admin-wait label=${label} elapsed=${elapsed}s"
+                  next_log=$((elapsed + log_every_seconds))
+                fi
+                sleep "${sleep_seconds}"
+              done
+            }
+            grant_optional_local_root_privileges() {
+              # alpha.64 v1 (Jack 09:35 RED + 10:01 design ack): drop admin
+              # bypass privs (READ_ONLY ADMIN / BINLOG ADMIN / CONNECTION ADMIN /
+              # REPLICATION SLAVE ADMIN / REPLICATION MASTER ADMIN). Only
+              # CMPD_OPTIONAL_MONITOR_PRIVS (BINLOG MONITOR / SLAVE MONITOR)
+              # remain — these are read-only monitoring privileges and do NOT
+              # bypass @@global.read_only. Tier A (Jack 10:05): failure on a
+              # MONITOR grant is allowed to log + continue (best-effort).
+              #
+              # alpha.64 v3 (Jack 11:14 live-gate RED): use inline QUOTED list
+              # to preserve multi-word priv name semantics. Unquoted
+              # `for privilege in ${CMPD_OPTIONAL_MONITOR_PRIVS}` would split
+              # the string on IFS into 4 single-word tokens (BINLOG / MONITOR
+              # / SLAVE / MONITOR) and emit invalid GRANT statements. See
+              # constant-declaration block above for full root cause.
+              local user="$1"
+              local host="$2"
+              local label="$3"
+              local privilege
+              for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do
+                if "${LOCAL[@]}" -e "
+                  SET SESSION sql_log_bin=0;
+                  GRANT ${privilege} ON *.* TO '${user}'@'${host}';
+                  FLUSH PRIVILEGES;
+                  SET SESSION sql_log_bin=1;
+                " >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                  prestop_watchdog_log "local-root-optional-privilege privilege=${privilege} label=${label} host=${host} rc=0 tier=monitor-best-effort"
+                else
+                  # Tier A: best-effort MONITOR grant; log 1227_swallowed for
+                  # observability and continue (do NOT propagate failure to
+                  # caller since these are monitoring-only and don't gate
+                  # primary-write/secondary-fence semantics).
+                  prestop_watchdog_log "local-root-optional-privilege privilege=${privilege} label=${label} host=${host} rc=1 tier=monitor-best-effort 1227_swallowed=true"
+                fi
+              done
+            }
+            set_local_root_account_state() {
+              local state="$1"
+              local label="$2"
+              local user password host mode sql
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              user="$(sql_quote "${MARIADB_ROOT_USER}")"
+              password="$(sql_quote "${MARIADB_ROOT_PASSWORD}")"
+              for host in localhost 127.0.0.1; do
+                if [ "${state}" = "LOCK" ]; then
+                  # alpha.64 v1 (Jack 09:35 RED): drop SUPER (admin bypass).
+                  # Use CMPD_SECONDARY_FENCE_GRANT_BODY which excludes SUPER /
+                  # READ_ONLY ADMIN / BINLOG ADMIN / CONNECTION ADMIN. SUPER
+                  # bypassed @@global.read_only=ON, defeating the very fence
+                  # this LOCK path was supposed to enforce.
+                  mode="read-replication-admin-only-no-bypass"
+                  sql="
+                    SET SESSION sql_log_bin=0;
+                    CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
+                    ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
+                    ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
+                    REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
+                    GRANT ${CMPD_SECONDARY_FENCE_GRANT_BODY} ON *.* TO '${user}'@'${host}';
+                    FLUSH PRIVILEGES;
+                    SET SESSION sql_log_bin=1;
+                  "
+                else
+                  # alpha.64 v1: replace GRANT ALL PRIVILEGES with explicit
+                  # primary grant body (CMPD_EXPLICIT_PRIMARY_GRANT_BODY)
+                  # aligned with switchover.sh's SWITCHOVER_EXPLICIT_PRIMARY_GRANT_BODY.
+                  # GRANT ALL PRIVILEGES bundled SUPER/READ_ONLY ADMIN/BINLOG
+                  # ADMIN which let user-facing root bypass read_only.
+                  mode="primary-write-no-bypass"
+                  sql="
+                    SET SESSION sql_log_bin=0;
+                    CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
+                    ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
+                    ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
+                    REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
+                    GRANT ${CMPD_EXPLICIT_PRIMARY_GRANT_BODY} ON *.* TO '${user}'@'${host}' WITH GRANT OPTION;
+                    FLUSH PRIVILEGES;
+                    SET SESSION sql_log_bin=1;
+                  "
+                fi
+                if "${LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                  if [ "${state}" = "LOCK" ]; then
+                    rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
+                  fi
+                  prestop_watchdog_log "local-root-account-${state} mode=${mode} label=${label} host=${host} rc=0 tier=required"
+                  grant_optional_local_root_privileges "${user}" "${host}" "${label}"
+                  continue
+                fi
+                # Tier B (Jack 10:05): account-state grant is required; failure
+                # MUST fail-closed. Caller (set_primary_read_write etc.) checks
+                # this rc and does NOT publish ready/role on rc!=0.
+                prestop_watchdog_log "local-root-account-${state} mode=${mode} label=${label} host=${host} rc=1 tier=required 1227_swallowed=true fail_closed=true"
+                return 1
+              done
+            }
+            set_remote_root_account_state() {
+              local state="$1"
+              local label="$2"
+              local user host password mode sql
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              user="$(sql_quote "${MARIADB_ROOT_USER}")"
+              host="$(sql_quote "${MARIADB_ROOT_HOST:-%}")"
+              password="$(sql_quote "${MARIADB_ROOT_PASSWORD}")"
+              case "${MARIADB_ROOT_HOST:-%}" in
+                localhost|127.0.0.1|::1)
+                  prestop_watchdog_log "remote-root-account-${state} label=${label} host=${host} rc=0 decision=skip-local-host"
+                  return 0
+                  ;;
+              esac
+              # alpha.80 v1 (Helen): the alpha.77 in-function marker check
+              # has been removed. alpha.79 v1 minimalist deleted the marker
+              # writer in switchover.sh, so this gate could never trip. Pure
+              # dead-code cleanup, no runtime behavior change.
+              if [ "${state}" = "LOCK" ]; then
+                # alpha.64 v1 (Jack 09:35 RED): drop SUPER (admin bypass).
+                # Use CMPD_SECONDARY_FENCE_GRANT_BODY shared with local LOCK.
+                mode="read-replication-only-no-bypass"
+                sql="
+                  SET SESSION sql_log_bin=0;
+                  CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
+                  ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
+                  ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
+                  REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
+                  GRANT ${CMPD_SECONDARY_FENCE_GRANT_BODY} ON *.* TO '${user}'@'${host}';
+                  FLUSH PRIVILEGES;
+                  SET SESSION sql_log_bin=1;
+                "
+              else
+                # alpha.64 v1: replace GRANT ALL PRIVILEGES with explicit
+                # CMPD_EXPLICIT_PRIMARY_GRANT_BODY.
+                mode="primary-write-no-bypass"
+                sql="
+                  SET SESSION sql_log_bin=0;
+                  CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
+                  ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
+                  ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
+                  REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
+                  GRANT ${CMPD_EXPLICIT_PRIMARY_GRANT_BODY} ON *.* TO '${user}'@'${host}' WITH GRANT OPTION;
+                  FLUSH PRIVILEGES;
+                  SET SESSION sql_log_bin=1;
+                "
+              fi
+              if "${LOCAL[@]}" -e "${sql}" \
+                >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                prestop_watchdog_log "remote-root-account-${state} mode=${mode} label=${label} host=${host} rc=0 tier=required"
+                return 0
+              fi
+              # Tier B (Jack 10:05): remote root account-state grant required;
+              # failure MUST fail-closed; caller does NOT publish ready/role.
+              prestop_watchdog_log "remote-root-account-${state} mode=${mode} label=${label} host=${host} rc=1 tier=required 1227_swallowed=true fail_closed=true"
+              return 1
+            }
+            grant_optional_remote_root_privileges() {
+              local label="${1:-remote-root-optional-privileges}"
+              local user host privilege
+              case "${MARIADB_ROOT_HOST:-%}" in
+                localhost|127.0.0.1|::1)
+                  return 0
+                  ;;
+              esac
+              user="$(sql_quote "${MARIADB_ROOT_USER}")"
+              host="$(sql_quote "${MARIADB_ROOT_HOST:-%}")"
+              # alpha.64 v1 (Jack 09:35 RED + 10:01 design ack): drop admin
+              # bypass privs (BINLOG ADMIN / READ_ONLY ADMIN / CONNECTION ADMIN).
+              # Only CMPD_OPTIONAL_MONITOR_PRIVS (BINLOG MONITOR / SLAVE MONITOR)
+              # remain — read-only monitoring privs that don't bypass read_only.
+              # Tier A (Jack 10:05): MONITOR grant failure log + continue.
+              #
+              # alpha.64 v3 (Jack 11:14 live-gate RED): inline QUOTED list to
+              # preserve multi-word priv name semantics; see constant block.
+              for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do
+                if "${LOCAL[@]}" -e "
+                  SET SESSION sql_log_bin=0;
+                  GRANT ${privilege} ON *.* TO '${user}'@'${host}';
+                  FLUSH PRIVILEGES;
+                  SET SESSION sql_log_bin=1;
+                " >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                  prestop_watchdog_log "remote-root-optional-privilege privilege=${privilege} label=${label} host=${host} rc=0 tier=monitor-best-effort"
+                else
+                  prestop_watchdog_log "remote-root-optional-privilege privilege=${privilege} label=${label} host=${host} rc=1 tier=monitor-best-effort 1227_swallowed=true"
+                fi
+              done
+            }
+            lock_remote_root_writes() {
+              set_remote_root_account_state "LOCK" "$1" || return 1
+              grant_optional_remote_root_privileges "$1" || true
+            }
+            unlock_remote_root_writes() {
+              set_remote_root_account_state "UNLOCK" "$1"
+            }
+            lock_local_root_writes() {
+              set_local_root_account_state "LOCK" "$1"
+            }
+            unlock_local_root_writes() {
+              set_local_root_account_state "UNLOCK" "$1"
+            }
+            query_slave_status_verbose() {
+              timeout 5 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                -S "${SOCK}" -e "SHOW SLAVE STATUS\\G" 2>/dev/null || true
+            }
+            slave_status_is_healthy() {
+              local slave_status="$1"
+              [ -n "${slave_status}" ] || return 1
+              case "${slave_status}" in
+                *"Slave_IO_Running: Yes"*) ;;
+                *) return 1 ;;
+              esac
+              case "${slave_status}" in
+                *"Slave_SQL_Running: Yes"*) ;;
+                *) return 1 ;;
+              esac
+              case "${slave_status}" in
+                *"Last_IO_Errno: 0"*) ;;
+                *) return 1 ;;
+              esac
+              case "${slave_status}" in
+                *"Last_SQL_Errno: 0"*) ;;
+                *) return 1 ;;
+              esac
+            }
+            slave_status_has_kb_health_check_repairable_error() {
+              local slave_status="$1"
+              [ -n "${slave_status}" ] || return 1
+              case "${slave_status}" in
+                *"Last_SQL_Errno: 1062"* | *"Last_Errno: 1062"* | \
+                *"Last_SQL_Errno: 1146"* | *"Last_Errno: 1146"*) ;;
+                *) return 1 ;;
+              esac
+              case "${slave_status}" in
+                *"kubeblocks.kb_health_check"*) ;;
+                *) return 1 ;;
+              esac
+            }
+            wait_for_replication_healthy() {
+              local label="$1"
+              local timeout_seconds="${2:-120}"
+              local sleep_seconds="${3:-2}"
+              local start now elapsed slave_status evidence_file current_syncer_role
+              start="$(date +%s)"
+              evidence_file="{{ .Values.dataMountPath }}/log/rejoin-replication-wait.log"
+              mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+              while true; do
+                # alpha.77 v3 (Helen TL): if syncer has flipped this pod to
+                # primary in DCS (e.g. a switchover OpsRequest just promoted
+                # this candidate), exit the secondary-rejoin wait immediately
+                # so the outer wait_for_mariadbd_with_role_reconcile loop can
+                # switch into the primary reconcile path on its next tick.
+                # Without this short-circuit, this loop will spin up to
+                # `timeout_seconds` (default 120s) trying to follow the OLD
+                # primary that is no longer the DCS primary, blowing past the
+                # switchover candidate-write-ready stage budget.
+                #
+                # Backward compatibility: when syncer continues to report
+                # role=secondary (the normal post-rejoin / lifecycle path),
+                # the loop body below runs unchanged. The check itself is
+                # bounded by `timeout 3` inside query_local_syncer_role and
+                # is best-effort (failure is treated as not-flipped, loop
+                # continues). Distinct sentinel log + return code 2 so
+                # downstream callers and closeout can distinguish "DCS
+                # promoted us mid-rejoin" from a real replication-not-
+                # healthy timeout (return 1).
+                current_syncer_role="$(query_local_syncer_role || true)"
+                if [ "${current_syncer_role}" = "primary" ]; then
+                  elapsed=$(($(date +%s) - start))
+                  prestop_watchdog_log "rejoin-replication-exit-on-dcs-primary label=${label} elapsed=${elapsed}s reason=dcs_promoted_during_secondary_rejoin"
+                  return 2
+                fi
+                slave_status="$(query_slave_status_verbose || true)"
+                if slave_status_is_healthy "${slave_status}"; then
+                  elapsed=$(($(date +%s) - start))
+                  prestop_watchdog_log "rejoin-replication-healthy label=${label} elapsed=${elapsed}s"
+                  return 0
+                fi
+                if repair_kb_health_check_replication_error "${label}" "${slave_status}"; then
+                  sleep "${sleep_seconds}"
+                  continue
+                fi
+                now="$(date +%s)"
+                elapsed=$((now - start))
+                if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
+                  {
+                    printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                    printf 'label=%s\n' "${label}"
+                    printf 'decision=replication-not-healthy\n'
+                    printf 'elapsed_seconds=%s\n' "${elapsed}"
+                    printf 'slave_status_begin\n'
+                    if [ -n "${slave_status}" ]; then
+                      printf '%s\n' "${slave_status}"
+                    else
+                      printf '<empty>\n'
+                    fi
+                    printf 'slave_status_end\n\n'
+                  } >> "${evidence_file}" 2>/dev/null || true
+                  prestop_watchdog_log "rejoin-replication-not-healthy label=${label} elapsed=${elapsed}s"
+                  return 1
+                fi
+                sleep "${sleep_seconds}"
+              done
+            }
+            keep_replica_pending_until_healthy() {
+              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required LOCK
+              # failures MUST propagate rc to caller. Caller pattern is
+              # `if ! keep_replica_pending_until_healthy ...; then return 1`,
+              # so propagating rc keeps the caller from publishing
+              # ready/role on locking failure.
+              local label="$1"
+              local rc=0
+              mark_replication_pending
+              lock_remote_root_writes "${label}-pending" || rc=1
+              set_fail_closed_read_only "${label}-pending" || rc=1
+              "${LOCAL[@]}" -e "START SLAVE;" 2>/dev/null || true # tier=error-recovery
+              lock_local_root_writes "${label}-pending" || rc=1
+              if [ "${rc}" -ne 0 ]; then
+                prestop_watchdog_log "keep-replica-pending label=${label} rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              wait_for_replication_healthy "${label}" 120 2
+            }
+            publish_replica_after_rejoin_ready() {
+              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
+              # mark_replication_ready (line below) is the publish point; if any
+              # required step fails (set_replica_read_only / expose_sql_listener),
+              # the function MUST return 1 BEFORE reaching mark_replication_ready.
+              local label="$1"
+              if ! keep_replica_pending_until_healthy "${label}-before-expose"; then
+                return 1
+              fi
+              if ! set_replica_read_only; then
+                prestop_watchdog_log "publish-replica-rejoin label=${label} step=before-expose rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              if ! expose_sql_listener_for_safe_role "${label}"; then
+                return 1
+              fi
+              "${LOCAL[@]}" -e "START SLAVE;" 2>/dev/null || true # tier=error-recovery
+              if ! set_replica_read_only; then
+                prestop_watchdog_log "publish-replica-rejoin label=${label} step=after-expose rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              if ! wait_for_replication_healthy "${label}-after-expose" 120 2; then
+                # tier=fail-path-defensive: replication is already
+                # known unhealthy; we mark pending and best-effort lock.
+                mark_replication_pending
+                lock_remote_root_writes "${label}-after-expose-not-healthy" || true # tier=fail-path-defensive
+                set_fail_closed_read_only "${label}-after-expose-not-healthy" || true # tier=fail-path-defensive
+                lock_local_root_writes "${label}-after-expose-not-healthy" || true # tier=fail-path-defensive
+                return 1
+              fi
+              mark_replication_ready
+              return 0
+            }
+            clear_local_kb_health_check_table() {
+              local decision="$1" evidence_file table_count row_count
+              if "${LOCAL[@]}" -e "
+                SET SESSION sql_log_bin=0;
+                CREATE DATABASE IF NOT EXISTS kubeblocks;
+                CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
+                DELETE FROM kubeblocks.kb_health_check;
+                SET SESSION sql_log_bin=1;
+              " 2>/dev/null; then
+                evidence_file="{{ .Values.dataMountPath }}/log/fresh-replica-health-check-cleanup.log"
+                mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+                table_count=$("${LOCAL[@]}" -N -s -e "
+                  SELECT COUNT(*)
+                  FROM information_schema.TABLES
+                  WHERE TABLE_SCHEMA = 'kubeblocks'
+                    AND TABLE_NAME = 'kb_health_check';
+                " 2>/dev/null || echo "unknown")
+                row_count=$("${LOCAL[@]}" -N -s -e "SELECT COUNT(*) FROM kubeblocks.kb_health_check;" 2>/dev/null || echo "unknown")
+                {
+                  printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                  printf 'decision=%s\n' "${decision}"
+                  printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
+                  printf 'primary_host=%s\n' "${PRIMARY_HOST:-unknown}"
+                  printf 'health_table_after_cleanup=%s\n' "${table_count}"
+                  printf 'health_rows_after_cleanup=%s\n' "${row_count}"
+                  printf '\n'
+                } >> "${evidence_file}" 2>/dev/null || true
+                echo "Prepared local kubeblocks health check table (${decision})."
+                return 0
+              fi
+              return 1
+            }
+            with_local_read_write_for_health_check_repair() {
+              local decision="$1"
+              local old_read_only rc
+              old_read_only="$(read_only_value || true)"
+              case "${old_read_only}" in
+                0|OFF)
+                  ;;
+                *)
+                  if ! "${LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
+                    prestop_watchdog_log "fresh-kb-health-check-repair read-only-open rc=1 decision=${decision}"
+                    return 1
+                  fi
+                  ;;
+              esac
+              clear_local_kb_health_check_table "${decision}"
+              rc=$?
+              case "${old_read_only}" in
+                0|OFF)
+                  ;;
+                *)
+                  set_fail_closed_read_only "${decision}-restore-read-only" || true
+                  ;;
+              esac
+              return "${rc}"
+            }
+            prepare_fresh_replica_for_sql_thread_start() {
+              local local_gtid="${1:-}"
+              [ -z "${local_gtid}" ] || return 0
+              if with_local_read_write_for_health_check_repair "cleared-local-kb-health-check-before-fresh-sql-thread"; then
+                return 0
+              fi
+              mark_replication_pending
+              # tier=error-recovery: cleanup already failed; defensive locking
+              # follows mark_replication_pending and the function returns 1.
+              set_fail_closed_read_only "fresh-health-check-cleanup-failed" || true # tier=error-recovery
+              lock_local_root_writes "fresh-health-check-cleanup-failed" || true # tier=error-recovery
+              echo "WARNING: failed to clear local kubeblocks health check table before fresh SQL thread starts; keeping roleProbe pending."
+              return 1
+            }
+            repair_kb_health_check_replication_error() {
+              local label="$1" slave_status="$2"
+              if ! slave_status_has_kb_health_check_repairable_error "${slave_status}"; then
+                return 1
+              fi
+              prestop_watchdog_log "fresh-kb-health-check-repair label=${label}"
+              "${LOCAL[@]}" -e "STOP SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
+              if ! with_local_read_write_for_health_check_repair "prepared-local-kb-health-check-after-replication-error"; then
+                # tier=error-recovery: repair attempt already failed; defensive
+                # locking follows mark_replication_pending and the function returns 1.
+                mark_replication_pending
+                set_fail_closed_read_only "fresh-health-check-replication-repair-failed" || true # tier=error-recovery
+                lock_local_root_writes "fresh-health-check-replication-repair-failed" || true # tier=error-recovery
+                echo "WARNING: failed to repair kubeblocks health check replication error; keeping roleProbe pending."
+                return 1
+              fi
+              "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
+              return 0
+            }
+            mariadbd_pids() {
+              if command -v pidof >/dev/null 2>&1; then
+                pidof mariadbd 2>/dev/null || true
+                return
+              fi
+              ps 2>/dev/null | awk '$NF ~ /mariadbd$/ {print $1}'
+            }
+            pause_syncer_for_prestop() {
+              local rc
+              [ -x /tools/syncerctl ] || return 0
+              timeout 3 /tools/syncerctl pause >> {{ .Values.dataMountPath }}/log/prestop-watchdog.log 2>&1
+              rc=$?
+              prestop_watchdog_log "syncerctl-pause rc=${rc}"
+              return 0
+            }
+            fence_read_only_for_prestop() {
+              timeout 2 "${LOCAL[@]}" -e "SET GLOBAL read_only = NO_LOCK_NO_ADMIN;" \
+                >> {{ .Values.dataMountPath }}/log/prestop-watchdog.log 2>&1 \
+                || timeout 2 "${LOCAL[@]}" -e "SET GLOBAL read_only = ON;" \
+                >> {{ .Values.dataMountPath }}/log/prestop-watchdog.log 2>&1 \
+                || timeout 2 "${LOCAL[@]}" -e "SET GLOBAL read_only = 1;" \
+                >> {{ .Values.dataMountPath }}/log/prestop-watchdog.log 2>&1 \
+                || true
+              timeout 2 "${LOCAL[@]}" \
+                -e "SELECT NOW(), @@global.read_only, @@global.gtid_binlog_state, @@global.gtid_binlog_pos;" \
+                >> {{ .Values.dataMountPath }}/log/prestop-watchdog.log 2>&1 || true
+            }
+            stop_mariadbd_for_prestop() {
+              local pids
+              pids="$(mariadbd_pids | tr '\n' ' ')"
+              if [ -z "${pids}" ]; then
+                prestop_watchdog_log "mariadbd pid not found"
+                return 0
+              fi
+              prestop_watchdog_log "term mariadbd pids=${pids}"
+              kill -TERM ${pids} 2>/dev/null || true
+              sleep 1
+              pids="$(mariadbd_pids | tr '\n' ' ')"
+              if [ -n "${pids}" ]; then
+                prestop_watchdog_log "kill mariadbd pids=${pids}"
+                kill -KILL ${pids} 2>/dev/null || true
+              fi
+            }
+            wait_for_mariadb_local() {
+              until "${LOCAL[@]}" -e "SELECT 1" >/dev/null 2>&1; do
+                if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+                  prestop_watchdog_log "connection-wait-exit reason=prestop-fence-started"
+                  return 1
+                fi
+                if ! kill -0 ${MARIADB_PID} 2>/dev/null; then
+                  prestop_watchdog_log "connection-wait-exit reason=mariadbd-exited"
+                  return 1
+                fi
+                sleep 2
+              done
+            }
+            start_mariadbd_process() {
+              local bind_address="$1"
+              local label="$2"
+              prestop_watchdog_log "start-mariadbd label=${label} bind_address=${bind_address}"
+              # alpha.86 v1 (Helen) — --defaults-extra-file must be the
+              # FIRST mariadbd option (MariaDB requires --defaults-* args
+              # to come before any other args). The loader file at
+              # {{ .Values.dataMountPath }}/runtime-overrides.cnf is
+              # created by init-syncer with the single directive
+              # `!includedir {{ .Values.dataMountPath }}/runtime-overrides.d/`.
+              # mariadbd silently accepts an empty dir, so fresh-bootstrap
+              # works before any reconfigure has populated the dir.
+              # Each successful reconfigure writes a per-parameter
+              # `.cnf` file into runtime-overrides.d/; mariadbd picks
+              # them up on next restart.
+              docker-entrypoint.sh mariadbd \
+                --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
+                --server-id=${SERVICE_ID} \
+                --log-bin={{ .Values.dataMountPath }}/binlog/${POD_NAME}-bin \
+                --skip-slave-start=ON \
+                --read-only=NO_LOCK_NO_ADMIN \
+                --thread-cache-size=100 \
+                --bind-address="${bind_address}" &
+              MARIADB_PID=$!
+              prestop_fence_watchdog &
+              PRESTOP_WATCHDOG_PID=$!
+            }
+            stop_mariadbd_process() {
+              local label="$1"
+              local i pids
+              pids="$(mariadbd_pids | tr '\n' ' ')"
+              if [ -z "${pids}" ]; then
+                prestop_watchdog_log "stop-mariadbd label=${label} pid-not-found"
+                return 0
+              fi
+              prestop_watchdog_log "stop-mariadbd label=${label} term pids=${pids}"
+              kill -TERM ${pids} 2>/dev/null || true
+              i=0
+              while [ "${i}" -lt 15 ]; do
+                pids="$(mariadbd_pids | tr '\n' ' ')"
+                [ -z "${pids}" ] && break
+                sleep 1
+                i=$((i + 1))
+              done
+              pids="$(mariadbd_pids | tr '\n' ' ')"
+              if [ -n "${pids}" ]; then
+                prestop_watchdog_log "stop-mariadbd label=${label} kill pids=${pids}"
+                kill -KILL ${pids} 2>/dev/null || true
+              fi
+              wait ${MARIADB_PID} 2>/dev/null || true
+            }
+            expose_sql_listener_for_safe_role() {
+              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
+              # touch .sql-listener-ready below is the publish point that lets
+              # the runtime accept TCP traffic; required local LOCK + read_only
+              # MUST hold BEFORE we open the listener. Failure of either MUST
+              # return 1 BEFORE touching .sql-listener-ready.
+              local label="$1"
+              if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+                prestop_watchdog_log "skip-sql-listener-expose label=${label} reason=prestop-fence-started"
+                mark_replication_pending
+                return 1
+              fi
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                return 0
+              fi
+              mark_replication_pending
+              prestop_watchdog_log "sql-listener-expose-begin label=${label}"
+              stop_mariadbd_process "sql-listener-${label}"
+              start_mariadbd_process "0.0.0.0" "sql-listener-${label}"
+              if ! wait_for_mariadb_local; then
+                wait ${MARIADB_PID}
+                exit $?
+              fi
+              if ! set_fail_closed_read_only "sql-listener-${label}"; then
+                prestop_watchdog_log "sql-listener-expose label=${label} step=set-read-only rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              if ! lock_local_root_writes "sql-listener-${label}"; then
+                prestop_watchdog_log "sql-listener-expose label=${label} step=lock-local-root rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              touch {{ .Values.dataMountPath }}/.sql-listener-ready
+              prestop_watchdog_log "sql-listener-expose-complete label=${label}"
+            }
+            expose_sql_listener_for_primary_role() {
+              local label="$1"
+              if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+                prestop_watchdog_log "skip-sql-listener-primary-expose label=${label} reason=prestop-fence-started"
+                mark_replication_pending
+                return 1
+              fi
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
+                "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
+                if set_primary_read_write; then
+                  touch {{ .Values.dataMountPath }}/.sql-listener-ready
+                  prestop_watchdog_log "sql-listener-primary-existing-reconciled label=${label}"
+                  return 0
+                fi
+                mark_replication_pending
+                prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} reason=existing-listener-local-write-not-ready"
+                return 1
+              fi
+              mark_replication_pending
+              prestop_watchdog_log "sql-listener-primary-expose-begin label=${label}"
+              stop_mariadbd_process "sql-listener-primary-${label}"
+              start_mariadbd_process "0.0.0.0" "sql-listener-primary-${label}"
+              if ! wait_for_mariadb_local; then
+                wait ${MARIADB_PID}
+                exit $?
+              fi
+              "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
+              "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
+              if ! set_primary_read_write; then
+                mark_replication_pending
+                prestop_watchdog_log "sql-listener-primary-expose-failed label=${label}"
+                return 1
+              fi
+              touch {{ .Values.dataMountPath }}/.sql-listener-ready
+              prestop_watchdog_log "sql-listener-primary-expose-complete label=${label}"
+            }
+            query_local_syncer_role() {
+              [ -x /tools/syncerctl ] || return 1
+              timeout 3 /tools/syncerctl --host 127.0.0.1 --port 3601 getrole 2>/dev/null | tr -d '\r\n'
+            }
+            query_primary_service_server_id() {
+              timeout 3 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || true
+            }
+            local_user_table_count() {
+              "${LOCAL[@]}" -e "
+                SELECT COUNT(*)
+                FROM information_schema.TABLES
+                WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys', 'kubeblocks');
+              " 2>/dev/null | tr -d '\r' | awk 'NF {print $1; exit}'
+            }
+            local_has_user_tables() {
+              local table_count
+              table_count="$(local_user_table_count || echo unknown)"
+              case "${table_count}" in
+                ''|*[!0-9]*)
+                  prestop_watchdog_log "runtime-secondary-follow-user-table-count rc=1 value=${table_count:-<empty>}"
+                  return 0
+                  ;;
+              esac
+              prestop_watchdog_log "runtime-secondary-follow-user-table-count rc=0 value=${table_count}"
+              [ "${table_count}" -gt 0 ]
+            }
+            reconcile_sql_listener_for_syncer_primary_once() {
+              local now primary_sid role
+              [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
+              # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_is_fresh`
+              # early-skip has been removed. alpha.79 v1 minimalist deleted the
+              # marker writer in switchover.sh, so this check could never observe
+              # a fresh marker and always fell through. Pure dead-code cleanup,
+              # no runtime behavior change.
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                role="$(query_local_syncer_role || true)"
+                [ "${role}" = "primary" ] || return 0
+                if [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && [ ! -f "{{ .Values.dataMountPath }}/.remote-root-fence-role" ] && [ ! -f "{{ .Values.dataMountPath }}/master.info" ]; then
+                  return 0
+                fi
+                prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role}"
+                expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener" || return 1
+                mark_replication_ready
+                prestop_watchdog_log "runtime-primary-listener-reconcile-repair-complete role=${role}"
+                return 0
+              fi
+              if [ "${POD_INDEX}" -gt 0 ] && [ ! -f "{{ .Values.dataMountPath }}/master.info" ]; then
+                now="$(date +%s)"
+                if [ "${now}" -lt "${SYNCER_PRIMARY_BOOTSTRAP_GRACE_UNTIL}" ]; then
+                  prestop_watchdog_log "runtime-primary-listener-reconcile-defer reason=fresh-bootstrap-grace pod_index=${POD_INDEX}"
+                  return 0
+                fi
+              fi
+              primary_sid="$(query_primary_service_server_id || true)"
+              if [ -n "${primary_sid}" ] && [ "${primary_sid}" != "${SERVICE_ID}" ]; then
+                prestop_watchdog_log "runtime-primary-listener-reconcile-defer reason=primary-service-routes-to-peer primary_sid=${primary_sid} service_id=${SERVICE_ID}"
+                return 0
+              fi
+              role="$(query_local_syncer_role || true)"
+              [ "${role}" = "primary" ] || return 0
+              prestop_watchdog_log "runtime-primary-listener-reconcile-begin role=${role}"
+              expose_sql_listener_for_primary_role "syncer-promoted-primary" || return 1
+              mark_replication_ready
+              prestop_watchdog_log "runtime-primary-listener-reconcile-complete role=${role}"
+            }
+            configure_replication_from_primary_service_once() {
+              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
+              # set_replica_read_only failure means the replica's lock state
+              # is not safe; we MUST return 1 so caller does not interpret
+              # this iteration as a successful follow attempt.
+              local label="${1:-runtime-secondary-follow}"
+              local primary_sid master_gtid local_gtid slave_status
+              mark_replication_pending
+              if ! set_replica_read_only; then
+                prestop_watchdog_log "configure-replication-from-primary label=${label} step=enter-set-replica-read-only rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              primary_sid="$(query_primary_service_server_id || true)"
+              if [ -z "${primary_sid}" ] || [ "${primary_sid}" = "${SERVICE_ID}" ]; then
+                prestop_watchdog_log "runtime-secondary-follow-configure-defer label=${label} reason=primary-service-not-peer primary_sid=${primary_sid:-<empty>} service_id=${SERVICE_ID}"
+                return 1
+              fi
+              if local_has_user_tables && fail_closed_for_gtid_divergence; then
+                prestop_watchdog_log "runtime-secondary-follow-configure-blocked label=${label} reason=gtid-divergence"
+                return 1
+              fi
+              master_gtid=$(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@global.gtid_binlog_pos;" 2>/dev/null || echo "")
+              local_gtid=$("${LOCAL[@]}" -e "SELECT @@global.gtid_slave_pos;" 2>/dev/null || echo "")
+              prestop_watchdog_log "runtime-secondary-follow-configure-begin label=${label} primary_sid=${primary_sid} service_id=${SERVICE_ID} local_gtid=${local_gtid:-<empty>} primary_gtid=${master_gtid:-<empty>}"
+              if [ -z "${local_gtid}" ]; then
+                if ! "${LOCAL[@]}" -e "
+                  STOP SLAVE;
+                  CHANGE MASTER TO
+                    MASTER_HOST='${PRIMARY_HOST}',
+                    MASTER_USER='${MARIADB_REPL_USER:-kb_replicator}',
+                    MASTER_PASSWORD='${MARIADB_ROOT_PASSWORD}',
+                    MASTER_USE_GTID=slave_pos,
+                    MASTER_CONNECT_RETRY=10;
+                  START SLAVE IO_THREAD;
+                " 2>/dev/null; then
+                  prestop_watchdog_log "runtime-secondary-follow-configure-io-failed label=${label}"
+                  return 1
+                fi
+                if ! prepare_fresh_replica_for_sql_thread_start "${local_gtid}"; then
+                  prestop_watchdog_log "runtime-secondary-follow-configure-pre-sql-failed label=${label}"
+                  return 1
+                fi
+                if ! "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null; then
+                  # tier=error-recovery: SQL thread start has already failed.
+                  # mark_replication_pending + best-effort defensive locks +
+                  # function returns 1.
+                  mark_replication_pending
+                  set_fail_closed_read_only "runtime-secondary-follow-sql-thread-start-failed" || true # tier=error-recovery
+                  lock_local_root_writes "runtime-secondary-follow-sql-thread-start-failed" || true # tier=error-recovery
+                  prestop_watchdog_log "runtime-secondary-follow-configure-sql-failed label=${label}"
+                  return 1
+                fi
+              else
+                if ! "${LOCAL[@]}" -e "
+                  STOP SLAVE;
+                  CHANGE MASTER TO
+                    MASTER_HOST='${PRIMARY_HOST}',
+                    MASTER_USER='${MARIADB_REPL_USER:-kb_replicator}',
+                    MASTER_PASSWORD='${MARIADB_ROOT_PASSWORD}',
+                    MASTER_USE_GTID=slave_pos,
+                    MASTER_CONNECT_RETRY=10;
+                  START SLAVE;
+                " 2>/dev/null; then
+                  prestop_watchdog_log "runtime-secondary-follow-configure-start-failed label=${label}"
+                  return 1
+                fi
+              fi
+              slave_status="$(query_slave_status_verbose || true)"
+              if [ -z "${slave_status}" ]; then
+                prestop_watchdog_log "runtime-secondary-follow-configure-no-slave-status label=${label}"
+                return 1
+              fi
+              if publish_replica_after_rejoin_ready "${label}"; then
+                prestop_watchdog_log "runtime-secondary-follow-configure-complete label=${label} primary_sid=${primary_sid}"
+                return 0
+              fi
+              if local_has_user_tables && fail_closed_for_gtid_divergence; then
+                prestop_watchdog_log "runtime-secondary-follow-configure-blocked label=${label} reason=gtid-divergence-after-configure"
+                return 1
+              fi
+              prestop_watchdog_log "runtime-secondary-follow-configure-not-healthy label=${label}"
+              return 1
+            }
+            reconcile_sql_listener_for_syncer_secondary_once() {
+              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
+              # mark_replication_ready (line below) is the publish point;
+              # set_replica_read_only failure MUST return 1 BEFORE marking ready.
+              local role slave_status
+              [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
+              role="$(query_local_syncer_role || true)"
+              [ "${role}" = "secondary" ] || return 0
+              if ! set_replica_read_only; then
+                mark_replication_pending
+                prestop_watchdog_log "runtime-secondary-listener-reconcile role=${role} step=set-replica-read-only rc=1 tier=required fail_closed=true"
+                return 1
+              fi
+              slave_status="$(query_slave_status_verbose || true)"
+              if slave_status_is_healthy "${slave_status}"; then
+                mark_replication_ready
+                prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
+                return 0
+              fi
+              if configure_replication_from_primary_service_once "runtime-secondary-follow"; then
+                prestop_watchdog_log "runtime-secondary-listener-reconcile-ready-after-configure role=${role}"
+                return 0
+              fi
+              mark_replication_pending
+              prestop_watchdog_log "runtime-secondary-listener-reconcile-pending role=${role}"
+            }
+            wait_for_mariadbd_with_role_reconcile() {
+              local rc=0
+              while kill -0 "${MARIADB_PID}" 2>/dev/null; do
+                reconcile_sql_listener_for_syncer_secondary_once || true
+                reconcile_sql_listener_for_syncer_primary_once || true
+                sleep 1
+              done
+              wait "${MARIADB_PID}" || rc=$?
+              return "${rc}"
+            }
+            prestop_fence_watchdog() {
+              local fired=false
+              local iter=0
+              while true; do
+                if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+                  iter=$((iter + 1))
+                  if [ "${fired}" = "false" ]; then
+                    fired=true
+                    prestop_watchdog_log "marker-detected pod=${POD_NAME:-unknown} mariadb_pid=${MARIADB_PID:-unknown}"
+                    touch {{ .Values.dataMountPath }}/.prestop-fence-watchdog-active 2>/dev/null || true
+                  fi
+                  mark_replication_pending
+                  if [ $((iter % 5)) -eq 1 ]; then
+                    pause_syncer_for_prestop
+                  fi
+                  fence_read_only_for_prestop
+                  stop_mariadbd_for_prestop
+                  sleep 1
+                  continue
+                fi
+                kill -0 "${MARIADB_PID}" 2>/dev/null || break
+                sleep 0.2
+              done
+              if [ "${fired}" = "true" ]; then
+                prestop_watchdog_log "exit"
+              fi
+            }
+
+            # Start local-only until the pod has a safe role. During replacement
+            # startup, read_only does not block privileged root writes in MariaDB,
+            # so root write privileges are fenced until the pod is a confirmed
+            # primary or a healthy replica.
+            start_mariadbd_process "127.0.0.1" "bootstrap-local-only"
+
+            # Wait for MariaDB to accept connections
+            if ! wait_for_mariadb_local; then
+              wait ${MARIADB_PID}
+              exit $?
+            fi
+            wait_for_internal_local_admin "startup-before-role-decision"
+            # tier=startup-defensive: pre-role-decision defensive locks. Role
+            # has not been determined yet; subsequent role-decision branches
+            # each install their own required Tier B locks (set_replica_read_only,
+            # expose_sql_listener_for_*_role) before publishing ready/role.
+            lock_local_root_writes "startup-before-role-decision-pre-remote" || true # tier=startup-defensive
+            lock_remote_root_writes "startup-before-role-decision" || true # tier=startup-defensive
+            set_fail_closed_read_only "startup-before-role-decision" || true # tier=startup-defensive
+            lock_local_root_writes "startup-before-role-decision" || true # tier=startup-defensive
+
+            # Determine role by querying the primary service VIP.
+            # timeout 10 prevents an indefinite hang if the primary is temporarily unresponsive
+            # (e.g. its semi-sync ACK receiver is stalled) — treat it as "no primary".
+            PRIMARY_SID=$(timeout 10 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+              -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || echo "")
+
+            # Check for existing slave config.
+            # Use tabular SHOW SLAVE STATUS (not \G) because -N suppresses field names in \G format.
+            SLAVE_STATUS=$("${LOCAL[@]}" -e "SHOW SLAVE STATUS;" 2>/dev/null)
+
+            if [ "${PRIMARY_SID}" = "${SERVICE_ID}" ]; then
+              # Primary service routes to us — we are the current primary.
+              # Clear any stale slave config and mark initialization as complete.
+              if ! expose_sql_listener_for_primary_role "primary-service-route"; then
+                wait ${MARIADB_PID}
+                exit 1
+              fi
+              mark_replication_ready
+              echo "Starting as primary (server_id=${SERVICE_ID})"
+            elif [ -n "${SLAVE_STATUS}" ]; then
+              # We have existing slave config from a previous run.
+              # Do not let an existing datadir self-elect while the primary service is
+              # temporarily empty. A terminating old primary can otherwise publish stale
+              # local transactions as the new source of truth.
+              if fail_closed_for_gtid_divergence; then
+                wait ${MARIADB_PID}
+                exit 1
+              fi
+              if [ "${POD_INDEX}" = "0" ] && [ -z "${PRIMARY_SID}" ]; then
+                if block_existing_datadir_self_election_without_primary; then
+                  wait ${MARIADB_PID}
+                  exit 1
+                fi
+                if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+                  wait ${MARIADB_PID}
+                  exit 1
+                fi
+                mark_replication_ready
+                echo "Starting as primary (pod-0 with stale slave config, no primary found)"
+              else
+                while true; do
+                  reconcile_sql_listener_for_syncer_primary_once || true
+                  if [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
+                     [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
+                     [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                    echo "Existing slave config accepted syncer primary promotion"
+                    break
+                  fi
+                  if publish_replica_after_rejoin_ready "existing-slave-config"; then
+                    echo "Resumed replication from existing slave config"
+                    break
+                  fi
+                  if fail_closed_for_gtid_divergence; then
+                    wait ${MARIADB_PID}
+                    exit 1
+                  fi
+                  echo "Existing slave config is not healthy yet; keeping replication pending and read-only, retrying in 5s."
+                  sleep 5
+                done
+              fi
+            elif [ -n "${PRIMARY_SID}" ] || [ "${POD_INDEX}" -gt 0 ]; then
+              # No slave config; we need to configure replication from the primary.
+              # Loop indefinitely until replication is successfully configured:
+              #   1. Find the primary (a server_id different from ours) — retry every 3s
+              #   2. Run CHANGE MASTER TO; START SLAVE
+              #   3. Verify SHOW SLAVE STATUS is non-empty (config stored); on failure,
+              #      sleep 5s and retry from step 1.
+              # .replication-pending stays set throughout so roleProbe does not publish a
+              # role, preventing a spurious "primary" report and the resulting split-brain race.
+              #
+              # Chart-side self-election paths (Path A 60s any-pod / Path B 30s non-pod-0)
+              # were removed 2026-05-05 to fix cycle 4 semisync n01 double-primary race
+              # (pod-0 default-primary by index + pod-1 self-elect after 30s both firing).
+              # Primary election now belongs entirely to syncer/DCS:
+              #   - Fresh bootstrap entry point: pod-0 default-primary by index (else branch below)
+              #   - Failover: syncer IsHealthiestMember fence (apecloud/syncer PR #142) +
+              #     AttemptAcquireLease + Promote()
+              # The loop never gives up on its own — chart waits for primary to appear,
+              # never self-elects. If pod-0 never comes (broken image), this pod stays in
+              # the loop and the cluster waits for kbagent restart / operator intervention.
+              # That is the intended trade-off of "primary election belongs to syncer/DCS".
+              #
+              # Set fail-closed read_only BEFORE entering the wait loop. mariadbd starts
+              # read-only from the command line, and this explicit set plus the local
+              # root write fence keeps the pod unwritable while role is unresolved.
+              # Cycle 6 (alpha.18) caught the previous default-writable behavior as a SQL
+              # invariant failure: pod-0 default-primary read_only=0 plus pod-1 waiting in
+              # the loop with default read_only=0 = two writable instances.
+              # tier=startup-defensive: pre-role-decision waiting loop entry;
+              # subsequent publish_replica_after_rejoin_ready (Tier B required)
+              # is the actual ready/role publish point.
+              set_fail_closed_read_only "wait-primary-loop-entry" || true # tier=startup-defensive
+              lock_local_root_writes "wait-primary-loop-entry" || true # tier=startup-defensive
+              _no_primary_iters=0
+              while true; do
+                # Step 1: find primary (timeout 10 prevents hang if primary unresponsive)
+                PRIMARY_SID=$(timeout 10 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                  -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || echo "")
+                if [ -z "${PRIMARY_SID}" ] || [ "${PRIMARY_SID}" = "${SERVICE_ID}" ]; then
+                  if [ ! -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                    reconcile_sql_listener_for_syncer_primary_once || true
+                    if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && [ ! -f "{{ .Values.dataMountPath }}/master.info" ]; then
+                      echo "Starting as primary after syncer promoted this pod"
+                      break
+                    fi
+                  fi
+                  _no_primary_iters=$((_no_primary_iters + 1))
+                  # Observability: log every 30s so external watchers see we are still waiting
+                  # for primary, not silently stuck. Does not change behavior.
+                  if [ $((_no_primary_iters % 10)) -eq 0 ]; then
+                    echo "INFO: primary not found at iter=${_no_primary_iters} (~$((_no_primary_iters * 3))s elapsed); still waiting for syncer/DCS to elect a primary"
+                  fi
+                  sleep 3
+                  continue
+                fi
+                # Step 2: configure replication
+                if fail_closed_for_gtid_divergence; then
+                  wait ${MARIADB_PID}
+                  exit 1
+                fi
+                MASTER_GTID=$(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                  -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@global.gtid_binlog_pos;" 2>/dev/null)
+                LOCAL_GTID=$("${LOCAL[@]}" -e "SELECT @@global.gtid_slave_pos;" 2>/dev/null || echo "")
+                if [ -z "${LOCAL_GTID}" ]; then
+                  if ! "${LOCAL[@]}" -e "
+                    STOP SLAVE;
+                    CHANGE MASTER TO
+                      MASTER_HOST='${PRIMARY_HOST}',
+                      MASTER_USER='${MARIADB_REPL_USER:-kb_replicator}',
+                      MASTER_PASSWORD='${MARIADB_ROOT_PASSWORD}',
+                      MASTER_USE_GTID=slave_pos,
+                      MASTER_CONNECT_RETRY=10;
+                    START SLAVE IO_THREAD;
+                  " 2>/dev/null; then
+                    echo "CHANGE MASTER TO or START SLAVE IO_THREAD failed; retrying in 5s"
+                    sleep 5
+                    continue
+                  fi
+                  if ! prepare_fresh_replica_for_sql_thread_start "${LOCAL_GTID}"; then
+                    sleep 5
+                    continue
+                  fi
+                  if ! "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null; then
+                    # tier=error-recovery: SQL thread start has already failed.
+                    # mark_replication_pending + best-effort defensive locks +
+                    # continue retry loop (does NOT publish ready/role).
+                    mark_replication_pending
+                    set_fail_closed_read_only "fresh-sql-thread-start-failed" || true # tier=error-recovery
+                    lock_local_root_writes "fresh-sql-thread-start-failed" || true # tier=error-recovery
+                    echo "START SLAVE SQL_THREAD failed; keeping roleProbe pending."
+                    sleep 5
+                    continue
+                  fi
+                else
+                  "${LOCAL[@]}" -e "
+                    STOP SLAVE;
+                    CHANGE MASTER TO
+                      MASTER_HOST='${PRIMARY_HOST}',
+                      MASTER_USER='${MARIADB_REPL_USER:-kb_replicator}',
+                      MASTER_PASSWORD='${MARIADB_ROOT_PASSWORD}',
+                      MASTER_USE_GTID=slave_pos,
+                      MASTER_CONNECT_RETRY=10;
+                    START SLAVE;
+                  " 2>/dev/null || true
+                fi
+                # Step 3: verify CHANGE MASTER TO actually stored config.
+                # If it failed (e.g. auth error, primary briefly unreachable), retry from step 1
+                # after a short backoff. Only remove .replication-pending once slave config is
+                # confirmed. Do NOT self-elect on failure.
+                SLAVE_STATUS_CHECK=$("${LOCAL[@]}" -e "SHOW SLAVE STATUS;" 2>/dev/null)
+                if [ -n "${SLAVE_STATUS_CHECK}" ]; then
+                  if publish_replica_after_rejoin_ready "new-slave-config"; then
+                    echo "Replication configured from primary ${PRIMARY_HOST} at GTID ${MASTER_GTID}"
+                    break
+                  fi
+                  if fail_closed_for_gtid_divergence; then
+                    wait ${MARIADB_PID}
+                    exit 1
+                  fi
+                  echo "Replication stored but not healthy yet; retrying in 5s"
+                  sleep 5
+                  continue
+                fi
+                echo "CHANGE MASTER TO did not store config; retrying in 5s"
+                sleep 5
+              done
+            else
+              # Pod-0, primary unreachable, no slave config: start as primary by default.
+              if ! expose_sql_listener_for_primary_role "default-pod0-primary"; then
+                wait ${MARIADB_PID}
+                exit 1
+              fi
+              mark_replication_ready
+              echo "Starting as primary by default (index=0)"
+            fi
+
+            # Background: clear the semi-sync ACK receiver deadlock when detected.
+            # When a secondary is RST-killed, MariaDB's ACK receiver thread can deadlock for
+            # ~150s (TCP retransmit timeout), blocking ALL new TCP connections to the primary.
+            # Detection: Unix socket shows clients=0 AND TCP connection to port 3306 fails.
+            # (Unix socket bypasses TCP; if TCP is blocked, it's the deadlock — not just a
+            #  transient state where the secondary is reconnecting.)
+            # Toggling rpl_semi_sync_master_enabled=0→1 stops and restarts the ACK receiver.
+            SOCK="/run/mysqld/mysqld.sock"
+            SOCK_CLI=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
+            TCP_CLI=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -P3306 -h127.0.0.1 -N -s)
+            (while kill -0 ${MARIADB_PID} 2>/dev/null; do
+              sleep 10
+              # Deadlock check: Unix socket works even during ACK receiver deadlock;
+              # TCP fails when deadlocked. Do NOT gate on clients=0: a force-killed
+              # slave leaves a CLOSE-WAIT connection that keeps clients=1, masking the
+              # deadlock. Check TCP directly — if it fails, toggle to restart ACK receiver.
+              if ! timeout 3 "${TCP_CLI[@]}" -e "SELECT 1;" >/dev/null 2>&1; then
+                if kill -0 ${MARIADB_PID} 2>/dev/null; then
+                  "${SOCK_CLI[@]}" \
+                    -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" \
+                    2>/dev/null || true
+                fi
+              fi
+            done) &
+
+            # Switchover is coordinated by /scripts/replication-switchover.sh
+            # through syncerctl, which creates the DCS switchover record. Remove
+            # stale raw-SQL trigger files from older script versions so they cannot
+            # race with syncer's HA loop.
+            rm -f {{ .Values.dataMountPath }}/.switchover-request \
+              {{ .Values.dataMountPath }}/.switchover-done \
+              {{ .Values.dataMountPath }}/.switchover-error
+
+            wait_for_mariadbd_with_role_reconcile
+        volumeMounts:
+          - mountPath: {{ .Values.dataMountPath }}
+            name: data
+          - mountPath: /etc/mysql/conf.d
+            name: mariadb-config
+          - mountPath: /tools
+            name: tools
+          - name: scripts
+            mountPath: /scripts
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  DATA_DIR="{{ .Values.dataMountPath }}"
+                  LOG_DIR="${DATA_DIR}/log"
+                  LOG_FILE="${LOG_DIR}/prestop-fence.log"
+                  INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
+                  mkdir -p "${LOG_DIR}" 2>/dev/null || true
+                  prestop_log() {
+                    line="$(date -u +"%Y-%m-%dT%H:%M:%SZ") prestop-fence $*"
+                    echo "${line}"
+                    printf '%s\n' "${line}" >> "${LOG_FILE}" 2>/dev/null || true
+                  }
+                  run_sql() {
+                    label="$1"
+                    mode="$2"
+                    sql="$3"
+                    if [ "${mode}" = "socket" ]; then
+                      timeout 3 mariadb -u"${INTERNAL_ROOT_USER}" -p"${MARIADB_ROOT_PASSWORD}" \
+                        -S /run/mysqld/mysqld.sock -e "${sql}" >> "${LOG_FILE}" 2>&1
+                    else
+                      timeout 3 mariadb -u"${INTERNAL_ROOT_USER}" -p"${MARIADB_ROOT_PASSWORD}" \
+                        -h127.0.0.1 -P3306 -e "${sql}" >> "${LOG_FILE}" 2>&1
+                    fi
+                    rc=$?
+                    prestop_log "${label} rc=${rc}"
+                    return "${rc}"
+                  }
+                  fence_read_only() {
+                    label="$1"
+                    mode="$2"
+                    run_sql "${label}-no-lock-no-admin" "${mode}" "SET GLOBAL read_only = NO_LOCK_NO_ADMIN;" \
+                      || run_sql "${label}-fallback-on" "${mode}" "SET GLOBAL read_only = ON;" \
+                      || run_sql "${label}-fallback-1" "${mode}" "SET GLOBAL read_only = 1;" \
+                      || true
+                  }
+                  prestop_sql_quote() {
+                    printf "%s" "$1" | sed "s/'/''/g"
+                  }
+                  lock_local_root_for_prestop() {
+                    # alpha.64 v1 (Jack 09:35 RED): drop SUPER (admin bypass).
+                    # NOTE: preStop hook is a SEPARATE shell scope (/bin/sh -c
+                    # block) so the main-container CMPD_SECONDARY_FENCE_GRANT_BODY
+                    # constant is NOT in scope here. The literal grant list
+                    # below MUST be kept in sync with the main-container constant
+                    # CMPD_SECONDARY_FENCE_GRANT_BODY (line ~155). ShellSpec
+                    # rendered-manifest negative grep enforces both callsites
+                    # do not contain SUPER / READ_ONLY ADMIN / BINLOG ADMIN /
+                    # CONNECTION ADMIN. Tier B (Jack 10:05): prestop LOCK is
+                    # required; failure MUST fail-closed (return 1) so caller
+                    # does not proceed.
+                    label="$1"
+                    mode="$2"
+                    user="$(prestop_sql_quote "${MARIADB_ROOT_USER}")"
+                    password="$(prestop_sql_quote "${MARIADB_ROOT_PASSWORD}")"
+                    for host in localhost 127.0.0.1; do
+                      sql="
+                        SET SESSION sql_log_bin=0;
+                        CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
+                        ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
+                        ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
+                        REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
+                        GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN ON *.* TO '${user}'@'${host}';
+                        FLUSH PRIVILEGES;
+                        SET SESSION sql_log_bin=1;
+                      "
+                      if run_sql "${label}-local-root-lock-${host}" "${mode}" "${sql}"; then
+                        prestop_log "local-root-lock label=${label} host=${host} mode=${mode} rc=0 tier=required"
+                        continue
+                      fi
+                      prestop_log "local-root-lock label=${label} host=${host} mode=${mode} rc=1 tier=required 1227_swallowed=true fail_closed=true"
+                      return 1
+                    done
+                  }
+                  mariadbd_pids() {
+                    if command -v pidof >/dev/null 2>&1; then
+                      pidof mariadbd 2>/dev/null || true
+                      return
+                    fi
+                    ps 2>/dev/null | awk '$NF ~ /mariadbd$/ {print $1}'
+                  }
+                  wait_mariadbd_exit() {
+                    limit="$1"
+                    i=0
+                    while [ "${i}" -lt "${limit}" ]; do
+                      pids="$(mariadbd_pids | tr '\n' ' ')"
+                      if [ -z "${pids}" ]; then
+                        prestop_log "mariadbd exited after ${i}s"
+                        return 0
+                      fi
+                      sleep 1
+                      i=$((i + 1))
+                    done
+                    prestop_log "mariadbd still running after ${limit}s pids=${pids}"
+                    return 1
+                  }
+
+                  prestop_log "begin pod=${POD_NAME:-unknown}"
+                  touch "${DATA_DIR}/.prestop-fence-started" "${DATA_DIR}/.replication-pending" 2>/dev/null || true
+                  rm -f "${DATA_DIR}/.replication-ready" 2>/dev/null || true
+                  # alpha.64 v2 (Jack 10:32 HOLD blocker 2): Tier B preStop
+                  # required LOCK MUST NOT be silently swallowed by trailing
+                  # `|| true`. socket→tcp fallback is best-effort attempt
+                  # ordering; double failure emits an explicit fail-closed
+                  # token for the runtime negative gate. preStop has already
+                  # removed `.replication-ready` above and set
+                  # `.prestop-fence-started`, so continuing to kill mariadbd
+                  # IS the fail-closed behavior at the pod level — but the
+                  # log token is what the live-gate runtime negative grep
+                  # asserts. Do NOT add `|| true` after this block.
+                  if ! lock_local_root_for_prestop "prestop" "socket"; then
+                    if ! lock_local_root_for_prestop "prestop" "tcp"; then
+                      prestop_log "prestop_lock_failed_both fail_closed=true tier=required"
+                    fi
+                  fi
+                  if [ -x /tools/syncerctl ]; then
+                    timeout 3 /tools/syncerctl pause >> "${LOG_FILE}" 2>&1
+                    prestop_log "syncerctl-pause rc=$?"
+                  else
+                    prestop_log "syncerctl-pause skipped: /tools/syncerctl missing"
+                  fi
+
+                  run_sql "socket-state-before" "socket" "SELECT NOW(), @@global.read_only, @@global.gtid_binlog_state, @@global.gtid_binlog_pos;" || true
+                  fence_read_only "socket-read-only" "socket"
+                  fence_read_only "tcp-read-only" "tcp"
+                  # This closes secondary IO with FIN instead of RST and avoids the
+                  # semi-sync ACK receiver deadlock on the primary. It is harmless on a primary.
+                  run_sql "socket-stop-slave-io" "socket" "STOP SLAVE IO_THREAD;" || true
+                  run_sql "tcp-stop-slave-io" "tcp" "STOP SLAVE IO_THREAD;" || true
+                  run_sql "socket-state-after-fence" "socket" "SELECT NOW(), @@global.read_only, @@global.gtid_binlog_state, @@global.gtid_binlog_pos;" || true
+
+                  pids="$(mariadbd_pids | tr '\n' ' ')"
+                  if [ -n "${pids}" ]; then
+                    prestop_log "term mariadbd pids=${pids}"
+                    kill -TERM ${pids} 2>/dev/null || true
+                  else
+                    prestop_log "mariadbd pid not found before term"
+                  fi
+
+                  if ! wait_mariadbd_exit 15; then
+                    pids="$(mariadbd_pids | tr '\n' ' ')"
+                    if [ -n "${pids}" ]; then
+                      prestop_log "kill mariadbd pids=${pids}"
+                      kill -KILL ${pids} 2>/dev/null || true
+                    fi
+                    if ! wait_mariadbd_exit 5; then
+                      touch "${DATA_DIR}/.prestop-fence-failed" 2>/dev/null || true
+                      prestop_log "end status=failed"
+                      exit 0
+                    fi
+                  fi
+
+                  touch "${DATA_DIR}/.prestop-fence-complete" 2>/dev/null || true
+                  prestop_log "end status=complete"
+        ports:
+          - containerPort: 3306
+            name: mariadb
+          - containerPort: 3601
+            name: ha
+        env:
+          # syncer DB engine reads KB_SERVICE_* for the root/poll DB
+          # credentials. KB_SERVICE_USER stays bound to MARIADB_ROOT_USER
+          # so syncer's startup readiness ping always works (root is the
+          # one user that always exists from mariadbd init). HA promote/
+          # demote SQL is NOT executed via this credential — see
+          # MYSQL_ADMIN_USER below.
+          - name: KB_SERVICE_USER
+            value: "$(MARIADB_ROOT_USER)"
+          - name: KB_SERVICE_PASSWORD
+            value: "$(MARIADB_ROOT_PASSWORD)"
+          # alpha.66 v1 (Jack 12:18 alpha.65 v2 install/script live-gate
+          # RED + Jack 12:34 alpha.66 v1 design HOLD): syncer's HA Promote/
+          # Demote SQL needs admin-bypass privileges (REPLICATION SLAVE
+          # ADMIN / READ_ONLY ADMIN / etc). alpha.64 v1 correctly removed
+          # these from user-facing root, so the syncer HA path was failing
+          # 1227. Upstream syncer (engines/mysql) already has a 3-tier
+          # credential model (Root / Admin / Replication) and an auto-switch
+          # in IsRunning() that swaps mgr.DB to AdminDB once the admin user
+          # is detected via `mysql.user WHERE host='%' AND user LIKE 'kb%'`.
+          # We inject MYSQL_ADMIN_USER=kb_internal_root (literal — NOT
+          # `$(MARIADB_INTERNAL_ROOT_USER)` because container env expansion
+          # order is not guaranteed) so syncer uses kb_internal_root for
+          # AdminDB. The bootstrap script also creates a detection-only
+          # `kb_internal_root@'%'` record (ACCOUNT LOCK + no privileges)
+          # so IsAdminCreated finds it without expanding the remote attack
+          # surface; the actual AdminDB connection from 127.0.0.1 matches
+          # `kb_internal_root@127.0.0.1` (full admin privileges).
+          - name: MYSQL_ADMIN_USER
+            value: "kb_internal_root"
+          - name: MYSQL_ADMIN_PASSWORD
+            value: "$(MARIADB_ROOT_PASSWORD)"
+          # alpha.72 v1 (Helen TL 22:14 autonomous decision after westonnnn
+          # 21:56 `8390cc8a` full TL autonomy + Jack XP review request
+          # `89591496`): explicitly set `MYSQL_REPLICATION_USER=kb_replicator`
+          # to override syncer's fallback to `MYSQL_ADMIN_USER`. Without this
+          # env, syncer's engines/mariadb/config.go:80 falls back to
+          # getAdminUserName() (= MYSQL_ADMIN_USER = kb_internal_root), and
+          # engines/mariadb/manager.go:794 calls `CHANGE MASTER TO
+          # master_user=kb_internal_root`. But `kb_internal_root@'%'` is the
+          # admin role with only REPLICATION CLIENT + REPLICATION MASTER ADMIN
+          # (no REPLICATION SLAVE — alpha.69 v1 narrowed the grants), so the
+          # secondary's REGISTER_SLAVE fails with Errno 1597 / Errno 1045
+          # access denied. Evidence in alpha.71 v1 N=1 RED:
+          # pod-1 SHOW SLAVE STATUS Master_User=kb_internal_root +
+          # Last_IO_Error=COM_REGISTER_SLAVE failed Access denied for user
+          # 'kb_internal_root'@'%' (Errno: 1045). alpha.72 v1 fixes this by
+          # (a) setting MYSQL_REPLICATION_USER to a dedicated `kb_replicator`
+          # user, (b) creating that user with `REPLICATION SLAVE ON *.*` priv
+          # in ensure_internal_local_admin within the same SQL block as
+          # kb_internal_root — NOT an atomic transaction; MariaDB DDL/GRANT
+          # statements are not transactional, so the bootstrap relies on
+          # idempotent convergence (CREATE IF NOT EXISTS + ALTER UNLOCK +
+          # REVOKE ALL + GRANT REPLICATION SLAVE) so retries can complete
+          # any partial state — and (c) chart member-join script reading
+          # MARIADB_REPLICATION_USER for its CHANGE MASTER TO. All three
+          # semisync call sites (syncer Follow + chart inline
+          # configure_replication_from_primary_service_once + chart
+          # member-join) converge on kb_replicator. kb_internal_root remains
+          # admin-role only, not leaking REPLICATION SLAVE priv to remote.
+          # Replication topology stays on pre-alpha.72 root path (alpha.72
+          # v1 scope-cap to semisync; replication kb_replicator deferred to
+          # alpha.73+).
+          - name: MYSQL_REPLICATION_USER
+            value: "kb_replicator"
+          # alpha.74 v1 (Helen TL autopilot mode westonnnn `df3c94b0` 01:28
+          # 12h-autonomous: TL self-determines + Jack XP review parallel
+          # non-blocking; root cause for alpha.73 v1 N=1 partial first-blocker
+          # = SQL replay 1396 on kb_replicator CREATE USER): mariadb 11.4
+          # image entrypoint /usr/local/bin/docker-entrypoint.sh examines
+          # MARIADB_REPLICATION_USER env at initdb time. If set, it runs
+          # `CREATE USER 'kb_replicator'@'%' IDENTIFIED BY ...; GRANT
+          # REPLICATION SLAVE ON *.* TO 'kb_replicator'@'%';` WITHOUT
+          # IF NOT EXISTS, WITHOUT SET SESSION sql_log_bin=0 wrapper. The
+          # CREATE USER is binlogged on pod-0; pod-1 also runs entrypoint
+          # initdb which creates kb_replicator@'%' locally; then pod-1
+          # START SLAVE replays pod-0 binlog CREATE USER -> 1396
+          # "Operation CREATE USER failed for 'kb_replicator'@'%'" because
+          # the entrypoint statement lacks IF NOT EXISTS clause.
+          #
+          # alpha.74 v1 fix: STOP setting MARIADB_REPLICATION_USER env
+          # entirely (so mariadb entrypoint doesn't trigger that CREATE/
+          # GRANT path), AND introduce a renamed `MARIADB_REPL_USER` shell
+          # variable for chart scripts (replication-member-join.sh + inline
+          # CHANGE MASTER TO) so the chart still has a well-known token to
+          # reference kb_replicator. syncer Go binary keeps reading
+          # MYSQL_REPLICATION_USER (engines/mariadb/config.go:80) — this
+          # env name is NOT consumed by mariadb image entrypoint, so syncer
+          # path stays converged to kb_replicator with no entrypoint side-
+          # effect. Chart's ensure_internal_local_admin still creates
+          # kb_replicator@'%' via INTERNAL_LOCAL with SET SESSION
+          # sql_log_bin=0 prefix, so chart's CREATE USER is NOT binlogged.
+          # Both pods bootstrap kb_replicator locally (idempotent) and no
+          # binlog event needs to replay through START SLAVE.
+          - name: MARIADB_REPL_USER
+            value: "kb_replicator"
+          - name: MARIADB_REPL_PASSWORD
+            value: "$(MARIADB_ROOT_PASSWORD)"
+          - name: MYSQL_REPLICATION_PASSWORD
+            value: "$(MARIADB_ROOT_PASSWORD)"
+          - name: KB_SERVICE_CHARACTER_TYPE
+            value: mariadb
+          - name: CLUSTER_DOMAIN
+            value: {{ .Values.clusterDomain | quote }}
+          - name: MARIADB_ROOT_HOST
+            value: {{ .Values.auth.rootHost | default "%" | quote }}
+          - name: MARIADB_INTERNAL_ROOT_USER
+            value: kb_internal_root
+          - name: MARIADB_ROLEPROBE_REQUIRE_SQL_LISTENER_READY
+            value: "true"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          # syncer uses this pod FQDN to wait for DNS readiness before control-plane actions.
+          - name: KB_POD_FQDN
+            value: "$(POD_NAME).$(CLUSTER_NAME)-$(COMPONENT_NAME)-headless.$(CLUSTER_NAMESPACE).svc.{{ .Values.clusterDomain }}"
+          - name: SERVICE_PORT
+            value: "3306"
+          - name: PATH
+            value: /tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: MARIADB_AUTO_UPGRADE
+            value: "1"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+      {{- include "mariadb.container.exporter" . | nindent 6 }}
+    volumes:
+      - name: tools
+        emptyDir: {}

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -40,7 +40,18 @@ spec:
       volumeName: mariadb-config
       namespace: {{ .Release.Namespace }}
       externalManaged: true
-      {{- include "mariadb.config.reconfigureAction" . | nindent 6 }}
+      {{- /* alpha.86 v1 (Helen 2026-05-19) — semisync uses the persisted
+             variant of reconfigureAction so SET GLOBAL values also land in
+             /var/lib/mysql/runtime-overrides.d/<param>.cnf, which mariadbd
+             loads at startup via --defaults-extra-file. Required because
+             mariadbd process restart (from any path: switchover promote
+             after PR #10252 fix, OOMKill, node drain, manual restart, etc.)
+             would otherwise wipe SET GLOBAL runtime state and revert to
+             chart defaults. Other topologies continue to use the base
+             helper (no persistence writes) because they do NOT have
+             init-syncer mkdir for runtime-overrides.d/ nor pass
+             --defaults-extra-file to mariadbd. */}}
+      {{- include "mariadb.config.reconfigureAction.persisted" . | nindent 6 }}
   scripts:
     - name: {{ include "mariadb.replication.scriptConfigMapName" . }}
       template: {{ include "mariadb.replication.scriptConfigMapName" . }}
@@ -91,6 +102,29 @@ spec:
           - |
             cp -r /bin/syncer /bin/syncerctl /tools/
             mkdir -p {{ .Values.dataMountPath }}
+            # alpha.86 v1 (Helen) — runtime override persistence layer.
+            # Per-parameter `.cnf` files live under runtime-overrides.d/;
+            # mariadbd loads them via --defaults-extra-file pointing at
+            # the loader file runtime-overrides.cnf (which `!includedir`
+            # the dir). KB's strict INI parser never sees `!includedir`
+            # because it does not parse this file. Group write (gid=1000
+            # matches the kbagent gid the main container chgrp below)
+            # so the reconfigureAction.persisted helper running in the
+            # mariadb container as the kbagent group can write override
+            # files; mariadbd reads via its mysql user.
+            mkdir -p {{ .Values.dataMountPath }}/runtime-overrides.d
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            # Loader file is created idempotently with the single
+            # `!includedir` directive. mariadbd silently accepts an
+            # empty dir; first reconfigure populates per-param files
+            # under runtime-overrides.d/. Loader file itself is
+            # treated as immutable shape; we always overwrite to the
+            # canonical content so a corrupted prior write cannot
+            # block mariadbd startup on the next restart.
+            printf '!includedir %s/runtime-overrides.d/\n' '{{ .Values.dataMountPath }}' > {{ .Values.dataMountPath }}/runtime-overrides.cnf
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
             rm -f {{ .Values.dataMountPath }}/.replication-ready {{ .Values.dataMountPath }}/.replication-divergence-pending
             rm -f {{ .Values.dataMountPath }}/.prestop-fence-started \
               {{ .Values.dataMountPath }}/.prestop-fence-complete \
@@ -146,6 +180,21 @@ spec:
             # Set data dir group to kbagent's GID (1000) and grant group write so that
             # kbagent can write switchover trigger files. Files inside remain mysql-owned.
             chgrp 1000 {{ .Values.dataMountPath }} && chmod g+w {{ .Values.dataMountPath }}
+            # alpha.86 v1 (Helen 2026-05-19) — re-apply runtime-overrides
+            # layer permissions AFTER the `chown -R mysql:mysql` above,
+            # which would otherwise reset the gid=1000 + g+rwx set by
+            # init-syncer. Idempotent canonical rewrite of the loader
+            # file recovers from accidental edits / corruption from
+            # prior generations (Jack 07:03 peer review B2 follow-up).
+            # mariadbd's --defaults-extra-file silently accepts an
+            # empty `runtime-overrides.d/` so this block is also safe
+            # on fresh bootstrap.
+            mkdir -p {{ .Values.dataMountPath }}/runtime-overrides.d
+            printf '!includedir %s/runtime-overrides.d/\n' '{{ .Values.dataMountPath }}' > {{ .Values.dataMountPath }}/runtime-overrides.cnf
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            chmod 0770 {{ .Values.dataMountPath }}/runtime-overrides.d 2>/dev/null || true
+            chgrp 1000 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
+            chmod 0660 {{ .Values.dataMountPath }}/runtime-overrides.cnf 2>/dev/null || true
             # Signal to roleProbe that this pod is initializing — prevents spurious "primary"
             # reports that would cause KubeBlocks to auto-trigger a switchover.
             rm -f {{ .Values.dataMountPath }}/.replication-ready
@@ -1419,7 +1468,19 @@ spec:
               local bind_address="$1"
               local label="$2"
               prestop_watchdog_log "start-mariadbd label=${label} bind_address=${bind_address}"
+              # alpha.86 v1 (Helen) — --defaults-extra-file must be the
+              # FIRST mariadbd option (MariaDB requires --defaults-* args
+              # to come before any other args). The loader file at
+              # {{ .Values.dataMountPath }}/runtime-overrides.cnf is
+              # created by init-syncer with the single directive
+              # `!includedir {{ .Values.dataMountPath }}/runtime-overrides.d/`.
+              # mariadbd silently accepts an empty dir, so fresh-bootstrap
+              # works before any reconfigure has populated the dir.
+              # Each successful reconfigure writes a per-parameter
+              # `.cnf` file into runtime-overrides.d/; mariadbd picks
+              # them up on next restart.
               docker-entrypoint.sh mariadbd \
+                --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
                 --log-bin={{ .Values.dataMountPath }}/binlog/${POD_NAME}-bin \
                 --skip-slave-start=ON \

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -98,6 +98,11 @@ spec:
             rm -f {{ .Values.dataMountPath }}/.sql-listener-ready \
               {{ .Values.dataMountPath }}/.remote-root-fence-role \
               {{ .Values.dataMountPath }}/.primary-read-write-ready
+            # alpha.80 v1 (Helen): removed `.switchover-fence-active` from this
+            # init rm list. alpha.79 v1 minimalist deleted the marker writer
+            # in switchover.sh so the marker file never appears anywhere; the
+            # init-syncer rm of it was a no-op safety net. Pure dead-code
+            # cleanup, no runtime behavior change.
             touch {{ .Values.dataMountPath }}/.replication-pending
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         name: init-syncer
@@ -163,8 +168,21 @@ spec:
             # RED. The constants below are inlined non-bypass grant lists kept
             # in sync with switchover.sh's SWITCHOVER_*_GRANT_BODY constants;
             # ShellSpec strong-binds the alignment.
-            CMPD_EXPLICIT_PRIMARY_GRANT_BODY="SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, CREATE USER"
-            CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN"
+            # alpha.81 v1: explicitly add SLAVE MONITOR to the grant bodies.
+            # Root cause: MariaDB 11.4 split legacy `REPLICATION CLIENT` into
+            # `BINLOG MONITOR` + `SLAVE MONITOR`. `GRANT REPLICATION CLIENT`
+            # only normalizes to `BINLOG MONITOR` in SHOW GRANTS — `SLAVE
+            # MONITOR` (required for `SHOW SLAVE STATUS`) is NOT included.
+            # Without `SLAVE MONITOR`, syncer engine's `IsSwitchoverDone()`
+            # in promotion_gate.go (which connects new primary -> old primary
+            # via `kb_internal_root@'%'` then issues `SHOW SLAVE STATUS`) gets
+            # ERROR 1227 ("need SLAVE MONITOR privilege"), returns false
+            # forever, the framework `HandlerSwitchoverForPrimary` cleanup
+            # gate never trips, and the DCS Switchover ConfigMap leaks. This
+            # broke same-cluster repeat switchover (the alpha.79 N=3 RED
+            # "there is another switchover unfinished" axis).
+            CMPD_EXPLICIT_PRIMARY_GRANT_BODY="SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, CREATE USER"
+            CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN"
             # Best-effort monitor privileges (read-only). These never bypass
             # read_only and are safe on user-facing root in any state. Tier A
             # by Jack 10:05: failure here is allowed to log + continue.
@@ -186,6 +204,13 @@ spec:
             # later pod accepts a local syncer primary role.
             SYNCER_PRIMARY_BOOTSTRAP_GRACE_SECONDS="${MARIADB_SYNCER_PRIMARY_BOOTSTRAP_GRACE_SECONDS:-45}"
             SYNCER_PRIMARY_BOOTSTRAP_GRACE_UNTIL="$(($(date +%s) + SYNCER_PRIMARY_BOOTSTRAP_GRACE_SECONDS))"
+            # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_is_fresh`
+            # function + `SWITCHOVER_FENCE_MARKER_MAX_AGE_SECONDS` env are
+            # removed. alpha.79 v1 minimalist deleted the marker writer in
+            # switchover.sh, so this consumer-side function never observed a
+            # fresh marker; the consumer checks in `reconcile_sql_listener_for_
+            # syncer_primary_once` and `set_remote_root_account_state` always
+            # fell through. Pure dead-code cleanup, no runtime behavior change.
             ROOT_LOCAL=(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
             INTERNAL_LOCAL=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
             LOCAL=("${ROOT_LOCAL[@]}")
@@ -775,6 +800,7 @@ spec:
                 ALTER USER '${user}'@'%' ACCOUNT UNLOCK;
                 REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'%';
                 GRANT REPLICATION CLIENT ON *.* TO '${user}'@'%';
+                GRANT SLAVE MONITOR ON *.* TO '${user}'@'%';
                 GRANT REPLICATION MASTER ADMIN ON *.* TO '${user}'@'%';
                 GRANT SELECT, INSERT, UPDATE ON kubeblocks.kb_health_check TO '${user}'@'%';
                 GRANT SELECT ON mysql.user TO '${user}'@'%';
@@ -1001,6 +1027,10 @@ spec:
                   return 0
                   ;;
               esac
+              # alpha.80 v1 (Helen): the alpha.77 in-function marker check
+              # has been removed. alpha.79 v1 minimalist deleted the marker
+              # writer in switchover.sh, so this gate could never trip. Pure
+              # dead-code cleanup, no runtime behavior change.
               if [ "${state}" = "LOCK" ]; then
                 # alpha.64 v1 (Jack 09:35 RED): drop SUPER (admin bypass).
                 # Use CMPD_SECONDARY_FENCE_GRANT_BODY shared with local LOCK.
@@ -1125,11 +1155,36 @@ spec:
               local label="$1"
               local timeout_seconds="${2:-120}"
               local sleep_seconds="${3:-2}"
-              local start now elapsed slave_status evidence_file
+              local start now elapsed slave_status evidence_file current_syncer_role
               start="$(date +%s)"
               evidence_file="{{ .Values.dataMountPath }}/log/rejoin-replication-wait.log"
               mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
               while true; do
+                # alpha.77 v3 (Helen TL): if syncer has flipped this pod to
+                # primary in DCS (e.g. a switchover OpsRequest just promoted
+                # this candidate), exit the secondary-rejoin wait immediately
+                # so the outer wait_for_mariadbd_with_role_reconcile loop can
+                # switch into the primary reconcile path on its next tick.
+                # Without this short-circuit, this loop will spin up to
+                # `timeout_seconds` (default 120s) trying to follow the OLD
+                # primary that is no longer the DCS primary, blowing past the
+                # switchover candidate-write-ready stage budget.
+                #
+                # Backward compatibility: when syncer continues to report
+                # role=secondary (the normal post-rejoin / lifecycle path),
+                # the loop body below runs unchanged. The check itself is
+                # bounded by `timeout 3` inside query_local_syncer_role and
+                # is best-effort (failure is treated as not-flipped, loop
+                # continues). Distinct sentinel log + return code 2 so
+                # downstream callers and closeout can distinguish "DCS
+                # promoted us mid-rejoin" from a real replication-not-
+                # healthy timeout (return 1).
+                current_syncer_role="$(query_local_syncer_role || true)"
+                if [ "${current_syncer_role}" = "primary" ]; then
+                  elapsed=$(($(date +%s) - start))
+                  prestop_watchdog_log "rejoin-replication-exit-on-dcs-primary label=${label} elapsed=${elapsed}s reason=dcs_promoted_during_secondary_rejoin"
+                  return 2
+                fi
                 slave_status="$(query_slave_status_verbose || true)"
                 if slave_status_is_healthy "${slave_status}"; then
                   elapsed=$(($(date +%s) - start))
@@ -1500,6 +1555,11 @@ spec:
             reconcile_sql_listener_for_syncer_primary_once() {
               local now primary_sid role
               [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
+              # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_is_fresh`
+              # early-skip has been removed. alpha.79 v1 minimalist deleted the
+              # marker writer in switchover.sh, so this check could never observe
+              # a fresh marker and always fell through. Pure dead-code cleanup,
+              # no runtime behavior change.
               if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
                 role="$(query_local_syncer_role || true)"
                 [ "${role}" = "primary" ] || return 0
@@ -2005,7 +2065,7 @@ spec:
                         ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
                         ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
                         REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
-                        GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO '${user}'@'${host}';
+                        GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN ON *.* TO '${user}'@'${host}';
                         FLUSH PRIVILEGES;
                         SET SESSION sql_log_bin=1;
                       "

--- a/addons/mariadb/templates/cmpv.yaml
+++ b/addons/mariadb/templates/cmpv.yaml
@@ -12,6 +12,19 @@ spec:
         - {{ include "mariadb.standalone.cmpdRegexpPattern" . }}
         - {{ include "mariadb.replication.cmpdRegexpPattern" . }}
         - {{ include "mariadb.semisync.cmpdRegexpPattern" . }}
+        # alpha.89 v1 commit 15 (Helen 2026-05-20, live N=1 first
+        # blocker from vcluster `mariadb-test5` rerun) — bind the
+        # merged replication CmpD to the same release set so the
+        # InstanceSet gets the engine / exporter / init-syncer
+        # images. Without this entry the rendered live InstanceSet
+        # leaves the mariadb / exporter / init-syncer image fields
+        # empty (Pod create fails with "spec.containers[*].image:
+        # Required value", controller log "ImageUtil parse image
+        # failed, image="""). The merged regex is more specific
+        # than `^mariadb-replication-[0-9]` (matches digits only),
+        # so adding the merged pattern alongside the existing three
+        # does not over-match.
+        - {{ include "mariadb.replication.merged.cmpdRegexpPattern" . }}
       releases:
         - 10.6.15
         - 11.4.5

--- a/addons/mariadb/templates/cmpv.yaml
+++ b/addons/mariadb/templates/cmpv.yaml
@@ -7,6 +7,16 @@ metadata:
   annotations:
     {{- include "mariadb.annotations" . | nindent 4 }}
 spec:
+  # NOTE on release evidence (see addon-api/12b-claimed-only-acceptance):
+  # As of this chart bump, only the following (CmpD, release) pairs have a
+  # recorded evidence-supported install + smoke chain:
+  #   - standalone cmpd                                                       10.6.15
+  #   - replication / semisync / replication-merged cmpd                      11.4.10
+  #   - galera cmpd                                                           11.4.10
+  # The other releases listed below (11.4.5, 11.4.8, 11.8.4, 12.0.2) are
+  # API-compatible declarations and have NOT been exercised end-to-end.
+  # Treat them as "declared but unverified" until a recorded test artifact
+  # exercises the install + smoke + lifecycle path on the matching release.
   compatibilityRules:
     - compDefs:
         - {{ include "mariadb.standalone.cmpdRegexpPattern" . }}

--- a/addons/mariadb/templates/configmap-scripts-replication.yaml
+++ b/addons/mariadb/templates/configmap-scripts-replication.yaml
@@ -14,3 +14,13 @@ data:
     {{- .Files.Get "scripts/replication-member-join.sh" | nindent 4 }}
   replication-switchover.sh: |-
     {{- .Files.Get "scripts/replication-switchover.sh" | nindent 4 }}
+  # alpha.89 v1 commit 5 (Helen 2026-05-19, C1 path lifecycle wiring) —
+  # mount validate-replication-mode.sh at /scripts so it is callable
+  # via `kubectl exec <pod> -c mariadb -- /scripts/validate-replication-mode.sh`
+  # (test runners + ad-hoc operators). A later commit can add a
+  # kbagent lifecycle action referencing this same path without
+  # re-touching the ConfigMap. The script stays read-only and uses
+  # the MYSQL_SOCKET / MYSQL_USER / MYSQL_PASSWORD / MYSQL_EXTRA_ARGS
+  # env passthroughs added in commit 4 v2 for connection context.
+  validate-replication-mode.sh: |-
+    {{- .Files.Get "scripts/validate-replication-mode.sh" | nindent 4 }}

--- a/addons/mariadb/templates/configmap-scripts-replication.yaml
+++ b/addons/mariadb/templates/configmap-scripts-replication.yaml
@@ -38,3 +38,17 @@ data:
   # backstop preventing the synthetic key from ever landing in my.cnf.
   replication-mode-mapper.sh: |-
     {{- .Files.Get "scripts/replication-mode-mapper.sh" | nindent 4 }}
+  # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack post-commit-13-v1
+  # install-time write-site requirement msg `696e7b16`) — install-time
+  # seeder that translates `MARIADB_REPLICATION_MODE` (set by Helm
+  # value mariadb.replication.mode → CmpD container env, commit 13 v1)
+  # into the four per-parameter override `.cnf` files under
+  # runtime-overrides.d/ BEFORE the first mariadbd start. Without this
+  # seeder the env wire was dormant: a chart user setting
+  # `mariadb.replication.mode=semisync` at install time would still
+  # boot async and not flip until the first reconfigureAction trigger.
+  # The seeder writes byte-identical content to what
+  # reconfigureAction.persisted writes for the same env, so the two
+  # write-sites converge.
+  seed-replication-mode-overrides.sh: |-
+    {{- .Files.Get "scripts/seed-replication-mode-overrides.sh" | nindent 4 }}

--- a/addons/mariadb/templates/configmap-scripts-replication.yaml
+++ b/addons/mariadb/templates/configmap-scripts-replication.yaml
@@ -24,3 +24,17 @@ data:
   # env passthroughs added in commit 4 v2 for connection context.
   validate-replication-mode.sh: |-
     {{- .Files.Get "scripts/validate-replication-mode.sh" | nindent 4 }}
+  # alpha.89 v1 commit 12 (Helen 2026-05-20, C3 design mapper) —
+  # mount replication-mode-mapper.sh at /scripts so the merged CmpD's
+  # reconfigureAction.persisted helper can source it before the main
+  # loop processes parameter assignments. The mapper translates the
+  # synthetic `replicationMode` ComponentSpec parameter
+  # ("async" | "semisync") into the four real engine variables
+  # (rpl_semi_sync_master_enabled / slave_enabled /
+  # master_wait_for_slave_count / master_timeout) and fails closed on
+  # invalid mode or conflict with user-supplied real-var values. The
+  # CUE `replicationmode?: _|_` declared in commit 11 v2
+  # (`mariadb-config-constraint.cue`) is the defense-in-depth
+  # backstop preventing the synthetic key from ever landing in my.cnf.
+  replication-mode-mapper.sh: |-
+    {{- .Files.Get "scripts/replication-mode-mapper.sh" | nindent 4 }}

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -144,6 +144,37 @@ spec:
     format: ini
     iniConfig:
       sectionName: mysqld
+  # alpha.89 v1 commit 3 v2 (Helen 2026-05-19, C1 path / Jack
+  # design review Class 4 sentinel + Class 4 fail-closed blocker
+  # B1) — declare a CUE-based parametersSchema so KB validates
+  # `rpl_semi_sync_*` parameter assignments before they reach the
+  # engine. The CUE file under config/mariadb-config-constraint.cue
+  # both declares the #MariaDBParameter type AND binds it to every
+  # INI section via `[SectionName=_]: #MariaDBParameter` — without
+  # the binding, KB's `ValidateConfigWithCue()` does not use the
+  # top-level definition and invalid values such as
+  # `rpl_semi_sync_master_enabled = MAYBE` slip through. With the
+  # binding in place, KB rejects unknown enum / out-of-range /
+  # wrong-type assignments at the controller parameter reconcile
+  # path (`ClassifyComponentParameters()` / `DoMerge()` calling
+  # the CUE validator), so an invalid value never lands in the
+  # rendered ConfigMap. PR #10254 once merged extends the
+  # validation to an earlier `ValidateComponentParameterAssignments()`
+  # entry that hard-rejects at OpsRequest validate-phase using the
+  # same schema.
+  #
+  # The CUE schema covers only the four semisync engine variables
+  # that are the real source-of-truth for replication mode. There
+  # is intentionally no synthetic `replicationMode` key — KB's
+  # ParamConfigRenderer has no transform hook to expand a single
+  # logical key into multiple engine variables, so a synthetic key
+  # would either be ignored or land in my.cnf verbatim and break
+  # mariadbd. The unified-switch UX is delivered via addon docs
+  # (and future helper scripts).
+  parametersSchema:
+    topLevelKey: MariaDBParameter
+    cue: |-
+      {{- .Files.Get "config/mariadb-config-constraint.cue" | nindent 6 }}
   {{- if hasKey $pd "staticParameters" }}
   staticParameters:
     {{- range (get $pd "staticParameters") }}

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -110,6 +110,52 @@ spec:
   {{- end }}
 
 ---
+# ParametersDefinition for the merged replication CmpD
+# (alpha.89 — topology merge under weston 2026-05-19 Option B).
+#
+# Binds to the new `mariadb-replication-merged-…` CmpD via
+# `^mariadb-replication-merged-` regex. The regex does NOT overlap
+# with `^mariadb-replication-` (old async CmpD) or `^mariadb-semisync-`
+# (old semisync CmpD); the `-merged-` middle segment ensures the
+# match is exclusive (Jack design Gate 3 — single PD per CmpD, no
+# double-match across PDs).
+#
+# This first commit reuses the same fileName / templateName as the
+# old semisync PD (`mariadb-semisync-config`) because the new merged
+# CmpD initially uses the same configspec name as cmpd-semisync.yaml.
+# Subsequent commits will rename the configspec to
+# `mariadb-replication-config` (single template) and update this PD
+# accordingly. For now this PD keeps the merged CmpD's semisync-style
+# parameters resolvable so reconfigureAction goes through the dynamic
+# path rather than rolling restart.
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: mariadb-replication-merged-pd
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+spec:
+  componentDef: {{ include "mariadb.replication.merged.cmpdRegexpPattern" . | quote }}
+  templateName: mariadb-semisync-config
+  fileName: my.cnf
+  fileFormatConfig:
+    format: ini
+    iniConfig:
+      sectionName: mysqld
+  {{- if hasKey $pd "staticParameters" }}
+  staticParameters:
+    {{- range (get $pd "staticParameters") }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if hasKey $pd "dynamicParameters" }}
+  dynamicParameters:
+    {{- range (get $pd "dynamicParameters") }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+
+---
 # ParametersDefinition for Galera MariaDB
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -57,6 +57,59 @@ spec:
   {{- end }}
 
 ---
+# ParametersDefinition for semisync MariaDB
+#
+# alpha.84 v1 (Helen 2026-05-19) — semisync topology previously had NO
+# ParametersDefinition. paramsdef.yaml declared standalone / replication /
+# galera but not semisync; replication PD `componentDef` regex
+# `^mariadb-replication-` did not match `^mariadb-semisync-` cmpd. With no
+# matching PD, the KB Configure controller treats dynamic parameters
+# (slow_query_log, long_query_time, etc.) as unknown-effect and falls back
+# to rolling restart, which on semisync triggers switchover/promote and
+# causes the new primary's mysqld to restart inside the container — losing
+# the `SET GLOBAL` runtime state applied by reconfigureAction. The fresh
+# clean-r1 evidence packet (`9502a88f...`) showed pod1 mysqld process-level
+# restart at 20:42:33 (k8s container restartCount=0, but mariadbd PID
+# changed via switchover promote path), reading old my.cnf from the
+# ConfigMap volume that had not yet propagated kubelet's sync.
+#
+# This semisync PD aligns with replication PD shape:
+#   componentDef: ^mariadb-semisync-
+#   templateName: mariadb-semisync-config  (matches cmpd-semisync.yaml's
+#     configs[0].name; NOT the ConfigMap object name
+#     `mariadb-semisync-config-template`, which is the Helm template
+#     identifier — see Galera comment for the same trap)
+#   fileName: my.cnf
+# Same staticParameters / dynamicParameters scope as other topologies
+# (sourced from `config/mariadb-config-effect-scope.yaml`).
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: mariadb-semisync-pd
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+spec:
+  componentDef: {{ include "mariadb.semisync.cmpdRegexpPattern" . | quote }}
+  templateName: mariadb-semisync-config
+  fileName: my.cnf
+  fileFormatConfig:
+    format: ini
+    iniConfig:
+      sectionName: mysqld
+  {{- if hasKey $pd "staticParameters" }}
+  staticParameters:
+    {{- range (get $pd "staticParameters") }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if hasKey $pd "dynamicParameters" }}
+  dynamicParameters:
+    {{- range (get $pd "dynamicParameters") }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+
+---
 # ParametersDefinition for Galera MariaDB
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -126,10 +126,14 @@ spec:
 # `mariadb-semisync-config` to `mariadb-replication-config`; this PD
 # tracks the rename so the binding stays consistent across the three
 # files (cmpd configspec name / PD templateName / PCR templateName).
-# The underlying ConfigMap object template is still
-# `mariadb-semisync-config-template` until the parameter-driven
-# defaults land, so PD parameter resolution continues to work
-# against the semisync ConfigMap content unchanged.
+# alpha.89 v1 commit 8 (Helen 2026-05-19) flipped the underlying
+# ConfigMap object template from `mariadb-semisync-config-template`
+# to `mariadb-replication-config-template` (async defaults). PD
+# parameter resolution now operates against the async ConfigMap;
+# the four `rpl_semi_sync_*` variables are absent from the default
+# my.cnf and only land when a Cluster CR explicitly sets them via
+# `spec.componentSpecs[].parameters` (validated by the CUE schema
+# declared below at commit 3 v2).
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -120,14 +120,16 @@ spec:
 # match is exclusive (Jack design Gate 3 — single PD per CmpD, no
 # double-match across PDs).
 #
-# This first commit reuses the same fileName / templateName as the
-# old semisync PD (`mariadb-semisync-config`) because the new merged
-# CmpD initially uses the same configspec name as cmpd-semisync.yaml.
-# Subsequent commits will rename the configspec to
-# `mariadb-replication-config` (single template) and update this PD
-# accordingly. For now this PD keeps the merged CmpD's semisync-style
-# parameters resolvable so reconfigureAction goes through the dynamic
-# path rather than rolling restart.
+# `templateName` must match the merged CmpD's configspec name
+# (`spec.configs[].name` in cmpd-replication-merged.yaml). alpha.89
+# v1 commit 2 (Helen 2026-05-19) renamed that configspec from
+# `mariadb-semisync-config` to `mariadb-replication-config`; this PD
+# tracks the rename so the binding stays consistent across the three
+# files (cmpd configspec name / PD templateName / PCR templateName).
+# The underlying ConfigMap object template is still
+# `mariadb-semisync-config-template` until the parameter-driven
+# defaults land, so PD parameter resolution continues to work
+# against the semisync ConfigMap content unchanged.
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:
@@ -136,7 +138,7 @@ metadata:
     {{- include "mariadb.labels" . | nindent 4 }}
 spec:
   componentDef: {{ include "mariadb.replication.merged.cmpdRegexpPattern" . | quote }}
-  templateName: mariadb-semisync-config
+  templateName: mariadb-replication-config
   fileName: my.cnf
   fileFormatConfig:
     format: ini

--- a/addons/mariadb/templates/pcr.yaml
+++ b/addons/mariadb/templates/pcr.yaml
@@ -76,11 +76,18 @@ spec:
 
 ---
 # ParamConfigRenderer for the merged replication CmpD
-# (alpha.89 — topology merge). Initial PCR uses the same
-# templateName as semisync because the merged CmpD currently inherits
-# cmpd-semisync.yaml's configspec name. Subsequent commits will switch
-# this PCR to a unified `mariadb-replication-config` template once the
-# CmpD's configspec is renamed.
+# (alpha.89 — topology merge).
+#
+# alpha.89 v1 commit 2 (Helen 2026-05-19) — `templateName` updated
+# from `mariadb-semisync-config` to `mariadb-replication-config` to
+# track the merged CmpD's configspec rename (cmpd-replication-merged
+# .yaml `spec.configs[].name`). KB Configure resolves this PCR's
+# templateName against the CmpD's configspec name, so they must
+# stay in lockstep. The underlying ConfigMap object template name
+# (`mariadb-semisync-config-template`) is not part of this rename;
+# it remains the rendered source until `replicationMode`
+# parameterization lands and async/semisync defaults can be
+# expressed in a unified template.
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParamConfigRenderer
 metadata:
@@ -91,7 +98,7 @@ spec:
   componentDef: {{ include "mariadb.replication.merged.cmpdName" . }}
   configs:
     - name: my.cnf
-      templateName: mariadb-semisync-config
+      templateName: mariadb-replication-config
       fileFormatConfig:
         format: ini
         iniConfig:

--- a/addons/mariadb/templates/pcr.yaml
+++ b/addons/mariadb/templates/pcr.yaml
@@ -42,7 +42,18 @@ spec:
     - mariadb-replication-pd
 
 ---
-# ParamConfigRenderer for semisync MariaDB
+# ParamConfigRenderer for semisync MariaDB.
+#
+# alpha.89 v1 (Helen 2026-05-19, Jack design review caveat) — fixed
+# parametersDefs from `mariadb-replication-pd` (which binds to
+# `^mariadb-replication-[0-9]` CmpD, NOT to semisync) to the correct
+# `mariadb-semisync-pd` (which binds to `^mariadb-semisync-` CmpD).
+# The previous wiring was a pre-existing bug that happened not to bite
+# under the old `^mariadb-replication-` wide regex; under the new
+# narrowed regex it would silently leave the semisync PCR pointing at
+# an unrelated PD. Since the deprecated semisync CmpD is kept around
+# to serve any already-bound Cluster, its PCR must reference the
+# matching PD or live config rendering will not resolve correctly.
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParamConfigRenderer
 metadata:
@@ -61,7 +72,34 @@ spec:
       reRenderResourceTypes:
         - vscale
   parametersDefs:
-    - mariadb-replication-pd
+    - mariadb-semisync-pd
+
+---
+# ParamConfigRenderer for the merged replication CmpD
+# (alpha.89 — topology merge). Initial PCR uses the same
+# templateName as semisync because the merged CmpD currently inherits
+# cmpd-semisync.yaml's configspec name. Subsequent commits will switch
+# this PCR to a unified `mariadb-replication-config` template once the
+# CmpD's configspec is renamed.
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParamConfigRenderer
+metadata:
+  name: {{ include "mariadb.replication.merged.cmpdName" . }}-pcr
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+spec:
+  componentDef: {{ include "mariadb.replication.merged.cmpdName" . }}
+  configs:
+    - name: my.cnf
+      templateName: mariadb-semisync-config
+      fileFormatConfig:
+        format: ini
+        iniConfig:
+          sectionName: mysqld
+      reRenderResourceTypes:
+        - vscale
+  parametersDefs:
+    - mariadb-replication-merged-pd
 
 ---
 # ParamConfigRenderer for Galera MariaDB

--- a/addons/mariadb/values.yaml
+++ b/addons/mariadb/values.yaml
@@ -26,6 +26,39 @@ defaultServiceVersion:
 etcd:
   etcdCmpdName: etcd
 
+## @section replication
+## alpha.89 v1 commit 13 (Helen 2026-05-20) — C3 design env plumbing
+## via Helm value (the conservative plumbing path: chart-install-time
+## configurable; runtime OpsRequest mode flip is deferred to a future
+## commit that wires a Cluster annotation OR a non-INI-bound PD).
+##
+## `mariadb.replication.mode` is the top-level switch consumed by the
+## addon-side mapper (`scripts/replication-mode-mapper.sh`) sourced
+## into the merged CmpD's `reconfigureAction.persisted` helper. The
+## mapper translates the value into the four real engine variables
+## (rpl_semi_sync_master_enabled / slave_enabled /
+## master_wait_for_slave_count / master_timeout) BEFORE the main
+## loop renders any my.cnf or runtime-overrides.d/ file. When the
+## value is empty (the default) the mapper is a no-op: the
+## "only-4-vars" path on existing clusters is unchanged. The CUE
+## `replicationmode?: _|_` declared in commit 11 v2 ensures the
+## synthetic key cannot leak into the rendered my.cnf even if a
+## future plumbing source sets it incorrectly.
+##
+## Accepted values: "", "async", "semisync".
+##   ""        — default; mapper no-op; existing behavior preserved.
+##   "async"   — mapper writes master_enabled=OFF / slave_enabled=OFF
+##               into runtime-overrides at first reconfigure.
+##   "semisync" — mapper writes master_enabled=ON / slave_enabled=ON
+##                + wait_for_slave_count=1 + timeout=10000 into
+##                runtime-overrides at first reconfigure.
+##
+## Invalid values fail the reconfigureAction with mapper rc=2
+## (invalid mode) and exit 1; the action does not produce any
+## partial state.
+replication:
+  mode: ""
+
 ## MySQL Authentication parameters
 auth:
   ## MYSQL_ROOT_HOST


### PR DESCRIPTION
## Summary

Rolls up 24 commits from the active MariaDB alpha.86 → alpha.90 work branch onto the existing `feat/mariadb-alpha37-semisync-fencing-pr` branch (the head of PR #2633). Without this PR the work branch is an orphan: it has the multi-topology merge, four live-cluster first-blocker fixes against alpha.89/alpha.90, and the addon-api/12b conformance fix from PR #2657, but no routing toward main.

Per weston's direction (2026-05-24 00:01), all subsequent MariaDB PRs should base on PR #2633's head; this PR establishes that chain by getting the alpha.90 work onto that base.

## Commit roll-up (24 commits, oldest → newest)

Alpha.76 → alpha.88 hardening and persistence:
- `61cc3823` alpha.76-85 semisync product chain hardening
- `d3edfa3b` alpha.86→alpha.87→alpha.88 persistence layer via mariadbd --defaults-extra-file

Alpha.89 topology-merge scaffolding and synthetic-parameter mapper (C1 + C3 paths):
- `3e22df58` topology merge scaffolding (single replication topology + merged CmpD)
- `98714037` rename merged CmpD configspec
- `25858716` merged PD CUE schema with INI section binding
- `a001e746` validate-replication-mode.sh read-only consistency check
- `ef5c3d95` mount validate-replication-mode.sh in replication script ConfigMap
- `5bf892bb` bump existing ShellSpec chart version literals to alpha.89
- `6449ec95` stage is_semisync_mode helper in replication-switchover.sh
- `472ee072` flip merged CmpD default to async
- `cb96ced9` sync paramsdef comment to default-async flip
- `dc645466` extend PD CUE schema with replicationMode + conditional derivation
- `202e35f8` forbid synthetic replicationmode in CUE
- `1e9bc910` addon mapper for replicationMode → 4 engine vars
- `30df1cbb` fix mapper rc-preservation and unconditional synthetic-strip
- `ae2698af` MARIADB_REPLICATION_MODE env wire via Helm value (C3 plumbing)
- `1f2fe79b` install-time write-site + Helm template-time fail-closed
- `b76f770a` close install-time write-site contract gaps B3+B4+B5
- `05dc1a20` refactor env-wire ShellSpec to grep tmp file

Alpha.89 → alpha.90 live N=1 first-blocker fixes:
- `b3d23c44` remove `replicationmode?: _|_` CUE bottom that breaks live PD OpenAPI schema gen
- `e7d2c9d4` add merged CmpD to ComponentVersion compatibilityRules
- `70bc7d11` drop MySQL-specific rpl_semi_sync_master_wait_for_slave_count
- `e373308b` alpha.89 → alpha.90 chart bump (CmpD immutability fix)

addon-api conformance:
- `a1d88ded` align README + chart claims with addon-api/12b acceptance (PR #2657)

## Boundary

- This PR is a roll-up against the alpha.37 fencing branch; it does NOT change the addon's `feat/...alpha37` baseline behavior. The 24 commits are the post-alpha.37 chain.
- An open follow-up PR (#2663) bases on `helen/mariadb-topology-merge-20260519` (this PR's head) with the BPT per-topology resolution comment + galera scripts ConfigMap helper fix; that PR will propagate through here.

## Test plan

- [x] Branch head is `de68fdb7` after PR #2663 merges (currently `a1d88ded` if PR #2663 not yet merged into this branch); the alpha.90 chart already has live N=1 GREEN evidence on idc/mariadb-test5 (`artifacts/alpha90-conformance-test-evidence.tar.gz` sha256 `518595924deb6ed53a1881353d814c137030c4331999e428ddecbe538d24c747`)
- [x] All 24 commits already passed Jack design review or live N=1 evidence at the time of original landing on the work branch
- [x] No new code changes in this PR — it is purely a routing PR to establish the alpha.90 work chain under PR #2633's head
