### PR TITLE
Fix PostgreSQL reconfigure script path

### DIFF
--- a/addons/postgresql/templates/_helpers.tpl
+++ b/addons/postgresql/templates/_helpers.tpl
@@ -233,7 +233,7 @@ reconfigure:
 
         env | cut -d= -f1 | grep -E '^[a-z0-9_.-][a-z0-9_.-]*$' | sort -u | while IFS= read -r param; do
           [ -n "${param}" ] || continue
-          /scripts/update-parameter.sh "${param}" "$(printenv "${param}")"
+          /kb-scripts/update-parameter.sh "${param}" "$(printenv "${param}")"
         done
 {{- end -}}
 


### PR DESCRIPTION
## Summary
- change PostgreSQL reconfigure action to call `/kb-scripts/update-parameter.sh`
- the current rendered action calls `/scripts/update-parameter.sh`, which is not present in the running PostgreSQL container

## Evidence
- replication N=1 on KB main `89a871657851e77b93f33d52220f5782c1f196da` + PostgreSQL addon main `c9989e923d3ed55bf99d1f6dae5d623d96d22329` reached runtime
- T01-T05 passed; T06 `Reconfiguring` failed
- KB controller log reports `exit code: 127 ... /scripts/update-parameter.sh: not found`
- live pod exposes addon script under `/kb-scripts/update-parameter.sh`

## Validation
- `git diff --check`
- `helm template postgresql addons/postgresql --namespace kb-system | rg -n 'reconfigure:|/kb-scripts/update-parameter|/scripts/update-parameter' -C 4`

## Runtime validation boundary
In-place patching the live `ComponentDefinition` is rejected as an immutable-field update, and patching the generated `InstanceSet` is overwritten by the controller from the `ComponentDefinition`. A patched addon chart/version must be deployed before we can rerun the focused T06 gate and full replication N=1.
