### PR TITLE
chore: support postgresql new versions 14.23/15.18/16.14/17.10/18.4

### DIFF
--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -8,7 +8,7 @@ version: 1.1.0-alpha.1
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # appVersion should be consistent with the highest PostgreSQL (with Patroni HA) kernel version.
-appVersion: "18.1.0"
+appVersion: "18.4.0"
 
 # Add a dependency to the kubeblocks definition library chart
 dependencies:

--- a/addons/postgresql/values.yaml
+++ b/addons/postgresql/values.yaml
@@ -92,7 +92,7 @@ versions:
         tag: "12.22"
   - major: "14"
     componentDef: "postgresql-14"
-    serviceVersion: "14.18.0"
+    serviceVersion: "14.23.0"
     minors:
       - version: "14.7.2"
         tag: "14.7.2-pgvector-v0.6.1"
@@ -100,35 +100,45 @@ versions:
         tag: "14.8.0-pgvector-v0.6.1"
       - version: "14.18.0"
         tag: "14.18"
+      - version: "14.23.0"
+        tag: "14.23"
   - major: "15"
     componentDef: "postgresql-15"
-    serviceVersion: "15.13.0"
+    serviceVersion: "15.18.0"
     minors:
       - version: "15.7.0"
         tag: "15.7.0"
       - version: "15.13.0"
         tag: "15.13"
+      - version: "15.18.0"
+        tag: "15.18"
   - major: "16"
     componentDef: "postgresql-16"
-    serviceVersion: "16.9.0"
+    serviceVersion: "16.14.0"
     minors:
       - version: "16.4.0"
         tag: "16.4.0"
       - version: "16.9.0"
         tag: "16.9"
+      - version: "16.14.0"
+        tag: "16.14"
   - major: "17"
     componentDef: "postgresql-17"
-    serviceVersion: "17.5.0"
+    serviceVersion: "17.10.0"
     minors:
       - version: "17.5.0"
         tag: "17.5"
         isDefault: true
+      - version: "17.10.0"
+        tag: "17.10"
   - major: "18"
     componentDef: "postgresql-18"
-    serviceVersion: "18.1.0"
+    serviceVersion: "18.4.0"
     minors:
       - version: "18.1.0"
         tag: "18.1"
+      - version: "18.4.0"
+        tag: "18.4"
 
 ## @section pgbouncer Parameters
 pgbouncer:


### PR DESCRIPTION
## Summary

- Add 5 new PostgreSQL minor versions to the addon: 14.23.0, 15.18.0, 16.14.0, 17.10.0, and 18.4.0
- Update each major version's default `serviceVersion` to the latest minor release
- Bump Chart `appVersion` to `18.4.0`

## Test plan

- [ ] `helm template test addons/postgresql` renders successfully
- [ ] Verify ComponentVersion includes the new releases with correct spilo image tags
- [ ] Create a cluster with `serviceVersion: "18.4.0"` and confirm deployment works