### PR TITLE
fix(mariadb): mark_replication_pending no longer clears .sql-listener-ready (alpha.102)

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1055,7 +1055,34 @@ type: application
 # actually worked in the kbagent context. Removing it does NOT
 # regress the actual safety posture; it removes a dead defense that
 # was leaving orphan files.
-version: 1.1.1-alpha.101
+# alpha.102 v1 (Helen 2026-05-26): mark_replication_pending no longer
+# clears .sql-listener-ready. That marker semantically represents
+# "mariadbd has been re-bound to 0.0.0.0 past the bootstrap 127.0.0.1-
+# only phase" — a per-process bind state, not a replication-ready state.
+# Pre-fix: in a runtime switchover (e.g. syncerctl switchover candidate
+# = pod-1), pod-1's secondary-reconciler ran briefly after syncer had
+# already promoted pod-1 to primary (race window where syncerctl getrole
+# returned stale "secondary"). set_replica_read_only failed because the
+# pod was already primary; the failure path called mark_replication_
+# pending which cleared .sql-listener-ready. The next-tick primary-
+# reconciler then took the bootstrap "fresh start" branch in
+# expose_sql_listener_for_primary_role and physically restarted mariadbd.
+# That restart killed the syncer lease, the demoted peer re-acquired
+# leader, wrote a kb_health_check INSERT as new "interim primary", then
+# the cluster flapped back — leaving 1-event orphan in domain 1 that
+# `EnsurePromoteGTIDContinuity` then refused to promote past, sticking
+# the demoted peer as a permanent secondary. Same cause on both topology
+# subpaths (cmpd-replication-merged.yaml + cmpd-semisync.yaml).
+# Fix: rm of .sql-listener-ready removed from mark_replication_pending
+# in both files. Bind state is reset only by the bootstrap path's
+# fresh start_mariadbd_process at line 1901 of cmpd-replication-merged
+# (a fresh container restart will rebuild it). Same CmpD immutability
+# rule applies — chart version bump required.
+# Same syncer image as alpha.101 (no syncer change in this bump; the
+# syncer-side double-stop fix is in apecloud/syncer branch
+# helen/mariadb-demote-pause-writecheck, image
+# apecloud/syncer:mariadb-fullfix-20260526-v5).
+version: 1.1.1-alpha.102
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -613,7 +613,17 @@ spec:
             mark_replication_pending() {
               rm -f {{ .Values.dataMountPath }}/.replication-ready
               rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              # DO NOT clear .sql-listener-ready here. That marker represents
+              # "mariadbd has been re-bound to 0.0.0.0 (past the bootstrap
+              # 127.0.0.1-only phase)" — a per-process state, not a
+              # replication-ready state. Clearing it during a runtime role
+              # transition causes the next reconcile_sql_listener_for_syncer_
+              # primary_once tick to take the bootstrap "fresh start" branch
+              # in expose_sql_listener_for_primary_role and physically restart
+              # mariadbd, which kills the syncer lease and triggers the
+              # demoted peer to re-acquire leader and write orphan events.
+              # Bind-state is only reset by the bootstrap start_mariadbd_process
+              # at line 1901 (a fresh container restart will rebuild it).
               rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
               touch {{ .Values.dataMountPath }}/.replication-pending
             }

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -495,7 +495,17 @@ spec:
             mark_replication_pending() {
               rm -f {{ .Values.dataMountPath }}/.replication-ready
               rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-              rm -f {{ .Values.dataMountPath }}/.sql-listener-ready
+              # DO NOT clear .sql-listener-ready here. That marker represents
+              # "mariadbd has been re-bound to 0.0.0.0 (past the bootstrap
+              # 127.0.0.1-only phase)" — a per-process bind state, not a
+              # replication-ready state. Clearing it during a runtime role
+              # transition causes the next reconcile_sql_listener_for_syncer_
+              # primary_once tick to take the bootstrap "fresh start" branch
+              # in expose_sql_listener_for_primary_role and physically restart
+              # mariadbd, which kills the syncer lease and triggers the
+              # demoted peer to re-acquire leader and write orphan events.
+              # Bind-state is only reset by the bootstrap start_mariadbd_process
+              # (a fresh container restart will rebuild it).
               rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
               touch {{ .Values.dataMountPath }}/.replication-pending
             }


### PR DESCRIPTION
## Summary

`mark_replication_pending` no longer clears `.sql-listener-ready`.
That marker is per-process bind state ("mariadbd has been re-bound to
0.0.0.0 past the bootstrap 127.0.0.1-only phase"), not a
replication-ready state. Conflating the two caused the addon to
physically restart mariadbd during a runtime switchover, dropping the
syncer lease and producing orphan events.

Bumps chart to alpha.102 per CmpD immutability rule (cmpd-*.yaml
mutated).

Companion to syncer PR https://github.com/apecloud/syncer/pull/167
(syncer-side fixes: pause-WriteCheck during Demote + Promote-side
GTID-aware catch-up wait). **Both PRs must land together**; either
alone is incomplete for the multi-event orphan-event class on
`syncerctl switchover`.

## Background

`syncerctl switchover --primary X --candidate Y` was leaving N-event
orphans in domain 1 on the demoting primary after each switchover,
followed by perpetual `EnsurePromoteGTIDContinuity` refuse-promote
loops on the demoted peer (it could never be re-promoted because it
had events the new primary lacked).

Root cause is multi-layer. Layer 5 (this PR) is the addon-side trigger
that destabilizes the syncer lease:

1. syncerctl switchover triggered; syncer promotes pod-1 to primary
   (sets `read_only=0` on pod-1)
2. addon's `wait_for_mariadbd_with_role_reconcile` loop ticks every
   1s, running BOTH `reconcile_sql_listener_for_syncer_secondary_once`
   AND `reconcile_sql_listener_for_syncer_primary_once`
3. Secondary reconciler queries `syncerctl getrole`; returns stale
   `"secondary"` briefly (syncer-internal role state lag) → reconciler
   proceeds with `set_replica_read_only` which fails because pod is
   already primary (`read_only=0`, `BINLOG ADMIN` bypass)
4. Failure path calls `mark_replication_pending` → previously cleared
   `.sql-listener-ready` ALONGSIDE the replication-ready markers
5. Next-tick primary reconciler sees `.sql-listener-ready` missing →
   takes the bootstrap "fresh start" branch in
   `expose_sql_listener_for_primary_role` → `stop_mariadbd_process`
   (TERM + KILL) → `start_mariadbd_process` to rebind 0.0.0.0
6. mariadbd restart drops the syncer lease; the demoted peer pod-0
   sees no leader, re-acquires lease, and writes a fresh
   `kb_health_check` INSERT as "interim primary"
7. New event lives only on pod-0; pod-1 (now real primary again)
   never receives it → orphan

## Iron evidence (pre-fix)

`pod-1 /var/lib/mysql/log/prestop-watchdog.log` at 2026-05-26 13:47:59Z:

```
set-replica-read-only label=replica-read-only rc=1 tier=required fail_closed=true
configure-replication-from-primary label=runtime-secondary-follow step=enter-set-replica-read-only rc=1
runtime-secondary-listener-reconcile-pending role=secondary   ← stale role
runtime-primary-listener-reconcile-begin role=primary         ← real role
sql-listener-primary-expose-begin label=syncer-promoted-primary
stop-mariadbd label=sql-listener-primary-syncer-promoted-primary term pids=1800   ← mariadbd killed by addon
start-mariadbd label=sql-listener-primary-syncer-promoted-primary bind_address=0.0.0.0
```

## Implementation

Remove the `rm -f .sql-listener-ready` line from
`mark_replication_pending` in both `cmpd-replication-merged.yaml` and
`cmpd-semisync.yaml`. The other markers
(`.replication-ready`, `.primary-read-write-ready`,
`.remote-root-fence-role`) are still cleared as before. Bind state is
only reset by the bootstrap `start_mariadbd_process` at line 1901 of
cmpd-replication-merged (a fresh container restart will rebuild it).

Inline comment in both files explains why.

## Test plan

- [x] Helm upgrade from alpha.101 → alpha.102 OK
  (kubectl get cmpd shows alpha.102 CmpDs Available)
- [x] Fresh cluster mdb-pwt7 on alpha.102 + syncer
  `apecloud/syncer:mariadb-fullfix-20260526-v5` (companion fixes
  from apecloud/syncer PR #167)
- [x] N=3 alternating `syncerctl switchover` PASS:
  - divergence-pending marker on both pods: 0/0 across all 3 runs
  - mariadbd "Normal shutdown" events during switchover window: 0
    (was 1 per run pre-fix)
  - Final SHOW SLAVE STATUS: Slave_IO/SQL_Running=Yes,
    Seconds_Behind_Master=0, Last_SQL_Errno=0
  - domain-1 binlog_pos identical between old and new primary
    after each switchover
- [ ] CM4 (KubeBlocks Reconfiguring static parameter) end-to-end —
  currently blocked by separate alpha.60 fence verifier bug in addon
  switchover script; will verify once that addon-side gap is closed
- [ ] Repeated full `kubeblocks-tests` engine-suite rounds — follow-up

## Coordinated changes

- apecloud/syncer PR #167 (syncer engine-side fixes). Either alone
  is incomplete for the multi-event orphan-event class.

## Boundary

This PR is the ADDON-SIDE fix only. Replication/galera/standalone
topologies are unaffected (their `mark_replication_pending`
functions live in cmpd-replication-merged.yaml + cmpd-semisync.yaml
only). Engine version unchanged.