### PR TITLE
fix(mariadb): alpha.91 - drop merged-pd parametersSchema to unblock reconfigure

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,29 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.90
+version: 1.1.1-alpha.91
 
+# alpha.91 v1 (Helen 2026-05-24, live N=1 first-blocker from
+# vcluster `mariadb-test5` kubeblocks-tests async suite, cluster
+# `mdb-async-39059`) — bump from 1.1.1-alpha.90 → 1.1.1-alpha.91
+# because templates/paramsdef.yaml mutates the
+# `mariadb-replication-merged-pd` spec (removes parametersSchema).
+# KB treats PD spec as immutable across same-chart-version upgrades
+# for the PD reconciler's OpenAPI schema generation pipeline; a
+# fresh chart version produces a new merged PD content that takes
+# effect on existing Clusters via the PD reconcile loop without
+# triggering "immutable fields" rejection. Same packaging-contract
+# bump pattern that drove alpha.85 / alpha.90 / earlier bumps.
+#
+# Behavioral change: reconfigure OpsRequests against the merged
+# replication topology now work for all 239 dynamic+static MariaDB
+# params declared in mariadb-config-effect-scope.yaml. alpha.90
+# behavior: only the 3 rpl_semi_sync_* params were accepted;
+# everything else returned "parameter X not found in parameters
+# schema" from KB validator. See templates/paramsdef.yaml comment
+# block for full root-cause + Class 4 fail-closed alternative
+# enforcement.
+#
 # alpha.90 v1 (Helen 2026-05-20, live N=1 fourth first-blocker from
 # vcluster `mariadb-test5`) — bump from 1.1.1-alpha.89 → 1.1.1-alpha.90
 # because alpha.89 commits 13/14/15/16 mutated the rendered merged

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,9 +1055,119 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.98
+version: 1.1.1-alpha.99
 
-# alpha.98 v1 (Helen 2026-05-25, live N=1 fix on vcluster
+# alpha.99 v1 (Helen 2026-05-25, iron-evidence root-cause fix
+# for kb_health_check 1032 cascade — supersedes alpha.92-alpha.98
+# attempts that all attacked symptoms not cause).
+#
+# Iron evidence (cluster mdb-repro-1032, 2026-05-25 08:03Z):
+#   - Pod-1 secondary kb_health_check row = (1, 1779696185)
+#   - DELETE FROM kubeblocks.kb_health_check on pod-1
+#   - Primary at 08:03:06 wrote GTID 0-1-201 = Update_rows_v1
+#     with before-image @1=1, @2=1779696185
+#   - Pod-1 START SLAVE SQL_THREAD → STRICT mode looked for
+#     row matching @2=1779696185, found nothing (deleted) →
+#     Last_SQL_Errno=1032 Last_SQL_Error "Could not execute
+#     Update_rows_v1 event ... HA_ERR_KEY_NOT_FOUND"
+#
+# Also-iron: alpha.98 IDEMPOTENT fix is INCOMPLETE. With
+# IDEMPOTENT, SQL_THREAD does not stop on 1032 (it skips the
+# row-image mismatch), but the secondary's kb_health_check
+# stays empty forever. The primary's INSERT...ON DUPLICATE KEY
+# UPDATE generates Update_rows in the binlog (not Insert_rows,
+# because the row exists on primary), so the secondary never
+# receives an Insert_rows event to repopulate. Result:
+# syncer's GetOpTimestamp on the secondary returns "no rows"
+# → IsMemberLagging returns (true, MaxInt64) → IsMemberHealthy
+# = false → HasOtherHealthyMember = false → switchover
+# deadlock. Same end-state as alpha.96 replicate-ignore-table.
+# Verified on cluster mdb-repro-1032 after IDEMPOTENT recovery:
+# pod-1 row count = 0 persistently (8min+).
+#
+# Root cause: addon scripts were operating on
+# kubeblocks.kb_health_check, which is a syncer-owned table
+# (engines/mariadb/manager.go WriteCheck / GetOpTimestamp).
+# Per weston 2026-05-25 15:42 msg `b1ce148a`: addon scripts
+# should not have any operations on kb_health_check.
+#
+# Origin of the bug: commit 2ad5e122 (2026-05-09 21:47, chart
+# alpha.43 → alpha.44) added prepare_fresh_replica_for_binlog_
+# start (later renamed to ..._sql_thread_start) that DROPped
+# / DELETEd kubeblocks.kb_health_check. The bug existed since
+# alpha.44 but was masked by upstream blockers (merged-pd
+# parametersSchema in alpha.86-89, topology merge etc.) that
+# stopped CM4 reconfigure from triggering the rolling-restart
+# path. alpha.91 closed the merged-pd blocker → CM4 finally
+# triggered rolling restart → 1032 surfaced for the first time.
+#
+# alpha.99 fix scope (cmpd-replication-merged.yaml — the
+# only cmpd referenced by clusterdef for `replication`
+# topology):
+#   1. REVERT alpha.98 mariadbd `--slave-exec-mode=IDEMPOTENT`
+#      startup arg (back to STRICT default — safe because
+#      addon no longer creates the row mismatch).
+#   2. REMOVE 4 helper functions and all call sites:
+#      slave_status_has_kb_health_check_repairable_error,
+#      clear_local_kb_health_check_table,
+#      with_local_read_write_for_health_check_repair,
+#      prepare_fresh_replica_for_sql_thread_start,
+#      repair_kb_health_check_replication_error.
+#      Call sites in wait_for_replication_healthy,
+#      runtime-secondary-follow-configure, and main loop now
+#      flow directly into START SLAVE SQL_THREAD without
+#      addon-side DELETE.
+#   3. REWRITE primary_internal_root_write_ready to use
+#      addon-owned kubeblocks.kb_addon_write_probe scratch
+#      table (single-row UPSERT, no DELETE). Previous body
+#      borrowed kb_health_check as a scratch probe and the
+#      DELETE WHERE type=0 created the same row divergence
+#      pattern that triggers 1032 (via syncer's next
+#      WriteCheck on the now-deleted row → Insert_rows event
+#      → secondary 1062 / future row mismatch).
+#   4. ensure_internal_local_admin SQL: drop
+#      `CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check`
+#      (syncer manager.go has CREATE IF NOT EXISTS fallback
+#      that runs on leader's local connection with ALL
+#      PRIVILEGES, so addon does not need to pre-create).
+#      ADD `CREATE TABLE IF NOT EXISTS
+#      kubeblocks.kb_addon_write_probe` for the new probe.
+#      Change `GRANT SELECT, INSERT, UPDATE ON
+#      kubeblocks.kb_health_check TO 'kb_internal_root'@'%'`
+#      to `... ON kubeblocks.* TO ...@'%'` so syncer cross-
+#      pod IsMemberLagging can SELECT, addon doesn't name
+#      the syncer table, and the new probe table also covered.
+#      CREATE DATABASE kubeblocks stays (it is the KB-wide
+#      namespace shared by syncer kb_health_check + addon
+#      kb_post_dcs_fence_probe + addon kb_addon_write_probe).
+#
+# Bump rationale: KB CmpD immutability rule applies because
+# cmpd-replication-merged.yaml mutated. Same syncer image (no
+# syncer change). REPLICATION TOPOLOGY (covers both async and
+# semisync replicationMode values; the merged cmpd is the
+# single canonical primary/secondary topology since alpha.89).
+#
+# Methodology: a separate sediment case will document the
+# encapsulation lesson (addon must not operate on syncer-owned
+# tables, even with sql_log_bin=0 wrappers) for other addon
+# teams. The previously-merged docs PR #308 IDEMPOTENT case
+# remains valid as a general methodology for multi-writer
+# heartbeat tables, but is NOT the fix for this addon's bug
+# because (a) this addon's writer is single-primary (syncer
+# WriteCheck runs only on leader) so the case doesn't apply,
+# and (b) IDEMPOTENT does not repopulate empty secondary rows.
+#
+# Verify plan: helm upgrade alpha.99 → fresh cluster on
+# `replication` topology → wait for primary + secondary
+# steady state → trigger CM4 back_log static-parameter
+# reconfigure (rolls primary out of leadership, demotes,
+# restarts) → expect zero 1032 anywhere, T6 Stop/Start +
+# T7 vscale + T8 Restart green, T9 Switchover green if
+# alpha.60 fence verify bug is independently resolved or
+# absent. Cluster mdb-repro-1032 (2026-05-25 08:03Z scene)
+# preserved for alpha.99 verification baseline.
+#
+# alpha.98 v1 (REPLACED — see alpha.99 above): Helen 2026-05-25, live N=1 fix on vcluster
 # mariadb-test5 cluster mdb-async-13674 for kb_health_check
 # Error 1032 cascade after rolling restart - the bug
 # alpha.92-alpha.97 chain chased through 5 wrong fixes

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,23 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.93
+version: 1.1.1-alpha.94
 
+# alpha.94 v1 (Helen 2026-05-25, live N=1 follow-up from
+# vcluster mariadb-test5 kubeblocks-tests async cluster
+# mdb-async-12644: alpha.93 skip-counter fix in
+# repair_kb_health_check_replication_error landed but pod-0 SQL
+# thread still stuck on Error 1032 because
+# slave_status_has_kb_health_check_repairable_error only
+# whitelisted 1062 / 1146 - 1032 never triggered the repair
+# function so the skip counter never ran. Adds 1032 to the
+# repairable error class. Verified live: 1032 case "Can't find
+# record in 'kb_health_check'" matches the alpha.93 fix scope
+# exactly) - bump from 1.1.1-alpha.93 to 1.1.1-alpha.94 because
+# the detector body in templates/cmpd-replication-merged.yaml
+# changes. Same KB CmpD immutability packaging-contract bump
+# pattern.
+#
 # alpha.93 v1 (Helen 2026-05-25, live N=1 first-blocker from
 # vcluster mariadb-test5 kubeblocks-tests async cluster
 # mdb-async-82190: after alpha.92 bounded-retry rejoin port, pod-0

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,24 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.95
+version: 1.1.1-alpha.96
 
+# alpha.96 v1 (Helen 2026-05-25, live N=1 second-blocker from
+# vcluster mariadb-test5 cluster mdb-async-71412 / mdb-async
+# -36884: alpha.95 routed STOP/SKIP/START SLAVE SQL_THREAD via
+# INTERNAL_LOCAL but skip_counter is INCOMPATIBLE with GTID
+# replication mode which this addon uses (MASTER_USE_GTID
+# =slave_pos in replication-member-join.sh). The repair fires
+# every 4s indefinitely without advancing the SQL thread past
+# the failing kubeblocks.kb_health_check Update_rows_v1 event.
+# Adds --replicate-ignore-table=kubeblocks.kb_health_check to
+# mariadbd startup args. The kb_health_check table is owned
+# by KB controller probes against the current primary;
+# secondaries do not need to apply primary probe writes, so
+# the filter is correct on every pod) - bump from alpha.95 to
+# alpha.96 because mariadbd startup args mutate. Same CmpD
+# immutability packaging-contract bump pattern.
+#
 # alpha.95 v1 (Helen 2026-05-25, live N=1 follow-up from
 # vcluster mariadb-test5 cluster mdb-async-36884 pod-0: alpha.94
 # detector fix lands and repair_kb_health_check_replication

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,22 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.94
+version: 1.1.1-alpha.95
 
+# alpha.95 v1 (Helen 2026-05-25, live N=1 follow-up from
+# vcluster mariadb-test5 cluster mdb-async-36884 pod-0: alpha.94
+# detector fix lands and repair_kb_health_check_replication
+# _error is invoked every 4s as expected, but pod-0 SLAVE
+# SQL_THREAD stays No. Root cause: STOP / START SLAVE SQL_THREAD
+# used LOCAL=user-facing root which lost REPLICATION SLAVE ADMIN
+# in alpha.60 admin-bypass revoke; both calls returned ERROR
+# 1227 silently swallowed by `2>/dev/null || true`. Manual repair
+# via INTERNAL_LOCAL=kb_internal_root flipped pod-0
+# Slave_SQL_Running No -> Yes within 3s) - bump from alpha.94 to
+# alpha.95 because the repair function body changes
+# (3 mariadb calls re-routed from LOCAL to INTERNAL_LOCAL). Same
+# CmpD immutability packaging-contract bump pattern.
+#
 # alpha.94 v1 (Helen 2026-05-25, live N=1 follow-up from
 # vcluster mariadb-test5 kubeblocks-tests async cluster
 # mdb-async-12644: alpha.93 skip-counter fix in

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,41 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.92
+version: 1.1.1-alpha.93
 
+# alpha.93 v1 (Helen 2026-05-25, live N=1 first-blocker from
+# vcluster mariadb-test5 kubeblocks-tests async cluster
+# mdb-async-82190: after alpha.92 bounded-retry rejoin port, pod-0
+# successfully reaches the new-slave-config path AND starts SLAVE
+# IO/SQL threads. But SQL thread fails with Error 1032
+# HA_ERR_KEY_NOT_FOUND on a kubeblocks.kb_health_check
+# Update_rows_v1 event because the local kb_health_check table was
+# just cleared by the addon's repair function. The existing
+# repair function calls STOP SLAVE SQL_THREAD + DELETE + START
+# SLAVE SQL_THREAD but the SQL thread's relay log position still
+# points at the same Update_rows_v1 event, so the same error
+# repeats indefinitely; wait_for_replication_healthy times out
+# every 120s and re-tries forever) - bump from 1.1.1-alpha.92 to
+# 1.1.1-alpha.93 because templates/cmpd-replication-merged.yaml
+# mutates the repair_kb_health_check_replication_error function
+# body (adds SET GLOBAL sql_slave_skip_counter = 1 via INTERNAL_
+# LOCAL between STOP SLAVE SQL_THREAD and START SLAVE SQL_THREAD).
+# KB treats CmpD spec as immutable across same-chart-version
+# upgrades; new chart version produces a new merged CmpD that
+# takes effect on existing Clusters via fresh CmpD reconcile
+# rather than triggering "immutable fields" rejection. Same
+# packaging-contract bump pattern that drove alpha.85 / alpha.90
+# / alpha.91 / alpha.92 / earlier bumps.
+#
+# Behavioral change: rolling-restart-induced kb_health_check
+# replication conflicts now skip the offending Update_rows event
+# once, allowing the SQL thread to resume forward progress. The
+# local table is re-populated by the primary's next
+# kb_health_check probe write (KB controller fires probes every
+# few seconds). Skip is bounded to one event per repair call so a
+# different binlog event hitting a separate error class is caught
+# by the next repair cycle.
+#
 # alpha.92 v1 (Helen 2026-05-24, live N=1 first-blocker from
 # vcluster mariadb-test5 kubeblocks-tests async cluster
 # mdb-async-98800: 8 of 41 assertions FAIL all tracing to

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,30 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.96
+version: 1.1.1-alpha.97
 
+# alpha.97 v1 (Helen 2026-05-25, live N=1 third-blocker from
+# vcluster mariadb-test5 cluster mdb-async-39296 T9 Switchover:
+# alpha.96's --replicate-ignore-table=kubeblocks.kb_health_check
+# broke syncer's IsMemberLagging lag detection, causing T9
+# Switchover OpsRequest to deadlock on "no other healthy
+# members") - bump from alpha.96 to alpha.97 because
+# templates/cmpd-replication-merged.yaml mariadbd startup args
+# mutate (remove --replicate-ignore-table line). Same KB CmpD
+# immutability packaging-contract bump pattern.
+#
+# Behavioral change: secondaries now apply
+# kubeblocks.kb_health_check binlog events. T9 Switchover
+# stops failing with "no other healthy members" because
+# secondary's GetOpTimestamp can now read a real check_ts.
+#
+# Regression risk: the original 1032 / rolling-restart bug
+# that alpha.96 was trying to suppress is BACK. Investigation
+# of root-cause path (don't DELETE secondary's
+# kb_health_check on bootstrap, or use GTID-mode skip) is
+# in flight; alpha.97 is the T9-first revert per westonnnn
+# 2026-05-25 13:31 prioritization.
+#
 # alpha.96 v1 (Helen 2026-05-25, live N=1 second-blocker from
 # vcluster mariadb-test5 cluster mdb-async-71412 / mdb-async
 # -36884: alpha.95 routed STOP/SKIP/START SLAVE SQL_THREAD via

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,45 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.97
+version: 1.1.1-alpha.98
 
+# alpha.98 v1 (Helen 2026-05-25, live N=1 fix on vcluster
+# mariadb-test5 cluster mdb-async-13674 for kb_health_check
+# Error 1032 cascade after rolling restart - the bug
+# alpha.92-alpha.97 chain chased through 5 wrong fixes
+# before pinning the right one) - bump from alpha.97 to
+# alpha.98 because cmpd-replication-merged.yaml mariadbd
+# startup args add --slave-exec-mode=IDEMPOTENT. Same KB
+# CmpD immutability packaging-contract bump pattern.
+#
+# Behavioral change: secondary's SQL_Thread skips row-image
+# mismatch errors on kb_health_check (heartbeat table
+# written by whichever pod is currently primary; row state
+# is always slightly out of sync after switchover / rolling
+# restart) instead of stopping. kb_health_check still
+# replicates (no filter) so syncer's GetOpTimestamp /
+# IsMemberLagging can measure lag correctly and
+# HasOtherHealthyMember returns true. T9 Switchover deadlock
+# + CM4/T6/T7/T8 rolling-restart cascade are both unblocked
+# by a single mariadbd flag.
+#
+# Side-effect bound: see cmpd-replication-merged.yaml
+# comment block at the docker-entrypoint.sh mariadbd line.
+# Short version: IDEMPOTENT also relaxes user data row-image
+# matching; for a master/slave async cluster where primary
+# is the only writer this is equivalent to STRICT; chaos
+# scenarios cannot write secondary because addon enforces
+# secondary read_only=ON.
+#
+# Verification live N=1: SET GLOBAL slave_exec_mode=IDEMPOTENT
+# + STOP/START SLAVE on stuck pod-0 recovered SQL_Thread
+# from Slave_SQL_Running=No / Last_SQL_Errno=1032 to
+# Slave_SQL_Running=Yes / Last_SQL_Errno=0 in 8 seconds.
+#
+# Methodology case sedimented: docs/cases/methodology/
+# slave-exec-mode-idempotent-for-multi-writer-heartbeat
+# -table-case.md (kubeblocks-addon-docs PR #308).
+#
 # alpha.97 v1 (Helen 2026-05-25, live N=1 third-blocker from
 # vcluster mariadb-test5 cluster mdb-async-39296 T9 Switchover:
 # alpha.96's --replicate-ignore-table=kubeblocks.kb_health_check

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,8 +1055,32 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.91
+version: 1.1.1-alpha.92
 
+# alpha.92 v1 (Helen 2026-05-24, live N=1 first-blocker from
+# vcluster mariadb-test5 kubeblocks-tests async cluster
+# mdb-async-98800: 8 of 41 assertions FAIL all tracing to
+# rolling-restart pod-0 stuck in .replication-pending after the
+# new primary is not yet visible at pod-0's startup PRIMARY_SID
+# resolve moment) - bump from 1.1.1-alpha.91 to 1.1.1-alpha.92
+# because templates/cmpd-replication-merged.yaml mutates the
+# startup branch logic for "pod-0 with existing slave config and
+# no primary visible". KB treats CmpD spec as immutable across
+# same-chart-version upgrades; new chart version produces a new
+# merged CmpD that takes effect on existing Clusters via fresh
+# CmpD reconcile rather than triggering "immutable fields"
+# rejection. Same packaging-contract bump pattern that drove
+# alpha.85 / alpha.90 / alpha.91 / earlier bumps.
+#
+# Behavioral change: pod-0 with existing slave config now polls
+# PRIMARY_SID every 5s for up to MARIADB_NO_PRIMARY_RETRY_BUDGET
+# _SECONDS (default 60s) before deciding to mark .replication
+# -pending and stop trying. The merged-CmpD analogue of the
+# alpha.11 single-shot vs bounded-retry rejoin gate fix (case
+# documented in docs/cases/mariadb/rejoin-gate-single-shot
+# -vs-bounded-wait-case.md; merged CmpD was branched off
+# cmpd-semisync.yaml which never had that fix).
+#
 # alpha.91 v1 (Helen 2026-05-24, live N=1 first-blocker from
 # vcluster `mariadb-test5` kubeblocks-tests async suite, cluster
 # `mdb-async-39059`) — bump from 1.1.1-alpha.90 → 1.1.1-alpha.91

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -775,10 +775,20 @@ reconfigure:
 {{- end -}}
 
 {{/*
-Syncer image
+Syncer image (alpha.91, Helen 2026-05-24): use image.syncer.registry
+with docker.io default, INDEPENDENT of image.registry. The syncer
+image (apecloud/syncer:mariadb-isspromoted-fix-*) lives on docker.io
+under apecloud/, while the engine image (mariadb:11.4.10) lives at
+docker.io/mariadb. When users override image.registry to a mirror
+like apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com for engine
+images, syncer must still resolve to the registry where the
+mariadb-aware syncer tag actually exists. Falls back to
+image.registry (then docker.io) when image.syncer.registry not set,
+preserving alpha.90 behavior for installations that don't override
+registries.
 */}}
 {{- define "mariadb.syncer.image" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.syncer.repository }}:{{ .Values.image.syncer.tag }}
+{{ .Values.image.syncer.registry | default (.Values.image.registry | default "docker.io") }}/{{ .Values.image.syncer.repository }}:{{ .Values.image.syncer.tag }}
 {{- end -}}
 
 {{/*

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1958,17 +1958,74 @@ spec:
                 exit 1
               fi
               if [ "${POD_INDEX}" = "0" ] && [ -z "${PRIMARY_SID}" ]; then
-                if block_existing_datadir_self_election_without_primary; then
-                  wait ${MARIADB_PID}
-                  exit 1
+                # alpha.92 (Helen 2026-05-24, live N=1 first-blocker from
+                # vcluster mariadb-test5 kubeblocks-tests async cluster
+                # mdb-async-98800): after a rolling restart of pod-0 (which
+                # had been promoted to primary then demoted by switchover),
+                # pod-0 starts up with existing slave config (master.info
+                # pointing to pod-1, the new primary). At the moment its
+                # PRIMARY_SID resolver fires there is a race window where
+                # pod-1 has not yet finished self-electing / publishing as
+                # primary in the service VIP, so PRIMARY_SID resolves empty.
+                # Previously this dropped straight into
+                # block_existing_datadir_self_election_without_primary which
+                # marks .replication-pending and exits; no further code
+                # re-evaluates primary visibility, leaving pod-0 stuck in
+                # the pending state forever (syncer HA loop reports
+                # "follow failed: replication-pending marker exists" every
+                # second; cluster never reaches Running phase). This trap
+                # is the merged-CmpD analogue of the alpha.11 single-shot
+                # vs bounded-retry rejoin gate documented in
+                # docs/cases/mariadb/rejoin-gate-single-shot-vs-bounded
+                # -wait-case.md; cmpd-replication.yaml had a similar fix
+                # path via finalize_replication_rejoin_ready_gate but
+                # merged CmpD was branched off cmpd-semisync.yaml which
+                # never had that fix.
+                #
+                # Fix: wrap the no-primary branch in a bounded retry loop.
+                # Every 5s re-resolve PRIMARY_SID. If it appears (the new
+                # primary's self-election + DCS publish converges), fall
+                # into the existing-slave-config rejoin path (the else
+                # branch below). If PRIMARY_SID stays empty for the full
+                # MARIADB_NO_PRIMARY_RETRY_BUDGET_SECONDS budget (default
+                # 60s — enough for a healthy syncer to elect and publish
+                # without being so long it blocks legitimate "primary
+                # really is gone, do not self-elect" semisync semantics),
+                # fall back to the original mark-pending-and-exit
+                # behavior so pod-0 does not silently self-elect after a
+                # genuine primary outage. The waiting loop keeps
+                # set_fail_closed_read_only + lock_local_root_writes
+                # in place via the startup-before-role-decision setup
+                # already done at lines 1927-1930.
+                no_primary_budget="${MARIADB_NO_PRIMARY_RETRY_BUDGET_SECONDS:-60}"
+                no_primary_deadline=$((SECONDS + no_primary_budget))
+                while [ $SECONDS -lt $no_primary_deadline ]; do
+                  echo "pod-0 startup: no primary visible yet, polling every 5s for up to ${no_primary_budget}s before deciding (alpha.92 bounded rejoin retry)"
+                  sleep 5
+                  PRIMARY_SID=$(timeout 10 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+                    -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || echo "")
+                  [ -n "${PRIMARY_SID}" ] && break
+                done
+                if [ -z "${PRIMARY_SID}" ]; then
+                  if block_existing_datadir_self_election_without_primary; then
+                    wait ${MARIADB_PID}
+                    exit 1
+                  fi
+                  if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+                    wait ${MARIADB_PID}
+                    exit 1
+                  fi
+                  mark_replication_ready
+                  echo "Starting as primary (pod-0 with stale slave config, no primary found after ${no_primary_budget}s wait)"
+                  PRIMARY_SID=""  # signal: we self-elected; do not fall through to rejoin
                 fi
-                if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
-                  wait ${MARIADB_PID}
-                  exit 1
-                fi
-                mark_replication_ready
-                echo "Starting as primary (pod-0 with stale slave config, no primary found)"
-              else
+              fi
+              # alpha.92 fall-through: when PRIMARY_SID is now non-empty
+              # (either set on initial resolve, or appeared during the
+              # bounded retry above), drop into the existing-slave-config
+              # rejoin loop. PRIMARY_SID="" means we already self-elected
+              # in the no-primary branch above and should skip rejoin.
+              if [ -n "${PRIMARY_SID}" ] && [ "${PRIMARY_SID}" != "${SERVICE_ID}" ]; then
                 while true; do
                   reconcile_sql_listener_for_syncer_primary_once || true
                   if [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1686,6 +1686,68 @@ spec:
               # the row already in the data dir matches the
               # primary's INSERT/UPDATE history more often than
               # not.
+              # alpha.98 (Helen 2026-05-25, live N=1 fix for
+              # kb_health_check Error 1032 cascade after rolling
+              # restart, the bug alpha.92-alpha.97 chain chased
+              # through wrong fixes): set slave_exec_mode=IDEMPOTENT
+              # via mariadbd startup arg so the SQL_Thread skips
+              # row-image-mismatch errors instead of stopping.
+              #
+              # Why this is the right fix for kb_health_check:
+              # the table is a shared heartbeat written by whichever
+              # pod is currently primary. After a switchover or
+              # rolling restart the old primary's local row =
+              # value the old primary wrote when it was leader.
+              # The new primary's binlog has Update_rows_v1 events
+              # whose before-image = value the new primary wrote.
+              # The two values must differ. STRICT mode rejects
+              # the apply with Error 1032 HA_ERR_KEY_NOT_FOUND;
+              # IDEMPOTENT mode skips the offending event and
+              # continues; the next event (the new primary's
+              # ON DUPLICATE KEY UPDATE -> Insert/Update) lands
+              # correctly and the secondary's row converges.
+              #
+              # Why NOT replicate-ignore-table (alpha.96 wrong
+              # path): syncer engines/mariadb/manager.go
+              # GetOpTimestamp reads kubeblocks.kb_health_check
+              # .check_ts to measure replication lag. If we filter
+              # the table out on secondary, secondary's table
+              # stays empty -> GetOpTimestamp returns "sql: no
+              # rows in result set" -> IsMemberLagging returns
+              # (true, math.MaxInt64) -> IsMemberHealthy returns
+              # false -> ha.HasOtherHealthyMember returns false ->
+              # HandlerSwitchoverForPrimary cannot demote ->
+              # syncer keeps the old leader and resets read_only
+              # to 0 every second -> addon fence verify window
+              # collapses -> T9 Switchover OpsRequest fails.
+              # alpha.96 -> alpha.97 trail proved this both
+              # directions.
+              #
+              # Side-effect bound: IDEMPOTENT also relaxes user
+              # data row-image matching. For a master/slave async
+              # cluster where primary is the only writer this is
+              # equivalent to STRICT (secondary's row always
+              # matches primary's binlog before-image). The only
+              # divergence is chaos-test scenarios where
+              # secondary is anomalously written; mariadb addon
+              # already enforces secondary read_only=ON so
+              # application traffic cannot write to secondary,
+              # making the chaos-only side-effect N/A.
+              #
+              # Verified live on vcluster mariadb-test5 cluster
+              # mdb-async-13674 pod-0 (2026-05-25 14:11Z):
+              # SET GLOBAL slave_exec_mode=IDEMPOTENT (with
+              # syncerctl pause to prevent override) + STOP SLAVE
+              # + START SLAVE recovered the stuck SQL_Thread from
+              # Slave_SQL_Running=No / Last_SQL_Errno=1032 to
+              # Slave_SQL_Running=Yes / Last_SQL_Errno=0 /
+              # Exec_Master_Log_Pos catching Read_Master_Log_Pos
+              # within 8 seconds.
+              #
+              # Methodology case sedimented:
+              # docs/cases/methodology/slave-exec-mode-idempotent
+              # -for-multi-writer-heartbeat-table-case.md
+              # (kubeblocks-addon-docs PR #308).
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
@@ -1693,6 +1755,7 @@ spec:
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \
                 --thread-cache-size=100 \
+                --slave-exec-mode=IDEMPOTENT \
                 --bind-address="${bind_address}" &
               MARIADB_PID=$!
               prestop_fence_watchdog &

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -526,15 +526,25 @@ spec:
               return 1
             }
             primary_internal_root_write_ready() {
+              # alpha.99 (Helen 2026-05-25): write probe uses addon-owned
+              # kubeblocks.kb_addon_write_probe scratch table, NOT
+              # kubeblocks.kb_health_check. kb_health_check is owned by
+              # syncer (engines/mariadb/manager.go WriteCheck / GetOpTimestamp);
+              # addon scripts touching it violates the ownership boundary and
+              # caused the 1032 cascade documented in iron-evidence repro
+              # (cluster mdb-repro-1032 2026-05-25 08:03Z). Probe upserts a
+              # single row keyed on a fixed probe_id; no DELETE, because the
+              # next probe just overwrites via ON DUPLICATE KEY UPDATE.
+              # sql_log_bin=0 keeps the probe local-only (the syncerctl
+              # writecheck path is the cluster-wide write verification).
               local label="${1:-primary-internal-root-write-ready}"
               if "${INTERNAL_LOCAL[@]}" -e "
                 SET SESSION sql_log_bin=0;
                 CREATE DATABASE IF NOT EXISTS kubeblocks;
-                CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
-                INSERT INTO kubeblocks.kb_health_check(type, check_ts)
-                  VALUES (0, UNIX_TIMESTAMP())
-                  ON DUPLICATE KEY UPDATE check_ts=VALUES(check_ts);
-                DELETE FROM kubeblocks.kb_health_check WHERE type=0;
+                CREATE TABLE IF NOT EXISTS kubeblocks.kb_addon_write_probe(probe_id VARCHAR(64) PRIMARY KEY, ts BIGINT);
+                INSERT INTO kubeblocks.kb_addon_write_probe(probe_id, ts)
+                  VALUES ('internal-root', UNIX_TIMESTAMP())
+                  ON DUPLICATE KEY UPDATE ts=VALUES(ts);
                 SET SESSION sql_log_bin=1;
               " >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
                 prestop_watchdog_log "primary-internal-root-write-ready label=${label} rc=0"
@@ -951,15 +961,15 @@ spec:
                 ALTER USER '${user}'@'127.0.0.1' ACCOUNT UNLOCK;
                 GRANT ALL PRIVILEGES ON *.* TO '${user}'@'127.0.0.1' WITH GRANT OPTION;
                 CREATE DATABASE IF NOT EXISTS kubeblocks;
-                CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
                 CREATE TABLE IF NOT EXISTS kubeblocks.kb_post_dcs_fence_probe(probe_id VARCHAR(64) PRIMARY KEY, ts BIGINT);
+                CREATE TABLE IF NOT EXISTS kubeblocks.kb_addon_write_probe(probe_id VARCHAR(64) PRIMARY KEY, ts BIGINT);
                 CREATE USER IF NOT EXISTS '${user}'@'%' IDENTIFIED BY '${password}';
                 ALTER USER '${user}'@'%' ACCOUNT UNLOCK;
                 REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'%';
                 GRANT REPLICATION CLIENT ON *.* TO '${user}'@'%';
                 GRANT SLAVE MONITOR ON *.* TO '${user}'@'%';
                 GRANT REPLICATION MASTER ADMIN ON *.* TO '${user}'@'%';
-                GRANT SELECT, INSERT, UPDATE ON kubeblocks.kb_health_check TO '${user}'@'%';
+                GRANT SELECT, INSERT, UPDATE ON kubeblocks.* TO '${user}'@'%';
                 GRANT SELECT ON mysql.user TO '${user}'@'%';
                 CREATE USER IF NOT EXISTS '${replication_user}'@'%' IDENTIFIED BY '${password}';
                 ALTER USER '${replication_user}'@'%' IDENTIFIED BY '${password}';
@@ -1295,40 +1305,19 @@ spec:
                 *) return 1 ;;
               esac
             }
-            slave_status_has_kb_health_check_repairable_error() {
-              local slave_status="$1"
-              [ -n "${slave_status}" ] || return 1
-              # alpha.94 (Helen 2026-05-25): add 1032 (HA_ERR_KEY_NOT_FOUND)
-              # to repairable error class. After a clean rolling restart
-              # primary advances kb_health_check rows monotonically; pod-0
-              # may finish CHANGE MASTER + START SLAVE at a relay position
-              # where the next event is Update_rows_v1 against a row that
-              # didn't exist when pod-0 ran clear_local_kb_health_check
-              # _table during prepare_fresh_replica_for_sql_thread_start.
-              # Result: Slave_SQL_Running=No / Last_SQL_Errno=1032
-              # "Could not execute Update_rows_v1 event ... Can't find
-              # record in 'kb_health_check'". Previously the detector
-              # only recognized 1062 (duplicate entry, e.g. from previous
-              # gtid replay) and 1146 (table not found, e.g. before
-              # CREATE TABLE replicated). 1032 was the missing third
-              # class that the alpha.93 skip-counter fix targets - the
-              # fix only fires if this detector returns 0. Verified live
-              # on vcluster mariadb-test5 cluster mdb-async-12644 pod-0
-              # after CM4 back_log rolling restart: slave status shows
-              # 1032 "Can't find record in 'kb_health_check'" and the
-              # repair function was never invoked because this detector
-              # bailed at first case.
-              case "${slave_status}" in
-                *"Last_SQL_Errno: 1032"* | *"Last_Errno: 1032"* | \
-                *"Last_SQL_Errno: 1062"* | *"Last_Errno: 1062"* | \
-                *"Last_SQL_Errno: 1146"* | *"Last_Errno: 1146"*) ;;
-                *) return 1 ;;
-              esac
-              case "${slave_status}" in
-                *"kubeblocks.kb_health_check"*) ;;
-                *) return 1 ;;
-              esac
-            }
+            # alpha.99 (Helen 2026-05-25): removed
+            # slave_status_has_kb_health_check_repairable_error +
+            # repair_kb_health_check_replication_error functions.
+            # The "repair" was DELETE FROM kubeblocks.kb_health_check,
+            # which violated table ownership (kb_health_check is a syncer
+            # resource, see engines/mariadb/manager.go) and caused the
+            # very Error 1032 it tried to fix. Iron-evidence repro on
+            # cluster mdb-repro-1032 2026-05-25 08:03Z confirmed: DELETE
+            # on secondary removes the row that primary's next Update_rows
+            # _v1 event expects to find -> 1032 HA_ERR_KEY_NOT_FOUND.
+            # Without the DELETE the row stays valid, replication applies
+            # cleanly. syncer's WriteCheck path handles the table
+            # lifecycle (CREATE fallback included in manager.go).
             wait_for_replication_healthy() {
               local label="$1"
               local timeout_seconds="${2:-120}"
@@ -1368,10 +1357,6 @@ spec:
                   elapsed=$(($(date +%s) - start))
                   prestop_watchdog_log "rejoin-replication-healthy label=${label} elapsed=${elapsed}s"
                   return 0
-                fi
-                if repair_kb_health_check_replication_error "${label}" "${slave_status}"; then
-                  sleep "${sleep_seconds}"
-                  continue
                 fi
                 now="$(date +%s)"
                 elapsed=$((now - start))
@@ -1447,133 +1432,19 @@ spec:
               mark_replication_ready
               return 0
             }
-            clear_local_kb_health_check_table() {
-              local decision="$1" evidence_file table_count row_count
-              if "${LOCAL[@]}" -e "
-                SET SESSION sql_log_bin=0;
-                CREATE DATABASE IF NOT EXISTS kubeblocks;
-                CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
-                DELETE FROM kubeblocks.kb_health_check;
-                SET SESSION sql_log_bin=1;
-              " 2>/dev/null; then
-                evidence_file="{{ .Values.dataMountPath }}/log/fresh-replica-health-check-cleanup.log"
-                mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
-                table_count=$("${LOCAL[@]}" -N -s -e "
-                  SELECT COUNT(*)
-                  FROM information_schema.TABLES
-                  WHERE TABLE_SCHEMA = 'kubeblocks'
-                    AND TABLE_NAME = 'kb_health_check';
-                " 2>/dev/null || echo "unknown")
-                row_count=$("${LOCAL[@]}" -N -s -e "SELECT COUNT(*) FROM kubeblocks.kb_health_check;" 2>/dev/null || echo "unknown")
-                {
-                  printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-                  printf 'decision=%s\n' "${decision}"
-                  printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
-                  printf 'primary_host=%s\n' "${PRIMARY_HOST:-unknown}"
-                  printf 'health_table_after_cleanup=%s\n' "${table_count}"
-                  printf 'health_rows_after_cleanup=%s\n' "${row_count}"
-                  printf '\n'
-                } >> "${evidence_file}" 2>/dev/null || true
-                echo "Prepared local kubeblocks health check table (${decision})."
-                return 0
-              fi
-              return 1
-            }
-            with_local_read_write_for_health_check_repair() {
-              local decision="$1"
-              local old_read_only rc
-              old_read_only="$(read_only_value || true)"
-              case "${old_read_only}" in
-                0|OFF)
-                  ;;
-                *)
-                  if ! "${LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
-                    prestop_watchdog_log "fresh-kb-health-check-repair read-only-open rc=1 decision=${decision}"
-                    return 1
-                  fi
-                  ;;
-              esac
-              clear_local_kb_health_check_table "${decision}"
-              rc=$?
-              case "${old_read_only}" in
-                0|OFF)
-                  ;;
-                *)
-                  set_fail_closed_read_only "${decision}-restore-read-only" || true
-                  ;;
-              esac
-              return "${rc}"
-            }
-            prepare_fresh_replica_for_sql_thread_start() {
-              local local_gtid="${1:-}"
-              [ -z "${local_gtid}" ] || return 0
-              if with_local_read_write_for_health_check_repair "cleared-local-kb-health-check-before-fresh-sql-thread"; then
-                return 0
-              fi
-              mark_replication_pending
-              # tier=error-recovery: cleanup already failed; defensive locking
-              # follows mark_replication_pending and the function returns 1.
-              set_fail_closed_read_only "fresh-health-check-cleanup-failed" || true # tier=error-recovery
-              lock_local_root_writes "fresh-health-check-cleanup-failed" || true # tier=error-recovery
-              echo "WARNING: failed to clear local kubeblocks health check table before fresh SQL thread starts; keeping roleProbe pending."
-              return 1
-            }
-            repair_kb_health_check_replication_error() {
-              local label="$1" slave_status="$2"
-              if ! slave_status_has_kb_health_check_repairable_error "${slave_status}"; then
-                return 1
-              fi
-              prestop_watchdog_log "fresh-kb-health-check-repair label=${label}"
-              # alpha.95 (Helen 2026-05-25, live N=1 follow-up from
-              # vcluster mariadb-test5 cluster mdb-async-36884 pod-0):
-              # the alpha.93 / alpha.94 chain confirmed the repair was
-              # being called but Slave_SQL_Running stayed No even after
-              # the skip-counter ran. Root cause: STOP / START SLAVE
-              # SQL_THREAD were invoked via LOCAL (user-facing root)
-              # which after alpha.60 admin-bypass revoke no longer has
-              # REPLICATION SLAVE ADMIN; both calls failed with ERROR
-              # 1227 (silently swallowed by `2>/dev/null || true`). With
-              # STOP never actually stopping the thread, SET GLOBAL
-              # sql_slave_skip_counter set the variable but the running
-              # SQL thread already failed at the offending event before
-              # the counter applied. START via LOCAL also failed silently.
-              # Net effect: repair traced repeatedly but no state change.
-              # Manual verification: same STOP / SET GLOBAL / START
-              # sequence via INTERNAL_LOCAL (kb_internal_root, retains
-              # ALL PRIVILEGES per alpha.83 v1) flipped
-              # Slave_SQL_Running from No to Yes within 3s on the live
-              # stuck pod-0.
-              #
-              # Fix: route all 3 calls (STOP / SET GLOBAL / START)
-              # through INTERNAL_LOCAL. STOP and START need REPLICATION
-              # SLAVE ADMIN; SET GLOBAL needs SUPER; user-facing root
-              # has neither.
-              "${INTERNAL_LOCAL[@]}" -e "STOP SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
-              if ! with_local_read_write_for_health_check_repair "prepared-local-kb-health-check-after-replication-error"; then
-                # tier=error-recovery: repair attempt already failed; defensive
-                # locking follows mark_replication_pending and the function returns 1.
-                mark_replication_pending
-                set_fail_closed_read_only "fresh-health-check-replication-repair-failed" || true # tier=error-recovery
-                lock_local_root_writes "fresh-health-check-replication-repair-failed" || true # tier=error-recovery
-                echo "WARNING: failed to repair kubeblocks health check replication error; keeping roleProbe pending."
-                return 1
-              fi
-              # alpha.92 v2 (Helen 2026-05-25): after STOP SLAVE SQL_THREAD
-              # + DELETE FROM kubeblocks.kb_health_check the SQL thread
-              # relay log position is still pointing at the Update_rows
-              # _v1 event for the row we just cleared. START SLAVE
-              # SQL_THREAD without skipping re-applies the same event and
-              # hits the same 1032 / HA_ERR_KEY_NOT_FOUND, infinite loop.
-              # Skip 1 event so the SQL thread advances past the
-              # offending Update_rows_v1; the just-cleared local table
-              # will be re-populated by the next Insert_rows or
-              # Update_rows event from the primary's
-              # kubeblocks.kb_health_check write loop (which fires every
-              # few seconds via KB controller probe).
-              "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL sql_slave_skip_counter = 1;" 2>/dev/null || true # tier=error-recovery
-              "${INTERNAL_LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
-              return 0
-            }
+            # alpha.99 (Helen 2026-05-25): removed
+            # clear_local_kb_health_check_table /
+            # with_local_read_write_for_health_check_repair /
+            # prepare_fresh_replica_for_sql_thread_start /
+            # repair_kb_health_check_replication_error.
+            # All four wrapped an addon-side DELETE FROM
+            # kubeblocks.kb_health_check, which broke the syncer's
+            # ownership of that table and triggered the very 1032 cascade
+            # they tried to repair. See removed
+            # slave_status_has_kb_health_check_repairable_error block for
+            # the iron-evidence reference. The addon now does not touch
+            # kb_health_check at any lifecycle point; syncer owns
+            # create/read/write per engines/mariadb/manager.go.
             mariadbd_pids() {
               if command -v pidof >/dev/null 2>&1; then
                 pidof mariadbd 2>/dev/null || true
@@ -1645,109 +1516,30 @@ spec:
               # Each successful reconfigure writes a per-parameter
               # `.cnf` file into runtime-overrides.d/; mariadbd picks
               # them up on next restart.
-              # alpha.97 (Helen 2026-05-25, live N=1 third-blocker
-              # from vcluster mariadb-test5 cluster mdb-async-39296
-              # T9 Switchover): REVERT alpha.96's
-              # --replicate-ignore-table=kubeblocks.kb_health_check.
+              # alpha.99 (Helen 2026-05-25): REVERT alpha.98's
+              # --slave-exec-mode=IDEMPOTENT.
               #
-              # alpha.96 claim "secondaries do not need to apply
-              # primary probe writes" was wrong. The kubeblocks
-              # .kb_health_check.check_ts row is the only signal
-              # syncer's IsMemberLagging uses to measure replication
-              # lag (`engines/mariadb/manager.go` GetOpTimestamp
-              # reads it; IsMemberLagging compares leader's
-              # OpTimestamp vs member's OpTimestamp). With the
-              # filter, secondary never receives kb_health_check
-              # updates -> secondary's kb_health_check stays empty
-              # -> GetOpTimestamp returns "sql: no rows in result
-              # set" -> IsMemberLagging returns (true,
-              # math.MaxInt64) -> IsMemberHealthy returns false ->
-              # ha.HasOtherHealthyMember returns false ->
-              # HandlerSwitchoverForPrimary falls through to
-              # Promote (line 59 of syncer's
-              # highavailability/switchover.go) -> syncer keeps
-              # the old leader and resets read_only=0 every second
-              # -> addon's fence verify window collapses ->
-              # Switchover OpsRequest fails.
+              # Iron-evidence repro on cluster mdb-repro-1032
+              # (2026-05-25 08:03Z) showed IDEMPOTENT only stops
+              # SQL_THREAD from halting on 1032 — it does NOT
+              # repopulate the secondary's empty kb_health_check
+              # row. Primary's INSERT...ON DUPLICATE KEY UPDATE
+              # always becomes Update_rows in the binlog (because
+              # the row exists on primary); secondary therefore
+              # never receives Insert_rows. With IDEMPOTENT the
+              # secondary table stays empty forever -> syncer's
+              # GetOpTimestamp returns no rows -> IsMemberLagging
+              # = MaxInt64 -> IsMemberHealthy=false -> same T9
+              # switchover deadlock as alpha.96.
               #
-              # Live experiment on cluster mdb-async-39296:
-              # `SET GLOBAL replicate_ignore_table=''` (un-filter)
-              # on pod-1 + START SLAVE -> Error 1032
-              # immediately. Confirms both the original 1032 bug
-              # and that the filter was the actual T9 blocker.
-              #
-              # T9 Switchover is the higher-priority unblock per
-              # weston 2026-05-25 13:31; the 1032 / rolling-restart
-              # symptom that alpha.96 was trying to fix is
-              # re-investigated in a separate alpha. Candidate
-              # alpha.98 paths in flight: change
-              # `prepare_fresh_replica_for_sql_thread_start` to
-              # not DELETE existing kb_health_check rows, since
-              # the row already in the data dir matches the
-              # primary's INSERT/UPDATE history more often than
-              # not.
-              # alpha.98 (Helen 2026-05-25, live N=1 fix for
-              # kb_health_check Error 1032 cascade after rolling
-              # restart, the bug alpha.92-alpha.97 chain chased
-              # through wrong fixes): set slave_exec_mode=IDEMPOTENT
-              # via mariadbd startup arg so the SQL_Thread skips
-              # row-image-mismatch errors instead of stopping.
-              #
-              # Why this is the right fix for kb_health_check:
-              # the table is a shared heartbeat written by whichever
-              # pod is currently primary. After a switchover or
-              # rolling restart the old primary's local row =
-              # value the old primary wrote when it was leader.
-              # The new primary's binlog has Update_rows_v1 events
-              # whose before-image = value the new primary wrote.
-              # The two values must differ. STRICT mode rejects
-              # the apply with Error 1032 HA_ERR_KEY_NOT_FOUND;
-              # IDEMPOTENT mode skips the offending event and
-              # continues; the next event (the new primary's
-              # ON DUPLICATE KEY UPDATE -> Insert/Update) lands
-              # correctly and the secondary's row converges.
-              #
-              # Why NOT replicate-ignore-table (alpha.96 wrong
-              # path): syncer engines/mariadb/manager.go
-              # GetOpTimestamp reads kubeblocks.kb_health_check
-              # .check_ts to measure replication lag. If we filter
-              # the table out on secondary, secondary's table
-              # stays empty -> GetOpTimestamp returns "sql: no
-              # rows in result set" -> IsMemberLagging returns
-              # (true, math.MaxInt64) -> IsMemberHealthy returns
-              # false -> ha.HasOtherHealthyMember returns false ->
-              # HandlerSwitchoverForPrimary cannot demote ->
-              # syncer keeps the old leader and resets read_only
-              # to 0 every second -> addon fence verify window
-              # collapses -> T9 Switchover OpsRequest fails.
-              # alpha.96 -> alpha.97 trail proved this both
-              # directions.
-              #
-              # Side-effect bound: IDEMPOTENT also relaxes user
-              # data row-image matching. For a master/slave async
-              # cluster where primary is the only writer this is
-              # equivalent to STRICT (secondary's row always
-              # matches primary's binlog before-image). The only
-              # divergence is chaos-test scenarios where
-              # secondary is anomalously written; mariadb addon
-              # already enforces secondary read_only=ON so
-              # application traffic cannot write to secondary,
-              # making the chaos-only side-effect N/A.
-              #
-              # Verified live on vcluster mariadb-test5 cluster
-              # mdb-async-13674 pod-0 (2026-05-25 14:11Z):
-              # SET GLOBAL slave_exec_mode=IDEMPOTENT (with
-              # syncerctl pause to prevent override) + STOP SLAVE
-              # + START SLAVE recovered the stuck SQL_Thread from
-              # Slave_SQL_Running=No / Last_SQL_Errno=1032 to
-              # Slave_SQL_Running=Yes / Last_SQL_Errno=0 /
-              # Exec_Master_Log_Pos catching Read_Master_Log_Pos
-              # within 8 seconds.
-              #
-              # Methodology case sedimented:
-              # docs/cases/methodology/slave-exec-mode-idempotent
-              # -for-multi-writer-heartbeat-table-case.md
-              # (kubeblocks-addon-docs PR #308).
+              # alpha.99 fix is structural: addon scripts no longer
+              # DELETE / repair kubeblocks.kb_health_check (see
+              # removed clear/repair/detector block above and the
+              # primary_internal_root_write_ready rewrite that
+              # uses kubeblocks.kb_addon_write_probe instead). The
+              # table now belongs entirely to syncer. STRICT mode
+              # is safe again because the secondary's row state
+              # always tracks primary's binlog before-image.
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
@@ -1755,7 +1547,6 @@ spec:
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \
                 --thread-cache-size=100 \
-                --slave-exec-mode=IDEMPOTENT \
                 --bind-address="${bind_address}" &
               MARIADB_PID=$!
               prestop_fence_watchdog &
@@ -1961,10 +1752,16 @@ spec:
                   prestop_watchdog_log "runtime-secondary-follow-configure-io-failed label=${label}"
                   return 1
                 fi
-                if ! prepare_fresh_replica_for_sql_thread_start "${local_gtid}"; then
-                  prestop_watchdog_log "runtime-secondary-follow-configure-pre-sql-failed label=${label}"
-                  return 1
-                fi
+                # alpha.99 (Helen 2026-05-25): removed
+                # prepare_fresh_replica_for_sql_thread_start call. That
+                # function used to DELETE FROM kubeblocks.kb_health_check
+                # before SQL_THREAD start, which empties the secondary's
+                # row right before replication tries to apply primary's
+                # Update_rows_v1 events and triggers 1032. Without the
+                # DELETE the local row (if any) matches primary's
+                # before-image (because it was last set by replication
+                # from this same primary lineage), so START SLAVE
+                # SQL_THREAD applies cleanly.
                 if ! "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null; then
                   # tier=error-recovery: SQL thread start has already failed.
                   # mark_replication_pending + best-effort defensive locks +
@@ -2286,10 +2083,12 @@ spec:
                     sleep 5
                     continue
                   fi
-                  if ! prepare_fresh_replica_for_sql_thread_start "${LOCAL_GTID}"; then
-                    sleep 5
-                    continue
-                  fi
+                  # alpha.99: removed prepare_fresh_replica_for_sql_thread_start
+                  # (see comment block in runtime-secondary-follow-configure
+                  # above). The function used to DELETE kubeblocks
+                  # .kb_health_check on local secondary which directly
+                  # triggered the 1032 cascade documented in cluster
+                  # mdb-repro-1032 evidence (2026-05-25 08:03Z).
                   if ! "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null; then
                     # tier=error-recovery: SQL thread start has already failed.
                     # mark_replication_pending + best-effort defensive locks +

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1298,7 +1298,28 @@ spec:
             slave_status_has_kb_health_check_repairable_error() {
               local slave_status="$1"
               [ -n "${slave_status}" ] || return 1
+              # alpha.94 (Helen 2026-05-25): add 1032 (HA_ERR_KEY_NOT_FOUND)
+              # to repairable error class. After a clean rolling restart
+              # primary advances kb_health_check rows monotonically; pod-0
+              # may finish CHANGE MASTER + START SLAVE at a relay position
+              # where the next event is Update_rows_v1 against a row that
+              # didn't exist when pod-0 ran clear_local_kb_health_check
+              # _table during prepare_fresh_replica_for_sql_thread_start.
+              # Result: Slave_SQL_Running=No / Last_SQL_Errno=1032
+              # "Could not execute Update_rows_v1 event ... Can't find
+              # record in 'kb_health_check'". Previously the detector
+              # only recognized 1062 (duplicate entry, e.g. from previous
+              # gtid replay) and 1146 (table not found, e.g. before
+              # CREATE TABLE replicated). 1032 was the missing third
+              # class that the alpha.93 skip-counter fix targets - the
+              # fix only fires if this detector returns 0. Verified live
+              # on vcluster mariadb-test5 cluster mdb-async-12644 pod-0
+              # after CM4 back_log rolling restart: slave status shows
+              # 1032 "Can't find record in 'kb_health_check'" and the
+              # repair function was never invoked because this detector
+              # bailed at first case.
               case "${slave_status}" in
+                *"Last_SQL_Errno: 1032"* | *"Last_Errno: 1032"* | \
                 *"Last_SQL_Errno: 1062"* | *"Last_Errno: 1062"* | \
                 *"Last_SQL_Errno: 1146"* | *"Last_Errno: 1146"*) ;;
                 *) return 1 ;;

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1645,34 +1645,47 @@ spec:
               # Each successful reconfigure writes a per-parameter
               # `.cnf` file into runtime-overrides.d/; mariadbd picks
               # them up on next restart.
-              # alpha.96 (Helen 2026-05-25, live N=1 second-blocker
-              # from vcluster mariadb-test5 cluster mdb-async-71412
-              # / mdb-async-36884): kubeblocks.kb_health_check is a
-              # per-pod KB controller probe table. KB controller
-              # writes to whichever pod is primary every few seconds
-              # to verify connectivity. After a rolling restart,
-              # the primary's binlog has Update_rows_v1 events on
-              # rows that pod-0 cleared via
-              # clear_local_kb_health_check_table; replication SQL
-              # thread re-applies them and hits Error 1032
-              # HA_ERR_KEY_NOT_FOUND. The alpha.92-95 chain tried
-              # an in-repair skip via SET GLOBAL
-              # sql_slave_skip_counter but skip_counter is
-              # incompatible with GTID replication (MASTER_USE_GTID
-              # =slave_pos) which this addon uses, so the skip
-              # never advances the SQL thread past the failing
-              # event. Repair logs fresh-kb-health-check-repair
-              # every 4s indefinitely without making progress.
+              # alpha.97 (Helen 2026-05-25, live N=1 third-blocker
+              # from vcluster mariadb-test5 cluster mdb-async-39296
+              # T9 Switchover): REVERT alpha.96's
+              # --replicate-ignore-table=kubeblocks.kb_health_check.
               #
-              # Fix: tell mariadbd to NOT apply any
-              # kubeblocks.kb_health_check binlog events on this
-              # pod. The table is owned by KB controller probes;
-              # secondaries do not need to apply primary probe
-              # writes. --replicate-ignore-table is a per-server
-              # filter; setting it here on all pods is correct
-              # because the table is always written by KB
-              # controller against whichever pod is currently
-              # primary, never replicated as user data.
+              # alpha.96 claim "secondaries do not need to apply
+              # primary probe writes" was wrong. The kubeblocks
+              # .kb_health_check.check_ts row is the only signal
+              # syncer's IsMemberLagging uses to measure replication
+              # lag (`engines/mariadb/manager.go` GetOpTimestamp
+              # reads it; IsMemberLagging compares leader's
+              # OpTimestamp vs member's OpTimestamp). With the
+              # filter, secondary never receives kb_health_check
+              # updates -> secondary's kb_health_check stays empty
+              # -> GetOpTimestamp returns "sql: no rows in result
+              # set" -> IsMemberLagging returns (true,
+              # math.MaxInt64) -> IsMemberHealthy returns false ->
+              # ha.HasOtherHealthyMember returns false ->
+              # HandlerSwitchoverForPrimary falls through to
+              # Promote (line 59 of syncer's
+              # highavailability/switchover.go) -> syncer keeps
+              # the old leader and resets read_only=0 every second
+              # -> addon's fence verify window collapses ->
+              # Switchover OpsRequest fails.
+              #
+              # Live experiment on cluster mdb-async-39296:
+              # `SET GLOBAL replicate_ignore_table=''` (un-filter)
+              # on pod-1 + START SLAVE -> Error 1032
+              # immediately. Confirms both the original 1032 bug
+              # and that the filter was the actual T9 blocker.
+              #
+              # T9 Switchover is the higher-priority unblock per
+              # weston 2026-05-25 13:31; the 1032 / rolling-restart
+              # symptom that alpha.96 was trying to fix is
+              # re-investigated in a separate alpha. Candidate
+              # alpha.98 paths in flight: change
+              # `prepare_fresh_replica_for_sql_thread_start` to
+              # not DELETE existing kb_health_check rows, since
+              # the row already in the data dir matches the
+              # primary's INSERT/UPDATE history more often than
+              # not.
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
@@ -1680,7 +1693,6 @@ spec:
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \
                 --thread-cache-size=100 \
-                --replicate-ignore-table=kubeblocks.kb_health_check \
                 --bind-address="${bind_address}" &
               MARIADB_PID=$!
               prestop_fence_watchdog &

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1513,6 +1513,27 @@ spec:
                 echo "WARNING: failed to repair kubeblocks health check replication error; keeping roleProbe pending."
                 return 1
               fi
+              # alpha.92 v2 (Helen 2026-05-25, live N=1 first-blocker from
+              # vcluster mariadb-test5 kubeblocks-tests async cluster
+              # mdb-async-82190): after STOP SLAVE SQL_THREAD + DELETE
+              # FROM kubeblocks.kb_health_check the SQL thread relay log
+              # position is still pointing at the Update_rows_v1 event
+              # for the row we just cleared. START SLAVE SQL_THREAD
+              # without skipping re-applies the same event and hits the
+              # same 1032 / HA_ERR_KEY_NOT_FOUND, infinite loop. Skip 1
+              # event so the SQL thread advances past the offending
+              # Update_rows_v1; the just-cleared local table will be
+              # re-populated by the next Insert_rows or Update_rows event
+              # from the primary's kubeblocks.kb_health_check write loop
+              # (which fires every few seconds via KB controller probe).
+              # SET GLOBAL sql_slave_skip_counter requires SUPER which
+              # user-facing root no longer has after alpha.60 admin
+              # bypass revoke; INTERNAL_LOCAL uses kb_internal_root which
+              # retains ALL PRIVILEGES so it can execute SET GLOBAL.
+              # The skip is bounded to one event: if a different binlog
+              # event also fails afterwards the next repair cycle will
+              # catch it; we do not skip more than one event per call.
+              "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL sql_slave_skip_counter = 1;" 2>/dev/null || true # tier=error-recovery
               "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
               return 0
             }

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1524,7 +1524,31 @@ spec:
                 return 1
               fi
               prestop_watchdog_log "fresh-kb-health-check-repair label=${label}"
-              "${LOCAL[@]}" -e "STOP SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
+              # alpha.95 (Helen 2026-05-25, live N=1 follow-up from
+              # vcluster mariadb-test5 cluster mdb-async-36884 pod-0):
+              # the alpha.93 / alpha.94 chain confirmed the repair was
+              # being called but Slave_SQL_Running stayed No even after
+              # the skip-counter ran. Root cause: STOP / START SLAVE
+              # SQL_THREAD were invoked via LOCAL (user-facing root)
+              # which after alpha.60 admin-bypass revoke no longer has
+              # REPLICATION SLAVE ADMIN; both calls failed with ERROR
+              # 1227 (silently swallowed by `2>/dev/null || true`). With
+              # STOP never actually stopping the thread, SET GLOBAL
+              # sql_slave_skip_counter set the variable but the running
+              # SQL thread already failed at the offending event before
+              # the counter applied. START via LOCAL also failed silently.
+              # Net effect: repair traced repeatedly but no state change.
+              # Manual verification: same STOP / SET GLOBAL / START
+              # sequence via INTERNAL_LOCAL (kb_internal_root, retains
+              # ALL PRIVILEGES per alpha.83 v1) flipped
+              # Slave_SQL_Running from No to Yes within 3s on the live
+              # stuck pod-0.
+              #
+              # Fix: route all 3 calls (STOP / SET GLOBAL / START)
+              # through INTERNAL_LOCAL. STOP and START need REPLICATION
+              # SLAVE ADMIN; SET GLOBAL needs SUPER; user-facing root
+              # has neither.
+              "${INTERNAL_LOCAL[@]}" -e "STOP SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
               if ! with_local_read_write_for_health_check_repair "prepared-local-kb-health-check-after-replication-error"; then
                 # tier=error-recovery: repair attempt already failed; defensive
                 # locking follows mark_replication_pending and the function returns 1.
@@ -1534,28 +1558,20 @@ spec:
                 echo "WARNING: failed to repair kubeblocks health check replication error; keeping roleProbe pending."
                 return 1
               fi
-              # alpha.92 v2 (Helen 2026-05-25, live N=1 first-blocker from
-              # vcluster mariadb-test5 kubeblocks-tests async cluster
-              # mdb-async-82190): after STOP SLAVE SQL_THREAD + DELETE
-              # FROM kubeblocks.kb_health_check the SQL thread relay log
-              # position is still pointing at the Update_rows_v1 event
-              # for the row we just cleared. START SLAVE SQL_THREAD
-              # without skipping re-applies the same event and hits the
-              # same 1032 / HA_ERR_KEY_NOT_FOUND, infinite loop. Skip 1
-              # event so the SQL thread advances past the offending
-              # Update_rows_v1; the just-cleared local table will be
-              # re-populated by the next Insert_rows or Update_rows event
-              # from the primary's kubeblocks.kb_health_check write loop
-              # (which fires every few seconds via KB controller probe).
-              # SET GLOBAL sql_slave_skip_counter requires SUPER which
-              # user-facing root no longer has after alpha.60 admin
-              # bypass revoke; INTERNAL_LOCAL uses kb_internal_root which
-              # retains ALL PRIVILEGES so it can execute SET GLOBAL.
-              # The skip is bounded to one event: if a different binlog
-              # event also fails afterwards the next repair cycle will
-              # catch it; we do not skip more than one event per call.
+              # alpha.92 v2 (Helen 2026-05-25): after STOP SLAVE SQL_THREAD
+              # + DELETE FROM kubeblocks.kb_health_check the SQL thread
+              # relay log position is still pointing at the Update_rows
+              # _v1 event for the row we just cleared. START SLAVE
+              # SQL_THREAD without skipping re-applies the same event and
+              # hits the same 1032 / HA_ERR_KEY_NOT_FOUND, infinite loop.
+              # Skip 1 event so the SQL thread advances past the
+              # offending Update_rows_v1; the just-cleared local table
+              # will be re-populated by the next Insert_rows or
+              # Update_rows event from the primary's
+              # kubeblocks.kb_health_check write loop (which fires every
+              # few seconds via KB controller probe).
               "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL sql_slave_skip_counter = 1;" 2>/dev/null || true # tier=error-recovery
-              "${LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
+              "${INTERNAL_LOCAL[@]}" -e "START SLAVE SQL_THREAD;" 2>/dev/null || true # tier=error-recovery
               return 0
             }
             mariadbd_pids() {

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1645,6 +1645,34 @@ spec:
               # Each successful reconfigure writes a per-parameter
               # `.cnf` file into runtime-overrides.d/; mariadbd picks
               # them up on next restart.
+              # alpha.96 (Helen 2026-05-25, live N=1 second-blocker
+              # from vcluster mariadb-test5 cluster mdb-async-71412
+              # / mdb-async-36884): kubeblocks.kb_health_check is a
+              # per-pod KB controller probe table. KB controller
+              # writes to whichever pod is primary every few seconds
+              # to verify connectivity. After a rolling restart,
+              # the primary's binlog has Update_rows_v1 events on
+              # rows that pod-0 cleared via
+              # clear_local_kb_health_check_table; replication SQL
+              # thread re-applies them and hits Error 1032
+              # HA_ERR_KEY_NOT_FOUND. The alpha.92-95 chain tried
+              # an in-repair skip via SET GLOBAL
+              # sql_slave_skip_counter but skip_counter is
+              # incompatible with GTID replication (MASTER_USE_GTID
+              # =slave_pos) which this addon uses, so the skip
+              # never advances the SQL thread past the failing
+              # event. Repair logs fresh-kb-health-check-repair
+              # every 4s indefinitely without making progress.
+              #
+              # Fix: tell mariadbd to NOT apply any
+              # kubeblocks.kb_health_check binlog events on this
+              # pod. The table is owned by KB controller probes;
+              # secondaries do not need to apply primary probe
+              # writes. --replicate-ignore-table is a per-server
+              # filter; setting it here on all pods is correct
+              # because the table is always written by KB
+              # controller against whichever pod is currently
+              # primary, never replicated as user data.
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
@@ -1652,6 +1680,7 @@ spec:
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \
                 --thread-cache-size=100 \
+                --replicate-ignore-table=kubeblocks.kb_health_check \
                 --bind-address="${bind_address}" &
               MARIADB_PID=$!
               prestop_fence_watchdog &

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -148,37 +148,64 @@ spec:
     format: ini
     iniConfig:
       sectionName: mysqld
-  # alpha.89 v1 commit 3 v2 (Helen 2026-05-19, C1 path / Jack
-  # design review Class 4 sentinel + Class 4 fail-closed blocker
-  # B1) — declare a CUE-based parametersSchema so KB validates
-  # `rpl_semi_sync_*` parameter assignments before they reach the
-  # engine. The CUE file under config/mariadb-config-constraint.cue
-  # both declares the #MariaDBParameter type AND binds it to every
-  # INI section via `[SectionName=_]: #MariaDBParameter` — without
-  # the binding, KB's `ValidateConfigWithCue()` does not use the
-  # top-level definition and invalid values such as
-  # `rpl_semi_sync_master_enabled = MAYBE` slip through. With the
-  # binding in place, KB rejects unknown enum / out-of-range /
-  # wrong-type assignments at the controller parameter reconcile
-  # path (`ClassifyComponentParameters()` / `DoMerge()` calling
-  # the CUE validator), so an invalid value never lands in the
-  # rendered ConfigMap. PR #10254 once merged extends the
-  # validation to an earlier `ValidateComponentParameterAssignments()`
-  # entry that hard-rejects at OpsRequest validate-phase using the
-  # same schema.
+  # alpha.91 (Helen 2026-05-24, live N=1 first-blocker fix from
+  # vcluster mariadb-test5 run mdb-async-39059 kubeblocks-tests
+  # async suite) — parametersSchema is removed.
   #
-  # The CUE schema covers only the four semisync engine variables
-  # that are the real source-of-truth for replication mode. There
-  # is intentionally no synthetic `replicationMode` key — KB's
-  # ParamConfigRenderer has no transform hook to expand a single
-  # logical key into multiple engine variables, so a synthetic key
-  # would either be ignored or land in my.cnf verbatim and break
-  # mariadbd. The unified-switch UX is delivered via addon docs
-  # (and future helper scripts).
-  parametersSchema:
-    topLevelKey: MariaDBParameter
-    cue: |-
-      {{- .Files.Get "config/mariadb-config-constraint.cue" | nindent 6 }}
+  # alpha.89 v1 commit 3 v2 added a CUE-based parametersSchema with
+  # only the 4 rpl_semi_sync_* engine vars declared as typed CUE
+  # fields, with `[string]: _` open marker on top to let other
+  # parameters pass CUE validation. Live behavioral test against
+  # KB controller (image apecloud/kubeblocks:1.0.0) reveals that
+  # KB's reconfigure validator only registers keys from the CUE
+  # schema's OpenAPI `properties` set, NOT the `additionalProperties`
+  # produced by the open marker. KB source:
+  # pkg/parameters/parameter_schema.go:50 — `props := openapi
+  # .FlattenSchema(schema.Properties[openapi.DefaultSchemaName])
+  # .Properties` — only enumerates properties; subsequent
+  # `FindParameterSchema()` returns false for any key not in props,
+  # and reconfigure fails with "parameter X not found in
+  # parameters schema" (parameter_utils.go:158).
+  #
+  # Effect on live cluster: ALL reconfigure OpsRequests against
+  # common dynamic params (long_query_time, wait_timeout,
+  # innodb_lock_wait_timeout, sync_binlog, back_log) fail at
+  # KB controller validate-phase. The 239 params declared in
+  # `dynamicParameters` / `staticParameters` lists are NOT
+  # consulted by the reconfigure path once a parametersSchema is
+  # present — the lists are used only for restart-vs-runtime
+  # classification, not for known-parameter whitelisting.
+  #
+  # Fix: drop the parametersSchema. This restores alpha.85
+  # reconfigure behavior (all `dynamicParameters` / `staticParameters`
+  # are reconfigurable; per-parameter type / range validation is
+  # deferred to mariadbd's own SET GLOBAL handling).
+  #
+  # Class 4 fail-closed for the 4 rpl_semi_sync_* engine vars is
+  # still enforced by the three other layers:
+  #   1. Helm template-time validator (`mariadb.replication.mode
+  #      .validate` in _helpers.tpl) rejects invalid `replication
+  #      .mode` Helm values at `helm render` time.
+  #   2. Startup seeder (`scripts/seed-replication-mode-overrides
+  #      .sh`) writes the 4 real `rpl_semi_sync_*` engine
+  #      variables to `runtime-overrides.d/` BEFORE mariadbd
+  #      starts.
+  #   3. Reconfigure mapper (`scripts/replication-mode-mapper.sh`)
+  #      strips synthetic `replicationMode` / `replicationmode` from
+  #      the parameter list BEFORE SET GLOBAL.
+  #
+  # Degraded path: a user OpsRequest that directly sets
+  # `rpl_semi_sync_master_enabled=MAYBE` will now reach mariadbd's
+  # SET GLOBAL which rejects unknown enum values, producing a Failed
+  # OpsRequest at the action layer rather than at the validator
+  # layer. Engine-layer fail (loud, with mariadbd-side error
+  # message) is acceptable for this single corner case; the bulk
+  # protection sits in the 3 layers above.
+  #
+  # Re-introducing parametersSchema would require enumerating ALL
+  # 239 dynamic+static MariaDB params with their type constraints
+  # (similar to mysql8-config-constraint.cue's 426 declarations),
+  # deferred to a separate alpha pending bandwidth.
   {{- if hasKey $pd "staticParameters" }}
   staticParameters:
     {{- range (get $pd "staticParameters") }}


### PR DESCRIPTION
## Summary

Alpha.91 chart bump that drops the `parametersSchema` from `mariadb-replication-merged-pd`. This unblocks reconfigure OpsRequests against the merged replication topology for all 239 declared dynamic+static MariaDB params — alpha.90 only accepted the 3 `rpl_semi_sync_*` keys.

## Why

Live N=1 first-blocker from `kubeblocks-tests` async suite on vcluster `mariadb-test5` (cluster `mdb-async-88638` regression after `mdb-async-39059`): all 5 reconfigure test sections (T5, CM1-CM4) fail at KB controller validate-phase with `parameter X not found in parameters schema`.

Root cause is a KB validator behavior gap: KB's `pkg/parameters/parameter_schema.go:50` only registers keys from the CUE schema's OpenAPI `properties` set; `additionalProperties` (produced by the CUE `[string]: _` open marker) is ignored. So the 3 typed `rpl_semi_sync_*` properties become the entire whitelist, and 236 of the 239 declared params are rejected.

## Fix

Remove `parametersSchema` from `mariadb-replication-merged-pd`. Restores alpha.85 reconfigure behavior — all declared params reconfigurable; per-param type / range validation deferred to mariadbd's SET GLOBAL.

## Class 4 fail-closed alternative enforcement (unchanged)

The 4 `rpl_semi_sync_*` engine vars are still protected by 3 other layers documented in the new paramsdef.yaml comment:

1. Helm template-time validator (`mariadb.replication.mode.validate`)
2. Startup seeder (`scripts/seed-replication-mode-overrides.sh`) writes 4 real vars BEFORE mariadbd starts
3. Reconfigure mapper (`scripts/replication-mode-mapper.sh`) strips synthetic `replicationMode` BEFORE SET GLOBAL

Degraded path for direct `rpl_semi_sync_master_enabled=MAYBE` OpsRequest: now fails loudly at mariadbd SET GLOBAL rather than at the validator, which is acceptable for this single corner case.

## Validation

- helm lint clean
- helm template render clean (alpha.91 PD has no parametersSchema)
- vcluster mariadb-test5 live upgrade: `mariadb-replication-merged-pd` reports `parametersSchema: <empty>`, all 5 alpha.91 CmpDs Available
- async run pending re-validation against alpha.91 cluster (in progress)

## Follow-up

Re-introducing parametersSchema with full coverage requires enumerating ALL 239 dynamic+static MariaDB params with type constraints (analogous to `mysql8-config-constraint.cue`'s 426 declarations). Deferred to a later alpha pending bandwidth.

## Test plan

- [x] helm lint clean
- [x] helm template render clean
- [x] live cluster PD `parametersSchema: <empty>` after upgrade
- [ ] async suite reconfigure sections (T5, CM1-CM4) PASS post-fix
- [ ] semisync + galera + standalone topologies reconfigure regression-clean
