### PR TITLE
chore(mongodb): config template ownership for KB 1.2

### DIFF
--- a/addons/mongodb/templates/cmpd-config-server.yaml
+++ b/addons/mongodb/templates/cmpd-config-server.yaml
@@ -16,6 +16,7 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400
+      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd-config-server.yaml
+++ b/addons/mongodb/templates/cmpd-config-server.yaml
@@ -16,7 +16,6 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400
-      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -16,6 +16,7 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400
+      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -16,7 +16,6 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400
-      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd-mongos.yaml
+++ b/addons/mongodb/templates/cmpd-mongos.yaml
@@ -32,6 +32,7 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400
+      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd-mongos.yaml
+++ b/addons/mongodb/templates/cmpd-mongos.yaml
@@ -32,7 +32,6 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400
-      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -39,7 +39,6 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400  # for only read
-      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -39,6 +39,7 @@ spec:
       volumeName: mongodb-config
       namespace: {{ .Release.Namespace }}
       defaultMode: 0400  # for only read
+      externalManaged: true
   logConfigs:
     {{- range $name,$pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/mongodb/templates/paramsdef.yaml
+++ b/addons/mongodb/templates/paramsdef.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
-  componentDef: "^(mongodb|mongo-shard|mongo-config-server)-.*"
+  componentDef: {{ printf "^(%s|%s|%s)$" (include "mongodb.compDefName" .) (include "mongodbShard.compDefName" .) (include "cfgServer.compDefName" .) | quote }}
   templateName: mongodb-config
   fileName: mongodb.conf
   fileFormatConfig:
@@ -37,7 +37,7 @@ metadata:
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
-  componentDef: "^mongo-mongos-.*"
+  componentDef: {{ printf "^%s$" (include "mongos.compDefName" .) | quote }}
   templateName: mongodb-config
   fileName: mongos.conf
   fileFormatConfig:

--- a/addons/mongodb/templates/paramsdef.yaml
+++ b/addons/mongodb/templates/paramsdef.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: {{ printf "mongodb-config-pd-%s" .Chart.Version }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+  annotations:
+    {{- include "mongodb.annotations" . | nindent 4 }}
+spec:
+  componentDef: "^(mongodb|mongo-shard|mongo-config-server)-.*"
+  templateName: mongodb-config
+  fileName: mongodb.conf
+  fileFormatConfig:
+    format: yaml
+  parametersSchema:
+    topLevelKey: MongoDBParameter
+    cue: |-
+      #MongoDBParameter: {
+        ...
+        systemLog?: {
+          ...
+          quiet?: bool | *false
+          verbosity?: int & >=0 & <=5 | *0
+        }
+      }
+  staticParameters:
+    - systemLog.quiet
+    - systemLog.verbosity
+---
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: {{ printf "mongos-config-pd-%s" .Chart.Version }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+  annotations:
+    {{- include "mongodb.annotations" . | nindent 4 }}
+spec:
+  componentDef: "^mongo-mongos-.*"
+  templateName: mongodb-config
+  fileName: mongos.conf
+  fileFormatConfig:
+    format: yaml
+  parametersSchema:
+    topLevelKey: MongoDBParameter
+    cue: |-
+      #MongoDBParameter: {
+        ...
+        systemLog?: {
+          ...
+          quiet?: bool | *false
+          verbosity?: int & >=0 & <=5 | *0
+        }
+      }
+  staticParameters:
+    - systemLog.quiet
+    - systemLog.verbosity


### PR DESCRIPTION
## Summary
- remove `externalManaged: true` from MongoDB config templates in replica set, shard, config server, and mongos ComponentDefinitions
- keep config templates controller-managed because this chart does not render a MongoDB ParametersDefinition/ParamConfigRenderer chain

## Evidence
- runtime smoke on KB 1.2.0-alpha.1 with addon main hit setup blocker before pod creation: `config/script template has no template specified: mongodb-config`
- live CmpD still had `template: mongodb5.0-config-template`, but Component had no `spec.configs[].configMap.name` and no MongoDB PD/PCR existed
- KB source path: `pkg/controller/component/synthesize_component.go` clears Template for externalManaged configs without ConfigMap source; component template precheck then fails

## Validation
- paired kubeblocks-tests PR adds static guard for externalManaged without parameters chain
- `./mongodb/run-tests.sh --addons-repo ../kubeblocks-addons -t static` => 21 PASS / 0 FAIL / 0 SKIP using this patch