### PR TITLE
acceptance: smoke-backup slice characterisation on feat/valkey-addon HEAD

### DIFF
--- a/.acceptance-journal/smoke-backup-20260525.md
+++ b/.acceptance-journal/smoke-backup-20260525.md
@@ -1,0 +1,19 @@
+# Smoke-backup acceptance journal (2026-05-25)
+
+This file seeds a development branch used to track an acceptance lane: characterising the intermittent smoke-backup slice (T16 Backup / T17 Restore / T18 Scheduled Backup / T19 No-op Upgrade) result on the current Valkey addon HEAD. It is independent of any in-flight role-probe fix.
+
+## Candidate package
+
+- target branch: `feat/valkey-addon`
+- development branch: `alice/smoke-backup-acceptance-20260525`
+- target branch HEAD at fork: `b9cc769e4dd971d0a89c13bbe6159c7d0acffd13`
+- KubeBlocks: KB main 1.2.0-alpha.x (controller image to be pinned at run time)
+- DataProtection: KB main 1.2.0-alpha.x
+- syncer: chart-default at run time
+- included PRs: none yet
+- excluded PRs: none yet
+- acceptance gate: smoke-backup slice (kubeblocks-tests/valkey/tests/smoke-backup.sh) over multiple fresh-cluster rounds; on first non-environment non-SKIP FAIL, follow autonomous-addon-development-loop rule #20 and freeze the live cluster for investigation
+
+## Scope
+
+This dev branch hosts child PRs only when a test, harness, chart, or addon code fix is needed during the acceptance lane. It does not bundle unrelated features. The main PR description tracks each child PR link, tested commit, and short result. Final integration into `feat/valkey-addon` requires human approval after the acceptance gate is satisfied.


### PR DESCRIPTION
## Purpose

Development-branch main PR for an acceptance lane: characterise the intermittent smoke-backup slice (T16 / T17 / T18 / T19) on the current `feat/valkey-addon` HEAD. This PR is a tracking surface for the acceptance journey, not a feature change. Final integration into `feat/valkey-addon` is gated by acceptance result + human integration approval.

## Verdict

**Closed: smoke-backup slice is not currently intermittent on this addon HEAD.** 5 fresh-cluster rounds back-to-back, every round PASS 48 / 0 / 1 (T19 SKIP is the documented no-op upgrade behaviour). The prior memory note about smoke-backup intermittency does not reproduce against the candidate package below.

This is **not** release-ready evidence: a single slice does not satisfy the autonomous-addon-development-loop rule #16 acceptance bar, which requires repeated full `kubeblocks-tests` engine-suite rounds on the fixed candidate package. Full-suite acceptance is tracked separately.

## Candidate package

- target branch: `feat/valkey-addon`
- development branch: `alice/smoke-backup-acceptance-20260525`
- target branch HEAD at fork: `b9cc769e4dd971d0a89c13bbe6159c7d0acffd13`
- KubeBlocks controller image (live, idc vcluster valkey-fresh-0008): `apecloud/kubeblocks:1.2.0-alpha.1-pr10280-16803efa` imageID `sha256:52135df30b2d82f077b6a84381b6ae99978ce6e9b80345a56fd03f584933865e` (acknowledged drift: this is a PR #10280 patch image left from prior acceptance; smoke-backup slice is orthogonal to the role-probe fix and the variable is recorded)
- DataProtection controller: `kubeblocks-dataprotection:1.2.0-alpha.1` imageID `sha256:952f83dee5b697d036e336a99a9896c51a7fe98c4d93afcdc9fcdd0c22dbe151`
- Valkey addon Helm release: revision 7, chart `valkey-0.1.1`, app version 9.0.0 (clean v3 chart, no live debug env)
- ActionSet: `valkey-physical-br` Available; BackupRepo: `r1-mn` Ready (MinIO, default)
- acceptance gate: `kubeblocks-tests/valkey/tests/smoke-backup.sh` over multiple fresh-cluster rounds; on first non-environment non-SKIP FAIL, follow autonomous-addon-development-loop rule #20 (freeze live cluster, investigate before next OpsRequest)
- included PRs (child PRs into this dev branch): _none_
- excluded PRs: _none_

## Child PR ledger

(none — no fixes were needed; smoke-backup slice was clean across N=5)

## Rounds ledger

| Round | Namespace | Result | PASS / FAIL / SKIP | Runner log sha256 |
| --- | --- | --- | --- | --- |
| 1 | `smoke-bk-r1` | PASS | 48 / 0 / 1 | `58993f0afa5dea99238c94d87f3e50010aef72f29a22475e920989d6bb6128fc` |
| 2 | `smoke-bk-r2` | PASS | 48 / 0 / 1 | `1852fe9f63cb8167365964229c016da7d83155c59b242574f9cdc3f39bd2c648` |
| 3 | `smoke-bk-r3` | PASS | 48 / 0 / 1 | `86124476f96535951bbd8ca933271971a53e81a4b20138df11589f62b068cbb6` |
| 4 | `smoke-bk-r4` | PASS | 48 / 0 / 1 | `d288790d1a15e4c01d26287c587ecc4d6109a4eacd3c2d6ac531ea959ffabe89` |
| 5 | `smoke-bk-r5` | PASS | 48 / 0 / 1 | `7e0825dbd535a9e2e0226743c997c80c6e2ab1829c8e5c7c14da8c0be4846bc4` |

T19 SKIP in each round is the documented no-op upgrade behaviour: cmpdef/version already matches the running cluster, so the OpsRequest succeeds without pod restart, and the runner skips the rolling-restart assertion rather than treating identical UIDs as a FAIL.

## Public hygiene checks

- [x] PR body has no internal task numbers, internal channel names, or agent code names
- [x] Seed file contains no in-flight evidence
- [x] Acceptance gate matches the engine-neutral autonomous-addon-development-loop skill (sha 367ac3109db02bfd74016cddb35875202168d11811c1e56af8f6eb834574e64e)
- [x] Verdict explicitly distinguishes slice characterisation (this PR) from release-ready (separate full-suite acceptance lane)
