### PR TITLE
fix(mariadb): alpha.101 set semisync wait_point=AFTER_SYNC (Phase 1)

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,7 +1055,38 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.100
+version: 1.1.1-alpha.101
+
+# alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
+# event / GTID divergence cascade surfaced after alpha.100): add
+# --rpl-semi-sync-master-wait-point=AFTER_SYNC to mariadbd startup.
+# Aligns mariadb default with MySQL 5.7+/8.0 default AFTER_SYNC,
+# instead of MariaDB historical default AFTER_COMMIT.
+#
+# AFTER_SYNC: primary waits replica semisync ACK BEFORE storage
+# commit (client does not see commit success until at least one
+# replica has acked binlog flush). AFTER_COMMIT (unpatched default):
+# storage commit FIRST then wait for ACK — window where binlog has
+# events no replica has yet acknowledged.
+#
+# Iron evidence on cluster mdb-a100-t9 pod-0 (2026-05-25 23:15Z):
+#   ENUM_VALUE_LIST: AFTER_SYNC, AFTER_COMMIT  (both supported)
+#   DEFAULT_VALUE: AFTER_COMMIT  (mariadb default is unsafe one)
+#   Live SET GLOBAL rpl_semi_sync_master_wait_point=AFTER_SYNC ok
+#   Rpl_semi_sync_master_no_tx = 30  (30 transactions committed
+#     without semisync ACK while running on AFTER_COMMIT)
+#
+# Partial mitigation only: when the replica is fully down for
+# longer than rpl_semi_sync_master_timeout (10s default), both
+# AFTER_SYNC and AFTER_COMMIT fall back to async. Orphan events
+# can still occur during pod-1 restart (typically 30-60s + IO
+# THREAD catch-up lag). Complete fix requires syncer-side
+# catch-up wait in mariadb engine Demote (Path B, separate PR).
+#
+# Bump rationale: cmpd-replication-merged.yaml mariadbd startup
+# args mutated; KB CmpD immutability rule applies. Same syncer
+# image. Three-level stack on top of alpha.99 (PR #2668) +
+# alpha.100 (PR #2673).
 
 # alpha.100 v1 (Helen 2026-05-25 PROTOTYPE — Path A for GTID 1950
 # out-of-order): add mariadbd `--gtid-domain-id=${SERVICE_ID}` to

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,7 +1055,34 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.101
+# alpha.102 v1 (Helen 2026-05-26): mark_replication_pending no longer
+# clears .sql-listener-ready. That marker semantically represents
+# "mariadbd has been re-bound to 0.0.0.0 past the bootstrap 127.0.0.1-
+# only phase" — a per-process bind state, not a replication-ready state.
+# Pre-fix: in a runtime switchover (e.g. syncerctl switchover candidate
+# = pod-1), pod-1's secondary-reconciler ran briefly after syncer had
+# already promoted pod-1 to primary (race window where syncerctl getrole
+# returned stale "secondary"). set_replica_read_only failed because the
+# pod was already primary; the failure path called mark_replication_
+# pending which cleared .sql-listener-ready. The next-tick primary-
+# reconciler then took the bootstrap "fresh start" branch in
+# expose_sql_listener_for_primary_role and physically restarted mariadbd.
+# That restart killed the syncer lease, the demoted peer re-acquired
+# leader, wrote a kb_health_check INSERT as new "interim primary", then
+# the cluster flapped back — leaving 1-event orphan in domain 1 that
+# `EnsurePromoteGTIDContinuity` then refused to promote past, sticking
+# the demoted peer as a permanent secondary. Same cause on both topology
+# subpaths (cmpd-replication-merged.yaml + cmpd-semisync.yaml).
+# Fix: rm of .sql-listener-ready removed from mark_replication_pending
+# in both files. Bind state is reset only by the bootstrap path's
+# fresh start_mariadbd_process at line 1901 of cmpd-replication-merged
+# (a fresh container restart will rebuild it). Same CmpD immutability
+# rule applies — chart version bump required.
+# Same syncer image as alpha.101 (no syncer change in this bump; the
+# syncer-side double-stop fix is in apecloud/syncer branch
+# helen/mariadb-demote-pause-writecheck, image
+# apecloud/syncer:mariadb-fullfix-20260526-v5).
+version: 1.1.1-alpha.102
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -613,7 +613,17 @@ spec:
             mark_replication_pending() {
               rm -f {{ .Values.dataMountPath }}/.replication-ready
               rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              # DO NOT clear .sql-listener-ready here. That marker represents
+              # "mariadbd has been re-bound to 0.0.0.0 (past the bootstrap
+              # 127.0.0.1-only phase)" — a per-process state, not a
+              # replication-ready state. Clearing it during a runtime role
+              # transition causes the next reconcile_sql_listener_for_syncer_
+              # primary_once tick to take the bootstrap "fresh start" branch
+              # in expose_sql_listener_for_primary_role and physically restart
+              # mariadbd, which kills the syncer lease and triggers the
+              # demoted peer to re-acquire leader and write orphan events.
+              # Bind-state is only reset by the bootstrap start_mariadbd_process
+              # at line 1901 (a fresh container restart will rebuild it).
               rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
               touch {{ .Values.dataMountPath }}/.replication-pending
             }

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1551,6 +1551,20 @@ spec:
               # local 0-1-213 (same domain 0) → 1950. With per-server
               # domain, pod-0 writes in domain 1, pod-1 in domain 2; their
               # sequences are independent → no strict-mode conflict.
+              # alpha.101 (Helen 2026-05-25): set
+              # --rpl-semi-sync-master-wait-point=AFTER_SYNC instead
+              # of MariaDB's default AFTER_COMMIT. AFTER_SYNC makes
+              # the primary wait for replica ACK BEFORE storage-
+              # engine commit (instead of after), so clients do not
+              # see commit return until at least one replica has
+              # acked the binlog. Aligns mariadb wait_point with
+              # MySQL 5.7+/8.0 default. Partial mitigation only:
+              # when replica is down for longer than
+              # rpl_semi_sync_master_timeout (10s default), both
+              # AFTER_SYNC and AFTER_COMMIT fall back to async, so
+              # orphan events can still occur during a long pod-1
+              # restart. A complete fix requires syncer Demote-time
+              # catch-up wait (Path B, separate PR).
               docker-entrypoint.sh mariadbd \
                 --defaults-extra-file={{ .Values.dataMountPath }}/runtime-overrides.cnf \
                 --server-id=${SERVICE_ID} \
@@ -1559,6 +1573,7 @@ spec:
                 --skip-slave-start=ON \
                 --read-only=NO_LOCK_NO_ADMIN \
                 --thread-cache-size=100 \
+                --rpl-semi-sync-master-wait-point=AFTER_SYNC \
                 --bind-address="${bind_address}" &
               MARIADB_PID=$!
               prestop_fence_watchdog &

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -495,7 +495,17 @@ spec:
             mark_replication_pending() {
               rm -f {{ .Values.dataMountPath }}/.replication-ready
               rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              # DO NOT clear .sql-listener-ready here. That marker represents
+              # "mariadbd has been re-bound to 0.0.0.0 (past the bootstrap
+              # 127.0.0.1-only phase)" — a per-process bind state, not a
+              # replication-ready state. Clearing it during a runtime role
+              # transition causes the next reconcile_sql_listener_for_syncer_
+              # primary_once tick to take the bootstrap "fresh start" branch
+              # in expose_sql_listener_for_primary_role and physically restart
+              # mariadbd, which kills the syncer lease and triggers the
+              # demoted peer to re-acquire leader and write orphan events.
+              # Bind-state is only reset by the bootstrap start_mariadbd_process
+              # (a fresh container restart will rebuild it).
               rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
               touch {{ .Values.dataMountPath }}/.replication-pending
             }


### PR DESCRIPTION
## Summary

Stacks on alpha.100 (PR #2673). Phase 1 of the orphan-event mitigation: set `--rpl-semi-sync-master-wait-point=AFTER_SYNC` on mariadbd startup, aligning the default with MySQL 5.7+/8.0 (AFTER_SYNC) instead of MariaDB's historical default AFTER_COMMIT.

**Single-line chart change**. No addon script changes.

## Why AFTER_SYNC matters

| Wait point | Order |
|-----------|-------|
| AFTER_COMMIT (mariadb default) | storage commit → wait ACK. Client sees commit before replica confirms. |
| AFTER_SYNC (mysql 5.7+ default) | wait ACK → storage commit. Client cannot see commit until replica confirms binlog flush. |

## Iron evidence

### Pre-fix (cluster mdb-a100-t9 on alpha.100, 2026-05-25 23:15Z)
```
ENUM_VALUE_LIST: AFTER_SYNC, AFTER_COMMIT  ← both supported by MariaDB 11.4.5
DEFAULT_VALUE: AFTER_COMMIT                 ← mariadb default is unsafe
Rpl_semi_sync_master_no_tx = 30             ← 30 transactions committed without semisync ACK while running on default
```

### Post-fix (cluster mdb-a101-cm4 on alpha.101, 2026-05-26 00:08Z)
- Both pods: `rpl_semi_sync_master_wait_point = AFTER_SYNC` (verified via SHOW GLOBAL VARIABLES)
- CM4 reconfigure OpsRequest STATUS = Succeed
- BUT same divergence-detected outcome as alpha.100:
  ```
  pod-0 (new secondary after switchover):
    gtid_binlog_state = 1-1-225, 2-2-75
  primary (pod-1):
    gtid_binlog_state = 1-1-224, 2-2-75
  pod-0 has 1-1-225 that primary lacks → addon fail_closed_for_gtid_divergence triggers → marker stuck
  ```

## Honest result: partial mitigation

AFTER_SYNC alone does NOT fully fix the orphan event problem. The pod-1 restart window (30-60s) is longer than semisync_master_timeout (10s default), so:
- pod-1 terminates → semisync_master_clients drops to 0
- After 10s timeout: pod-0 falls back to async (rpl_semi_sync_master_status = OFF)
- pod-0 continues writing async (syncer kb_health_check every second)
- pod-1 comes back, replication resumes, but pod-1 may not catch up before KB triggers switchover
- Same orphan event class as before

This PR closes the in-flight ACK window only. **Phase 2 (syncer-side catch-up wait in mariadb engine Demote) is still required** to close the restart window. Tracked as separate follow-up.

## Test plan

- [x] helm lint
- [x] helm template render
- [x] Fresh cluster bootstrap on alpha.101 verifies wait_point=AFTER_SYNC on both pods
- [x] CM4 reconfigure runs to OpsRequest Succeed
- [ ] N≥3 rounds CM4 to characterize orphan-event frequency reduction (qualitative — same divergence still seen this run)
- [ ] T9 switchover + alpha.60 fence bug still pending separate fix
- [ ] In-place upgrade alpha.100 → alpha.101 verify
- [ ] Phase 2 (syncer catch-up wait) follow-up PR

## Trigger

weston DM `5e9383c4` (2026-05-25 23:54Z): "mariadb chart 加 `rpl_semi_sync_master_wait_point=AFTER_SYNC`，先测下". This PR implements that direction. The qualitative result (still see same divergence) confirms the prior analysis that AFTER_SYNC is necessary but not sufficient.

## Related

- Methodology doc: kubeblocks-addon-docs PR #319 (addon fix-at-wrong-layer trap case)
- Phase 2 candidate: syncer mariadb engine Demote catch-up wait
- Independent: alpha.60 fence verifier bug (T9 path, separate workstream)
