### PR TITLE
fix(valkey): require sentinel quorum on (epoch, runid) before emitting versioned roleProbe token

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -485,6 +485,201 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should eq "REJECT"
       End
     End
+
+    Context "v3 quorum across configured sentinels (Edward+Bob2 sign-off contract)"
+      # The roleProbe must not emit `<role> <epoch>` while Sentinels are
+      # in a split-view at the same config-epoch. The quorum gate filters
+      # each sentinel's response by (uint64 epoch, hex runid, no
+      # transient/failure flags), then requires a strict majority of the
+      # CONFIGURED sentinel count to fall in a single (epoch, runid)
+      # group. Otherwise fall back to legacy single-token output so the
+      # controller stays on its EventTime path and the Pod annotation is
+      # not advanced to `engine:N` prematurely.
+
+      # Compute strict majority of total configured sentinel count, NOT
+      # of reachable/valid count.
+      min_valid_for() {
+        local total="$1"
+        printf "%s" "$(( total / 2 + 1 ))"
+      }
+
+      # Encode a list of (epoch, runid, flags) triples (one per sentinel
+      # entry, "skip" for unreachable) and decide quorum: emit either
+      # `EMIT <epoch>:<runid>` or `LEGACY` plus a diagnostic suffix.
+      quorum_decide() {
+        local total="$1"; shift
+        local min_valid
+        min_valid=$(min_valid_for "${total}")
+        local entry epoch runid flags
+        local -a keys=()
+        for entry in "$@"; do
+          # skip = unreachable sentinel
+          if [ "${entry}" = "skip" ]; then
+            continue
+          fi
+          IFS='|' read -r epoch runid flags <<< "${entry}"
+          case "${epoch}" in
+            ''|*[!0-9]*) continue ;;
+          esac
+          case "${runid}" in
+            ''|*[!0-9a-fA-F]*) continue ;;
+          esac
+          case ",${flags}," in
+            *,failover_in_progress,*|*,force_failover,*|*,s_down,*|*,o_down,*) continue ;;
+          esac
+          keys+=("${epoch}:${runid}")
+        done
+        local valid_count=${#keys[@]}
+        if [ "${valid_count}" -lt "${min_valid}" ]; then
+          printf "LEGACY"
+          return 0
+        fi
+        local first="${keys[0]}"
+        local k
+        for k in "${keys[@]}"; do
+          if [ "${k}" != "${first}" ]; then
+            printf "LEGACY"
+            return 0
+          fi
+        done
+        printf "EMIT %s" "${first}"
+        return 0
+      }
+
+      It "3/3 sentinels agree on a single (epoch, runid) → versioned (pre)"
+        When call quorum_decide 3 "16|3119abcd|master" "16|3119abcd|master" "16|3119abcd|master"
+        The status should be success
+        The stdout should eq "EMIT 16:3119abcd"
+      End
+
+      It "3/3 sentinels agree on the converged post-failover view → versioned (post3+)"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "17|00d5beef|master"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "post0 view: 2 old-quorum (epoch16) sentinels + 1 partial new sentinel (empty runid) → versioned on the still-stable OLD quorum"
+        # At the very start of the failover, two sentinels still believe
+        # the old master at epoch 16, and one has just begun voting for
+        # the new master at epoch 17 with the runid not yet filled. The
+        # invalid third entry is dropped; the remaining two-of-three
+        # quorum still authorities the OLD (epoch, runid) which is the
+        # current cluster state. Emitting at this point is safe because
+        # the controller's Pod annotation is already at engine:16, so
+        # the same-version refresh is a no-op.
+        When call quorum_decide 3 "16|3119abcd|master" "16|3119abcd|master" "17||master"
+        The status should be success
+        The stdout should eq "EMIT 16:3119abcd"
+      End
+
+      It "post1/post2 split view: old master with failover_in_progress flag is dropped, two new master views disagree on runid (one empty) → legacy"
+        When call quorum_decide 3 "17|3119abcd|master,failover_in_progress,force_failover" "17||master" "17|00d5beef|master"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "majority of configured (2 of 3) agree, third invalid (empty runid) → versioned"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "17||master"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "majority of configured (2 of 3) agree, third invalid (non-numeric epoch) → versioned"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "abc|abc|master"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "majority of configured (2 of 3) agree, third invalid (failover_in_progress flag) → versioned"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "17|deadbeef|master,failover_in_progress"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "only 1 valid of 3 configured → legacy (single-sentinel cannot self-quorum)"
+        When call quorum_decide 3 "17|00d5beef|master" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "2 valid at SAME epoch but DIFFERENT runid → legacy (master identity split)"
+        When call quorum_decide 3 "17|00d5beef|master" "17|deadbeef|master" "17||master"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "2 valid at DIFFERENT epochs → legacy (epoch split)"
+        When call quorum_decide 3 "17|00d5beef|master" "16|3119abcd|master" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "all 3 sentinels unreachable → legacy"
+        When call quorum_decide 3 "skip" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "5-sentinel configured: 3 agree (majority) → versioned even if 2 invalid"
+        When call quorum_decide 5 "17|00d5beef|master" "17|00d5beef|master" "17|00d5beef|master" "17||master" "skip"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "5-sentinel configured: 2 agree (below majority of 3) → legacy"
+        When call quorum_decide 5 "17|00d5beef|master" "17|00d5beef|master" "17||master" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "min_valid is floor(total/2)+1, not ceil(total/2)"
+        When call min_valid_for 3
+        The status should be success
+        The stdout should eq "2"
+      End
+
+      It "min_valid for 4 configured is 3 (strict majority)"
+        When call min_valid_for 4
+        The status should be success
+        The stdout should eq "3"
+      End
+
+      It "min_valid for 5 configured is 3"
+        When call min_valid_for 5
+        The status should be success
+        The stdout should eq "3"
+      End
+    End
+
+    Context "v3 grep-level assertions on the production script"
+      check_role_script="../scripts/check-role.sh"
+
+      It "computes min_valid as configured_count/2+1"
+        When call grep -F 'min_valid=$((configured_count / 2 + 1))' "${check_role_script}"
+        The status should be success
+        The stdout should include "configured_count"
+      End
+
+      It "drops sentinel views with transient/failure flags from quorum"
+        When call grep -F 'failover_in_progress' "${check_role_script}"
+        The status should be success
+        The stdout should include "failover_in_progress"
+      End
+
+      It "captures sentinel flags alongside config-epoch and runid"
+        When call grep -F 'flags_marker' "${check_role_script}"
+        The status should be success
+        The stdout should include "flags_marker"
+      End
+
+      It "decides primary token from quorum runid match, not local INFO=master"
+        # The block that sets authoritative_role must only compare
+        # local_run_id with sentinel_master_runid, no role_line check.
+        When call grep -A 8 'authoritative_role=""' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinel_master_runid"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -429,10 +429,14 @@ Describe "Valkey Check-Role Bash Script Tests"
       It "rejects non-hex sentinel master runid via case-statement shape guard"
         # Per Edward msg=2140dce9, an empty check alone is not enough:
         # a non-empty but malformed runid (e.g. `not-a-real-runid!`)
-        # would otherwise enter the engine-version path.
-        When call grep -F "''|*[!0-9a-fA-F]*) continue ;;" "${check_role_script}"
+        # would otherwise enter the engine-version path. The production
+        # path now records the rejection reason in `__drop_reason` so
+        # the debug instrumentation can report which sentinel views were
+        # excluded; the character-set pattern lives on the right side of
+        # the `case` arm.
+        When call grep -F '__drop_reason="runid_empty_or_non_hex"' "${check_role_script}"
         The status should be success
-        The stdout should include "0-9a-fA-F"
+        The stdout should include "runid_empty_or_non_hex"
       End
     End
 
@@ -678,6 +682,50 @@ Describe "Valkey Check-Role Bash Script Tests"
         When call grep -A 8 'authoritative_role=""' "${check_role_script}"
         The status should be success
         The stdout should include "sentinel_master_runid"
+      End
+    End
+
+    Context "VALKEY_CHECK_ROLE_DEBUG diagnostic instrumentation (env-gated)"
+      # When the operator sets VALKEY_CHECK_ROLE_DEBUG=1, each call must
+      # append one JSON-shaped line to /tmp/check-role-debug.log with the
+      # raw per-sentinel readings plus the quorum decision. Stdout MUST
+      # stay on the production contract — debug must not leak into the
+      # role token under any path.
+      check_role_script="../scripts/check-role.sh"
+
+      It "is gated by VALKEY_CHECK_ROLE_DEBUG env (default off)"
+        When call grep -F 'VALKEY_CHECK_ROLE_DEBUG' "${check_role_script}"
+        The status should be success
+        The stdout should include "VALKEY_CHECK_ROLE_DEBUG"
+      End
+
+      It "writes the diagnostic record to a Pod-local file under /tmp"
+        When call grep -F '__check_role_debug_log="/tmp/check-role-debug.log"' "${check_role_script}"
+        The status should be success
+        The stdout should include "/tmp/check-role-debug.log"
+      End
+
+      It "records both the per-sentinel raw fields and the quorum decision reason"
+        # We rely on these names so off-line analysis tooling has a stable
+        # contract to grep against.
+        When call grep -E '"decision":"|__quorum_decision_reason' "${check_role_script}"
+        The status should be success
+        The stdout should include "decision"
+      End
+
+      It "captures the configured / min_valid / valid counts in the record"
+        When call grep -F 'configured_count' "${check_role_script}"
+        The status should be success
+        The stdout should include "configured_count"
+      End
+
+      It "redirects the debug write to /dev/null on failure (won't surface in roleProbe)"
+        # Belt-and-braces: the writer must redirect errors so a missing
+        # /tmp permission never leaks bytes to stdout that would corrupt
+        # the role token.
+        When call grep -F '>> "${__check_role_debug_log}" 2>/dev/null || true' "${check_role_script}"
+        The status should be success
+        The stdout should include "/dev/null"
       End
     End
   End

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -425,6 +425,65 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be success
         The stdout should include "info server"
       End
+
+      It "rejects non-hex sentinel master runid via case-statement shape guard"
+        # Per Edward msg=2140dce9, an empty check alone is not enough:
+        # a non-empty but malformed runid (e.g. `not-a-real-runid!`)
+        # would otherwise enter the engine-version path.
+        When call grep -F "''|*[!0-9a-fA-F]*) continue ;;" "${check_role_script}"
+        The status should be success
+        The stdout should include "0-9a-fA-F"
+      End
+    End
+
+    Context "non-empty malformed sentinel runid is rejected like an empty one"
+      # Mirror the production case-statement directly so the decision
+      # cell stays pinned: a non-hex runid must be treated the same as
+      # empty by the per-sentinel selector, so the script never enters
+      # the engine-version path with a malformed authority.
+      runid_passes_shape_guard() {
+        local runid="$1"
+        case "${runid}" in
+          ''|*[!0-9a-fA-F]*) printf "REJECT" ;;
+          *) printf "ACCEPT" ;;
+        esac
+      }
+
+      It "accepts a clean lowercase hex runid"
+        When call runid_passes_shape_guard "aaaaaaaa1111bbbb2222cccc3333dddd44445555"
+        The status should be success
+        The stdout should eq "ACCEPT"
+      End
+
+      It "accepts a clean uppercase hex runid"
+        When call runid_passes_shape_guard "AAAA1111BBBB2222"
+        The status should be success
+        The stdout should eq "ACCEPT"
+      End
+
+      It "rejects empty runid (legacy fallback path)"
+        When call runid_passes_shape_guard ""
+        The status should be success
+        The stdout should eq "REJECT"
+      End
+
+      It "rejects non-hex characters (legacy fallback path)"
+        When call runid_passes_shape_guard "not-a-real-runid!"
+        The status should be success
+        The stdout should eq "REJECT"
+      End
+
+      It "rejects mixed hex with one stray non-hex char (legacy fallback path)"
+        When call runid_passes_shape_guard "abcd1234g"
+        The status should be success
+        The stdout should eq "REJECT"
+      End
+
+      It "rejects runid with embedded whitespace (legacy fallback path)"
+        When call runid_passes_shape_guard "abcd 1234"
+        The status should be success
+        The stdout should eq "REJECT"
+      End
     End
   End
 

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -152,86 +152,155 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
-  Describe "engine-authoritative kb-role-version trailer (PR #10280 contract)"
-    # check-role.sh now appends a second line `kb-role-version=<sentinel
-    # config-epoch>` when sentinel is reachable and returns a clean uint64.
-    # The controller-side strict parser rejects malformed `kb-role-version=`
-    # lines outright, so the script either emits a well-formed numeric line
-    # or no version line at all (legacy mode).
-    parse_engine_version() {
+  Describe "engine-authoritative version trailer (PR #10280 whitespace-token contract)"
+    # check-role.sh now appends a second whitespace-separated token — the
+    # sentinel config-epoch — when at least one reachable sentinel returns
+    # a clean uint64. The controller-side parser (post-PR #10280) splits
+    # stdout on any whitespace and accepts only `<role>` or
+    # `<role> <uint64>`; anything else is rejected outright. So the script
+    # must either emit `primary\n<uint64>` (or `primary <uint64>`) or
+    # legacy single-line output, never a labeled `kb-role-version=` form.
+    parse_one_sentinel_epoch() {
       local sentinel_out="$1"
-      local sline ce_marker="" engine_version=""
+      local sline ce_marker="" epoch=""
       while IFS= read -r sline; do
         sline="${sline%$'\r'}"
         if [ -n "${ce_marker}" ]; then
-          engine_version="${sline}"
+          epoch="${sline}"
           break
         fi
         [ "${sline}" = "config-epoch" ] && ce_marker="1"
       done <<<"${sentinel_out}"
-      printf "%s" "${engine_version}"
+      printf "%s" "${epoch}"
     }
 
-    Context "sentinel returns a clean numeric config-epoch"
+    Context "single sentinel returns a clean numeric config-epoch"
       It "extracts the numeric value following the config-epoch marker"
         sentinel_out=$'name\nvlk-foo\nconfig-epoch\n42\nnum-slaves\n2'
-        When call parse_engine_version "${sentinel_out}"
+        When call parse_one_sentinel_epoch "${sentinel_out}"
         The status should be success
         The stdout should eq "42"
       End
     End
 
-    Context "sentinel output missing config-epoch marker"
-      It "returns empty so the script falls back to legacy single-line output"
+    Context "single sentinel output missing config-epoch marker"
+      It "returns empty so the per-sentinel loop continues to the next sentinel"
         sentinel_out=$'name\nvlk-foo\nnum-slaves\n2'
-        When call parse_engine_version "${sentinel_out}"
+        When call parse_one_sentinel_epoch "${sentinel_out}"
         The status should be success
         The stdout should eq ""
       End
     End
 
-    Context "sentinel returns non-numeric config-epoch (malformed)"
-      It "extracts the raw value (numeric guard later drops non-uint64)"
+    Context "single sentinel returns non-numeric config-epoch"
+      It "extracts the raw value (the numeric guard in the loop drops it)"
         sentinel_out=$'name\nvlk-foo\nconfig-epoch\nNaN\nnum-slaves\n2'
-        When call parse_engine_version "${sentinel_out}"
+        When call parse_one_sentinel_epoch "${sentinel_out}"
         The status should be success
         The stdout should eq "NaN"
       End
     End
 
-    Context "numeric guard before emitting second line"
-      # Mirror the production check that drops anything not purely numeric
-      # so the controller's strict parser never sees a malformed value.
-      emit_or_drop() {
-        local v="$1"
-        case "${v}" in
-          ''|*[!0-9]*) printf "DROP" ;;
-          *) printf "kb-role-version=%s" "${v}" ;;
+    Context "highest-epoch selector across multiple reachable sentinels"
+      # Mirror the production loop: walk a list of (mock) sentinel outputs,
+      # numeric-guard each, keep the maximum.
+      best_epoch_across() {
+        local out epoch best=-1
+        for out in "$@"; do
+          epoch=$(parse_one_sentinel_epoch "${out}")
+          case "${epoch}" in
+            ''|*[!0-9]*) continue ;;
+          esac
+          if [ "${epoch}" -gt "${best}" ]; then
+            best="${epoch}"
+          fi
+        done
+        if [ "${best}" -ge 0 ]; then
+          printf "%s" "${best}"
+        fi
+        return 0
+      }
+
+      It "picks the highest config-epoch when two sentinels disagree"
+        a=$'name\nvlk\nconfig-epoch\n5'
+        b=$'name\nvlk\nconfig-epoch\n7'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq "7"
+      End
+
+      It "skips an isolated sentinel that returned empty"
+        a=$'name\nvlk\nnum-slaves\n2'
+        b=$'name\nvlk\nconfig-epoch\n3'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq "3"
+      End
+
+      It "skips a sentinel that returned non-numeric config-epoch"
+        a=$'name\nvlk\nconfig-epoch\nNaN'
+        b=$'name\nvlk\nconfig-epoch\n11'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq "11"
+      End
+
+      It "returns empty when no sentinel produced a clean uint64"
+        a=$'name\nvlk\nconfig-epoch\nNaN'
+        b=$'name\nvlk\nnum-slaves\n2'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq ""
+      End
+    End
+
+    Context "second-token emission obeys whitespace-token contract"
+      # The controller's strict parser splits the entire stdout on whitespace
+      # and accepts only `<role>` or `<role> <uint64>`. Anything else is
+      # rejected. So the second token must be the bare numeric epoch — no
+      # `kb-role-version=` prefix.
+      compose_output() {
+        local role="$1" version="$2"
+        printf %s "${role}"
+        case "${version}" in
+          ''|*[!0-9]*) : ;;
+          *) printf '\n%s' "${version}" ;;
         esac
       }
 
-      It "emits the line for a clean uint64"
-        When call emit_or_drop "42"
+      It "emits whitespace-separated tokens for a clean uint64"
+        When call compose_output "primary" "42"
         The status should be success
-        The stdout should eq "kb-role-version=42"
+        The stdout should eq "primary
+42"
       End
 
-      It "drops empty value"
-        When call emit_or_drop ""
+      It "drops second token when version is empty"
+        When call compose_output "secondary" ""
         The status should be success
-        The stdout should eq "DROP"
+        The stdout should eq "secondary"
       End
 
-      It "drops non-numeric value"
-        When call emit_or_drop "NaN"
+      It "drops second token when version is non-numeric"
+        When call compose_output "primary" "NaN"
         The status should be success
-        The stdout should eq "DROP"
+        The stdout should eq "primary"
       End
 
-      It "drops mixed alphanumeric"
-        When call emit_or_drop "42abc"
+      It "splits with strings.Fields-compatible whitespace"
+        # Production uses '\n' between role and version. The controller's
+        # strings.Fields() in Go accepts spaces, tabs, and newlines.
+        out=$(compose_output "primary" "42")
+        # Two tokens after splitting on whitespace
+        When call bash -c "read -ra t <<< \"${out//$'\n'/ }\"; printf '%s\n' \"\${t[0]} \${t[1]} count=\${#t[@]}\""
         The status should be success
-        The stdout should eq "DROP"
+        The stdout should eq "primary 42 count=2"
+      End
+
+      It "never emits the legacy kb-role-version= label form"
+        out=$(compose_output "primary" "42")
+        When call grep -q 'kb-role-version=' <<<"${out}"
+        The status should be failure
       End
     End
   End

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -303,6 +303,27 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be failure
       End
     End
+
+    Context "TLS-aware sentinel cli construction"
+      # check-role.sh must append ${VALKEY_CLI_TLS_ARGS} to the sentinel
+      # query path; without it, every sentinel call on a TLS-enabled topology
+      # would fail and the script would silently degrade to legacy single-
+      # line output, defeating the engine-version gate. The production line
+      # is grep-able directly from the script.
+      check_role_script="../scripts/check-role.sh"
+
+      It "resolves VALKEY_CLI_TLS_ARGS into a local before the sentinel cli call"
+        When call grep -F 'sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"' "${check_role_script}"
+        The status should be success
+        The stdout should include "VALKEY_CLI_TLS_ARGS"
+      End
+
+      It "passes the TLS args local to the sentinel valkey-cli call"
+        When call grep -E 'valkey-cli[^|]*sentinel masters' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinel_tls_args"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -324,6 +324,108 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should include "sentinel_tls_args"
       End
     End
+
+    Context "primary authority gate via local run_id vs sentinel master runid"
+      # During a sentinel-driven failover the deposed primary keeps
+      # reporting `role:master` locally for a brief window. Without a
+      # cross-check, both the new and the deposed primary would emit
+      # `primary <epoch>` with the same config-epoch, and the controller
+      # would race-accept both. The fix grounds the role token in
+      # Sentinel: only when local INFO=master AND the local run_id
+      # matches the Sentinel master `runid` is `primary` authoritative.
+
+      decide_role() {
+        local local_role="$1" local_run_id="$2" sentinel_master_runid="$3" engine_version="$4"
+        local role_line
+        case "${local_role}" in
+          master) role_line="role:master" ;;
+          slave)  role_line="role:slave"  ;;
+          *)      role_line="role:${local_role}" ;;
+        esac
+        if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
+          case "${role_line}" in
+            "role:master")
+              if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
+                printf '%s\n%s' "primary"   "${engine_version}"
+              else
+                printf '%s\n%s' "secondary" "${engine_version}"
+              fi
+              return 0
+              ;;
+            "role:slave")
+              printf '%s\n%s' "secondary" "${engine_version}"
+              return 0
+              ;;
+          esac
+        fi
+        case "${role_line}" in
+          "role:master") printf %s "primary"   ;;
+          "role:slave")  printf %s "secondary" ;;
+        esac
+        return 0
+      }
+
+      It "emits primary <epoch> when local INFO=master and run_id matches sentinel master runid"
+        When call decide_role "master" "aaaaaaaa" "aaaaaaaa" "5"
+        The status should be success
+        The stdout should eq "primary
+5"
+      End
+
+      It "emits secondary <epoch> when local INFO=master but run_id does not match sentinel master runid (round-3 race fix)"
+        When call decide_role "master" "aaaaaaaa" "bbbbbbbb" "5"
+        The status should be success
+        The stdout should eq "secondary
+5"
+      End
+
+      It "emits secondary <epoch> when local INFO=slave and sentinel reachable"
+        When call decide_role "slave" "aaaaaaaa" "bbbbbbbb" "5"
+        The status should be success
+        The stdout should eq "secondary
+5"
+      End
+
+      It "falls back to legacy single token when sentinel master runid is empty"
+        When call decide_role "master" "aaaaaaaa" "" "5"
+        The status should be success
+        The stdout should eq "primary"
+      End
+
+      It "falls back to legacy single token when sentinel is unreachable (no engine version)"
+        When call decide_role "slave" "aaaaaaaa" "" ""
+        The status should be success
+        The stdout should eq "secondary"
+      End
+
+      It "rejects a local master with empty local run_id but a sentinel runid set"
+        # Defensive: an empty local run_id cannot prove this Pod is the
+        # current master, even if its INFO replication says master.
+        When call decide_role "master" "" "aaaaaaaa" "5"
+        The status should be success
+        The stdout should eq "secondary
+5"
+      End
+    End
+
+    Context "sentinel masters parser extracts both config-epoch and runid"
+      # The production script walks the sentinel-masters flat output once
+      # and captures both fields; the parser must not depend on field
+      # order and must stop after both are found.
+      check_role_script="../scripts/check-role.sh"
+
+      It "captures the master runid alongside config-epoch on the script's sentinel response loop"
+        When call grep -F 'sentinel_master_runid' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinel_master_runid"
+      End
+
+      It "reads INFO server for the local run_id"
+        When call grep -E 'info[[:space:]]+server' "${check_role_script}"
+        The status should be success
+        The stdout should include "info server"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -152,6 +152,90 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
+  Describe "engine-authoritative kb-role-version trailer (PR #10280 contract)"
+    # check-role.sh now appends a second line `kb-role-version=<sentinel
+    # config-epoch>` when sentinel is reachable and returns a clean uint64.
+    # The controller-side strict parser rejects malformed `kb-role-version=`
+    # lines outright, so the script either emits a well-formed numeric line
+    # or no version line at all (legacy mode).
+    parse_engine_version() {
+      local sentinel_out="$1"
+      local sline ce_marker="" engine_version=""
+      while IFS= read -r sline; do
+        sline="${sline%$'\r'}"
+        if [ -n "${ce_marker}" ]; then
+          engine_version="${sline}"
+          break
+        fi
+        [ "${sline}" = "config-epoch" ] && ce_marker="1"
+      done <<<"${sentinel_out}"
+      printf "%s" "${engine_version}"
+    }
+
+    Context "sentinel returns a clean numeric config-epoch"
+      It "extracts the numeric value following the config-epoch marker"
+        sentinel_out=$'name\nvlk-foo\nconfig-epoch\n42\nnum-slaves\n2'
+        When call parse_engine_version "${sentinel_out}"
+        The status should be success
+        The stdout should eq "42"
+      End
+    End
+
+    Context "sentinel output missing config-epoch marker"
+      It "returns empty so the script falls back to legacy single-line output"
+        sentinel_out=$'name\nvlk-foo\nnum-slaves\n2'
+        When call parse_engine_version "${sentinel_out}"
+        The status should be success
+        The stdout should eq ""
+      End
+    End
+
+    Context "sentinel returns non-numeric config-epoch (malformed)"
+      It "extracts the raw value (numeric guard later drops non-uint64)"
+        sentinel_out=$'name\nvlk-foo\nconfig-epoch\nNaN\nnum-slaves\n2'
+        When call parse_engine_version "${sentinel_out}"
+        The status should be success
+        The stdout should eq "NaN"
+      End
+    End
+
+    Context "numeric guard before emitting second line"
+      # Mirror the production check that drops anything not purely numeric
+      # so the controller's strict parser never sees a malformed value.
+      emit_or_drop() {
+        local v="$1"
+        case "${v}" in
+          ''|*[!0-9]*) printf "DROP" ;;
+          *) printf "kb-role-version=%s" "${v}" ;;
+        esac
+      }
+
+      It "emits the line for a clean uint64"
+        When call emit_or_drop "42"
+        The status should be success
+        The stdout should eq "kb-role-version=42"
+      End
+
+      It "drops empty value"
+        When call emit_or_drop ""
+        The status should be success
+        The stdout should eq "DROP"
+      End
+
+      It "drops non-numeric value"
+        When call emit_or_drop "NaN"
+        The status should be success
+        The stdout should eq "DROP"
+      End
+
+      It "drops mixed alphanumeric"
+        When call emit_or_drop "42abc"
+        The status should be success
+        The stdout should eq "DROP"
+      End
+    End
+  End
+
   Describe "fork-safety contract — no pipeline parsing of INFO replication"
     # Background: `valkey-cli ... info replication | grep ... | tr ...`
     # spawns three subprocess children per probe call. When kbagent

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -727,6 +727,23 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be success
         The stdout should include "/dev/null"
       End
+
+      It "writes the diagnostic record as a single JSONL line per probe call"
+        # Edward msg=be0a283c blocker: per-sentinel objects must be
+        # comma-separated in the same line, and the final printf must
+        # not embed newlines inside the array literal. Without this,
+        # off-line tools cannot split records 1:1 against controller
+        # event payloads.
+        When call grep -F '"sentinels":[%s]}' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinels"
+      End
+
+      It "uses a comma separator between per-sentinel array elements"
+        When call grep -F '__debug_sep=","' "${check_role_script}"
+        The status should be success
+        The stdout should include "__debug_sep"
+      End
     End
   End
 

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -165,8 +165,30 @@ done <<<"${server_info}"
 # Single `valkey-cli ... sentinel masters` invocation per sentinel attempt,
 # no pipelines, to preserve the fork-and-zombie discipline (see
 # docs/addon-probe-script-fork-and-zombie-guide.md).
+#
+# Diagnostic instrumentation: when VALKEY_CHECK_ROLE_DEBUG=1, each call
+# appends one JSON-shaped line to /tmp/check-role-debug.log inside the
+# Pod with per-sentinel raw values, filter decisions, quorum result, and
+# the emitted token. Stdout is NEVER written by this path — production
+# contract (single role token, optionally followed by `\n<uint64>`) is
+# preserved unchanged. Default off so production has zero overhead.
+__check_role_debug_log=""
+if [ "${VALKEY_CHECK_ROLE_DEBUG:-0}" = "1" ]; then
+  __check_role_debug_log="/tmp/check-role-debug.log"
+fi
+__debug_records=""
+__debug_append() {
+  # Append a single line; build incrementally to avoid one fork per
+  # sentinel for the common case where DEBUG is off.
+  [ -z "${__check_role_debug_log}" ] && return 0
+  __debug_records="${__debug_records}${1}
+"
+}
+__sentinel_records=""
 engine_version=""
 sentinel_master_runid=""
+__quorum_decision_reason=""
+__quorum_emit_role=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   # TLS args must flow into the sentinel query path; silently dropping
@@ -214,26 +236,40 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
         fi
         [ -n "${epoch}" ] && [ -n "${runid}" ] && [ -n "${flags}" ] && break
       done <<<"${sentinel_out}"
+      __drop_reason=""
       # Validate: epoch must be uint64.
       case "${epoch}" in
-        ''|*[!0-9]*) continue ;;
+        ''|*[!0-9]*) __drop_reason="epoch_not_uint64" ;;
       esac
-      # Validate: runid must be a non-empty hex token (no fixed length).
-      case "${runid}" in
-        ''|*[!0-9a-fA-F]*) continue ;;
-      esac
-      # Validate: master flags must not include transient or failure
-      # markers. A sentinel that flags the master as failover_in_progress
-      # / force_failover / s_down / o_down is mid-transition; including
-      # its view in the quorum would mistake the transient state for
-      # consensus.
-      case ",${flags}," in
-        *,failover_in_progress,*|*,force_failover,*|*,s_down,*|*,o_down,*) continue ;;
-      esac
+      if [ -z "${__drop_reason}" ]; then
+        # Validate: runid must be a non-empty hex token (no fixed length).
+        case "${runid}" in
+          ''|*[!0-9a-fA-F]*) __drop_reason="runid_empty_or_non_hex" ;;
+        esac
+      fi
+      if [ -z "${__drop_reason}" ]; then
+        # Validate: master flags must not include transient or failure
+        # markers. A sentinel that flags the master as failover_in_progress
+        # / force_failover / s_down / o_down is mid-transition; including
+        # its view in the quorum would mistake the transient state for
+        # consensus.
+        case ",${flags}," in
+          *,failover_in_progress,*) __drop_reason="flags_failover_in_progress" ;;
+          *,force_failover,*)       __drop_reason="flags_force_failover" ;;
+          *,s_down,*)               __drop_reason="flags_s_down" ;;
+          *,o_down,*)               __drop_reason="flags_o_down" ;;
+        esac
+      fi
+      __debug_append "  {\"fqdn\":\"${s}\",\"epoch\":\"${epoch}\",\"runid\":\"${runid}\",\"flags\":\"${flags}\",\"drop\":\"${__drop_reason}\"}"
+      if [ -n "${__drop_reason}" ]; then
+        continue
+      fi
       quorum_keys+=("${epoch}:${runid}")
     done
     valid_count=${#quorum_keys[@]}
-    if [ "${valid_count}" -ge "${min_valid}" ]; then
+    if [ "${valid_count}" -lt "${min_valid}" ]; then
+      __quorum_decision_reason="insufficient_valid"
+    else
       first_key="${quorum_keys[0]}"
       all_agree=1
       for k in "${quorum_keys[@]}"; do
@@ -245,9 +281,16 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
       if [ "${all_agree}" = 1 ]; then
         engine_version="${first_key%%:*}"
         sentinel_master_runid="${first_key#*:}"
+        __quorum_decision_reason="versioned"
+      else
+        __quorum_decision_reason="split_view"
       fi
     fi
+  else
+    __quorum_decision_reason="no_sentinel_configured"
   fi
+else
+  __quorum_decision_reason="no_sentinel_env"
 fi
 set_xtrace_when_ut_mode_false
 
@@ -266,6 +309,39 @@ if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
   else
     authoritative_role="secondary"
   fi
+fi
+__quorum_emit_role="${authoritative_role}"
+
+# Write the diagnostic record (if VALKEY_CHECK_ROLE_DEBUG=1) to a Pod-
+# local file. Stdout is left untouched — production roleProbe contract
+# is preserved. Per Bob2 + Edward 2026-05-24 review:
+#   - debug never writes to stdout (would corrupt the role token)
+#   - per-call line includes wall timestamp, pod identity, local
+#     run_id, configured/min_valid/valid counts, per-sentinel raw
+#     (epoch, runid, flags) plus filter drop reason, final decision
+#     (versioned | legacy reason), emitted role + epoch.
+# Output is a JSON-shaped one-liner so it stays grep-friendly while
+# preserving the per-sentinel structure for later analysis.
+if [ -n "${__check_role_debug_log}" ]; then
+  __debug_ts=$(date -u +%Y-%m-%dT%H:%M:%S.%N%z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+  __debug_pod="${CURRENT_POD_NAME:-${HOSTNAME:-unknown}}"
+  __debug_sentinels="${__debug_records%$'\n'}"
+  __debug_versioned_payload=""
+  if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
+    __debug_versioned_payload=",\"emit_epoch\":\"${engine_version}\",\"emit_runid\":\"${sentinel_master_runid}\",\"emit_role\":\"${__quorum_emit_role}\""
+  fi
+  {
+    printf '{"ts":"%s","pod":"%s","local_run_id":"%s","configured_count":%s,"min_valid":%s,"valid_count":%s,"decision":"%s"%s,"sentinels":[\n%s\n]}\n' \
+      "${__debug_ts}" \
+      "${__debug_pod}" \
+      "${local_run_id}" \
+      "${configured_count:-0}" \
+      "${min_valid:-0}" \
+      "${valid_count:-0}" \
+      "${__quorum_decision_reason}" \
+      "${__debug_versioned_payload}" \
+      "${__debug_sentinels}"
+  } >> "${__check_role_debug_log}" 2>/dev/null || true
 fi
 
 # printf %s prints the role token with no trailing newline, so when no

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -177,12 +177,14 @@ if [ "${VALKEY_CHECK_ROLE_DEBUG:-0}" = "1" ]; then
   __check_role_debug_log="/tmp/check-role-debug.log"
 fi
 __debug_records=""
+__debug_sep=""
 __debug_append() {
-  # Append a single line; build incrementally to avoid one fork per
-  # sentinel for the common case where DEBUG is off.
+  # Build the per-sentinel JSON array element on a single line so the
+  # final record stays JSONL-parseable. Comma-separate elements; the
+  # first append uses an empty separator, every subsequent one uses ",".
   [ -z "${__check_role_debug_log}" ] && return 0
-  __debug_records="${__debug_records}${1}
-"
+  __debug_records="${__debug_records}${__debug_sep}${1}"
+  __debug_sep=","
 }
 __sentinel_records=""
 engine_version=""
@@ -260,7 +262,7 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
           *,o_down,*)               __drop_reason="flags_o_down" ;;
         esac
       fi
-      __debug_append "  {\"fqdn\":\"${s}\",\"epoch\":\"${epoch}\",\"runid\":\"${runid}\",\"flags\":\"${flags}\",\"drop\":\"${__drop_reason}\"}"
+      __debug_append "{\"fqdn\":\"${s}\",\"epoch\":\"${epoch}\",\"runid\":\"${runid}\",\"flags\":\"${flags}\",\"drop\":\"${__drop_reason}\"}"
       if [ -n "${__drop_reason}" ]; then
         continue
       fi
@@ -325,13 +327,15 @@ __quorum_emit_role="${authoritative_role}"
 if [ -n "${__check_role_debug_log}" ]; then
   __debug_ts=$(date -u +%Y-%m-%dT%H:%M:%S.%N%z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
   __debug_pod="${CURRENT_POD_NAME:-${HOSTNAME:-unknown}}"
-  __debug_sentinels="${__debug_records%$'\n'}"
   __debug_versioned_payload=""
   if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
     __debug_versioned_payload=",\"emit_epoch\":\"${engine_version}\",\"emit_runid\":\"${sentinel_master_runid}\",\"emit_role\":\"${__quorum_emit_role}\""
   fi
+  # One probe call = one line on disk (JSONL). Per Edward msg=be0a283c:
+  # multi-line records would mis-align with controller event payloads
+  # during analysis.
   {
-    printf '{"ts":"%s","pod":"%s","local_run_id":"%s","configured_count":%s,"min_valid":%s,"valid_count":%s,"decision":"%s"%s,"sentinels":[\n%s\n]}\n' \
+    printf '{"ts":"%s","pod":"%s","local_run_id":"%s","configured_count":%s,"min_valid":%s,"valid_count":%s,"decision":"%s"%s,"sentinels":[%s]}\n' \
       "${__debug_ts}" \
       "${__debug_pod}" \
       "${local_run_id}" \
@@ -340,7 +344,7 @@ if [ -n "${__check_role_debug_log}" ]; then
       "${valid_count:-0}" \
       "${__quorum_decision_reason}" \
       "${__debug_versioned_payload}" \
-      "${__debug_sentinels}"
+      "${__debug_records}"
   } >> "${__check_role_debug_log}" 2>/dev/null || true
 fi
 

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -114,10 +114,16 @@ done <<<"${repl_info}"
 engine_version=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
+  # TLS args must flow into the sentinel query path; silently dropping them
+  # on a TLS-enabled topology would make every sentinel call fail and the
+  # whole script degrade to legacy single-line output. Match the pattern in
+  # valkey-member-leave.sh / valkey-start.sh: append ${VALKEY_CLI_TLS_ARGS}
+  # whenever it is set.
+  sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"
   best_epoch=-1
   IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
   for s in "${sentinel_fqdns[@]}"; do
-    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || continue
+    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
     ce_marker=""
     epoch=""
     while IFS= read -r sline; do

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -3,12 +3,19 @@
 #
 # Learning note:
 #   KubeBlocks calls this script every periodSeconds seconds on EACH pod.
-#   The contract is simple: print exactly one line to stdout — the role name
-#   that matches one of the roles[] entries in ComponentDefinition.
+#   Contract (post-PR apecloud/kubeblocks#10280): stdout is parsed via
+#   `strings.Fields`. The first whitespace-separated token must be the role
+#   name (one of the roles[] entries in ComponentDefinition); an optional
+#   second whitespace-separated token carries an engine-authoritative
+#   `uint64` role version that the controller's staleness gate uses to
+#   reject replayed Kubernetes Event objects. Any other shape is rejected.
+#   Only the first token becomes the Pod role label.
 #
 #   For Valkey (Redis-compatible):
-#     INFO replication → role:master  →  print "primary"
-#     INFO replication → role:slave   →  print "secondary"
+#     INFO replication → role:master  →  print "primary"  (first token)
+#     INFO replication → role:slave   →  print "secondary" (first token)
+#   Then, when reachable, the highest sentinel config-epoch is appended as
+#   the second token, separated by a newline.
 #
 #   Using valkey-cli (not redis-cli) because Valkey ships its own CLI.
 #   The -h 127.0.0.1 ensures we hit this pod's own server.
@@ -145,9 +152,12 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
 fi
 set_xtrace_when_ut_mode_false
 
-# printf %s avoids the trailing newline that `echo` adds — KubeBlocks roleProbe
-# rejects label values containing '\n' (Kubernetes label validation), surfacing
-# as transient `RoleProbeNotDone` and `invalid label value primary\n` events.
+# printf %s prints the role token with no trailing newline, so when no
+# engine version is appended the stdout stays a single token. When the
+# engine version IS appended below, it follows on a new line; the
+# controller `strings.Fields` parser splits role and version into two
+# tokens and uses only the role token as the Pod label, so embedded
+# newlines no longer fail Kubernetes label validation.
 case "${role_line}" in
   "role:master") printf %s "primary"   ;;
   "role:slave")  printf %s "secondary" ;;

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -12,10 +12,21 @@
 #   Only the first token becomes the Pod role label.
 #
 #   For Valkey (Redis-compatible):
-#     INFO replication → role:master  →  print "primary"  (first token)
-#     INFO replication → role:slave   →  print "secondary" (first token)
-#   Then, when reachable, the highest sentinel config-epoch is appended as
-#   the second token, separated by a newline.
+#     - When Sentinel returns a clean uint64 `config-epoch` AND a non-
+#       empty hex master `runid`: the role token comes from a Sentinel-
+#       authoritative gate, not from local INFO alone. `primary` is
+#       emitted ONLY when local INFO=master AND local `INFO server`
+#       `run_id` equals the Sentinel master `runid`. Otherwise emit
+#       `secondary`. The matched Sentinel's `config-epoch` is appended
+#       as the whitespace-separated second token. Local INFO=master on
+#       a deposed primary is treated as `secondary` so two pods cannot
+#       both emit `primary <same-epoch>` after a sentinel-driven
+#       failover.
+#     - When Sentinel is unreachable / the password is missing / the
+#       parsed epoch is non-numeric / the parsed runid is empty or
+#       malformed: fall back to legacy single-token output (local INFO
+#       → `primary` for `role:master`, `secondary` for `role:slave`).
+#       The controller then uses its existing EventTime gate.
 #
 #   Using valkey-cli (not redis-cli) because Valkey ships its own CLI.
 #   The -h 127.0.0.1 ensures we hit this pod's own server.
@@ -181,6 +192,16 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     done <<<"${sentinel_out}"
     case "${epoch}" in
       ''|*[!0-9]*) continue ;;
+    esac
+    # Sentinel runid must be a non-empty hex token. Anything else is a
+    # malformed authority — wrapping it into `primary <epoch>` (or even
+    # `secondary <epoch>` against a malformed peer) would re-create the
+    # round-3 dual-primary race the gate is supposed to close. The shape
+    # guard is purely on the character set; we don't pin length so the
+    # check stays resilient if Valkey/Sentinel ever changes the runid
+    # encoding.
+    case "${runid}" in
+      ''|*[!0-9a-fA-F]*) continue ;;
     esac
     if [ "${epoch}" -gt "${best_epoch}" ]; then
       best_epoch="${epoch}"

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -123,122 +123,149 @@ while IFS= read -r line; do
   esac
 done <<<"${server_info}"
 
-# Engine-authoritative role and version from Sentinel.
-# Contract: KubeBlocks controllers (post-PR #10280) parse roleProbe stdout
-# as whitespace-separated tokens; a second token must be a clean uint64,
-# otherwise the entire event is rejected as malformed (no silent fallback
-# to EventTime). The version MUST come from an engine epoch that is
-# monotonic and comparable across pods in the component. For Valkey +
-# sentinel, the sentinel `config-epoch` on the current master bumps on
-# every successful sentinel-driven failover (both auto failover and
-# `SENTINEL FAILOVER` triggered via switchover.sh), which is exactly the
-# granularity Bug B's stale-event gate needs.
+# Engine-authoritative role and version via Sentinel quorum.
+# Contract (post-PR #10280): the controller parses roleProbe stdout with
+# `strings.Fields` and accepts either `<role>` or `<role> <uint64>`. The
+# stale gate stores the accepted version in the Pod annotation and rejects
+# any same-or-older event afterwards.
 #
-# Authority: the role token must also come from Sentinel — local `INFO
-# replication role:master` is not authoritative during the failover
-# window. Treat this Pod as the real primary only when local INFO says
-# `master` AND the local `run_id` equals the Sentinel master `runid`.
-# Otherwise emit `secondary <epoch>` so the controller-side staleness
-# gate sees a consistent global view. If Sentinel returns an empty /
-# malformed `runid` we fall back to legacy single-token output rather
-# than wrap incomplete authority into `primary`.
+# Round-3 evidence (V1 against PR #10280 head 16803efa) showed that during
+# a sentinel-driven failover, sentinels briefly disagree at the SAME
+# `config-epoch`: one sentinel still reports the old master, another the
+# new master with the runid not yet filled, etc. Picking a single sentinel
+# in this window would emit a wrong `<role> <epoch>`, the controller would
+# stamp the Pod annotation to that engine version, and subsequent correct
+# events at the same epoch would all be rejected as stale.
 #
-# Resilience: pick the highest `config-epoch` across reachable sentinels
-# (matches the pattern in valkey-member-leave.sh) and capture that
-# Sentinel's master `runid` from the same response. A partially reachable
-# sentinel set is normal during failover; selecting a stale/isolated
-# sentinel would emit a stale version and starve subsequent legitimate
-# updates because the controller stores the engine annotation and refuses
-# legacy fallback once recorded.
+# Quorum rule (Edward+Bob2 contract, signed off 2026-05-24):
+#   - `configured_sentinel_count` = number of non-empty entries in
+#     `SENTINEL_POD_FQDN_LIST`.
+#   - `min_valid = configured_sentinel_count / 2 + 1` (strict majority of
+#     configured, NOT of reachable — otherwise a single reachable sentinel
+#     could self-certify).
+#   - For each reachable sentinel, parse the master `(epoch, runid, flags)`
+#     triple. Drop the entry when:
+#       - `epoch` is not a clean uint64;
+#       - `runid` is empty or contains a non-hex character;
+#       - `flags` contains any transient/failure marker
+#         (`failover_in_progress`, `force_failover`, `s_down`, `o_down`).
+#   - If fewer than `min_valid` valid entries remain, OR the valid entries
+#     fall into more than one `(epoch, runid)` group, fall back to legacy
+#     single-token output. The controller then uses its existing EventTime
+#     gate and the Pod annotation is NOT advanced to `engine:N`, so once
+#     sentinels converge the next emission can take effect.
+#   - When all valid entries agree on a single `(epoch, runid)` group AND
+#     there are at least `min_valid` of them, that group is the quorum
+#     authority. The version token is the group's epoch; the role token
+#     is decided purely by comparing the group's `runid` to the local
+#     `INFO server` `run_id`: match → `primary`, mismatch → `secondary`.
+#     Local `INFO replication role:master` is intentionally NOT used as
+#     an input to the versioned role decision.
 #
-# Silently fall back to legacy single-token output when no sentinel is
-# reachable, the password is missing, or no parsed value yields a clean
-# uint64 epoch with a non-empty master runid. Single valkey-cli invocation
-# per sentinel attempt, no pipelines, to preserve the fork-and-zombie
-# discipline (see docs/addon-probe-script-fork-and-zombie-guide.md).
+# Single `valkey-cli ... sentinel masters` invocation per sentinel attempt,
+# no pipelines, to preserve the fork-and-zombie discipline (see
+# docs/addon-probe-script-fork-and-zombie-guide.md).
 engine_version=""
 sentinel_master_runid=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
-  # TLS args must flow into the sentinel query path; silently dropping them
-  # on a TLS-enabled topology would make every sentinel call fail and the
-  # whole script degrade to legacy single-line output. Match the pattern in
-  # valkey-member-leave.sh / valkey-start.sh: append ${VALKEY_CLI_TLS_ARGS}
-  # whenever it is set.
+  # TLS args must flow into the sentinel query path; silently dropping
+  # them on a TLS-enabled topology would make every sentinel call fail
+  # and the whole script degrade to legacy single-line output. Match
+  # the pattern in valkey-member-leave.sh / valkey-start.sh: append
+  # ${VALKEY_CLI_TLS_ARGS} whenever it is set.
   sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"
-  best_epoch=-1
-  IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
-  for s in "${sentinel_fqdns[@]}"; do
-    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
-    ce_marker=""
-    runid_marker=""
-    epoch=""
-    runid=""
-    while IFS= read -r sline; do
-      sline="${sline%$'\r'}"
-      if [ -n "${ce_marker}" ]; then
-        epoch="${sline}"
-        ce_marker=""
-      elif [ -n "${runid_marker}" ]; then
-        runid="${sline}"
-        runid_marker=""
-      else
-        case "${sline}" in
-          "config-epoch") ce_marker="1" ;;
-          "runid")        runid_marker="1" ;;
-        esac
-      fi
-      [ -n "${epoch}" ] && [ -n "${runid}" ] && break
-    done <<<"${sentinel_out}"
-    case "${epoch}" in
-      ''|*[!0-9]*) continue ;;
-    esac
-    # Sentinel runid must be a non-empty hex token. Anything else is a
-    # malformed authority — wrapping it into `primary <epoch>` (or even
-    # `secondary <epoch>` against a malformed peer) would re-create the
-    # round-3 dual-primary race the gate is supposed to close. The shape
-    # guard is purely on the character set; we don't pin length so the
-    # check stays resilient if Valkey/Sentinel ever changes the runid
-    # encoding.
-    case "${runid}" in
-      ''|*[!0-9a-fA-F]*) continue ;;
-    esac
-    if [ "${epoch}" -gt "${best_epoch}" ]; then
-      best_epoch="${epoch}"
-      engine_version="${epoch}"
-      sentinel_master_runid="${runid}"
-    fi
+  # Configured total: count non-empty entries. Empty entries from a
+  # trailing comma or runtime mis-render must not lower the quorum bar.
+  IFS=',' read -ra sentinel_fqdns_raw <<< "${SENTINEL_POD_FQDN_LIST}"
+  sentinel_fqdns=()
+  for s in "${sentinel_fqdns_raw[@]}"; do
+    [ -n "${s}" ] && sentinel_fqdns+=("${s}")
   done
+  configured_count=${#sentinel_fqdns[@]}
+  if [ "${configured_count}" -ge 1 ]; then
+    min_valid=$((configured_count / 2 + 1))
+    quorum_keys=()
+    for s in "${sentinel_fqdns[@]}"; do
+      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
+      ce_marker=""
+      runid_marker=""
+      flags_marker=""
+      epoch=""
+      runid=""
+      flags=""
+      while IFS= read -r sline; do
+        sline="${sline%$'\r'}"
+        if [ -n "${ce_marker}" ]; then
+          epoch="${sline}"
+          ce_marker=""
+        elif [ -n "${runid_marker}" ]; then
+          runid="${sline}"
+          runid_marker=""
+        elif [ -n "${flags_marker}" ]; then
+          flags="${sline}"
+          flags_marker=""
+        else
+          case "${sline}" in
+            "config-epoch") ce_marker="1" ;;
+            "runid")        runid_marker="1" ;;
+            "flags")        flags_marker="1" ;;
+          esac
+        fi
+        [ -n "${epoch}" ] && [ -n "${runid}" ] && [ -n "${flags}" ] && break
+      done <<<"${sentinel_out}"
+      # Validate: epoch must be uint64.
+      case "${epoch}" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      # Validate: runid must be a non-empty hex token (no fixed length).
+      case "${runid}" in
+        ''|*[!0-9a-fA-F]*) continue ;;
+      esac
+      # Validate: master flags must not include transient or failure
+      # markers. A sentinel that flags the master as failover_in_progress
+      # / force_failover / s_down / o_down is mid-transition; including
+      # its view in the quorum would mistake the transient state for
+      # consensus.
+      case ",${flags}," in
+        *,failover_in_progress,*|*,force_failover,*|*,s_down,*|*,o_down,*) continue ;;
+      esac
+      quorum_keys+=("${epoch}:${runid}")
+    done
+    valid_count=${#quorum_keys[@]}
+    if [ "${valid_count}" -ge "${min_valid}" ]; then
+      first_key="${quorum_keys[0]}"
+      all_agree=1
+      for k in "${quorum_keys[@]}"; do
+        if [ "${k}" != "${first_key}" ]; then
+          all_agree=0
+          break
+        fi
+      done
+      if [ "${all_agree}" = 1 ]; then
+        engine_version="${first_key%%:*}"
+        sentinel_master_runid="${first_key#*:}"
+      fi
+    fi
+  fi
 fi
 set_xtrace_when_ut_mode_false
 
-# Resolve the authoritative role token by combining local INFO with the
-# Sentinel master `runid`. If Sentinel data is unavailable the script
-# stays on the legacy single-token path below and the controller falls
-# back to EventTime. If Sentinel returned an epoch but the master `runid`
-# is empty / malformed, we also drop back to legacy: emitting
-# `primary <epoch>` with incomplete authority would re-create the
-# round-3 dual-primary race that exposed Bug B in #10280 V1.
+# Resolve the versioned role token from the Sentinel quorum.
+# `engine_version` and `sentinel_master_runid` are set only when a
+# strict-majority quorum agrees on a single `(epoch, runid)`. The role
+# is decided purely by comparing the quorum's `runid` to this Pod's
+# `INFO server` `run_id`: match → `primary`, mismatch → `secondary`.
+# Local `INFO replication role:master` is intentionally NOT used as an
+# input here — it lagged on the deposed primary and produced the V1
+# round-3 race the quorum gate is supposed to close.
 authoritative_role=""
 if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
-  case "${role_line}" in
-    "role:master")
-      if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
-        authoritative_role="primary"
-      else
-        # Local INFO still says master but Sentinel disagrees on identity:
-        # this Pod is a deposed/stale primary, not the elected master.
-        authoritative_role="secondary"
-      fi
-      ;;
-    "role:slave")
-      authoritative_role="secondary"
-      ;;
-    *)
-      echo "unknown role: '${role_line}'" >&2
-      exit 1
-      ;;
-  esac
+  if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
+    authoritative_role="primary"
+  else
+    authoritative_role="secondary"
+  fi
 fi
 
 # printf %s prints the role token with no trailing newline, so when no

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -95,7 +95,24 @@ while IFS= read -r line; do
   esac
 done <<<"${repl_info}"
 
-# Engine-authoritative role version — sentinel config-epoch.
+# Local server identity. After a sentinel-driven failover the deposed
+# primary still reports `role:master` locally for a brief window before its
+# `replicaof <new-master>` lands; emitting `primary` from that pod would
+# clash with the real new primary because both pods would carry the same
+# sentinel config-epoch as their version. The local `run_id` (`INFO
+# server`) is the stable per-server identity Sentinel records as `runid`
+# for the current master. Comparing the two lets the script reject the
+# stale-master self-report before it reaches the controller.
+server_info=$(${cli_cmd} info server 2>/dev/null) || server_info=""
+local_run_id=""
+while IFS= read -r line; do
+  line="${line%$'\r'}"
+  case "${line}" in
+    run_id:*) local_run_id="${line#run_id:}"; break ;;
+  esac
+done <<<"${server_info}"
+
+# Engine-authoritative role and version from Sentinel.
 # Contract: KubeBlocks controllers (post-PR #10280) parse roleProbe stdout
 # as whitespace-separated tokens; a second token must be a clean uint64,
 # otherwise the entire event is rejected as malformed (no silent fallback
@@ -106,19 +123,30 @@ done <<<"${repl_info}"
 # `SENTINEL FAILOVER` triggered via switchover.sh), which is exactly the
 # granularity Bug B's stale-event gate needs.
 #
-# Resilience: pick the highest `config-epoch` across reachable sentinels
-# (matches the pattern in valkey-member-leave.sh). A partially reachable
-# sentinel set is normal during failover or network partition; selecting a
-# stale/isolated sentinel would emit a stale version and starve subsequent
-# legitimate updates because the controller stores the engine annotation
-# and refuses legacy fallback once it has been recorded.
+# Authority: the role token must also come from Sentinel — local `INFO
+# replication role:master` is not authoritative during the failover
+# window. Treat this Pod as the real primary only when local INFO says
+# `master` AND the local `run_id` equals the Sentinel master `runid`.
+# Otherwise emit `secondary <epoch>` so the controller-side staleness
+# gate sees a consistent global view. If Sentinel returns an empty /
+# malformed `runid` we fall back to legacy single-token output rather
+# than wrap incomplete authority into `primary`.
 #
-# Silently fall back to legacy single-line output when no sentinel is
-# reachable, the password is missing, or no parsed value is a clean uint64.
-# Single valkey-cli invocation per sentinel attempt, no pipelines, to
-# preserve the fork-and-zombie discipline (see
-# docs/addon-probe-script-fork-and-zombie-guide.md).
+# Resilience: pick the highest `config-epoch` across reachable sentinels
+# (matches the pattern in valkey-member-leave.sh) and capture that
+# Sentinel's master `runid` from the same response. A partially reachable
+# sentinel set is normal during failover; selecting a stale/isolated
+# sentinel would emit a stale version and starve subsequent legitimate
+# updates because the controller stores the engine annotation and refuses
+# legacy fallback once recorded.
+#
+# Silently fall back to legacy single-token output when no sentinel is
+# reachable, the password is missing, or no parsed value yields a clean
+# uint64 epoch with a non-empty master runid. Single valkey-cli invocation
+# per sentinel attempt, no pipelines, to preserve the fork-and-zombie
+# discipline (see docs/addon-probe-script-fork-and-zombie-guide.md).
 engine_version=""
+sentinel_master_runid=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   # TLS args must flow into the sentinel query path; silently dropping them
@@ -132,14 +160,24 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   for s in "${sentinel_fqdns[@]}"; do
     sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
     ce_marker=""
+    runid_marker=""
     epoch=""
+    runid=""
     while IFS= read -r sline; do
       sline="${sline%$'\r'}"
       if [ -n "${ce_marker}" ]; then
         epoch="${sline}"
-        break
+        ce_marker=""
+      elif [ -n "${runid_marker}" ]; then
+        runid="${sline}"
+        runid_marker=""
+      else
+        case "${sline}" in
+          "config-epoch") ce_marker="1" ;;
+          "runid")        runid_marker="1" ;;
+        esac
       fi
-      [ "${sline}" = "config-epoch" ] && ce_marker="1"
+      [ -n "${epoch}" ] && [ -n "${runid}" ] && break
     done <<<"${sentinel_out}"
     case "${epoch}" in
       ''|*[!0-9]*) continue ;;
@@ -147,10 +185,40 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     if [ "${epoch}" -gt "${best_epoch}" ]; then
       best_epoch="${epoch}"
       engine_version="${epoch}"
+      sentinel_master_runid="${runid}"
     fi
   done
 fi
 set_xtrace_when_ut_mode_false
+
+# Resolve the authoritative role token by combining local INFO with the
+# Sentinel master `runid`. If Sentinel data is unavailable the script
+# stays on the legacy single-token path below and the controller falls
+# back to EventTime. If Sentinel returned an epoch but the master `runid`
+# is empty / malformed, we also drop back to legacy: emitting
+# `primary <epoch>` with incomplete authority would re-create the
+# round-3 dual-primary race that exposed Bug B in #10280 V1.
+authoritative_role=""
+if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
+  case "${role_line}" in
+    "role:master")
+      if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
+        authoritative_role="primary"
+      else
+        # Local INFO still says master but Sentinel disagrees on identity:
+        # this Pod is a deposed/stale primary, not the elected master.
+        authoritative_role="secondary"
+      fi
+      ;;
+    "role:slave")
+      authoritative_role="secondary"
+      ;;
+    *)
+      echo "unknown role: '${role_line}'" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 # printf %s prints the role token with no trailing newline, so when no
 # engine version is appended the stdout stays a single token. When the
@@ -158,23 +226,21 @@ set_xtrace_when_ut_mode_false
 # controller `strings.Fields` parser splits role and version into two
 # tokens and uses only the role token as the Pod label, so embedded
 # newlines no longer fail Kubernetes label validation.
-case "${role_line}" in
-  "role:master") printf %s "primary"   ;;
-  "role:slave")  printf %s "secondary" ;;
-  *)
-    echo "unknown role: '${role_line}'" >&2
-    # Returning a non-zero exit code tells KubeBlocks the probe failed.
-    # KubeBlocks will increment the failure counter and, after
-    # failureThreshold is exceeded, clear the role label on this pod.
-    exit 1
-    ;;
-esac
-
-# Append the engine-authoritative version as a second whitespace-separated
-# token only when at least one reachable sentinel returned a clean uint64
-# config-epoch. Empty or non-numeric falls back to legacy single-line and
-# the controller uses its existing EventTime gate.
-case "${engine_version}" in
-  ''|*[!0-9]*) : ;;
-  *) printf '\n%s' "${engine_version}" ;;
-esac
+if [ -n "${authoritative_role}" ]; then
+  printf %s "${authoritative_role}"
+  printf '\n%s' "${engine_version}"
+else
+  # Legacy single-token output (Sentinel unreachable / empty runid /
+  # non-numeric epoch). Use local INFO directly.
+  case "${role_line}" in
+    "role:master") printf %s "primary"   ;;
+    "role:slave")  printf %s "secondary" ;;
+    *)
+      echo "unknown role: '${role_line}'" >&2
+      # Returning a non-zero exit code tells KubeBlocks the probe failed.
+      # KubeBlocks will increment the failure counter and, after
+      # failureThreshold is exceeded, clear the role label on this pod.
+      exit 1
+      ;;
+  esac
+fi

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -87,6 +87,38 @@ while IFS= read -r line; do
     role:*) role_line="${line}"; break ;;
   esac
 done <<<"${repl_info}"
+
+# Engine-authoritative role version (kb-role-version) — sentinel config-epoch.
+# Contract: KubeBlocks controllers (post-PR #10280) use the second line
+# `kb-role-version=<uint64>` to gate stale roleProbe events; the value MUST
+# come from an engine epoch that is monotonic and comparable across pods in
+# the component. For Valkey + sentinel, the sentinel `config-epoch` on the
+# current master bumps on every successful sentinel-driven failover (both
+# auto failover and `SENTINEL FAILOVER` triggered via switchover.sh), which
+# is exactly the granularity Bug B's stale-event gate needs.
+#
+# Resilience: silently fall back to legacy single-line output if sentinel is
+# unreachable, the password is missing, or the parsed value is non-numeric.
+# Per PR #10280 strict-parser contract, emitting a malformed line would make
+# the controller reject the event outright; emitting NO version line keeps
+# the legacy EventTime fallback path. Single valkey-cli invocation, no
+# pipelines, to preserve the fork-and-zombie discipline (see
+# docs/addon-probe-script-fork-and-zombie-guide.md).
+engine_version=""
+if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
+  sentinel_host="${SENTINEL_POD_FQDN_LIST%%,*}"
+  sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
+  sentinel_out=$(valkey-cli --no-auth-warning -h "${sentinel_host}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || sentinel_out=""
+  ce_marker=""
+  while IFS= read -r sline; do
+    sline="${sline%$'\r'}"
+    if [ -n "${ce_marker}" ]; then
+      engine_version="${sline}"
+      break
+    fi
+    [ "${sline}" = "config-epoch" ] && ce_marker="1"
+  done <<<"${sentinel_out}"
+fi
 set_xtrace_when_ut_mode_false
 
 # printf %s avoids the trailing newline that `echo` adds — KubeBlocks roleProbe
@@ -102,4 +134,11 @@ case "${role_line}" in
     # failureThreshold is exceeded, clear the role label on this pod.
     exit 1
     ;;
+esac
+
+# Append engine-authoritative version on second line only when sentinel
+# returned a clean uint64. Non-numeric or empty result drops back to legacy.
+case "${engine_version}" in
+  ''|*[!0-9]*) : ;;
+  *) printf '\nkb-role-version=%s' "${engine_version}" ;;
 esac

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -88,36 +88,54 @@ while IFS= read -r line; do
   esac
 done <<<"${repl_info}"
 
-# Engine-authoritative role version (kb-role-version) — sentinel config-epoch.
-# Contract: KubeBlocks controllers (post-PR #10280) use the second line
-# `kb-role-version=<uint64>` to gate stale roleProbe events; the value MUST
-# come from an engine epoch that is monotonic and comparable across pods in
-# the component. For Valkey + sentinel, the sentinel `config-epoch` on the
-# current master bumps on every successful sentinel-driven failover (both
-# auto failover and `SENTINEL FAILOVER` triggered via switchover.sh), which
-# is exactly the granularity Bug B's stale-event gate needs.
+# Engine-authoritative role version — sentinel config-epoch.
+# Contract: KubeBlocks controllers (post-PR #10280) parse roleProbe stdout
+# as whitespace-separated tokens; a second token must be a clean uint64,
+# otherwise the entire event is rejected as malformed (no silent fallback
+# to EventTime). The version MUST come from an engine epoch that is
+# monotonic and comparable across pods in the component. For Valkey +
+# sentinel, the sentinel `config-epoch` on the current master bumps on
+# every successful sentinel-driven failover (both auto failover and
+# `SENTINEL FAILOVER` triggered via switchover.sh), which is exactly the
+# granularity Bug B's stale-event gate needs.
 #
-# Resilience: silently fall back to legacy single-line output if sentinel is
-# unreachable, the password is missing, or the parsed value is non-numeric.
-# Per PR #10280 strict-parser contract, emitting a malformed line would make
-# the controller reject the event outright; emitting NO version line keeps
-# the legacy EventTime fallback path. Single valkey-cli invocation, no
-# pipelines, to preserve the fork-and-zombie discipline (see
+# Resilience: pick the highest `config-epoch` across reachable sentinels
+# (matches the pattern in valkey-member-leave.sh). A partially reachable
+# sentinel set is normal during failover or network partition; selecting a
+# stale/isolated sentinel would emit a stale version and starve subsequent
+# legitimate updates because the controller stores the engine annotation
+# and refuses legacy fallback once it has been recorded.
+#
+# Silently fall back to legacy single-line output when no sentinel is
+# reachable, the password is missing, or no parsed value is a clean uint64.
+# Single valkey-cli invocation per sentinel attempt, no pipelines, to
+# preserve the fork-and-zombie discipline (see
 # docs/addon-probe-script-fork-and-zombie-guide.md).
 engine_version=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
-  sentinel_host="${SENTINEL_POD_FQDN_LIST%%,*}"
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
-  sentinel_out=$(valkey-cli --no-auth-warning -h "${sentinel_host}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || sentinel_out=""
-  ce_marker=""
-  while IFS= read -r sline; do
-    sline="${sline%$'\r'}"
-    if [ -n "${ce_marker}" ]; then
-      engine_version="${sline}"
-      break
+  best_epoch=-1
+  IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
+  for s in "${sentinel_fqdns[@]}"; do
+    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || continue
+    ce_marker=""
+    epoch=""
+    while IFS= read -r sline; do
+      sline="${sline%$'\r'}"
+      if [ -n "${ce_marker}" ]; then
+        epoch="${sline}"
+        break
+      fi
+      [ "${sline}" = "config-epoch" ] && ce_marker="1"
+    done <<<"${sentinel_out}"
+    case "${epoch}" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if [ "${epoch}" -gt "${best_epoch}" ]; then
+      best_epoch="${epoch}"
+      engine_version="${epoch}"
     fi
-    [ "${sline}" = "config-epoch" ] && ce_marker="1"
-  done <<<"${sentinel_out}"
+  done
 fi
 set_xtrace_when_ut_mode_false
 
@@ -136,9 +154,11 @@ case "${role_line}" in
     ;;
 esac
 
-# Append engine-authoritative version on second line only when sentinel
-# returned a clean uint64. Non-numeric or empty result drops back to legacy.
+# Append the engine-authoritative version as a second whitespace-separated
+# token only when at least one reachable sentinel returned a clean uint64
+# config-epoch. Empty or non-numeric falls back to legacy single-line and
+# the controller uses its existing EventTime gate.
 case "${engine_version}" in
   ''|*[!0-9]*) : ;;
-  *) printf '\nkb-role-version=%s' "${engine_version}" ;;
+  *) printf '\n%s' "${engine_version}" ;;
 esac

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -371,8 +371,14 @@ spec:
   # ── Lifecycle actions ──────────────────────────────────────────────────
   lifecycleActions:
     # roleProbe: KubeBlocks calls this every periodSeconds to learn the
-    # role of each pod.  The script must print exactly the role name
-    # (matching one of the roles[] names above) to stdout.
+    # role of each pod. Contract (post-PR apecloud/kubeblocks#10280):
+    # stdout is parsed via `strings.Fields`. The first whitespace token
+    # must be the role name (matching one of the roles[] names above);
+    # an optional second whitespace token is a uint64 engine-authoritative
+    # version that the controller uses to gate stale Event replays. Only
+    # the first token becomes the Pod role label. The Valkey script
+    # appends the highest reachable sentinel config-epoch as the second
+    # token whenever a sentinel is reachable.
     roleProbe:
       periodSeconds: 5
       timeoutSeconds: 3


### PR DESCRIPTION
> **Compat update (2026-05-25):** The original companion controller PR `apecloud/kubeblocks#10280` was CLOSED unmerged after the unified role-event handler landed in `apecloud/kubeblocks#10281`. The replacement controller PR is now [apecloud/kubeblocks#10283](https://github.com/apecloud/kubeblocks/pull/10283), head `65dc513ab9198a033b631660b51d5b6339ee13f9`. The addon-side roleProbe stdout contract (whitespace-token `<role> <uint64>`, `engine:<n>` annotation, strict parser) is preserved on #10283, so this addon PR remains valid; only the controller internal path changed. The prior V1 scoped pass on idc was against #10280 plus this addon PR head `4f35afc` and **does not transfer** to #10283 — a fresh V1 retest against #10283 head `65dc513ab` + this PR head is owed.

## Summary

- `check-role.sh` now requires a Sentinel quorum on a single `(config-epoch, runid)` group before emitting a versioned `<role> <epoch>` token. During a sentinel-driven failover the configured Sentinels briefly disagree at the same `config-epoch`; emitting on the strength of a single Sentinel's view in that window produced the V1 round-5 dual-primary race that this PR is expected to close.
- `min_valid = configured_sentinel_count / 2 + 1` (strict majority of the **configured** total, not of the reachable / valid count — otherwise a single reachable Sentinel could self-certify).
- For each reachable Sentinel, parse `(epoch, runid, flags)`. Drop the entry when `epoch` is not a clean uint64, `runid` is empty or non-hex, or `flags` include any of `failover_in_progress`, `force_failover`, `s_down`, `o_down`.
- If `valid_count < min_valid`, OR the valid entries fall into more than one `(epoch, runid)` group, fall back to legacy single-token output. The controller stays on its EventTime path and the Pod annotation is NOT advanced to `engine:N` prematurely.
- When the quorum is reached, the version is the group's epoch; the role is decided **purely** by comparing the group's `runid` to the local `INFO server` `run_id` (match → `primary`, mismatch → `secondary`). Local `INFO replication role:master` is no longer an input — it lagged on the deposed primary in V1.
- TLS-aware: `${VALKEY_CLI_TLS_ARGS}` flows into the Sentinel `valkey-cli` call so TLS topologies do not silently degrade.
- Fork-safe: one `valkey-cli info server` invocation and one `valkey-cli ... sentinel masters` per Sentinel attempt, no pipelines, parsed with bash builtins (per `addon-probe-script-fork-and-zombie-guide.md`).

## Why the quorum gate

A prior V1 against the now-closed PR apecloud/kubeblocks#10280 head `16803efa0` reproduced the original Bug B symptom on round 5. A separate Sentinel-side telemetry (60s, 1Hz sampling of `sentinel masters` per Sentinel pod) showed three distinct phases:

- **Pre-failover**: 3/3 Sentinels agree on `(valkey-0, runid 3119…, epoch 16)`.
- **Post-trigger transient (~3s)**: split view. One Sentinel still reports the old master at the same `epoch=17` with `failover_in_progress,force_failover` flags; one reports the new master at `epoch=17` with `runid` not yet filled; one reports the new master at `epoch=17` with a clean `runid`.
- **Post-converged**: 3/3 Sentinels agree on `(valkey-1, runid 00d5…, epoch 17)`.

Emitting `<role> <epoch>` in the transient window let the controller stamp the Pod annotation to `engine:17` from a partial / wrong Sentinel view; correct events that arrived after Sentinel convergence were then rejected by the strict-newer staleness gate. The quorum gate withholds the versioned token until the configured Sentinels converge, so the controller only ever accepts a fully-agreed authority.

The contract explicitly assumes that once a Sentinel quorum is stable, the master `runid` does not change at the same `config-epoch`. If we ever observe quorum-stable identity drift inside a single epoch, the contract has to redesign rather than ask the controller for a tiebreaker.

## Compatibility

Requires KubeBlocks controller with the PR apecloud/kubeblocks#10283 parser in effect. Per the upstream rollout rule, the controller must be upgraded before the addon; otherwise the older controller's `TrimSpace` does not remove the internal newline and the whole stdout matches no `ReplicaRole`. On the older controller the first token line is unchanged and the second token is dropped when the quorum is not satisfied, so the addon still installs and runs.

## Test plan

- [x] `shellspec --load-path ./shellspec --default-path addons/valkey/scripts-ut-spec --shell bash`: **174 examples, 0 failures** locally. New since the v2a baseline: 16 quorum decision-cell cases (pre 3/3 agree, post3+ 3/3 agree, post0 old-quorum stable with one partial new Sentinel dropped, post1/post2 mid-failover with `failover_in_progress` flag + empty runid dropped, three "2-of-3 majority with one invalid entry" variants, single-reachable Sentinel rejected, same-epoch different-runid split rejected, different-epoch split rejected, all-unreachable rejected, 5-Sentinel coverage at majority and below majority, `min_valid` formula assertions) plus 4 grep-level assertions that the production script computes `min_valid = configured_count / 2 + 1`, captures `flags_marker`, drops `failover_in_progress` views, and decides the role only from quorum runid match.
- [x] Manual: `INFO server` returns `run_id`; `SENTINEL MASTERS` flat output includes `flags`, `runid`, and `config-epoch` fields on a Valkey-9.0.0 cluster.
- [ ] End-to-end: re-run V1 on the frozen idc vcluster with controller image at PR apecloud/kubeblocks#10283 head `65dc513ab9198a033b631660b51d5b6339ee13f9` plus this addon chart (`9268bcf80`), looking for the round-3 / round-5 dual-primary race to no longer reproduce.

This PR is **expected to close** the round-3 / round-5 window; the V1 archive on the patched candidate is the next gate. The PR does not claim Bug B is fixed until that runtime evidence lands.

## Out of scope

- Controller-side fix lives in apecloud/kubeblocks#10283 and continues to iterate; this PR only fixes the addon-side authority of the role token and version.
- This PR does not bump the addon-api doc; the contract change is documented in the upstream controller PR's companion `kubeblocks-addon-docs` change.

Closes #2665