### PR TITLE
fix(valkey): narrow legacy roleProbe fallback when sentinel quorum is invalid

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -841,6 +841,62 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should equal "2"
       End
     End
+
+    Context "quorum-entry gate depends only on SENTINEL_POD_FQDN_LIST"
+      # Background: Bob2 review on PR apecloud/kubeblocks-addons#2676.
+      # The earlier gate `[ -n "${SENTINEL_PASSWORD}" ] && [ -n "${SENTINEL_POD_FQDN_LIST}" ]`
+      # would route a sentinel-configured-but-password-missing topology
+      # to `no_sentinel_env`, and the no-sentinel fallback emits legacy
+      # `primary` from `role:master` — which is exactly the cross-mode
+      # strip path this PR exists to close. Sentinel topology must be
+      # detected by FQDN list alone; password is only an auth flag.
+      check_role_script="../scripts/check-role.sh"
+
+      It "outer gate keys on SENTINEL_POD_FQDN_LIST only, not also SENTINEL_PASSWORD"
+        # The fixed gate must NOT couple SENTINEL_PASSWORD with FQDN
+        # via `&&` at the outer-if level.
+        When call grep -F 'if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then' "${check_role_script}"
+        The status should be success
+        The stdout should include 'SENTINEL_POD_FQDN_LIST'
+      End
+
+      It "must not couple SENTINEL_PASSWORD into the outer quorum-entry gate"
+        # Negative assertion: the legacy
+        # `if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]`
+        # pattern must be gone. Wrap in `|| true` so a zero match (grep
+        # exit 1) does not fail the `status should be success` assertion.
+        When call bash -c 'grep -c -F "if [ -n \"\${SENTINEL_PASSWORD:-}\" ] && [ -n \"\${SENTINEL_POD_FQDN_LIST:-}\" ]" ../scripts/check-role.sh || true'
+        The status should be success
+        The stdout should equal "0"
+      End
+
+      It "sentinel-cli auth flag is conditional on SENTINEL_PASSWORD presence"
+        # The cli call must consume a pre-computed sentinel_auth_args
+        # variable rather than always hard-coding `-a "${SENTINEL_PASSWORD}"`.
+        # That way missing password leaves auth args empty and the cli
+        # call NOAUTH-fails, routing to `insufficient_valid`.
+        When call grep -F '${sentinel_auth_args} ${sentinel_tls_args} sentinel masters' "${check_role_script}"
+        The status should be success
+        The stdout should include 'sentinel_auth_args'
+      End
+
+      It "no_sentinel_env branch is no longer reachable via missing password alone"
+        # If only password is missing but FQDN is set, the new outer gate
+        # enters the quorum path; per-sentinel calls NOAUTH-fail and the
+        # decision becomes `insufficient_valid`. The `no_sentinel_env`
+        # reason is now only reachable when FQDN list is empty.
+        When call grep -c -F '__quorum_decision_reason="no_sentinel_env"' "${check_role_script}"
+        The status should be success
+        # Exactly one occurrence — in the else branch of the FQDN gate.
+        The stdout should equal "1"
+      End
+
+      It "documents that missing password does not mean no-sentinel"
+        When call grep -c -F 'Password is only' "${check_role_script}"
+        The status should be success
+        The stdout should not equal "0"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -485,6 +485,201 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should eq "REJECT"
       End
     End
+
+    Context "v3 quorum across configured sentinels (Edward+Bob2 sign-off contract)"
+      # The roleProbe must not emit `<role> <epoch>` while Sentinels are
+      # in a split-view at the same config-epoch. The quorum gate filters
+      # each sentinel's response by (uint64 epoch, hex runid, no
+      # transient/failure flags), then requires a strict majority of the
+      # CONFIGURED sentinel count to fall in a single (epoch, runid)
+      # group. Otherwise fall back to legacy single-token output so the
+      # controller stays on its EventTime path and the Pod annotation is
+      # not advanced to `engine:N` prematurely.
+
+      # Compute strict majority of total configured sentinel count, NOT
+      # of reachable/valid count.
+      min_valid_for() {
+        local total="$1"
+        printf "%s" "$(( total / 2 + 1 ))"
+      }
+
+      # Encode a list of (epoch, runid, flags) triples (one per sentinel
+      # entry, "skip" for unreachable) and decide quorum: emit either
+      # `EMIT <epoch>:<runid>` or `LEGACY` plus a diagnostic suffix.
+      quorum_decide() {
+        local total="$1"; shift
+        local min_valid
+        min_valid=$(min_valid_for "${total}")
+        local entry epoch runid flags
+        local -a keys=()
+        for entry in "$@"; do
+          # skip = unreachable sentinel
+          if [ "${entry}" = "skip" ]; then
+            continue
+          fi
+          IFS='|' read -r epoch runid flags <<< "${entry}"
+          case "${epoch}" in
+            ''|*[!0-9]*) continue ;;
+          esac
+          case "${runid}" in
+            ''|*[!0-9a-fA-F]*) continue ;;
+          esac
+          case ",${flags}," in
+            *,failover_in_progress,*|*,force_failover,*|*,s_down,*|*,o_down,*) continue ;;
+          esac
+          keys+=("${epoch}:${runid}")
+        done
+        local valid_count=${#keys[@]}
+        if [ "${valid_count}" -lt "${min_valid}" ]; then
+          printf "LEGACY"
+          return 0
+        fi
+        local first="${keys[0]}"
+        local k
+        for k in "${keys[@]}"; do
+          if [ "${k}" != "${first}" ]; then
+            printf "LEGACY"
+            return 0
+          fi
+        done
+        printf "EMIT %s" "${first}"
+        return 0
+      }
+
+      It "3/3 sentinels agree on a single (epoch, runid) → versioned (pre)"
+        When call quorum_decide 3 "16|3119abcd|master" "16|3119abcd|master" "16|3119abcd|master"
+        The status should be success
+        The stdout should eq "EMIT 16:3119abcd"
+      End
+
+      It "3/3 sentinels agree on the converged post-failover view → versioned (post3+)"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "17|00d5beef|master"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "post0 view: 2 old-quorum (epoch16) sentinels + 1 partial new sentinel (empty runid) → versioned on the still-stable OLD quorum"
+        # At the very start of the failover, two sentinels still believe
+        # the old master at epoch 16, and one has just begun voting for
+        # the new master at epoch 17 with the runid not yet filled. The
+        # invalid third entry is dropped; the remaining two-of-three
+        # quorum still authorities the OLD (epoch, runid) which is the
+        # current cluster state. Emitting at this point is safe because
+        # the controller's Pod annotation is already at engine:16, so
+        # the same-version refresh is a no-op.
+        When call quorum_decide 3 "16|3119abcd|master" "16|3119abcd|master" "17||master"
+        The status should be success
+        The stdout should eq "EMIT 16:3119abcd"
+      End
+
+      It "post1/post2 split view: old master with failover_in_progress flag is dropped, two new master views disagree on runid (one empty) → legacy"
+        When call quorum_decide 3 "17|3119abcd|master,failover_in_progress,force_failover" "17||master" "17|00d5beef|master"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "majority of configured (2 of 3) agree, third invalid (empty runid) → versioned"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "17||master"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "majority of configured (2 of 3) agree, third invalid (non-numeric epoch) → versioned"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "abc|abc|master"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "majority of configured (2 of 3) agree, third invalid (failover_in_progress flag) → versioned"
+        When call quorum_decide 3 "17|00d5beef|master" "17|00d5beef|master" "17|deadbeef|master,failover_in_progress"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "only 1 valid of 3 configured → legacy (single-sentinel cannot self-quorum)"
+        When call quorum_decide 3 "17|00d5beef|master" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "2 valid at SAME epoch but DIFFERENT runid → legacy (master identity split)"
+        When call quorum_decide 3 "17|00d5beef|master" "17|deadbeef|master" "17||master"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "2 valid at DIFFERENT epochs → legacy (epoch split)"
+        When call quorum_decide 3 "17|00d5beef|master" "16|3119abcd|master" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "all 3 sentinels unreachable → legacy"
+        When call quorum_decide 3 "skip" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "5-sentinel configured: 3 agree (majority) → versioned even if 2 invalid"
+        When call quorum_decide 5 "17|00d5beef|master" "17|00d5beef|master" "17|00d5beef|master" "17||master" "skip"
+        The status should be success
+        The stdout should eq "EMIT 17:00d5beef"
+      End
+
+      It "5-sentinel configured: 2 agree (below majority of 3) → legacy"
+        When call quorum_decide 5 "17|00d5beef|master" "17|00d5beef|master" "17||master" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "min_valid is floor(total/2)+1, not ceil(total/2)"
+        When call min_valid_for 3
+        The status should be success
+        The stdout should eq "2"
+      End
+
+      It "min_valid for 4 configured is 3 (strict majority)"
+        When call min_valid_for 4
+        The status should be success
+        The stdout should eq "3"
+      End
+
+      It "min_valid for 5 configured is 3"
+        When call min_valid_for 5
+        The status should be success
+        The stdout should eq "3"
+      End
+    End
+
+    Context "v3 grep-level assertions on the production script"
+      check_role_script="../scripts/check-role.sh"
+
+      It "computes min_valid as configured_count/2+1"
+        When call grep -F 'min_valid=$((configured_count / 2 + 1))' "${check_role_script}"
+        The status should be success
+        The stdout should include "configured_count"
+      End
+
+      It "drops sentinel views with transient/failure flags from quorum"
+        When call grep -F 'failover_in_progress' "${check_role_script}"
+        The status should be success
+        The stdout should include "failover_in_progress"
+      End
+
+      It "captures sentinel flags alongside config-epoch and runid"
+        When call grep -F 'flags_marker' "${check_role_script}"
+        The status should be success
+        The stdout should include "flags_marker"
+      End
+
+      It "decides primary token from quorum runid match, not local INFO=master"
+        # The block that sets authoritative_role must only compare
+        # local_run_id with sentinel_master_runid, no role_line check.
+        When call grep -A 8 'authoritative_role=""' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinel_master_runid"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -429,10 +429,14 @@ Describe "Valkey Check-Role Bash Script Tests"
       It "rejects non-hex sentinel master runid via case-statement shape guard"
         # Per Edward msg=2140dce9, an empty check alone is not enough:
         # a non-empty but malformed runid (e.g. `not-a-real-runid!`)
-        # would otherwise enter the engine-version path.
-        When call grep -F "''|*[!0-9a-fA-F]*) continue ;;" "${check_role_script}"
+        # would otherwise enter the engine-version path. The production
+        # path now records the rejection reason in `__drop_reason` so
+        # the debug instrumentation can report which sentinel views were
+        # excluded; the character-set pattern lives on the right side of
+        # the `case` arm.
+        When call grep -F '__drop_reason="runid_empty_or_non_hex"' "${check_role_script}"
         The status should be success
-        The stdout should include "0-9a-fA-F"
+        The stdout should include "runid_empty_or_non_hex"
       End
     End
 
@@ -678,6 +682,50 @@ Describe "Valkey Check-Role Bash Script Tests"
         When call grep -A 8 'authoritative_role=""' "${check_role_script}"
         The status should be success
         The stdout should include "sentinel_master_runid"
+      End
+    End
+
+    Context "VALKEY_CHECK_ROLE_DEBUG diagnostic instrumentation (env-gated)"
+      # When the operator sets VALKEY_CHECK_ROLE_DEBUG=1, each call must
+      # append one JSON-shaped line to /tmp/check-role-debug.log with the
+      # raw per-sentinel readings plus the quorum decision. Stdout MUST
+      # stay on the production contract — debug must not leak into the
+      # role token under any path.
+      check_role_script="../scripts/check-role.sh"
+
+      It "is gated by VALKEY_CHECK_ROLE_DEBUG env (default off)"
+        When call grep -F 'VALKEY_CHECK_ROLE_DEBUG' "${check_role_script}"
+        The status should be success
+        The stdout should include "VALKEY_CHECK_ROLE_DEBUG"
+      End
+
+      It "writes the diagnostic record to a Pod-local file under /tmp"
+        When call grep -F '__check_role_debug_log="/tmp/check-role-debug.log"' "${check_role_script}"
+        The status should be success
+        The stdout should include "/tmp/check-role-debug.log"
+      End
+
+      It "records both the per-sentinel raw fields and the quorum decision reason"
+        # We rely on these names so off-line analysis tooling has a stable
+        # contract to grep against.
+        When call grep -E '"decision":"|__quorum_decision_reason' "${check_role_script}"
+        The status should be success
+        The stdout should include "decision"
+      End
+
+      It "captures the configured / min_valid / valid counts in the record"
+        When call grep -F 'configured_count' "${check_role_script}"
+        The status should be success
+        The stdout should include "configured_count"
+      End
+
+      It "redirects the debug write to /dev/null on failure (won't surface in roleProbe)"
+        # Belt-and-braces: the writer must redirect errors so a missing
+        # /tmp permission never leaks bytes to stdout that would corrupt
+        # the role token.
+        When call grep -F '>> "${__check_role_debug_log}" 2>/dev/null || true' "${check_role_script}"
+        The status should be success
+        The stdout should include "/dev/null"
       End
     End
   End

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -425,6 +425,65 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be success
         The stdout should include "info server"
       End
+
+      It "rejects non-hex sentinel master runid via case-statement shape guard"
+        # Per Edward msg=2140dce9, an empty check alone is not enough:
+        # a non-empty but malformed runid (e.g. `not-a-real-runid!`)
+        # would otherwise enter the engine-version path.
+        When call grep -F "''|*[!0-9a-fA-F]*) continue ;;" "${check_role_script}"
+        The status should be success
+        The stdout should include "0-9a-fA-F"
+      End
+    End
+
+    Context "non-empty malformed sentinel runid is rejected like an empty one"
+      # Mirror the production case-statement directly so the decision
+      # cell stays pinned: a non-hex runid must be treated the same as
+      # empty by the per-sentinel selector, so the script never enters
+      # the engine-version path with a malformed authority.
+      runid_passes_shape_guard() {
+        local runid="$1"
+        case "${runid}" in
+          ''|*[!0-9a-fA-F]*) printf "REJECT" ;;
+          *) printf "ACCEPT" ;;
+        esac
+      }
+
+      It "accepts a clean lowercase hex runid"
+        When call runid_passes_shape_guard "aaaaaaaa1111bbbb2222cccc3333dddd44445555"
+        The status should be success
+        The stdout should eq "ACCEPT"
+      End
+
+      It "accepts a clean uppercase hex runid"
+        When call runid_passes_shape_guard "AAAA1111BBBB2222"
+        The status should be success
+        The stdout should eq "ACCEPT"
+      End
+
+      It "rejects empty runid (legacy fallback path)"
+        When call runid_passes_shape_guard ""
+        The status should be success
+        The stdout should eq "REJECT"
+      End
+
+      It "rejects non-hex characters (legacy fallback path)"
+        When call runid_passes_shape_guard "not-a-real-runid!"
+        The status should be success
+        The stdout should eq "REJECT"
+      End
+
+      It "rejects mixed hex with one stray non-hex char (legacy fallback path)"
+        When call runid_passes_shape_guard "abcd1234g"
+        The status should be success
+        The stdout should eq "REJECT"
+      End
+
+      It "rejects runid with embedded whitespace (legacy fallback path)"
+        When call runid_passes_shape_guard "abcd 1234"
+        The status should be success
+        The stdout should eq "REJECT"
+      End
     End
   End
 

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -152,86 +152,155 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
-  Describe "engine-authoritative kb-role-version trailer (PR #10280 contract)"
-    # check-role.sh now appends a second line `kb-role-version=<sentinel
-    # config-epoch>` when sentinel is reachable and returns a clean uint64.
-    # The controller-side strict parser rejects malformed `kb-role-version=`
-    # lines outright, so the script either emits a well-formed numeric line
-    # or no version line at all (legacy mode).
-    parse_engine_version() {
+  Describe "engine-authoritative version trailer (PR #10280 whitespace-token contract)"
+    # check-role.sh now appends a second whitespace-separated token — the
+    # sentinel config-epoch — when at least one reachable sentinel returns
+    # a clean uint64. The controller-side parser (post-PR #10280) splits
+    # stdout on any whitespace and accepts only `<role>` or
+    # `<role> <uint64>`; anything else is rejected outright. So the script
+    # must either emit `primary\n<uint64>` (or `primary <uint64>`) or
+    # legacy single-line output, never a labeled `kb-role-version=` form.
+    parse_one_sentinel_epoch() {
       local sentinel_out="$1"
-      local sline ce_marker="" engine_version=""
+      local sline ce_marker="" epoch=""
       while IFS= read -r sline; do
         sline="${sline%$'\r'}"
         if [ -n "${ce_marker}" ]; then
-          engine_version="${sline}"
+          epoch="${sline}"
           break
         fi
         [ "${sline}" = "config-epoch" ] && ce_marker="1"
       done <<<"${sentinel_out}"
-      printf "%s" "${engine_version}"
+      printf "%s" "${epoch}"
     }
 
-    Context "sentinel returns a clean numeric config-epoch"
+    Context "single sentinel returns a clean numeric config-epoch"
       It "extracts the numeric value following the config-epoch marker"
         sentinel_out=$'name\nvlk-foo\nconfig-epoch\n42\nnum-slaves\n2'
-        When call parse_engine_version "${sentinel_out}"
+        When call parse_one_sentinel_epoch "${sentinel_out}"
         The status should be success
         The stdout should eq "42"
       End
     End
 
-    Context "sentinel output missing config-epoch marker"
-      It "returns empty so the script falls back to legacy single-line output"
+    Context "single sentinel output missing config-epoch marker"
+      It "returns empty so the per-sentinel loop continues to the next sentinel"
         sentinel_out=$'name\nvlk-foo\nnum-slaves\n2'
-        When call parse_engine_version "${sentinel_out}"
+        When call parse_one_sentinel_epoch "${sentinel_out}"
         The status should be success
         The stdout should eq ""
       End
     End
 
-    Context "sentinel returns non-numeric config-epoch (malformed)"
-      It "extracts the raw value (numeric guard later drops non-uint64)"
+    Context "single sentinel returns non-numeric config-epoch"
+      It "extracts the raw value (the numeric guard in the loop drops it)"
         sentinel_out=$'name\nvlk-foo\nconfig-epoch\nNaN\nnum-slaves\n2'
-        When call parse_engine_version "${sentinel_out}"
+        When call parse_one_sentinel_epoch "${sentinel_out}"
         The status should be success
         The stdout should eq "NaN"
       End
     End
 
-    Context "numeric guard before emitting second line"
-      # Mirror the production check that drops anything not purely numeric
-      # so the controller's strict parser never sees a malformed value.
-      emit_or_drop() {
-        local v="$1"
-        case "${v}" in
-          ''|*[!0-9]*) printf "DROP" ;;
-          *) printf "kb-role-version=%s" "${v}" ;;
+    Context "highest-epoch selector across multiple reachable sentinels"
+      # Mirror the production loop: walk a list of (mock) sentinel outputs,
+      # numeric-guard each, keep the maximum.
+      best_epoch_across() {
+        local out epoch best=-1
+        for out in "$@"; do
+          epoch=$(parse_one_sentinel_epoch "${out}")
+          case "${epoch}" in
+            ''|*[!0-9]*) continue ;;
+          esac
+          if [ "${epoch}" -gt "${best}" ]; then
+            best="${epoch}"
+          fi
+        done
+        if [ "${best}" -ge 0 ]; then
+          printf "%s" "${best}"
+        fi
+        return 0
+      }
+
+      It "picks the highest config-epoch when two sentinels disagree"
+        a=$'name\nvlk\nconfig-epoch\n5'
+        b=$'name\nvlk\nconfig-epoch\n7'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq "7"
+      End
+
+      It "skips an isolated sentinel that returned empty"
+        a=$'name\nvlk\nnum-slaves\n2'
+        b=$'name\nvlk\nconfig-epoch\n3'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq "3"
+      End
+
+      It "skips a sentinel that returned non-numeric config-epoch"
+        a=$'name\nvlk\nconfig-epoch\nNaN'
+        b=$'name\nvlk\nconfig-epoch\n11'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq "11"
+      End
+
+      It "returns empty when no sentinel produced a clean uint64"
+        a=$'name\nvlk\nconfig-epoch\nNaN'
+        b=$'name\nvlk\nnum-slaves\n2'
+        When call best_epoch_across "${a}" "${b}"
+        The status should be success
+        The stdout should eq ""
+      End
+    End
+
+    Context "second-token emission obeys whitespace-token contract"
+      # The controller's strict parser splits the entire stdout on whitespace
+      # and accepts only `<role>` or `<role> <uint64>`. Anything else is
+      # rejected. So the second token must be the bare numeric epoch — no
+      # `kb-role-version=` prefix.
+      compose_output() {
+        local role="$1" version="$2"
+        printf %s "${role}"
+        case "${version}" in
+          ''|*[!0-9]*) : ;;
+          *) printf '\n%s' "${version}" ;;
         esac
       }
 
-      It "emits the line for a clean uint64"
-        When call emit_or_drop "42"
+      It "emits whitespace-separated tokens for a clean uint64"
+        When call compose_output "primary" "42"
         The status should be success
-        The stdout should eq "kb-role-version=42"
+        The stdout should eq "primary
+42"
       End
 
-      It "drops empty value"
-        When call emit_or_drop ""
+      It "drops second token when version is empty"
+        When call compose_output "secondary" ""
         The status should be success
-        The stdout should eq "DROP"
+        The stdout should eq "secondary"
       End
 
-      It "drops non-numeric value"
-        When call emit_or_drop "NaN"
+      It "drops second token when version is non-numeric"
+        When call compose_output "primary" "NaN"
         The status should be success
-        The stdout should eq "DROP"
+        The stdout should eq "primary"
       End
 
-      It "drops mixed alphanumeric"
-        When call emit_or_drop "42abc"
+      It "splits with strings.Fields-compatible whitespace"
+        # Production uses '\n' between role and version. The controller's
+        # strings.Fields() in Go accepts spaces, tabs, and newlines.
+        out=$(compose_output "primary" "42")
+        # Two tokens after splitting on whitespace
+        When call bash -c "read -ra t <<< \"${out//$'\n'/ }\"; printf '%s\n' \"\${t[0]} \${t[1]} count=\${#t[@]}\""
         The status should be success
-        The stdout should eq "DROP"
+        The stdout should eq "primary 42 count=2"
+      End
+
+      It "never emits the legacy kb-role-version= label form"
+        out=$(compose_output "primary" "42")
+        When call grep -q 'kb-role-version=' <<<"${out}"
+        The status should be failure
       End
     End
   End

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -303,6 +303,27 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be failure
       End
     End
+
+    Context "TLS-aware sentinel cli construction"
+      # check-role.sh must append ${VALKEY_CLI_TLS_ARGS} to the sentinel
+      # query path; without it, every sentinel call on a TLS-enabled topology
+      # would fail and the script would silently degrade to legacy single-
+      # line output, defeating the engine-version gate. The production line
+      # is grep-able directly from the script.
+      check_role_script="../scripts/check-role.sh"
+
+      It "resolves VALKEY_CLI_TLS_ARGS into a local before the sentinel cli call"
+        When call grep -F 'sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"' "${check_role_script}"
+        The status should be success
+        The stdout should include "VALKEY_CLI_TLS_ARGS"
+      End
+
+      It "passes the TLS args local to the sentinel valkey-cli call"
+        When call grep -E 'valkey-cli[^|]*sentinel masters' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinel_tls_args"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -324,6 +324,108 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should include "sentinel_tls_args"
       End
     End
+
+    Context "primary authority gate via local run_id vs sentinel master runid"
+      # During a sentinel-driven failover the deposed primary keeps
+      # reporting `role:master` locally for a brief window. Without a
+      # cross-check, both the new and the deposed primary would emit
+      # `primary <epoch>` with the same config-epoch, and the controller
+      # would race-accept both. The fix grounds the role token in
+      # Sentinel: only when local INFO=master AND the local run_id
+      # matches the Sentinel master `runid` is `primary` authoritative.
+
+      decide_role() {
+        local local_role="$1" local_run_id="$2" sentinel_master_runid="$3" engine_version="$4"
+        local role_line
+        case "${local_role}" in
+          master) role_line="role:master" ;;
+          slave)  role_line="role:slave"  ;;
+          *)      role_line="role:${local_role}" ;;
+        esac
+        if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
+          case "${role_line}" in
+            "role:master")
+              if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
+                printf '%s\n%s' "primary"   "${engine_version}"
+              else
+                printf '%s\n%s' "secondary" "${engine_version}"
+              fi
+              return 0
+              ;;
+            "role:slave")
+              printf '%s\n%s' "secondary" "${engine_version}"
+              return 0
+              ;;
+          esac
+        fi
+        case "${role_line}" in
+          "role:master") printf %s "primary"   ;;
+          "role:slave")  printf %s "secondary" ;;
+        esac
+        return 0
+      }
+
+      It "emits primary <epoch> when local INFO=master and run_id matches sentinel master runid"
+        When call decide_role "master" "aaaaaaaa" "aaaaaaaa" "5"
+        The status should be success
+        The stdout should eq "primary
+5"
+      End
+
+      It "emits secondary <epoch> when local INFO=master but run_id does not match sentinel master runid (round-3 race fix)"
+        When call decide_role "master" "aaaaaaaa" "bbbbbbbb" "5"
+        The status should be success
+        The stdout should eq "secondary
+5"
+      End
+
+      It "emits secondary <epoch> when local INFO=slave and sentinel reachable"
+        When call decide_role "slave" "aaaaaaaa" "bbbbbbbb" "5"
+        The status should be success
+        The stdout should eq "secondary
+5"
+      End
+
+      It "falls back to legacy single token when sentinel master runid is empty"
+        When call decide_role "master" "aaaaaaaa" "" "5"
+        The status should be success
+        The stdout should eq "primary"
+      End
+
+      It "falls back to legacy single token when sentinel is unreachable (no engine version)"
+        When call decide_role "slave" "aaaaaaaa" "" ""
+        The status should be success
+        The stdout should eq "secondary"
+      End
+
+      It "rejects a local master with empty local run_id but a sentinel runid set"
+        # Defensive: an empty local run_id cannot prove this Pod is the
+        # current master, even if its INFO replication says master.
+        When call decide_role "master" "" "aaaaaaaa" "5"
+        The status should be success
+        The stdout should eq "secondary
+5"
+      End
+    End
+
+    Context "sentinel masters parser extracts both config-epoch and runid"
+      # The production script walks the sentinel-masters flat output once
+      # and captures both fields; the parser must not depend on field
+      # order and must stop after both are found.
+      check_role_script="../scripts/check-role.sh"
+
+      It "captures the master runid alongside config-epoch on the script's sentinel response loop"
+        When call grep -F 'sentinel_master_runid' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinel_master_runid"
+      End
+
+      It "reads INFO server for the local run_id"
+        When call grep -E 'info[[:space:]]+server' "${check_role_script}"
+        The status should be success
+        The stdout should include "info server"
+      End
+    End
   End
 
   Describe "fork-safety contract — no pipeline parsing of INFO replication"

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -152,6 +152,90 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
+  Describe "engine-authoritative kb-role-version trailer (PR #10280 contract)"
+    # check-role.sh now appends a second line `kb-role-version=<sentinel
+    # config-epoch>` when sentinel is reachable and returns a clean uint64.
+    # The controller-side strict parser rejects malformed `kb-role-version=`
+    # lines outright, so the script either emits a well-formed numeric line
+    # or no version line at all (legacy mode).
+    parse_engine_version() {
+      local sentinel_out="$1"
+      local sline ce_marker="" engine_version=""
+      while IFS= read -r sline; do
+        sline="${sline%$'\r'}"
+        if [ -n "${ce_marker}" ]; then
+          engine_version="${sline}"
+          break
+        fi
+        [ "${sline}" = "config-epoch" ] && ce_marker="1"
+      done <<<"${sentinel_out}"
+      printf "%s" "${engine_version}"
+    }
+
+    Context "sentinel returns a clean numeric config-epoch"
+      It "extracts the numeric value following the config-epoch marker"
+        sentinel_out=$'name\nvlk-foo\nconfig-epoch\n42\nnum-slaves\n2'
+        When call parse_engine_version "${sentinel_out}"
+        The status should be success
+        The stdout should eq "42"
+      End
+    End
+
+    Context "sentinel output missing config-epoch marker"
+      It "returns empty so the script falls back to legacy single-line output"
+        sentinel_out=$'name\nvlk-foo\nnum-slaves\n2'
+        When call parse_engine_version "${sentinel_out}"
+        The status should be success
+        The stdout should eq ""
+      End
+    End
+
+    Context "sentinel returns non-numeric config-epoch (malformed)"
+      It "extracts the raw value (numeric guard later drops non-uint64)"
+        sentinel_out=$'name\nvlk-foo\nconfig-epoch\nNaN\nnum-slaves\n2'
+        When call parse_engine_version "${sentinel_out}"
+        The status should be success
+        The stdout should eq "NaN"
+      End
+    End
+
+    Context "numeric guard before emitting second line"
+      # Mirror the production check that drops anything not purely numeric
+      # so the controller's strict parser never sees a malformed value.
+      emit_or_drop() {
+        local v="$1"
+        case "${v}" in
+          ''|*[!0-9]*) printf "DROP" ;;
+          *) printf "kb-role-version=%s" "${v}" ;;
+        esac
+      }
+
+      It "emits the line for a clean uint64"
+        When call emit_or_drop "42"
+        The status should be success
+        The stdout should eq "kb-role-version=42"
+      End
+
+      It "drops empty value"
+        When call emit_or_drop ""
+        The status should be success
+        The stdout should eq "DROP"
+      End
+
+      It "drops non-numeric value"
+        When call emit_or_drop "NaN"
+        The status should be success
+        The stdout should eq "DROP"
+      End
+
+      It "drops mixed alphanumeric"
+        When call emit_or_drop "42abc"
+        The status should be success
+        The stdout should eq "DROP"
+      End
+    End
+  End
+
   Describe "fork-safety contract — no pipeline parsing of INFO replication"
     # Background: `valkey-cli ... info replication | grep ... | tr ...`
     # spawns three subprocess children per probe call. When kbagent

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -727,6 +727,23 @@ Describe "Valkey Check-Role Bash Script Tests"
         The status should be success
         The stdout should include "/dev/null"
       End
+
+      It "writes the diagnostic record as a single JSONL line per probe call"
+        # Edward msg=be0a283c blocker: per-sentinel objects must be
+        # comma-separated in the same line, and the final printf must
+        # not embed newlines inside the array literal. Without this,
+        # off-line tools cannot split records 1:1 against controller
+        # event payloads.
+        When call grep -F '"sentinels":[%s]}' "${check_role_script}"
+        The status should be success
+        The stdout should include "sentinels"
+      End
+
+      It "uses a comma separator between per-sentinel array elements"
+        When call grep -F '__debug_sep=","' "${check_role_script}"
+        The status should be success
+        The stdout should include "__debug_sep"
+      End
     End
   End
 

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -747,6 +747,102 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
+  Describe "legacy fallback cross-mode safety (no_quorum + sentinel configured)"
+    # Background: PR apecloud/kubeblocks#10283 splits the controller-side
+    # `LastRoleEventVersionAnnotationKey` (legacy EventTime) from
+    # `LastRoleEngineVersionAnnotationKey` (engine version). The
+    # controller's `removeExclusiveRoleLabels()` peer-cleanup only gates
+    # against the incoming event's own mode, so a legacy `primary`
+    # event from one pod can strip another pod's engine-versioned
+    # `primary` label. After the strip, the engine-versioned pod's
+    # subsequent `primary engine:<N>` events are rejected by the strict
+    # `engine:>` staleness gate (its `previousRole` annotation was
+    # cleared) and the role label is never repaired.
+    #
+    # r4 T09 reproduced this on idc (archive sha
+    # 575ed6c444cf6224c74629a2abc28f16f80c35e62f13f6cada4c5ae782302920):
+    # valkey-3 successfully promoted to engine `primary 3`, then valkey-2
+    # — with Sentinel quorum transiently invalid — emitted legacy
+    # `primary` from `local INFO=master`, which the controller used to
+    # exclusive-clean valkey-3, leaving the cluster permanently
+    # labelless.
+    #
+    # check-role.sh defence: when Sentinel is configured (any of
+    # `insufficient_valid`, `split_view`, etc.) but quorum is invalid,
+    # do NOT emit legacy `primary` from `local INFO=master`. Emit
+    # `secondary` instead, so the primary Service may briefly have no
+    # endpoint while Sentinel converges but no engine-versioned peer
+    # can be cleaned. `no_sentinel_env` / `no_sentinel_configured`
+    # paths keep the original local-INFO mapping because they are the
+    # only authority for standalone topologies.
+    Context "Sentinel configured + quorum invalid + INFO=master"
+      check_role_script="../scripts/check-role.sh"
+
+      It "branches on quorum decision reason via a no_sentinel_env|no_sentinel_configured case"
+        When call grep -F 'no_sentinel_env|no_sentinel_configured' "${check_role_script}"
+        The status should be success
+        The stdout should include 'no_sentinel_env|no_sentinel_configured'
+      End
+
+      It "documents the cross-mode safety rationale next to the fallback case"
+        When call grep -c -F 'no engine-versioned peer can be exclusive-cleaned' "${check_role_script}"
+        The status should be success
+        The stdout should not equal "0"
+      End
+
+      It "ensures the quorum-invalid branch maps role:master to secondary (not primary)"
+        # In the *quorum-invalid* fallback, role:master and role:slave
+        # both collapse to `secondary`. Production line shape:
+        # `"role:master"|"role:slave") printf %s "secondary" ;;`
+        When call grep -F '"role:master"|"role:slave") printf %s "secondary"' "${check_role_script}"
+        The status should be success
+        The stdout should include 'secondary'
+      End
+    End
+
+    Context "Sentinel not configured (no_sentinel_env / no_sentinel_configured)"
+      check_role_script="../scripts/check-role.sh"
+
+      It "keeps role:master → primary for standalone topology"
+        # In the *no_sentinel* fallback, role:master must still map to primary
+        # because local INFO is the only authority for standalone.
+        When call grep -F '"role:master") printf %s "primary"' "${check_role_script}"
+        The status should be success
+        The stdout should include 'primary'
+      End
+
+      It "documents that the no-sentinel branch preserves original local-INFO mapping"
+        When call grep -c -F 'only authority for standalone' "${check_role_script}"
+        The status should be success
+        The stdout should not equal "0"
+      End
+    End
+
+    Context "role:slave under any quorum decision"
+      check_role_script="../scripts/check-role.sh"
+
+      It "maps to secondary in the no_sentinel fallback"
+        When call grep -c -F '"role:slave")  printf %s "secondary"' "${check_role_script}"
+        The status should be success
+        The stdout should not equal "0"
+      End
+    End
+
+    Context "unknown role under any quorum decision"
+      check_role_script="../scripts/check-role.sh"
+
+      It "exits non-zero so KubeBlocks clears the stale role label via failureThreshold"
+        # The unknown-role branch must remain `echo + exit 1` in both
+        # the no-sentinel and the quorum-invalid path.
+        When call grep -c -F "unknown role: '" "${check_role_script}"
+        The status should be success
+        # Two occurrences: one for no_sentinel branch, one for
+        # quorum-invalid branch.
+        The stdout should equal "2"
+      End
+    End
+  End
+
   Describe "fork-safety contract — no pipeline parsing of INFO replication"
     # Background: `valkey-cli ... info replication | grep ... | tr ...`
     # spawns three subprocess children per probe call. When kbagent

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -165,8 +165,30 @@ done <<<"${server_info}"
 # Single `valkey-cli ... sentinel masters` invocation per sentinel attempt,
 # no pipelines, to preserve the fork-and-zombie discipline (see
 # docs/addon-probe-script-fork-and-zombie-guide.md).
+#
+# Diagnostic instrumentation: when VALKEY_CHECK_ROLE_DEBUG=1, each call
+# appends one JSON-shaped line to /tmp/check-role-debug.log inside the
+# Pod with per-sentinel raw values, filter decisions, quorum result, and
+# the emitted token. Stdout is NEVER written by this path — production
+# contract (single role token, optionally followed by `\n<uint64>`) is
+# preserved unchanged. Default off so production has zero overhead.
+__check_role_debug_log=""
+if [ "${VALKEY_CHECK_ROLE_DEBUG:-0}" = "1" ]; then
+  __check_role_debug_log="/tmp/check-role-debug.log"
+fi
+__debug_records=""
+__debug_append() {
+  # Append a single line; build incrementally to avoid one fork per
+  # sentinel for the common case where DEBUG is off.
+  [ -z "${__check_role_debug_log}" ] && return 0
+  __debug_records="${__debug_records}${1}
+"
+}
+__sentinel_records=""
 engine_version=""
 sentinel_master_runid=""
+__quorum_decision_reason=""
+__quorum_emit_role=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   # TLS args must flow into the sentinel query path; silently dropping
@@ -214,26 +236,40 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
         fi
         [ -n "${epoch}" ] && [ -n "${runid}" ] && [ -n "${flags}" ] && break
       done <<<"${sentinel_out}"
+      __drop_reason=""
       # Validate: epoch must be uint64.
       case "${epoch}" in
-        ''|*[!0-9]*) continue ;;
+        ''|*[!0-9]*) __drop_reason="epoch_not_uint64" ;;
       esac
-      # Validate: runid must be a non-empty hex token (no fixed length).
-      case "${runid}" in
-        ''|*[!0-9a-fA-F]*) continue ;;
-      esac
-      # Validate: master flags must not include transient or failure
-      # markers. A sentinel that flags the master as failover_in_progress
-      # / force_failover / s_down / o_down is mid-transition; including
-      # its view in the quorum would mistake the transient state for
-      # consensus.
-      case ",${flags}," in
-        *,failover_in_progress,*|*,force_failover,*|*,s_down,*|*,o_down,*) continue ;;
-      esac
+      if [ -z "${__drop_reason}" ]; then
+        # Validate: runid must be a non-empty hex token (no fixed length).
+        case "${runid}" in
+          ''|*[!0-9a-fA-F]*) __drop_reason="runid_empty_or_non_hex" ;;
+        esac
+      fi
+      if [ -z "${__drop_reason}" ]; then
+        # Validate: master flags must not include transient or failure
+        # markers. A sentinel that flags the master as failover_in_progress
+        # / force_failover / s_down / o_down is mid-transition; including
+        # its view in the quorum would mistake the transient state for
+        # consensus.
+        case ",${flags}," in
+          *,failover_in_progress,*) __drop_reason="flags_failover_in_progress" ;;
+          *,force_failover,*)       __drop_reason="flags_force_failover" ;;
+          *,s_down,*)               __drop_reason="flags_s_down" ;;
+          *,o_down,*)               __drop_reason="flags_o_down" ;;
+        esac
+      fi
+      __debug_append "  {\"fqdn\":\"${s}\",\"epoch\":\"${epoch}\",\"runid\":\"${runid}\",\"flags\":\"${flags}\",\"drop\":\"${__drop_reason}\"}"
+      if [ -n "${__drop_reason}" ]; then
+        continue
+      fi
       quorum_keys+=("${epoch}:${runid}")
     done
     valid_count=${#quorum_keys[@]}
-    if [ "${valid_count}" -ge "${min_valid}" ]; then
+    if [ "${valid_count}" -lt "${min_valid}" ]; then
+      __quorum_decision_reason="insufficient_valid"
+    else
       first_key="${quorum_keys[0]}"
       all_agree=1
       for k in "${quorum_keys[@]}"; do
@@ -245,9 +281,16 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
       if [ "${all_agree}" = 1 ]; then
         engine_version="${first_key%%:*}"
         sentinel_master_runid="${first_key#*:}"
+        __quorum_decision_reason="versioned"
+      else
+        __quorum_decision_reason="split_view"
       fi
     fi
+  else
+    __quorum_decision_reason="no_sentinel_configured"
   fi
+else
+  __quorum_decision_reason="no_sentinel_env"
 fi
 set_xtrace_when_ut_mode_false
 
@@ -266,6 +309,39 @@ if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
   else
     authoritative_role="secondary"
   fi
+fi
+__quorum_emit_role="${authoritative_role}"
+
+# Write the diagnostic record (if VALKEY_CHECK_ROLE_DEBUG=1) to a Pod-
+# local file. Stdout is left untouched — production roleProbe contract
+# is preserved. Per Bob2 + Edward 2026-05-24 review:
+#   - debug never writes to stdout (would corrupt the role token)
+#   - per-call line includes wall timestamp, pod identity, local
+#     run_id, configured/min_valid/valid counts, per-sentinel raw
+#     (epoch, runid, flags) plus filter drop reason, final decision
+#     (versioned | legacy reason), emitted role + epoch.
+# Output is a JSON-shaped one-liner so it stays grep-friendly while
+# preserving the per-sentinel structure for later analysis.
+if [ -n "${__check_role_debug_log}" ]; then
+  __debug_ts=$(date -u +%Y-%m-%dT%H:%M:%S.%N%z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+  __debug_pod="${CURRENT_POD_NAME:-${HOSTNAME:-unknown}}"
+  __debug_sentinels="${__debug_records%$'\n'}"
+  __debug_versioned_payload=""
+  if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
+    __debug_versioned_payload=",\"emit_epoch\":\"${engine_version}\",\"emit_runid\":\"${sentinel_master_runid}\",\"emit_role\":\"${__quorum_emit_role}\""
+  fi
+  {
+    printf '{"ts":"%s","pod":"%s","local_run_id":"%s","configured_count":%s,"min_valid":%s,"valid_count":%s,"decision":"%s"%s,"sentinels":[\n%s\n]}\n' \
+      "${__debug_ts}" \
+      "${__debug_pod}" \
+      "${local_run_id}" \
+      "${configured_count:-0}" \
+      "${min_valid:-0}" \
+      "${valid_count:-0}" \
+      "${__quorum_decision_reason}" \
+      "${__debug_versioned_payload}" \
+      "${__debug_sentinels}"
+  } >> "${__check_role_debug_log}" 2>/dev/null || true
 fi
 
 # printf %s prints the role token with no trailing newline, so when no

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -177,12 +177,14 @@ if [ "${VALKEY_CHECK_ROLE_DEBUG:-0}" = "1" ]; then
   __check_role_debug_log="/tmp/check-role-debug.log"
 fi
 __debug_records=""
+__debug_sep=""
 __debug_append() {
-  # Append a single line; build incrementally to avoid one fork per
-  # sentinel for the common case where DEBUG is off.
+  # Build the per-sentinel JSON array element on a single line so the
+  # final record stays JSONL-parseable. Comma-separate elements; the
+  # first append uses an empty separator, every subsequent one uses ",".
   [ -z "${__check_role_debug_log}" ] && return 0
-  __debug_records="${__debug_records}${1}
-"
+  __debug_records="${__debug_records}${__debug_sep}${1}"
+  __debug_sep=","
 }
 __sentinel_records=""
 engine_version=""
@@ -260,7 +262,7 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
           *,o_down,*)               __drop_reason="flags_o_down" ;;
         esac
       fi
-      __debug_append "  {\"fqdn\":\"${s}\",\"epoch\":\"${epoch}\",\"runid\":\"${runid}\",\"flags\":\"${flags}\",\"drop\":\"${__drop_reason}\"}"
+      __debug_append "{\"fqdn\":\"${s}\",\"epoch\":\"${epoch}\",\"runid\":\"${runid}\",\"flags\":\"${flags}\",\"drop\":\"${__drop_reason}\"}"
       if [ -n "${__drop_reason}" ]; then
         continue
       fi
@@ -325,13 +327,15 @@ __quorum_emit_role="${authoritative_role}"
 if [ -n "${__check_role_debug_log}" ]; then
   __debug_ts=$(date -u +%Y-%m-%dT%H:%M:%S.%N%z 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
   __debug_pod="${CURRENT_POD_NAME:-${HOSTNAME:-unknown}}"
-  __debug_sentinels="${__debug_records%$'\n'}"
   __debug_versioned_payload=""
   if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
     __debug_versioned_payload=",\"emit_epoch\":\"${engine_version}\",\"emit_runid\":\"${sentinel_master_runid}\",\"emit_role\":\"${__quorum_emit_role}\""
   fi
+  # One probe call = one line on disk (JSONL). Per Edward msg=be0a283c:
+  # multi-line records would mis-align with controller event payloads
+  # during analysis.
   {
-    printf '{"ts":"%s","pod":"%s","local_run_id":"%s","configured_count":%s,"min_valid":%s,"valid_count":%s,"decision":"%s"%s,"sentinels":[\n%s\n]}\n' \
+    printf '{"ts":"%s","pod":"%s","local_run_id":"%s","configured_count":%s,"min_valid":%s,"valid_count":%s,"decision":"%s"%s,"sentinels":[%s]}\n' \
       "${__debug_ts}" \
       "${__debug_pod}" \
       "${local_run_id}" \
@@ -340,7 +344,7 @@ if [ -n "${__check_role_debug_log}" ]; then
       "${valid_count:-0}" \
       "${__quorum_decision_reason}" \
       "${__debug_versioned_payload}" \
-      "${__debug_sentinels}"
+      "${__debug_records}"
   } >> "${__check_role_debug_log}" 2>/dev/null || true
 fi
 

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -114,10 +114,16 @@ done <<<"${repl_info}"
 engine_version=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
+  # TLS args must flow into the sentinel query path; silently dropping them
+  # on a TLS-enabled topology would make every sentinel call fail and the
+  # whole script degrade to legacy single-line output. Match the pattern in
+  # valkey-member-leave.sh / valkey-start.sh: append ${VALKEY_CLI_TLS_ARGS}
+  # whenever it is set.
+  sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"
   best_epoch=-1
   IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
   for s in "${sentinel_fqdns[@]}"; do
-    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || continue
+    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
     ce_marker=""
     epoch=""
     while IFS= read -r sline; do

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -3,12 +3,19 @@
 #
 # Learning note:
 #   KubeBlocks calls this script every periodSeconds seconds on EACH pod.
-#   The contract is simple: print exactly one line to stdout — the role name
-#   that matches one of the roles[] entries in ComponentDefinition.
+#   Contract (post-PR apecloud/kubeblocks#10280): stdout is parsed via
+#   `strings.Fields`. The first whitespace-separated token must be the role
+#   name (one of the roles[] entries in ComponentDefinition); an optional
+#   second whitespace-separated token carries an engine-authoritative
+#   `uint64` role version that the controller's staleness gate uses to
+#   reject replayed Kubernetes Event objects. Any other shape is rejected.
+#   Only the first token becomes the Pod role label.
 #
 #   For Valkey (Redis-compatible):
-#     INFO replication → role:master  →  print "primary"
-#     INFO replication → role:slave   →  print "secondary"
+#     INFO replication → role:master  →  print "primary"  (first token)
+#     INFO replication → role:slave   →  print "secondary" (first token)
+#   Then, when reachable, the highest sentinel config-epoch is appended as
+#   the second token, separated by a newline.
 #
 #   Using valkey-cli (not redis-cli) because Valkey ships its own CLI.
 #   The -h 127.0.0.1 ensures we hit this pod's own server.
@@ -145,9 +152,12 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
 fi
 set_xtrace_when_ut_mode_false
 
-# printf %s avoids the trailing newline that `echo` adds — KubeBlocks roleProbe
-# rejects label values containing '\n' (Kubernetes label validation), surfacing
-# as transient `RoleProbeNotDone` and `invalid label value primary\n` events.
+# printf %s prints the role token with no trailing newline, so when no
+# engine version is appended the stdout stays a single token. When the
+# engine version IS appended below, it follows on a new line; the
+# controller `strings.Fields` parser splits role and version into two
+# tokens and uses only the role token as the Pod label, so embedded
+# newlines no longer fail Kubernetes label validation.
 case "${role_line}" in
   "role:master") printf %s "primary"   ;;
   "role:slave")  printf %s "secondary" ;;

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -12,10 +12,21 @@
 #   Only the first token becomes the Pod role label.
 #
 #   For Valkey (Redis-compatible):
-#     INFO replication → role:master  →  print "primary"  (first token)
-#     INFO replication → role:slave   →  print "secondary" (first token)
-#   Then, when reachable, the highest sentinel config-epoch is appended as
-#   the second token, separated by a newline.
+#     - When Sentinel returns a clean uint64 `config-epoch` AND a non-
+#       empty hex master `runid`: the role token comes from a Sentinel-
+#       authoritative gate, not from local INFO alone. `primary` is
+#       emitted ONLY when local INFO=master AND local `INFO server`
+#       `run_id` equals the Sentinel master `runid`. Otherwise emit
+#       `secondary`. The matched Sentinel's `config-epoch` is appended
+#       as the whitespace-separated second token. Local INFO=master on
+#       a deposed primary is treated as `secondary` so two pods cannot
+#       both emit `primary <same-epoch>` after a sentinel-driven
+#       failover.
+#     - When Sentinel is unreachable / the password is missing / the
+#       parsed epoch is non-numeric / the parsed runid is empty or
+#       malformed: fall back to legacy single-token output (local INFO
+#       → `primary` for `role:master`, `secondary` for `role:slave`).
+#       The controller then uses its existing EventTime gate.
 #
 #   Using valkey-cli (not redis-cli) because Valkey ships its own CLI.
 #   The -h 127.0.0.1 ensures we hit this pod's own server.
@@ -181,6 +192,16 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     done <<<"${sentinel_out}"
     case "${epoch}" in
       ''|*[!0-9]*) continue ;;
+    esac
+    # Sentinel runid must be a non-empty hex token. Anything else is a
+    # malformed authority — wrapping it into `primary <epoch>` (or even
+    # `secondary <epoch>` against a malformed peer) would re-create the
+    # round-3 dual-primary race the gate is supposed to close. The shape
+    # guard is purely on the character set; we don't pin length so the
+    # check stays resilient if Valkey/Sentinel ever changes the runid
+    # encoding.
+    case "${runid}" in
+      ''|*[!0-9a-fA-F]*) continue ;;
     esac
     if [ "${epoch}" -gt "${best_epoch}" ]; then
       best_epoch="${epoch}"

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -358,17 +358,48 @@ if [ -n "${authoritative_role}" ]; then
   printf %s "${authoritative_role}"
   printf '\n%s' "${engine_version}"
 else
-  # Legacy single-token output (Sentinel unreachable / empty runid /
-  # non-numeric epoch). Use local INFO directly.
-  case "${role_line}" in
-    "role:master") printf %s "primary"   ;;
-    "role:slave")  printf %s "secondary" ;;
+  # Legacy single-token fallback. The mode of fallback matters: when
+  # Sentinel is *not configured at all* the local INFO is the only
+  # authority and `role:master` legitimately means `primary`. But when
+  # Sentinel *is* configured and the quorum is merely transiently
+  # invalid (split-view, insufficient_valid, flags transient, missing
+  # auth), a sibling pod may already hold an engine-versioned `primary`
+  # annotation on the controller. Emitting plain legacy `primary` from
+  # this Pod's `role:master` in that window lets the controller's
+  # cross-mode `removeExclusiveRoleLabels` strip the sibling's
+  # engine-versioned label, after which the controller's strict
+  # `engine:>` gate refuses to repair the missing label even when this
+  # Pod resumes emitting versioned output (the same-version events are
+  # rejected as staleRoleEventVersion).
+  #
+  # Safe degrade: when Sentinel is configured but quorum is transiently
+  # invalid, emit `secondary` regardless of local INFO. The primary
+  # Service may have no endpoint briefly while Sentinel converges, but
+  # no engine-versioned peer can be exclusive-cleaned. When Sentinel is
+  # not configured / not envvar-provided (`no_sentinel_env` /
+  # `no_sentinel_configured`), keep the original local-INFO mapping
+  # because that is the only authority for standalone / no-sentinel
+  # topologies.
+  case "${__quorum_decision_reason}" in
+    no_sentinel_env|no_sentinel_configured)
+      case "${role_line}" in
+        "role:master") printf %s "primary"   ;;
+        "role:slave")  printf %s "secondary" ;;
+        *)
+          echo "unknown role: '${role_line}'" >&2
+          exit 1
+          ;;
+      esac
+      ;;
     *)
-      echo "unknown role: '${role_line}'" >&2
-      # Returning a non-zero exit code tells KubeBlocks the probe failed.
-      # KubeBlocks will increment the failure counter and, after
-      # failureThreshold is exceeded, clear the role label on this pod.
-      exit 1
+      # insufficient_valid / split_view / future quorum-invalid reasons
+      case "${role_line}" in
+        "role:master"|"role:slave") printf %s "secondary" ;;
+        *)
+          echo "unknown role: '${role_line}'" >&2
+          exit 1
+          ;;
+      esac
       ;;
   esac
 fi

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -123,122 +123,149 @@ while IFS= read -r line; do
   esac
 done <<<"${server_info}"
 
-# Engine-authoritative role and version from Sentinel.
-# Contract: KubeBlocks controllers (post-PR #10280) parse roleProbe stdout
-# as whitespace-separated tokens; a second token must be a clean uint64,
-# otherwise the entire event is rejected as malformed (no silent fallback
-# to EventTime). The version MUST come from an engine epoch that is
-# monotonic and comparable across pods in the component. For Valkey +
-# sentinel, the sentinel `config-epoch` on the current master bumps on
-# every successful sentinel-driven failover (both auto failover and
-# `SENTINEL FAILOVER` triggered via switchover.sh), which is exactly the
-# granularity Bug B's stale-event gate needs.
+# Engine-authoritative role and version via Sentinel quorum.
+# Contract (post-PR #10280): the controller parses roleProbe stdout with
+# `strings.Fields` and accepts either `<role>` or `<role> <uint64>`. The
+# stale gate stores the accepted version in the Pod annotation and rejects
+# any same-or-older event afterwards.
 #
-# Authority: the role token must also come from Sentinel — local `INFO
-# replication role:master` is not authoritative during the failover
-# window. Treat this Pod as the real primary only when local INFO says
-# `master` AND the local `run_id` equals the Sentinel master `runid`.
-# Otherwise emit `secondary <epoch>` so the controller-side staleness
-# gate sees a consistent global view. If Sentinel returns an empty /
-# malformed `runid` we fall back to legacy single-token output rather
-# than wrap incomplete authority into `primary`.
+# Round-3 evidence (V1 against PR #10280 head 16803efa) showed that during
+# a sentinel-driven failover, sentinels briefly disagree at the SAME
+# `config-epoch`: one sentinel still reports the old master, another the
+# new master with the runid not yet filled, etc. Picking a single sentinel
+# in this window would emit a wrong `<role> <epoch>`, the controller would
+# stamp the Pod annotation to that engine version, and subsequent correct
+# events at the same epoch would all be rejected as stale.
 #
-# Resilience: pick the highest `config-epoch` across reachable sentinels
-# (matches the pattern in valkey-member-leave.sh) and capture that
-# Sentinel's master `runid` from the same response. A partially reachable
-# sentinel set is normal during failover; selecting a stale/isolated
-# sentinel would emit a stale version and starve subsequent legitimate
-# updates because the controller stores the engine annotation and refuses
-# legacy fallback once recorded.
+# Quorum rule (Edward+Bob2 contract, signed off 2026-05-24):
+#   - `configured_sentinel_count` = number of non-empty entries in
+#     `SENTINEL_POD_FQDN_LIST`.
+#   - `min_valid = configured_sentinel_count / 2 + 1` (strict majority of
+#     configured, NOT of reachable — otherwise a single reachable sentinel
+#     could self-certify).
+#   - For each reachable sentinel, parse the master `(epoch, runid, flags)`
+#     triple. Drop the entry when:
+#       - `epoch` is not a clean uint64;
+#       - `runid` is empty or contains a non-hex character;
+#       - `flags` contains any transient/failure marker
+#         (`failover_in_progress`, `force_failover`, `s_down`, `o_down`).
+#   - If fewer than `min_valid` valid entries remain, OR the valid entries
+#     fall into more than one `(epoch, runid)` group, fall back to legacy
+#     single-token output. The controller then uses its existing EventTime
+#     gate and the Pod annotation is NOT advanced to `engine:N`, so once
+#     sentinels converge the next emission can take effect.
+#   - When all valid entries agree on a single `(epoch, runid)` group AND
+#     there are at least `min_valid` of them, that group is the quorum
+#     authority. The version token is the group's epoch; the role token
+#     is decided purely by comparing the group's `runid` to the local
+#     `INFO server` `run_id`: match → `primary`, mismatch → `secondary`.
+#     Local `INFO replication role:master` is intentionally NOT used as
+#     an input to the versioned role decision.
 #
-# Silently fall back to legacy single-token output when no sentinel is
-# reachable, the password is missing, or no parsed value yields a clean
-# uint64 epoch with a non-empty master runid. Single valkey-cli invocation
-# per sentinel attempt, no pipelines, to preserve the fork-and-zombie
-# discipline (see docs/addon-probe-script-fork-and-zombie-guide.md).
+# Single `valkey-cli ... sentinel masters` invocation per sentinel attempt,
+# no pipelines, to preserve the fork-and-zombie discipline (see
+# docs/addon-probe-script-fork-and-zombie-guide.md).
 engine_version=""
 sentinel_master_runid=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
-  # TLS args must flow into the sentinel query path; silently dropping them
-  # on a TLS-enabled topology would make every sentinel call fail and the
-  # whole script degrade to legacy single-line output. Match the pattern in
-  # valkey-member-leave.sh / valkey-start.sh: append ${VALKEY_CLI_TLS_ARGS}
-  # whenever it is set.
+  # TLS args must flow into the sentinel query path; silently dropping
+  # them on a TLS-enabled topology would make every sentinel call fail
+  # and the whole script degrade to legacy single-line output. Match
+  # the pattern in valkey-member-leave.sh / valkey-start.sh: append
+  # ${VALKEY_CLI_TLS_ARGS} whenever it is set.
   sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"
-  best_epoch=-1
-  IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
-  for s in "${sentinel_fqdns[@]}"; do
-    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
-    ce_marker=""
-    runid_marker=""
-    epoch=""
-    runid=""
-    while IFS= read -r sline; do
-      sline="${sline%$'\r'}"
-      if [ -n "${ce_marker}" ]; then
-        epoch="${sline}"
-        ce_marker=""
-      elif [ -n "${runid_marker}" ]; then
-        runid="${sline}"
-        runid_marker=""
-      else
-        case "${sline}" in
-          "config-epoch") ce_marker="1" ;;
-          "runid")        runid_marker="1" ;;
-        esac
-      fi
-      [ -n "${epoch}" ] && [ -n "${runid}" ] && break
-    done <<<"${sentinel_out}"
-    case "${epoch}" in
-      ''|*[!0-9]*) continue ;;
-    esac
-    # Sentinel runid must be a non-empty hex token. Anything else is a
-    # malformed authority — wrapping it into `primary <epoch>` (or even
-    # `secondary <epoch>` against a malformed peer) would re-create the
-    # round-3 dual-primary race the gate is supposed to close. The shape
-    # guard is purely on the character set; we don't pin length so the
-    # check stays resilient if Valkey/Sentinel ever changes the runid
-    # encoding.
-    case "${runid}" in
-      ''|*[!0-9a-fA-F]*) continue ;;
-    esac
-    if [ "${epoch}" -gt "${best_epoch}" ]; then
-      best_epoch="${epoch}"
-      engine_version="${epoch}"
-      sentinel_master_runid="${runid}"
-    fi
+  # Configured total: count non-empty entries. Empty entries from a
+  # trailing comma or runtime mis-render must not lower the quorum bar.
+  IFS=',' read -ra sentinel_fqdns_raw <<< "${SENTINEL_POD_FQDN_LIST}"
+  sentinel_fqdns=()
+  for s in "${sentinel_fqdns_raw[@]}"; do
+    [ -n "${s}" ] && sentinel_fqdns+=("${s}")
   done
+  configured_count=${#sentinel_fqdns[@]}
+  if [ "${configured_count}" -ge 1 ]; then
+    min_valid=$((configured_count / 2 + 1))
+    quorum_keys=()
+    for s in "${sentinel_fqdns[@]}"; do
+      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
+      ce_marker=""
+      runid_marker=""
+      flags_marker=""
+      epoch=""
+      runid=""
+      flags=""
+      while IFS= read -r sline; do
+        sline="${sline%$'\r'}"
+        if [ -n "${ce_marker}" ]; then
+          epoch="${sline}"
+          ce_marker=""
+        elif [ -n "${runid_marker}" ]; then
+          runid="${sline}"
+          runid_marker=""
+        elif [ -n "${flags_marker}" ]; then
+          flags="${sline}"
+          flags_marker=""
+        else
+          case "${sline}" in
+            "config-epoch") ce_marker="1" ;;
+            "runid")        runid_marker="1" ;;
+            "flags")        flags_marker="1" ;;
+          esac
+        fi
+        [ -n "${epoch}" ] && [ -n "${runid}" ] && [ -n "${flags}" ] && break
+      done <<<"${sentinel_out}"
+      # Validate: epoch must be uint64.
+      case "${epoch}" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      # Validate: runid must be a non-empty hex token (no fixed length).
+      case "${runid}" in
+        ''|*[!0-9a-fA-F]*) continue ;;
+      esac
+      # Validate: master flags must not include transient or failure
+      # markers. A sentinel that flags the master as failover_in_progress
+      # / force_failover / s_down / o_down is mid-transition; including
+      # its view in the quorum would mistake the transient state for
+      # consensus.
+      case ",${flags}," in
+        *,failover_in_progress,*|*,force_failover,*|*,s_down,*|*,o_down,*) continue ;;
+      esac
+      quorum_keys+=("${epoch}:${runid}")
+    done
+    valid_count=${#quorum_keys[@]}
+    if [ "${valid_count}" -ge "${min_valid}" ]; then
+      first_key="${quorum_keys[0]}"
+      all_agree=1
+      for k in "${quorum_keys[@]}"; do
+        if [ "${k}" != "${first_key}" ]; then
+          all_agree=0
+          break
+        fi
+      done
+      if [ "${all_agree}" = 1 ]; then
+        engine_version="${first_key%%:*}"
+        sentinel_master_runid="${first_key#*:}"
+      fi
+    fi
+  fi
 fi
 set_xtrace_when_ut_mode_false
 
-# Resolve the authoritative role token by combining local INFO with the
-# Sentinel master `runid`. If Sentinel data is unavailable the script
-# stays on the legacy single-token path below and the controller falls
-# back to EventTime. If Sentinel returned an epoch but the master `runid`
-# is empty / malformed, we also drop back to legacy: emitting
-# `primary <epoch>` with incomplete authority would re-create the
-# round-3 dual-primary race that exposed Bug B in #10280 V1.
+# Resolve the versioned role token from the Sentinel quorum.
+# `engine_version` and `sentinel_master_runid` are set only when a
+# strict-majority quorum agrees on a single `(epoch, runid)`. The role
+# is decided purely by comparing the quorum's `runid` to this Pod's
+# `INFO server` `run_id`: match → `primary`, mismatch → `secondary`.
+# Local `INFO replication role:master` is intentionally NOT used as an
+# input here — it lagged on the deposed primary and produced the V1
+# round-3 race the quorum gate is supposed to close.
 authoritative_role=""
 if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
-  case "${role_line}" in
-    "role:master")
-      if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
-        authoritative_role="primary"
-      else
-        # Local INFO still says master but Sentinel disagrees on identity:
-        # this Pod is a deposed/stale primary, not the elected master.
-        authoritative_role="secondary"
-      fi
-      ;;
-    "role:slave")
-      authoritative_role="secondary"
-      ;;
-    *)
-      echo "unknown role: '${role_line}'" >&2
-      exit 1
-      ;;
-  esac
+  if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
+    authoritative_role="primary"
+  else
+    authoritative_role="secondary"
+  fi
 fi
 
 # printf %s prints the role token with no trailing newline, so when no

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -191,7 +191,12 @@ engine_version=""
 sentinel_master_runid=""
 __quorum_decision_reason=""
 __quorum_emit_role=""
-if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
+if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
+  # Sentinel topology is detected by FQDN list alone. Password is only
+  # an auth flag for the sentinel-cli call; missing password does NOT
+  # mean "no Sentinel". Treating a missing password as `no_sentinel_env`
+  # would re-open the cross-mode legacy `primary` fallback that this
+  # whole quorum path exists to block (see fallback branches below).
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   # TLS args must flow into the sentinel query path; silently dropping
   # them on a TLS-enabled topology would make every sentinel call fail
@@ -199,6 +204,15 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   # the pattern in valkey-member-leave.sh / valkey-start.sh: append
   # ${VALKEY_CLI_TLS_ARGS} whenever it is set.
   sentinel_tls_args="${VALKEY_CLI_TLS_ARGS:-}"
+  # Auth flag is conditional: only add -a when the password is set.
+  # When password is missing on a sentinel-configured topology, the
+  # cli call will fail (NOAUTH) and the per-sentinel drop will push
+  # the decision to `insufficient_valid`, which the fallback branch
+  # now correctly maps to `secondary`.
+  sentinel_auth_args=""
+  if [ -n "${SENTINEL_PASSWORD:-}" ]; then
+    sentinel_auth_args="-a ${SENTINEL_PASSWORD}"
+  fi
   # Configured total: count non-empty entries. Empty entries from a
   # trailing comma or runtime mis-render must not lower the quorum bar.
   IFS=',' read -ra sentinel_fqdns_raw <<< "${SENTINEL_POD_FQDN_LIST}"
@@ -211,7 +225,7 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     min_valid=$((configured_count / 2 + 1))
     quorum_keys=()
     for s in "${sentinel_fqdns[@]}"; do
-      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
+      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" ${sentinel_auth_args} ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
       ce_marker=""
       runid_marker=""
       flags_marker=""

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -95,7 +95,24 @@ while IFS= read -r line; do
   esac
 done <<<"${repl_info}"
 
-# Engine-authoritative role version — sentinel config-epoch.
+# Local server identity. After a sentinel-driven failover the deposed
+# primary still reports `role:master` locally for a brief window before its
+# `replicaof <new-master>` lands; emitting `primary` from that pod would
+# clash with the real new primary because both pods would carry the same
+# sentinel config-epoch as their version. The local `run_id` (`INFO
+# server`) is the stable per-server identity Sentinel records as `runid`
+# for the current master. Comparing the two lets the script reject the
+# stale-master self-report before it reaches the controller.
+server_info=$(${cli_cmd} info server 2>/dev/null) || server_info=""
+local_run_id=""
+while IFS= read -r line; do
+  line="${line%$'\r'}"
+  case "${line}" in
+    run_id:*) local_run_id="${line#run_id:}"; break ;;
+  esac
+done <<<"${server_info}"
+
+# Engine-authoritative role and version from Sentinel.
 # Contract: KubeBlocks controllers (post-PR #10280) parse roleProbe stdout
 # as whitespace-separated tokens; a second token must be a clean uint64,
 # otherwise the entire event is rejected as malformed (no silent fallback
@@ -106,19 +123,30 @@ done <<<"${repl_info}"
 # `SENTINEL FAILOVER` triggered via switchover.sh), which is exactly the
 # granularity Bug B's stale-event gate needs.
 #
-# Resilience: pick the highest `config-epoch` across reachable sentinels
-# (matches the pattern in valkey-member-leave.sh). A partially reachable
-# sentinel set is normal during failover or network partition; selecting a
-# stale/isolated sentinel would emit a stale version and starve subsequent
-# legitimate updates because the controller stores the engine annotation
-# and refuses legacy fallback once it has been recorded.
+# Authority: the role token must also come from Sentinel — local `INFO
+# replication role:master` is not authoritative during the failover
+# window. Treat this Pod as the real primary only when local INFO says
+# `master` AND the local `run_id` equals the Sentinel master `runid`.
+# Otherwise emit `secondary <epoch>` so the controller-side staleness
+# gate sees a consistent global view. If Sentinel returns an empty /
+# malformed `runid` we fall back to legacy single-token output rather
+# than wrap incomplete authority into `primary`.
 #
-# Silently fall back to legacy single-line output when no sentinel is
-# reachable, the password is missing, or no parsed value is a clean uint64.
-# Single valkey-cli invocation per sentinel attempt, no pipelines, to
-# preserve the fork-and-zombie discipline (see
-# docs/addon-probe-script-fork-and-zombie-guide.md).
+# Resilience: pick the highest `config-epoch` across reachable sentinels
+# (matches the pattern in valkey-member-leave.sh) and capture that
+# Sentinel's master `runid` from the same response. A partially reachable
+# sentinel set is normal during failover; selecting a stale/isolated
+# sentinel would emit a stale version and starve subsequent legitimate
+# updates because the controller stores the engine annotation and refuses
+# legacy fallback once recorded.
+#
+# Silently fall back to legacy single-token output when no sentinel is
+# reachable, the password is missing, or no parsed value yields a clean
+# uint64 epoch with a non-empty master runid. Single valkey-cli invocation
+# per sentinel attempt, no pipelines, to preserve the fork-and-zombie
+# discipline (see docs/addon-probe-script-fork-and-zombie-guide.md).
 engine_version=""
+sentinel_master_runid=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   # TLS args must flow into the sentinel query path; silently dropping them
@@ -132,14 +160,24 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   for s in "${sentinel_fqdns[@]}"; do
     sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
     ce_marker=""
+    runid_marker=""
     epoch=""
+    runid=""
     while IFS= read -r sline; do
       sline="${sline%$'\r'}"
       if [ -n "${ce_marker}" ]; then
         epoch="${sline}"
-        break
+        ce_marker=""
+      elif [ -n "${runid_marker}" ]; then
+        runid="${sline}"
+        runid_marker=""
+      else
+        case "${sline}" in
+          "config-epoch") ce_marker="1" ;;
+          "runid")        runid_marker="1" ;;
+        esac
       fi
-      [ "${sline}" = "config-epoch" ] && ce_marker="1"
+      [ -n "${epoch}" ] && [ -n "${runid}" ] && break
     done <<<"${sentinel_out}"
     case "${epoch}" in
       ''|*[!0-9]*) continue ;;
@@ -147,10 +185,40 @@ if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     if [ "${epoch}" -gt "${best_epoch}" ]; then
       best_epoch="${epoch}"
       engine_version="${epoch}"
+      sentinel_master_runid="${runid}"
     fi
   done
 fi
 set_xtrace_when_ut_mode_false
+
+# Resolve the authoritative role token by combining local INFO with the
+# Sentinel master `runid`. If Sentinel data is unavailable the script
+# stays on the legacy single-token path below and the controller falls
+# back to EventTime. If Sentinel returned an epoch but the master `runid`
+# is empty / malformed, we also drop back to legacy: emitting
+# `primary <epoch>` with incomplete authority would re-create the
+# round-3 dual-primary race that exposed Bug B in #10280 V1.
+authoritative_role=""
+if [ -n "${engine_version}" ] && [ -n "${sentinel_master_runid}" ]; then
+  case "${role_line}" in
+    "role:master")
+      if [ -n "${local_run_id}" ] && [ "${local_run_id}" = "${sentinel_master_runid}" ]; then
+        authoritative_role="primary"
+      else
+        # Local INFO still says master but Sentinel disagrees on identity:
+        # this Pod is a deposed/stale primary, not the elected master.
+        authoritative_role="secondary"
+      fi
+      ;;
+    "role:slave")
+      authoritative_role="secondary"
+      ;;
+    *)
+      echo "unknown role: '${role_line}'" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 # printf %s prints the role token with no trailing newline, so when no
 # engine version is appended the stdout stays a single token. When the
@@ -158,23 +226,21 @@ set_xtrace_when_ut_mode_false
 # controller `strings.Fields` parser splits role and version into two
 # tokens and uses only the role token as the Pod label, so embedded
 # newlines no longer fail Kubernetes label validation.
-case "${role_line}" in
-  "role:master") printf %s "primary"   ;;
-  "role:slave")  printf %s "secondary" ;;
-  *)
-    echo "unknown role: '${role_line}'" >&2
-    # Returning a non-zero exit code tells KubeBlocks the probe failed.
-    # KubeBlocks will increment the failure counter and, after
-    # failureThreshold is exceeded, clear the role label on this pod.
-    exit 1
-    ;;
-esac
-
-# Append the engine-authoritative version as a second whitespace-separated
-# token only when at least one reachable sentinel returned a clean uint64
-# config-epoch. Empty or non-numeric falls back to legacy single-line and
-# the controller uses its existing EventTime gate.
-case "${engine_version}" in
-  ''|*[!0-9]*) : ;;
-  *) printf '\n%s' "${engine_version}" ;;
-esac
+if [ -n "${authoritative_role}" ]; then
+  printf %s "${authoritative_role}"
+  printf '\n%s' "${engine_version}"
+else
+  # Legacy single-token output (Sentinel unreachable / empty runid /
+  # non-numeric epoch). Use local INFO directly.
+  case "${role_line}" in
+    "role:master") printf %s "primary"   ;;
+    "role:slave")  printf %s "secondary" ;;
+    *)
+      echo "unknown role: '${role_line}'" >&2
+      # Returning a non-zero exit code tells KubeBlocks the probe failed.
+      # KubeBlocks will increment the failure counter and, after
+      # failureThreshold is exceeded, clear the role label on this pod.
+      exit 1
+      ;;
+  esac
+fi

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -87,6 +87,38 @@ while IFS= read -r line; do
     role:*) role_line="${line}"; break ;;
   esac
 done <<<"${repl_info}"
+
+# Engine-authoritative role version (kb-role-version) — sentinel config-epoch.
+# Contract: KubeBlocks controllers (post-PR #10280) use the second line
+# `kb-role-version=<uint64>` to gate stale roleProbe events; the value MUST
+# come from an engine epoch that is monotonic and comparable across pods in
+# the component. For Valkey + sentinel, the sentinel `config-epoch` on the
+# current master bumps on every successful sentinel-driven failover (both
+# auto failover and `SENTINEL FAILOVER` triggered via switchover.sh), which
+# is exactly the granularity Bug B's stale-event gate needs.
+#
+# Resilience: silently fall back to legacy single-line output if sentinel is
+# unreachable, the password is missing, or the parsed value is non-numeric.
+# Per PR #10280 strict-parser contract, emitting a malformed line would make
+# the controller reject the event outright; emitting NO version line keeps
+# the legacy EventTime fallback path. Single valkey-cli invocation, no
+# pipelines, to preserve the fork-and-zombie discipline (see
+# docs/addon-probe-script-fork-and-zombie-guide.md).
+engine_version=""
+if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
+  sentinel_host="${SENTINEL_POD_FQDN_LIST%%,*}"
+  sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
+  sentinel_out=$(valkey-cli --no-auth-warning -h "${sentinel_host}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || sentinel_out=""
+  ce_marker=""
+  while IFS= read -r sline; do
+    sline="${sline%$'\r'}"
+    if [ -n "${ce_marker}" ]; then
+      engine_version="${sline}"
+      break
+    fi
+    [ "${sline}" = "config-epoch" ] && ce_marker="1"
+  done <<<"${sentinel_out}"
+fi
 set_xtrace_when_ut_mode_false
 
 # printf %s avoids the trailing newline that `echo` adds — KubeBlocks roleProbe
@@ -102,4 +134,11 @@ case "${role_line}" in
     # failureThreshold is exceeded, clear the role label on this pod.
     exit 1
     ;;
+esac
+
+# Append engine-authoritative version on second line only when sentinel
+# returned a clean uint64. Non-numeric or empty result drops back to legacy.
+case "${engine_version}" in
+  ''|*[!0-9]*) : ;;
+  *) printf '\nkb-role-version=%s' "${engine_version}" ;;
 esac

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -88,36 +88,54 @@ while IFS= read -r line; do
   esac
 done <<<"${repl_info}"
 
-# Engine-authoritative role version (kb-role-version) — sentinel config-epoch.
-# Contract: KubeBlocks controllers (post-PR #10280) use the second line
-# `kb-role-version=<uint64>` to gate stale roleProbe events; the value MUST
-# come from an engine epoch that is monotonic and comparable across pods in
-# the component. For Valkey + sentinel, the sentinel `config-epoch` on the
-# current master bumps on every successful sentinel-driven failover (both
-# auto failover and `SENTINEL FAILOVER` triggered via switchover.sh), which
-# is exactly the granularity Bug B's stale-event gate needs.
+# Engine-authoritative role version — sentinel config-epoch.
+# Contract: KubeBlocks controllers (post-PR #10280) parse roleProbe stdout
+# as whitespace-separated tokens; a second token must be a clean uint64,
+# otherwise the entire event is rejected as malformed (no silent fallback
+# to EventTime). The version MUST come from an engine epoch that is
+# monotonic and comparable across pods in the component. For Valkey +
+# sentinel, the sentinel `config-epoch` on the current master bumps on
+# every successful sentinel-driven failover (both auto failover and
+# `SENTINEL FAILOVER` triggered via switchover.sh), which is exactly the
+# granularity Bug B's stale-event gate needs.
 #
-# Resilience: silently fall back to legacy single-line output if sentinel is
-# unreachable, the password is missing, or the parsed value is non-numeric.
-# Per PR #10280 strict-parser contract, emitting a malformed line would make
-# the controller reject the event outright; emitting NO version line keeps
-# the legacy EventTime fallback path. Single valkey-cli invocation, no
-# pipelines, to preserve the fork-and-zombie discipline (see
+# Resilience: pick the highest `config-epoch` across reachable sentinels
+# (matches the pattern in valkey-member-leave.sh). A partially reachable
+# sentinel set is normal during failover or network partition; selecting a
+# stale/isolated sentinel would emit a stale version and starve subsequent
+# legitimate updates because the controller stores the engine annotation
+# and refuses legacy fallback once it has been recorded.
+#
+# Silently fall back to legacy single-line output when no sentinel is
+# reachable, the password is missing, or no parsed value is a clean uint64.
+# Single valkey-cli invocation per sentinel attempt, no pipelines, to
+# preserve the fork-and-zombie discipline (see
 # docs/addon-probe-script-fork-and-zombie-guide.md).
 engine_version=""
 if [ -n "${SENTINEL_PASSWORD:-}" ] && [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
-  sentinel_host="${SENTINEL_POD_FQDN_LIST%%,*}"
   sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
-  sentinel_out=$(valkey-cli --no-auth-warning -h "${sentinel_host}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || sentinel_out=""
-  ce_marker=""
-  while IFS= read -r sline; do
-    sline="${sline%$'\r'}"
-    if [ -n "${ce_marker}" ]; then
-      engine_version="${sline}"
-      break
+  best_epoch=-1
+  IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
+  for s in "${sentinel_fqdns[@]}"; do
+    sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" -a "${SENTINEL_PASSWORD}" sentinel masters 2>/dev/null) || continue
+    ce_marker=""
+    epoch=""
+    while IFS= read -r sline; do
+      sline="${sline%$'\r'}"
+      if [ -n "${ce_marker}" ]; then
+        epoch="${sline}"
+        break
+      fi
+      [ "${sline}" = "config-epoch" ] && ce_marker="1"
+    done <<<"${sentinel_out}"
+    case "${epoch}" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    if [ "${epoch}" -gt "${best_epoch}" ]; then
+      best_epoch="${epoch}"
+      engine_version="${epoch}"
     fi
-    [ "${sline}" = "config-epoch" ] && ce_marker="1"
-  done <<<"${sentinel_out}"
+  done
 fi
 set_xtrace_when_ut_mode_false
 
@@ -136,9 +154,11 @@ case "${role_line}" in
     ;;
 esac
 
-# Append engine-authoritative version on second line only when sentinel
-# returned a clean uint64. Non-numeric or empty result drops back to legacy.
+# Append the engine-authoritative version as a second whitespace-separated
+# token only when at least one reachable sentinel returned a clean uint64
+# config-epoch. Empty or non-numeric falls back to legacy single-line and
+# the controller uses its existing EventTime gate.
 case "${engine_version}" in
   ''|*[!0-9]*) : ;;
-  *) printf '\nkb-role-version=%s' "${engine_version}" ;;
+  *) printf '\n%s' "${engine_version}" ;;
 esac

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -371,8 +371,14 @@ spec:
   # ── Lifecycle actions ──────────────────────────────────────────────────
   lifecycleActions:
     # roleProbe: KubeBlocks calls this every periodSeconds to learn the
-    # role of each pod.  The script must print exactly the role name
-    # (matching one of the roles[] names above) to stdout.
+    # role of each pod. Contract (post-PR apecloud/kubeblocks#10280):
+    # stdout is parsed via `strings.Fields`. The first whitespace token
+    # must be the role name (matching one of the roles[] names above);
+    # an optional second whitespace token is a uint64 engine-authoritative
+    # version that the controller uses to gate stale Event replays. Only
+    # the first token becomes the Pod role label. The Valkey script
+    # appends the highest reachable sentinel config-epoch as the second
+    # token whenever a sentinel is reachable.
     roleProbe:
       periodSeconds: 5
       timeoutSeconds: 3


### PR DESCRIPTION
## Summary

`check-role.sh` no longer emits legacy single-token `primary` from `local INFO replication role:master` when the Sentinel quorum is transiently invalid but Sentinel is configured. In that window it emits `secondary` instead. The standalone / no-Sentinel paths (`__quorum_decision_reason` = `no_sentinel_env` / `no_sentinel_configured`) keep the original local-INFO mapping.

## Why

This addon-side patch addresses a Bug-B-class regression observed when the addon is paired with the post-apecloud/kubeblocks#10283 controller (which splits `LastRoleEventVersionAnnotationKey` from `LastRoleEngineVersionAnnotationKey`). The controller's `removeExclusiveRoleLabels()` only gates peer cleanup against the incoming event's own mode. A legacy `primary` event from one Pod therefore strips a sibling Pod's engine-versioned `primary` label, and the strict `engine:>` staleness gate then rejects subsequent same-version repair events because the previousRole annotation has been cleared.

The trigger is exactly the transient window in which check-role.sh falls back to legacy output:

- Pod A has Sentinel quorum, emits `primary <epoch>` (engine-versioned). Controller writes Pod A's role label + `LastRoleEngineVersionAnnotationKey=<epoch>`.
- Pod B has the same local `INFO replication role:master` view (transitional state during a switchover, scale-out, or a Sentinel split) but its quorum is invalid (`insufficient_valid` / `split_view`). Pre-patch, Pod B emits plain `primary` from local INFO. Post-patch, Pod B emits `secondary`.

On the closed-PR apecloud/kubeblocks#10280 path this issue did not surface because the controller did not split annotation keys. On the apecloud/kubeblocks#10283 path the issue becomes visible whenever two pods straddle modes, which is exactly the case across the switchover convergence window.

## Reproduction reference

This PR's RED case is sourced from the live freeze archive sha `575ed6c444cf6224c74629a2abc28f16f80c35e62f13f6cada4c5ae782302920`, captured from a full-suite acceptance round on idc vcluster valkey-fresh-0008 (cluster `vlk-smoke-lc-...` after T09 pre-scale-in switchover). The controller timeline showed `valkey-3 primary engine:3 accepted (exclusiveClean=true)` followed seconds later by `valkey-2 primary legacy accepted (exclusiveClean=true)` and then `valkey-2 secondary engine:3 accepted`, after which the controller rejected every subsequent `valkey-3 primary engine:3` event as `staleRoleEventVersion`. Cluster `Component.phase` stayed `Failed` with `RoleProbeNotDone: some instances do not have roles`; the engine data plane was healthy throughout. The companion controller-side mitigation (cross-mode aware peer cleanup / same-version engine repair) lives in apecloud/kubeblocks#10283.

## Scope

- `addons/valkey/scripts/check-role.sh`: split the legacy fallback into two branches keyed by `__quorum_decision_reason`. Sentinel-configured-but-quorum-invalid now emits `secondary` for both `role:master` and `role:slave`. Sentinel-not-configured keeps the original local-INFO mapping. Unknown-role guard unchanged.
- `addons/valkey/scripts-ut-spec/check_role_spec.sh`: add a `legacy fallback cross-mode safety` Describe block covering four checks (Sentinel configured + quorum invalid + INFO=master → secondary; Sentinel not configured + INFO=master → primary; role:slave maps to secondary in the no_sentinel branch; unknown role exits non-zero in both branches). Total shellspec count holds; the new tests pass alongside the existing engine-version-trailer suite.

Out of scope:

- Controller-side cross-mode peer cleanup / same-version engine repair — that lives in apecloud/kubeblocks#10283.
- Sentinel `failover-abort-slave-timeout` tuning — unrelated to the cross-mode write-then-strip mechanism.
- Standalone / no-Sentinel topology fallback — explicitly preserved by the `no_sentinel_env` / `no_sentinel_configured` branch.

## Test plan

- [x] `shellspec` passes on the updated `check_role_spec.sh` (legacy fallback cross-mode safety: Sentinel configured + INFO=master → secondary; no_sentinel + INFO=master → primary; role:slave → secondary; unknown role → exit 1).
- [x] Existing engine-version-trailer Describe blocks unchanged and pass.
- [ ] End-to-end: rerun the full-suite acceptance loop on idc vcluster valkey-fresh-0008 with `apecloud/kubeblocks:1.2.0-alpha.1-pr10283-714f684b` controller image + this addon HEAD, looking for T09 pre-scale-in switchover to converge without `RoleProbeNotDone` deadlock.

## Compatibility

This patch only narrows the fallback path. Engine-version trailer output is unchanged for any path where Sentinel quorum is achieved. Standalone topologies still emit `primary` from local `INFO=master`. The companion controller-side patch (apecloud/kubeblocks#10283) is the contract-level fix; this PR is a defence-in-depth that reduces the trigger surface on the addon side and unblocks acceptance runs while the controller patch lands.

## Public hygiene checks

- [x] Commit message and PR body state public facts only (no internal task numbers, channel names, or agent code names).
- [x] All cross-references use the upstream PR / archive identifiers.
- [x] Status: defence-in-depth `narrow legacy fallback`; not a contract change.
