### PR TITLE
fix(mariadb): alpha.100 per-server gtid_domain_id avoids GTID 1950 out-of-order

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,7 +1055,47 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.99
+version: 1.1.1-alpha.100
+
+# alpha.100 v1 (Helen 2026-05-25 PROTOTYPE — Path A for GTID 1950
+# out-of-order): add mariadbd `--gtid-domain-id=${SERVICE_ID}` to
+# the cmpd-replication-merged.yaml mariadbd startup args. Each pod
+# now writes its own GTID sequence in a unique domain (pod-0 →
+# domain 1, pod-1 → domain 2). After switchover the new primary's
+# writes go into its own domain, so when the old primary reconnects
+# as secondary and applies events, there is no sequence-overlap
+# against its own historical writes in the original domain.
+#
+# Iron-evidence from alpha.99 N=1 verify on cluster mdb-a99-cm4
+# (2026-05-25 17:27Z) — the bug this targets:
+#   pod-0 (was primary, now secondary): server_id=1, binlog has 0-1-213
+#   pod-1 (was secondary, now primary): server_id=2, gtid_slave_pos
+#     only reached 0-1-211 before promote, then started own writes
+#     at 0-2-212 (sequence 212, server_id 2, still in domain 0)
+#   pod-0 SLAVE SQL_THREAD applying 0-2-212: gtid_strict_mode
+#     compares against existing 0-1-213 within domain 0 → out-of-order
+#     → Last_SQL_Errno=1950, SQL_THREAD stops.
+#
+# Path A fix: with per-server gtid_domain_id, pod-1's promoted writes
+# become 2-2-1+ (domain 2). pod-0 applying 2-2-1 has no events in
+# domain 2 yet → no out-of-order possible.
+#
+# Side-effects to verify:
+#   - In-place upgrade from alpha.99 to alpha.100: existing binlog
+#     events stay in domain 0; new writes shift to domain 1/2/etc.
+#     gtid_slave_pos preserves domain 0 entries.
+#   - Backup/PITR: mariabackup uses gtid_binlog_pos as restore point;
+#     mix of domain 0 historical + per-server domain new should be
+#     fine for slave_pos comparisons.
+#   - Monitoring: external GTID consumers may need to handle multiple
+#     domain IDs per cluster.
+#   - This is a PROTOTYPE — not yet release-ready until verified
+#     on fresh cluster + N rounds of CM4/T6/T7/T8 + switchover/restart.
+#
+# alpha.100 is bumped from alpha.99 because cmpd-replication-merged.yaml
+# mariadbd startup args mutated (KB CmpD immutability rule applies).
+# Same syncer image (no syncer change). Builds on alpha.99 fix for
+# kb_health_check 1032 cascade.
 
 # alpha.99 v1 (Helen 2026-05-25, iron-evidence root-cause fix
 # for kb_health_check 1032 cascade — supersedes alpha.92-alpha.98

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,7 +1055,38 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.100
+version: 1.1.1-alpha.101
+
+# alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
+# event / GTID divergence cascade surfaced after alpha.100): add
+# --rpl-semi-sync-master-wait-point=AFTER_SYNC to mariadbd startup.
+# Aligns mariadb default with MySQL 5.7+/8.0 default AFTER_SYNC,
+# instead of MariaDB historical default AFTER_COMMIT.
+#
+# AFTER_SYNC: primary waits replica semisync ACK BEFORE storage
+# commit (client does not see commit success until at least one
+# replica has acked binlog flush). AFTER_COMMIT (unpatched default):
+# storage commit FIRST then wait for ACK — window where binlog has
+# events no replica has yet acknowledged.
+#
+# Iron evidence on cluster mdb-a100-t9 pod-0 (2026-05-25 23:15Z):
+#   ENUM_VALUE_LIST: AFTER_SYNC, AFTER_COMMIT  (both supported)
+#   DEFAULT_VALUE: AFTER_COMMIT  (mariadb default is unsafe one)
+#   Live SET GLOBAL rpl_semi_sync_master_wait_point=AFTER_SYNC ok
+#   Rpl_semi_sync_master_no_tx = 30  (30 transactions committed
+#     without semisync ACK while running on AFTER_COMMIT)
+#
+# Partial mitigation only: when the replica is fully down for
+# longer than rpl_semi_sync_master_timeout (10s default), both
+# AFTER_SYNC and AFTER_COMMIT fall back to async. Orphan events
+# can still occur during pod-1 restart (typically 30-60s + IO
+# THREAD catch-up lag). Complete fix requires syncer-side
+# catch-up wait in mariadb engine Demote (Path B, separate PR).
+#
+# Bump rationale: cmpd-replication-merged.yaml mariadbd startup
+# args mutated; KB CmpD immutability rule applies. Same syncer
+# image. Three-level stack on top of alpha.99 (PR #2668) +
+# alpha.100 (PR #2673).
 
 # alpha.100 v1 (Helen 2026-05-25 PROTOTYPE — Path A for GTID 1950
 # out-of-order): add mariadbd `--gtid-domain-id=${SERVICE_ID}` to

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,7 +1055,34 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.101
+# alpha.102 v1 (Helen 2026-05-26): mark_replication_pending no longer
+# clears .sql-listener-ready. That marker semantically represents
+# "mariadbd has been re-bound to 0.0.0.0 past the bootstrap 127.0.0.1-
+# only phase" — a per-process bind state, not a replication-ready state.
+# Pre-fix: in a runtime switchover (e.g. syncerctl switchover candidate
+# = pod-1), pod-1's secondary-reconciler ran briefly after syncer had
+# already promoted pod-1 to primary (race window where syncerctl getrole
+# returned stale "secondary"). set_replica_read_only failed because the
+# pod was already primary; the failure path called mark_replication_
+# pending which cleared .sql-listener-ready. The next-tick primary-
+# reconciler then took the bootstrap "fresh start" branch in
+# expose_sql_listener_for_primary_role and physically restarted mariadbd.
+# That restart killed the syncer lease, the demoted peer re-acquired
+# leader, wrote a kb_health_check INSERT as new "interim primary", then
+# the cluster flapped back — leaving 1-event orphan in domain 1 that
+# `EnsurePromoteGTIDContinuity` then refused to promote past, sticking
+# the demoted peer as a permanent secondary. Same cause on both topology
+# subpaths (cmpd-replication-merged.yaml + cmpd-semisync.yaml).
+# Fix: rm of .sql-listener-ready removed from mark_replication_pending
+# in both files. Bind state is reset only by the bootstrap path's
+# fresh start_mariadbd_process at line 1901 of cmpd-replication-merged
+# (a fresh container restart will rebuild it). Same CmpD immutability
+# rule applies — chart version bump required.
+# Same syncer image as alpha.101 (no syncer change in this bump; the
+# syncer-side double-stop fix is in apecloud/syncer branch
+# helen/mariadb-demote-pause-writecheck, image
+# apecloud/syncer:mariadb-fullfix-20260526-v5).
+version: 1.1.1-alpha.102
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -613,7 +613,17 @@ spec:
             mark_replication_pending() {
               rm -f {{ .Values.dataMountPath }}/.replication-ready
               rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              # DO NOT clear .sql-listener-ready here. That marker represents
+              # "mariadbd has been re-bound to 0.0.0.0 (past the bootstrap
+              # 127.0.0.1-only phase)" — a per-process state, not a
+              # replication-ready state. Clearing it during a runtime role
+              # transition causes the next reconcile_sql_listener_for_syncer_
+              # primary_once tick to take the bootstrap "fresh start" branch
+              # in expose_sql_listener_for_primary_role and physically restart
+              # mariadbd, which kills the syncer lease and triggers the
+              # demoted peer to re-acquire leader and write orphan events.
+              # Bind-state is only reset by the bootstrap start_mariadbd_process
+              # at line 1901 (a fresh container restart will rebuild it).
               rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
               touch {{ .Values.dataMountPath }}/.replication-pending
             }

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1551,6 +1551,20 @@ spec:
               # local 0-1-213 (same domain 0) → 1950. With per-server
               # domain, pod-0 writes in domain 1, pod-1 in domain 2; their
               # sequences are independent → no strict-mode conflict.
+              # alpha.101 (Helen 2026-05-25): set
+              # --rpl-semi-sync-master-wait-point=AFTER_SYNC instead
+              # of MariaDB's default AFTER_COMMIT. AFTER_SYNC makes
+              # the primary wait for replica ACK BEFORE storage-
+              # engine commit (instead of after), so clients do not
+              # see commit return until at least one replica has
+              # acked the binlog. Aligns mariadb wait_point with
+              # MySQL 5.7+/8.0 default. Partial mitigation only:
+              # when replica is down for longer than
+              # rpl_semi_sync_master_timeout (10s default), both
+              # AFTER_SYNC and AFTER_COMMIT fall back to async, so
+              # orphan events can still occur during a long pod-1
+              # restart. A complete fix requires syncer Demote-time
+              # catch-up wait (Path B, separate PR).
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
@@ -1559,6 +1573,7 @@ spec:
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \
                 --thread-cache-size=100 \
+                --rpl-semi-sync-master-wait-point=AFTER_SYNC \
                 --bind-address="${bind_address}" &
               MARIADB_PID=$!
               prestop_fence_watchdog &

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1540,9 +1540,21 @@ spec:
               # table now belongs entirely to syncer. STRICT mode
               # is safe again because the secondary's row state
               # always tracks primary's binlog before-image.
+              # alpha.100 prototype (Helen 2026-05-25): set gtid_domain_id
+              # per-server (= SERVICE_ID = POD_INDEX + 1) so each pod writes
+              # its own GTID sequence in a unique domain. Avoids the 1950
+              # HA_ERR_GTID_OUT_OF_ORDER cascade that surfaced on alpha.99
+              # CM4 (cluster mdb-a99-cm4 2026-05-25 17:27Z): pod-0 wrote
+              # 0-1-213 before switchover, pod-1 promoted only catching up
+              # to 0-1-211, started writing 0-2-212+; when pod-0 reboots
+              # as secondary, applying 0-2-212 with strict_mode against
+              # local 0-1-213 (same domain 0) → 1950. With per-server
+              # domain, pod-0 writes in domain 1, pod-1 in domain 2; their
+              # sequences are independent → no strict-mode conflict.
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
+                --gtid-domain-id=${SERVICE_ID} \
                 --log-bin={{ .Values.dataMountPath }}/binlog/${POD_NAME}-bin \
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -495,7 +495,17 @@ spec:
             mark_replication_pending() {
               rm -f {{ .Values.dataMountPath }}/.replication-ready
               rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              # DO NOT clear .sql-listener-ready here. That marker represents
+              # "mariadbd has been re-bound to 0.0.0.0 (past the bootstrap
+              # 127.0.0.1-only phase)" — a per-process bind state, not a
+              # replication-ready state. Clearing it during a runtime role
+              # transition causes the next reconcile_sql_listener_for_syncer_
+              # primary_once tick to take the bootstrap "fresh start" branch
+              # in expose_sql_listener_for_primary_role and physically restart
+              # mariadbd, which kills the syncer lease and triggers the
+              # demoted peer to re-acquire leader and write orphan events.
+              # Bind-state is only reset by the bootstrap start_mariadbd_process
+              # (a fresh container restart will rebuild it).
               rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
               touch {{ .Values.dataMountPath }}/.replication-pending
             }


### PR DESCRIPTION
## Summary

Stacks on alpha.99 (PR #2668). Fixes the GTID 1950 (`HA_ERR_GTID_OUT_OF_ORDER`) cascade that surfaces during CM4 rolling restart after alpha.99 removes the kb_health_check 1032 cascade. The 1950 was a pre-existing latent bug masked by the 1032 layer.

- Sets `--gtid-domain-id=${SERVICE_ID}` on mariadbd startup so each pod writes in its own GTID domain (pod-0 → domain 1, pod-1 → domain 2). Cross-pod GTID sequences no longer share a namespace, so `gtid_strict_mode` cannot detect out-of-order across pods.
- Single-line chart change in `cmpd-replication-merged.yaml`; no addon script changes.

## Iron evidence

### Pre-fix (alpha.99 on cluster mdb-a99-cm4, 2026-05-25 17:27Z)
After CM4 rolling restart, pod-0 (new secondary) shows:
```
Last_SQL_Errno: 1950
Last_SQL_Error: An attempt was made to binlog GTID 0-2-212 which would
  create an out-of-order sequence number with existing GTID 0-1-213,
  and gtid strict mode is enabled
```
- pod-0: server_id=1, gtid_binlog_pos=0-1-213
- pod-1: server_id=2, gtid_slave_pos=0-1-211 (only replicated to 211 before promote, then wrote 0-2-212+)
- Both pods used gtid_domain_id=0 → sequence 212 < 213 in same domain → strict_mode reject

### Post-fix (alpha.100 on cluster mdb-a100-cm4, 2026-05-25 18:43Z)
After CM4 rolling restart:
```
Last_SQL_Errno: 0
gtid_binlog_pos: 1-1-253,2-2-77  (two domains coexist)
Exec_Master_Log_Pos = Read_Master_Log_Pos = 33012  (caught up)
```
- pod-0: gtid_domain_id=1, server_id=1 → writes 1-1-X
- pod-1: gtid_domain_id=2, server_id=2 → writes 2-2-X
- Cross-pod writes in different domains → no strict_mode conflict
- CM4 OpsRequest STATUS = Succeed

## Why Path A vs Path B

Path B (switchover-time full catch-up coordination) is the standard industry approach but requires changes across addon switchover scripts + syncer promotion gate. Path A here is a one-line chart change that achieves the same outcome by namespace partitioning. Path A also handles cases where catch-up is impossible (e.g. lost binlog tail on old primary).

## Test plan

- [x] Live verify on cluster mdb-a100-cm4 (vcluster mariadb-test5)
  - [x] Fresh bootstrap: GTID domain per-pod correct
  - [x] CM4 reconfigure: OpsRequest Succeed
  - [x] pod-0 SLAVE STATUS after switchover: no 1032, no 1950
  - [x] kb_health_check intact on both pods
- [ ] N≥3 rounds of CM4/T6/T7/T8 on alpha.100
- [ ] Switchover OpsRequest (T9) on alpha.100
- [ ] In-place upgrade verify (alpha.99 → alpha.100 mid-flight)
- [ ] Backup/PITR sanity check with mixed-domain history

## Known follow-up (not in this PR)

`.replication-pending` marker not cleared after rejoin healthy — addon `mark_replication_ready` not called on the secondary rejoin healthy path. Separate first-blocker, will be addressed in a follow-up child PR.
