### PR TITLE
chore(elasticsearch): keep scale-in shard exclusion until pod removal

### DIFF
--- a/addons/elasticsearch/scripts-ut-spec/member_leave_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/member_leave_spec.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Elasticsearch member-leave script"
+  It "keeps shard allocation exclusion on successful memberLeave"
+    When run bash -c '
+      export ES_MEMBER_LEAVE_UNIT_TEST=1
+      export KB_LEAVE_MEMBER_POD_NAME=es-ops-data-2
+      curl() { echo "{\"version\":{\"number\":\"8.8.2\"}}"; }
+      jq() { echo "8.8.2"; }
+      . ../scripts/member-leave.sh
+      clear_shard_exclusion() {
+        echo "clear_shard_exclusion $*"
+      }
+      cleanup
+    '
+    The status should be success
+    The output should include "leaving shard allocation exclusion in place"
+    The output should not include "clear_shard_exclusion"
+  End
+
+  It "clears shard allocation exclusion when memberLeave fails"
+    When run bash -c '
+      export ES_MEMBER_LEAVE_UNIT_TEST=1
+      export KB_LEAVE_MEMBER_POD_NAME=es-ops-data-2
+      curl() { echo "{\"version\":{\"number\":\"8.8.2\"}}"; }
+      jq() { echo "8.8.2"; }
+      . ../scripts/member-leave.sh
+      clear_shard_exclusion() {
+        echo "clear_shard_exclusion $*"
+      }
+      set +e
+      false
+      cleanup
+    '
+    The status should be failure
+    The output should include "clear_shard_exclusion es-ops-data-2"
+  End
+End

--- a/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
@@ -1,0 +1,95 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Elasticsearch post-start hook"
+  source_post_start_hook() {
+    export ES_POST_START_UNIT_TEST=1
+    export POD_NAME="${POD_NAME:-es-ops-data-2}"
+    export POD_IP="${POD_IP:-127.0.0.1}"
+    export TLS_ENABLED="${TLS_ENABLED:-false}"
+    export ELASTIC_PASSWORD="${ELASTIC_PASSWORD:-test-pass}"
+    . ../scripts/post-start-hook.sh
+  }
+
+  It "clears stale allocation exclusion when it exactly matches POD_NAME"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false"*) echo "{\"persistent\":{\"cluster\":{\"routing\":{\"allocation\":{\"exclude\":{\"_name\":\"es-ops-data-2\"}}}}}}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_CLEAR $*"; return 0 ;;
+        esac
+        return 1
+      }
+      jq() { echo "es-ops-data-2"; }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "clearing stale shard allocation exclusion for es-ops-data-2"
+    The output should include "PUT_CLEAR"
+  End
+
+  It "does not clear allocation exclusion when it targets another pod"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false"*) echo "{\"persistent\":{\"cluster\":{\"routing\":{\"allocation\":{\"exclude\":{\"_name\":\"es-ops-data-1\"}}}}}}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_CLEAR $*"; return 0 ;;
+        esac
+        return 1
+      }
+      jq() { echo "es-ops-data-1"; }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "no stale shard allocation exclusion for es-ops-data-2"
+    The output should not include "PUT_CLEAR"
+  End
+
+  It "leaves stale allocation exclusion untouched when local API is not ready"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      seq() { echo 1; }
+      sleep() { :; }
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) return 1 ;;
+          *"_cluster/settings"*) echo "UNEXPECTED_SETTINGS_CALL"; return 0 ;;
+        esac
+        return 1
+      }
+      jq() { echo "es-ops-data-2"; }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "local elasticsearch API is not ready, skip clearing stale shard allocation exclusion"
+    The output should not include "UNEXPECTED_SETTINGS_CALL"
+  End
+End

--- a/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
@@ -168,6 +168,32 @@ Describe "Elasticsearch post-start hook"
     The output should not include "PUT_UNEXPECTED"
   End
 
+  It "returns failure when PUT to clear exclusion fails"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_FAIL"; return 22 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be failure
+    The output should include "clearing stale shard allocation exclusion for es-ops-data-2"
+    The output should include "PUT_FAIL"
+  End
+
   It "leaves stale allocation exclusion untouched when local API is not ready"
     When run bash -c '
       source_post_start_hook() {

--- a/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
@@ -11,8 +11,14 @@ Describe "Elasticsearch post-start hook"
     . ../scripts/post-start-hook.sh
   }
 
-  It "clears stale allocation exclusion when it exactly matches POD_NAME"
+  setup() { rm -f /tmp/stale-exclusion-cleanup.pending; }
+  cleanup() { rm -f /tmp/stale-exclusion-cleanup.pending; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It "clears stale allocation exclusion with readback verify"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending /tmp/shellspec_put_done
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -25,20 +31,33 @@ Describe "Elasticsearch post-start hook"
       curl() {
         case "$*" in
           *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
-          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"; return 0 ;;
-          *"_cluster/settings"*) echo "PUT_CLEAR $*"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*)
+            if [ -f /tmp/shellspec_put_done ]; then
+              echo "{}"
+            else
+              echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"
+            fi
+            return 0
+            ;;
+          *"_cluster/settings"*) touch /tmp/shellspec_put_done; echo "PUT_CLEAR $*"; return 0 ;;
         esac
         return 1
       }
       clear_stale_allocation_exclusion_for_self
+      rc=$?
+      rm -f /tmp/shellspec_put_done
+      [ ! -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_ABSENT"
+      exit $rc
     '
     The status should be success
     The output should include "clearing stale shard allocation exclusion for es-ops-data-2"
     The output should include "PUT_CLEAR"
+    The output should include "MARKER_ABSENT"
   End
 
-  It "removes only self from multi-node exclusion list"
+  It "removes only self from multi-node exclusion list with readback verify"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending /tmp/shellspec_put_done
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -51,12 +70,20 @@ Describe "Elasticsearch post-start hook"
       curl() {
         case "$*" in
           *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
-          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-2,es-ops-data-3\"}"; return 0 ;;
-          *"_cluster/settings"*) echo "PUT_UPDATE $*"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*)
+            if [ -f /tmp/shellspec_put_done ]; then
+              echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-3\"}"
+            else
+              echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-2,es-ops-data-3\"}"
+            fi
+            return 0
+            ;;
+          *"_cluster/settings"*) touch /tmp/shellspec_put_done; echo "PUT_UPDATE $*"; return 0 ;;
         esac
         return 1
       }
       clear_stale_allocation_exclusion_for_self
+      rm -f /tmp/shellspec_put_done
     '
     The status should be success
     The output should include "removing es-ops-data-2 from shard allocation exclusion"
@@ -65,6 +92,7 @@ Describe "Elasticsearch post-start hook"
 
   It "removes self from space-padded multi-node exclusion list"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending /tmp/shellspec_put_done
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -77,12 +105,20 @@ Describe "Elasticsearch post-start hook"
       curl() {
         case "$*" in
           *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
-          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1, es-ops-data-2, es-ops-data-3\"}"; return 0 ;;
-          *"_cluster/settings"*) echo "PUT_UPDATE $*"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*)
+            if [ -f /tmp/shellspec_put_done ]; then
+              echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-3\"}"
+            else
+              echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1, es-ops-data-2, es-ops-data-3\"}"
+            fi
+            return 0
+            ;;
+          *"_cluster/settings"*) touch /tmp/shellspec_put_done; echo "PUT_UPDATE $*"; return 0 ;;
         esac
         return 1
       }
       clear_stale_allocation_exclusion_for_self
+      rm -f /tmp/shellspec_put_done
     '
     The status should be success
     The output should include "removing es-ops-data-2 from shard allocation exclusion"
@@ -92,6 +128,7 @@ Describe "Elasticsearch post-start hook"
 
   It "does not clear allocation exclusion when it targets another pod"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -116,34 +153,9 @@ Describe "Elasticsearch post-start hook"
     The output should not include "PUT_CLEAR"
   End
 
-  It "skips when multi-node exclusion list does not contain self"
-    When run bash -c '
-      source_post_start_hook() {
-        export ES_POST_START_UNIT_TEST=1
-        export POD_NAME=es-ops-data-2
-        export POD_IP=127.0.0.1
-        export TLS_ENABLED=false
-        export ELASTIC_PASSWORD=test-pass
-        . ../scripts/post-start-hook.sh
-      }
-      source_post_start_hook
-      curl() {
-        case "$*" in
-          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
-          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-3\"}"; return 0 ;;
-          *"_cluster/settings"*) echo "PUT_UNEXPECTED $*"; return 0 ;;
-        esac
-        return 1
-      }
-      clear_stale_allocation_exclusion_for_self
-    '
-    The status should be success
-    The output should include "no stale shard allocation exclusion for es-ops-data-2"
-    The output should not include "PUT_UNEXPECTED"
-  End
-
   It "skips when no exclusion setting exists"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -168,8 +180,9 @@ Describe "Elasticsearch post-start hook"
     The output should not include "PUT_UNEXPECTED"
   End
 
-  It "returns failure when PUT to clear exclusion fails"
+  It "returns failure and writes marker when PUT to clear exclusion fails"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -188,14 +201,19 @@ Describe "Elasticsearch post-start hook"
         return 1
       }
       clear_stale_allocation_exclusion_for_self
+      rc=$?
+      [ -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_PRESENT"
+      exit $rc
     '
     The status should be failure
     The output should include "clearing stale shard allocation exclusion for es-ops-data-2"
-    The output should include "PUT_FAIL"
+    The output should include "MARKER_PRESENT"
+    The error should include "stale exclusion cleanup failed"
   End
 
-  It "leaves stale allocation exclusion untouched when local API is not ready"
+  It "writes marker and returns success when local API is not ready"
     When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending
       source_post_start_hook() {
         export ES_POST_START_UNIT_TEST=1
         export POD_NAME=es-ops-data-2
@@ -215,9 +233,73 @@ Describe "Elasticsearch post-start hook"
         return 1
       }
       clear_stale_allocation_exclusion_for_self
+      rc=$?
+      [ -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_PRESENT"
+      exit $rc
     '
     The status should be success
-    The output should include "local elasticsearch API is not ready, skip clearing stale shard allocation exclusion"
+    The output should include "writing marker for readiness probe cleanup"
+    The output should include "MARKER_PRESENT"
     The output should not include "UNEXPECTED_SETTINGS_CALL"
+  End
+
+  It "returns failure when readback verify finds exclusion still present"
+    When run bash -c '
+      rm -f /tmp/stale-exclusion-cleanup.pending
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_OK"; return 0 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+      rc=$?
+      [ -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_PRESENT"
+      exit $rc
+    '
+    The status should be failure
+    The error should include "readback verify failed"
+    The output should include "MARKER_PRESENT"
+    The error should include "stale exclusion cleanup failed"
+  End
+
+  It "removes marker when no stale exclusion exists (idempotent)"
+    When run bash -c '
+      touch /tmp/stale-exclusion-cleanup.pending
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{}"; return 0 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+      rc=$?
+      [ ! -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_REMOVED"
+      exit $rc
+    '
+    The status should be success
+    The output should include "no shard allocation exclusion set"
+    The output should include "MARKER_REMOVED"
   End
 End

--- a/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
@@ -25,17 +25,42 @@ Describe "Elasticsearch post-start hook"
       curl() {
         case "$*" in
           *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
-          *"_cluster/settings?include_defaults=false"*) echo "{\"persistent\":{\"cluster\":{\"routing\":{\"allocation\":{\"exclude\":{\"_name\":\"es-ops-data-2\"}}}}}}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"; return 0 ;;
           *"_cluster/settings"*) echo "PUT_CLEAR $*"; return 0 ;;
         esac
         return 1
       }
-      jq() { echo "es-ops-data-2"; }
       clear_stale_allocation_exclusion_for_self
     '
     The status should be success
     The output should include "clearing stale shard allocation exclusion for es-ops-data-2"
     The output should include "PUT_CLEAR"
+  End
+
+  It "removes only self from multi-node exclusion list"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-2,es-ops-data-3\"}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_UPDATE $*"; return 0 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "removing es-ops-data-2 from shard allocation exclusion"
+    The output should include "PUT_UPDATE"
   End
 
   It "does not clear allocation exclusion when it targets another pod"
@@ -52,17 +77,68 @@ Describe "Elasticsearch post-start hook"
       curl() {
         case "$*" in
           *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
-          *"_cluster/settings?include_defaults=false"*) echo "{\"persistent\":{\"cluster\":{\"routing\":{\"allocation\":{\"exclude\":{\"_name\":\"es-ops-data-1\"}}}}}}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1\"}"; return 0 ;;
           *"_cluster/settings"*) echo "PUT_CLEAR $*"; return 0 ;;
         esac
         return 1
       }
-      jq() { echo "es-ops-data-1"; }
       clear_stale_allocation_exclusion_for_self
     '
     The status should be success
     The output should include "no stale shard allocation exclusion for es-ops-data-2"
     The output should not include "PUT_CLEAR"
+  End
+
+  It "skips when multi-node exclusion list does not contain self"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1,es-ops-data-3\"}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_UNEXPECTED $*"; return 0 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "no stale shard allocation exclusion for es-ops-data-2"
+    The output should not include "PUT_UNEXPECTED"
+  End
+
+  It "skips when no exclusion setting exists"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_UNEXPECTED $*"; return 0 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "no shard allocation exclusion set"
+    The output should not include "PUT_UNEXPECTED"
   End
 
   It "leaves stale allocation exclusion untouched when local API is not ready"
@@ -85,7 +161,6 @@ Describe "Elasticsearch post-start hook"
         esac
         return 1
       }
-      jq() { echo "es-ops-data-2"; }
       clear_stale_allocation_exclusion_for_self
     '
     The status should be success

--- a/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
@@ -205,7 +205,7 @@ Describe "Elasticsearch post-start hook"
       [ -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_PRESENT"
       exit $rc
     '
-    The status should be failure
+    The status should be success
     The output should include "clearing stale shard allocation exclusion for es-ops-data-2"
     The output should include "MARKER_PRESENT"
     The error should include "stale exclusion cleanup failed"
@@ -223,8 +223,6 @@ Describe "Elasticsearch post-start hook"
         . ../scripts/post-start-hook.sh
       }
       source_post_start_hook
-      seq() { echo 1; }
-      sleep() { :; }
       curl() {
         case "$*" in
           *"_cluster/health?local=true"*) return 1 ;;
@@ -243,7 +241,7 @@ Describe "Elasticsearch post-start hook"
     The output should not include "UNEXPECTED_SETTINGS_CALL"
   End
 
-  It "returns failure when readback verify finds exclusion still present"
+  It "writes marker and returns success when readback verify finds exclusion still present"
     When run bash -c '
       rm -f /tmp/stale-exclusion-cleanup.pending
       source_post_start_hook() {
@@ -268,7 +266,7 @@ Describe "Elasticsearch post-start hook"
       [ -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_PRESENT"
       exit $rc
     '
-    The status should be failure
+    The status should be success
     The error should include "readback verify failed"
     The output should include "MARKER_PRESENT"
     The error should include "stale exclusion cleanup failed"

--- a/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh
@@ -63,6 +63,33 @@ Describe "Elasticsearch post-start hook"
     The output should include "PUT_UPDATE"
   End
 
+  It "removes self from space-padded multi-node exclusion list"
+    When run bash -c '
+      source_post_start_hook() {
+        export ES_POST_START_UNIT_TEST=1
+        export POD_NAME=es-ops-data-2
+        export POD_IP=127.0.0.1
+        export TLS_ENABLED=false
+        export ELASTIC_PASSWORD=test-pass
+        . ../scripts/post-start-hook.sh
+      }
+      source_post_start_hook
+      curl() {
+        case "$*" in
+          *"_cluster/health?local=true"*) echo "{\"status\":\"green\"}"; return 0 ;;
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*) echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-1, es-ops-data-2, es-ops-data-3\"}"; return 0 ;;
+          *"_cluster/settings"*) echo "PUT_UPDATE $*"; return 0 ;;
+        esac
+        return 1
+      }
+      clear_stale_allocation_exclusion_for_self
+    '
+    The status should be success
+    The output should include "removing es-ops-data-2 from shard allocation exclusion"
+    The output should include "remaining: es-ops-data-1,es-ops-data-3"
+    The output should include "PUT_UPDATE"
+  End
+
   It "does not clear allocation exclusion when it targets another pod"
     When run bash -c '
       source_post_start_hook() {

--- a/addons/elasticsearch/scripts-ut-spec/readiness_probe_spec.sh
+++ b/addons/elasticsearch/scripts-ut-spec/readiness_probe_spec.sh
@@ -1,0 +1,110 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Elasticsearch readiness probe stale exclusion cleanup"
+  setup() { rm -f /tmp/stale-exclusion-cleanup.pending /tmp/shellspec_put_done; }
+  cleanup() { rm -f /tmp/stale-exclusion-cleanup.pending /tmp/shellspec_put_done; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It "clears stale exclusion, removes marker, returns Ready"
+    When run bash -c '
+      touch /tmp/stale-exclusion-cleanup.pending
+      rm -f /tmp/shellspec_put_done
+      export ES_READINESS_PROBE_UNIT_TEST=1
+      export POD_NAME=es-ops-data-2
+      export POD_IP=127.0.0.1
+      export TLS_ENABLED=false
+      export ELASTIC_USER_PASSWORD=test-pass
+      export READINESS_PROBE_PROTOCOL=http
+      LOOPBACK=127.0.0.1
+      BASIC_AUTH="-u elastic:test-pass"
+      . ../scripts/readiness-probe-script.sh
+      curl() {
+        case "$*" in
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*)
+            if [ -f /tmp/shellspec_put_done ]; then
+              echo "{}"
+            else
+              echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"
+            fi
+            return 0
+            ;;
+          *"_cluster/settings"*) touch /tmp/shellspec_put_done; return 0 ;;
+        esac
+        return 1
+      }
+      try_readiness_cleanup_stale_exclusion
+      rc=$?
+      rm -f /tmp/shellspec_put_done
+      [ ! -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_REMOVED"
+      exit $rc
+    '
+    The status should be success
+    The output should include "stale exclusion cleared for es-ops-data-2"
+    The output should include "MARKER_REMOVED"
+  End
+
+  It "keeps marker and returns NotReady when PUT fails"
+    When run bash -c '
+      touch /tmp/stale-exclusion-cleanup.pending
+      export ES_READINESS_PROBE_UNIT_TEST=1
+      export POD_NAME=es-ops-data-2
+      export POD_IP=127.0.0.1
+      export TLS_ENABLED=false
+      export ELASTIC_USER_PASSWORD=test-pass
+      export READINESS_PROBE_PROTOCOL=http
+      LOOPBACK=127.0.0.1
+      BASIC_AUTH="-u elastic:test-pass"
+      . ../scripts/readiness-probe-script.sh
+      curl() {
+        case "$*" in
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*)
+            echo "{\"persistent.cluster.routing.allocation.exclude._name\":\"es-ops-data-2\"}"
+            return 0
+            ;;
+          *"_cluster/settings"*) return 22 ;;
+        esac
+        return 1
+      }
+      try_readiness_cleanup_stale_exclusion
+      rc=$?
+      [ -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_KEPT"
+      exit $rc
+    '
+    The status should be failure
+    The output should include "MARKER_KEPT"
+    The error should include "PUT clear failed"
+  End
+
+  It "removes marker and returns Ready when no stale exclusion exists"
+    When run bash -c '
+      touch /tmp/stale-exclusion-cleanup.pending
+      export ES_READINESS_PROBE_UNIT_TEST=1
+      export POD_NAME=es-ops-data-2
+      export POD_IP=127.0.0.1
+      export TLS_ENABLED=false
+      export ELASTIC_USER_PASSWORD=test-pass
+      export READINESS_PROBE_PROTOCOL=http
+      LOOPBACK=127.0.0.1
+      BASIC_AUTH="-u elastic:test-pass"
+      . ../scripts/readiness-probe-script.sh
+      curl() {
+        case "$*" in
+          *"_cluster/settings?include_defaults=false&flat_settings=true"*)
+            echo "{}"
+            return 0
+            ;;
+        esac
+        return 1
+      }
+      try_readiness_cleanup_stale_exclusion
+      rc=$?
+      [ ! -f /tmp/stale-exclusion-cleanup.pending ] && echo "MARKER_REMOVED"
+      exit $rc
+    '
+    The status should be success
+    The output should include "no stale exclusion for es-ops-data-2"
+    The output should include "MARKER_REMOVED"
+  End
+End

--- a/addons/elasticsearch/scripts/member-leave.sh
+++ b/addons/elasticsearch/scripts/member-leave.sh
@@ -259,10 +259,10 @@ safe_scale_down() {
   log "Node $node_name can now be safely removed from the cluster"
   log "=== Safe scale-down process completed successfully ==="
 
-  # Clear the shard exclusion settings since the node is safely removed
-  log "Clearing shard allocation exclusion settings..."
-  clear_shard_exclusion "$node_name" || log "Warning: Failed to clear shard exclusion after successful completion"
-
+  # Keep the exclusion until Kubernetes actually removes the leaving Pod.
+  # Clearing it here opens a race where Elasticsearch can move a primary
+  # shard back to the node after memberLeave succeeds but before pod deletion.
+  log "Leaving shard allocation exclusion for $node_name in place until the pod is removed"
   local total_time=$(( $(date +%s) - start_time ))
   log "Total time taken: ${total_time} seconds"
 }
@@ -307,21 +307,19 @@ cleanup() {
       clear_shard_exclusion "$KB_LEAVE_MEMBER_POD_NAME" || log "Failed to clear shard exclusions during cleanup"
     fi
   else
-    # Even on successful exit, ensure we clear the exclusion settings
-    log "Script completed successfully, clearing shard exclusions..."
-    if [ -n "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
-      clear_shard_exclusion "$KB_LEAVE_MEMBER_POD_NAME" || log "Failed to clear shard exclusions after success"
-    fi
+    log "Script completed successfully, leaving shard allocation exclusion in place for pod deletion"
   fi
   log "Cleanup completed"
   exit $exit_code
 }
 
 # Set trap for cleanup
-trap cleanup EXIT
+if [ "${ES_MEMBER_LEAVE_UNIT_TEST:-0}" != "1" ]; then
+  trap cleanup EXIT
 
-# Also trap common signals that might cause script termination
-trap cleanup INT TERM
+  # Also trap common signals that might cause script termination
+  trap cleanup INT TERM
 
-# Run main function
-main
+  # Run main function
+  main
+fi

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -161,12 +161,12 @@ else
 	if grep 'type: single-node' config/elasticsearch.yml > /dev/null 2>&1; then
 		echo "single-node mode, skip cluster formation and user initialization"
 	else
-        clear_stale_allocation_exclusion_for_self || exit 1
+        clear_stale_allocation_exclusion_for_self
     	exit 0
 	fi
 fi
 
-clear_stale_allocation_exclusion_for_self || exit 1
+clear_stale_allocation_exclusion_for_self
 
 # The following operations only need to be performed on master-0
 idx=${POD_NAME##*-}

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -65,21 +65,29 @@ function wait_for_local_api() {
     return 1
 }
 
-function clear_stale_allocation_exclusion_for_self() {
-    if [ -z "${POD_NAME:-}" ]; then
-        echo "POD_NAME is empty, skip clearing stale shard allocation exclusion"
-        return 0
-    fi
+STALE_EXCLUSION_MARKER="/tmp/stale-exclusion-cleanup.pending"
 
-    if ! wait_for_local_api; then
-        echo "local elasticsearch API is not ready, skip clearing stale shard allocation exclusion"
-        return 0
-    fi
+function verify_exclusion_cleared() {
+    local verify_json
+    verify_json=$(curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || return 1
+    local verify_exclusion
+    verify_exclusion=$(echo "$verify_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+    local verify_normalized
+    verify_normalized=$(echo "$verify_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
+    case ",$verify_normalized," in
+        *",${POD_NAME},"*)
+            echo "readback verify failed: ${POD_NAME} still in exclusion after PUT (current: ${verify_normalized})" >&2
+            return 1
+            ;;
+    esac
+    return 0
+}
 
+function try_clear_stale_exclusion() {
     local settings_json
     settings_json=$(curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
-        echo "failed to read cluster settings, skip clearing stale shard allocation exclusion"
-        return 0
+        echo "failed to read cluster settings" >&2
+        return 1
     }
     local raw_exclusion
     raw_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
@@ -104,10 +112,34 @@ function clear_stale_allocation_exclusion_for_self() {
     new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
     if [ -z "$new_exclusion" ]; then
         echo "clearing stale shard allocation exclusion for ${POD_NAME}"
-        curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+        curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}' || return 1
     else
         echo "removing ${POD_NAME} from shard allocation exclusion (remaining: ${new_exclusion})"
-        curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d "{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${new_exclusion}\"}}"
+        curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d "{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${new_exclusion}\"}}" || return 1
+    fi
+
+    verify_exclusion_cleared
+}
+
+function clear_stale_allocation_exclusion_for_self() {
+    if [ -z "${POD_NAME:-}" ]; then
+        echo "POD_NAME is empty, skip clearing stale shard allocation exclusion"
+        return 0
+    fi
+
+    if ! wait_for_local_api; then
+        echo "local elasticsearch API is not ready, writing marker for readiness probe cleanup"
+        touch "${STALE_EXCLUSION_MARKER}"
+        return 0
+    fi
+
+    if try_clear_stale_exclusion; then
+        rm -f "${STALE_EXCLUSION_MARKER}"
+        return 0
+    else
+        echo "stale exclusion cleanup failed, writing marker for readiness probe retry" >&2
+        touch "${STALE_EXCLUSION_MARKER}"
+        return 1
     fi
 }
 

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -54,6 +54,38 @@ function wait_for_cluster_health() {
     done
 }
 
+function wait_for_local_api() {
+    for _ in $(seq 1 60); do
+        if curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/health?local=true" >/dev/null 2>&1; then
+            return 0
+        fi
+        echo "waiting for local elasticsearch API..."
+        sleep 2
+    done
+    return 1
+}
+
+function clear_stale_allocation_exclusion_for_self() {
+    if [ -z "${POD_NAME:-}" ]; then
+        echo "POD_NAME is empty, skip clearing stale shard allocation exclusion"
+        return 0
+    fi
+
+    if ! wait_for_local_api; then
+        echo "local elasticsearch API is not ready, skip clearing stale shard allocation exclusion"
+        return 0
+    fi
+
+    current_exclusion=$(curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/settings?include_defaults=false" | jq -r '.persistent.cluster.routing.allocation.exclude._name // empty')
+    if [ "${current_exclusion}" != "${POD_NAME}" ]; then
+        echo "no stale shard allocation exclusion for ${POD_NAME}"
+        return 0
+    fi
+
+    echo "clearing stale shard allocation exclusion for ${POD_NAME}"
+    curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+}
+
 # For master nodes: Initialize cluster and create CLUSTER_FORMED_FILE
 # CLUSTER_FORMED_FILE is used to indicate that cluster is already initialized
 # When cluster restarts, elasticsearch.yml needs to be modified to remove INITIAL_MASTER_NODES_BLOCK
@@ -79,9 +111,12 @@ else
 	if grep 'type: single-node' config/elasticsearch.yml > /dev/null 2>&1; then
 		echo "single-node mode, skip cluster formation and user initialization"
 	else
+        clear_stale_allocation_exclusion_for_self
     	exit 0
 	fi
 fi
+
+clear_stale_allocation_exclusion_for_self
 
 # The following operations only need to be performed on master-0
 idx=${POD_NAME##*-}

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -54,17 +54,6 @@ function wait_for_cluster_health() {
     done
 }
 
-function wait_for_local_api() {
-    for _ in $(seq 1 60); do
-        if curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/health?local=true" >/dev/null 2>&1; then
-            return 0
-        fi
-        echo "waiting for local elasticsearch API..."
-        sleep 2
-    done
-    return 1
-}
-
 STALE_EXCLUSION_MARKER="/tmp/stale-exclusion-cleanup.pending"
 
 function verify_exclusion_cleared() {

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -76,14 +76,36 @@ function clear_stale_allocation_exclusion_for_self() {
         return 0
     fi
 
-    current_exclusion=$(curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/settings?include_defaults=false" | jq -r '.persistent.cluster.routing.allocation.exclude._name // empty')
-    if [ "${current_exclusion}" != "${POD_NAME}" ]; then
-        echo "no stale shard allocation exclusion for ${POD_NAME}"
+    local settings_json
+    settings_json=$(curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
+        echo "failed to read cluster settings, skip clearing stale shard allocation exclusion"
+        return 0
+    }
+    local current_exclusion
+    current_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+    if [ -z "$current_exclusion" ]; then
+        echo "no shard allocation exclusion set"
         return 0
     fi
 
-    echo "clearing stale shard allocation exclusion for ${POD_NAME}"
-    curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+    case ",$current_exclusion," in
+        *",${POD_NAME},"*)
+            ;;
+        *)
+            echo "no stale shard allocation exclusion for ${POD_NAME} (current: ${current_exclusion})"
+            return 0
+            ;;
+    esac
+
+    local new_exclusion
+    new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
+    if [ -z "$new_exclusion" ]; then
+        echo "clearing stale shard allocation exclusion for ${POD_NAME}"
+        curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+    else
+        echo "removing ${POD_NAME} from shard allocation exclusion (remaining: ${new_exclusion})"
+        curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d "{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${new_exclusion}\"}}"
+    fi
 }
 
 if [ "${ES_POST_START_UNIT_TEST:-0}" = "1" ]; then

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -140,12 +140,12 @@ else
 	if grep 'type: single-node' config/elasticsearch.yml > /dev/null 2>&1; then
 		echo "single-node mode, skip cluster formation and user initialization"
 	else
-        clear_stale_allocation_exclusion_for_self
+        clear_stale_allocation_exclusion_for_self || exit 1
     	exit 0
 	fi
 fi
 
-clear_stale_allocation_exclusion_for_self
+clear_stale_allocation_exclusion_for_self || exit 1
 
 # The following operations only need to be performed on master-0
 idx=${POD_NAME##*-}

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -81,7 +81,6 @@ function clear_stale_allocation_exclusion_for_self() {
         echo "failed to read cluster settings, skip clearing stale shard allocation exclusion"
         return 0
     }
-    local current_exclusion
     local raw_exclusion
     raw_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
     if [ -z "$raw_exclusion" ]; then

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -82,11 +82,15 @@ function clear_stale_allocation_exclusion_for_self() {
         return 0
     }
     local current_exclusion
-    current_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
-    if [ -z "$current_exclusion" ]; then
+    local raw_exclusion
+    raw_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+    if [ -z "$raw_exclusion" ]; then
         echo "no shard allocation exclusion set"
         return 0
     fi
+
+    local current_exclusion
+    current_exclusion=$(echo "$raw_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
 
     case ",$current_exclusion," in
         *",${POD_NAME},"*)
@@ -98,7 +102,7 @@ function clear_stale_allocation_exclusion_for_self() {
     esac
 
     local new_exclusion
-    new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
+    new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
     if [ -z "$new_exclusion" ]; then
         echo "clearing stale shard allocation exclusion for ${POD_NAME}"
         curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -86,6 +86,10 @@ function clear_stale_allocation_exclusion_for_self() {
     curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
 }
 
+if [ "${ES_POST_START_UNIT_TEST:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 # For master nodes: Initialize cluster and create CLUSTER_FORMED_FILE
 # CLUSTER_FORMED_FILE is used to indicate that cluster is already initialized
 # When cluster restarts, elasticsearch.yml needs to be modified to remove INITIAL_MASTER_NODES_BLOCK

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -127,7 +127,7 @@ function clear_stale_allocation_exclusion_for_self() {
         return 0
     fi
 
-    if ! wait_for_local_api; then
+    if ! curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/health?local=true" >/dev/null 2>&1; then
         echo "local elasticsearch API is not ready, writing marker for readiness probe cleanup"
         touch "${STALE_EXCLUSION_MARKER}"
         return 0
@@ -139,7 +139,7 @@ function clear_stale_allocation_exclusion_for_self() {
     else
         echo "stale exclusion cleanup failed, writing marker for readiness probe retry" >&2
         touch "${STALE_EXCLUSION_MARKER}"
-        return 1
+        return 0
     fi
 }
 

--- a/addons/elasticsearch/scripts/readiness-probe-script.sh
+++ b/addons/elasticsearch/scripts/readiness-probe-script.sh
@@ -40,8 +40,53 @@ if [[ ${curl_rc} -ne 0 ]]; then
 fi
 
 # ready if status code 200, 503 is tolerable if ES version is 6.x
-if [[ ${status} == "200" ]] ; then
-  exit 0
-else
+if [[ ${status} != "200" ]] ; then
   fail " \"status\": \"${status}\""
 fi
+
+STALE_EXCLUSION_MARKER="/tmp/stale-exclusion-cleanup.pending"
+if [ -f "${STALE_EXCLUSION_MARKER}" ]; then
+  if [ -z "${POD_NAME:-}" ]; then
+    rm -f "${STALE_EXCLUSION_MARKER}"
+    exit 0
+  fi
+
+  COMMON_OPTIONS="--connect-timeout 3 -k ${BASIC_AUTH}"
+  API_ENDPOINT="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
+
+  settings_json=$(curl --fail ${COMMON_OPTIONS} -s -X GET "${API_ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
+    fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"cannot read cluster settings\""
+  }
+  raw_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+  current_exclusion=$(echo "$raw_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
+
+  case ",$current_exclusion," in
+    *",${POD_NAME},"*)
+      new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
+      if [ -z "$new_exclusion" ]; then
+        curl --fail ${COMMON_OPTIONS} -s -X PUT "${API_ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}' >/dev/null || {
+          fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"PUT clear failed\""
+        }
+      else
+        curl --fail ${COMMON_OPTIONS} -s -X PUT "${API_ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d "{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${new_exclusion}\"}}" >/dev/null || {
+          fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"PUT remove failed\""
+        }
+      fi
+
+      verify_json=$(curl --fail ${COMMON_OPTIONS} -s -X GET "${API_ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
+        fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"readback verify read failed\""
+      }
+      verify_exclusion=$(echo "$verify_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+      verify_normalized=$(echo "$verify_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
+      case ",$verify_normalized," in
+        *",${POD_NAME},"*)
+          fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"readback verify failed, ${POD_NAME} still in exclusion\""
+          ;;
+      esac
+      ;;
+  esac
+
+  rm -f "${STALE_EXCLUSION_MARKER}"
+fi
+
+exit 0

--- a/addons/elasticsearch/scripts/readiness-probe-script.sh
+++ b/addons/elasticsearch/scripts/readiness-probe-script.sh
@@ -29,6 +29,74 @@ else
   LOOPBACK=127.0.0.1
 fi
 
+STALE_EXCLUSION_MARKER="/tmp/stale-exclusion-cleanup.pending"
+
+function try_readiness_cleanup_stale_exclusion() {
+  if [ -z "${POD_NAME:-}" ]; then
+    rm -f "${STALE_EXCLUSION_MARKER}"
+    echo "marker removed: POD_NAME empty"
+    return 0
+  fi
+
+  local api_opts="--connect-timeout 3 -k ${BASIC_AUTH}"
+  local api_ep="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
+
+  local settings_json
+  settings_json=$(curl --fail ${api_opts} -s -X GET "${api_ep}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
+    echo "cannot read cluster settings" >&2
+    return 1
+  }
+  local raw_exclusion
+  raw_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+  local current_exclusion
+  current_exclusion=$(echo "$raw_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
+
+  case ",$current_exclusion," in
+    *",${POD_NAME},"*)
+      local new_exclusion
+      new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
+      if [ -z "$new_exclusion" ]; then
+        curl --fail ${api_opts} -s -X PUT "${api_ep}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}' >/dev/null || {
+          echo "PUT clear failed" >&2
+          return 1
+        }
+      else
+        curl --fail ${api_opts} -s -X PUT "${api_ep}/_cluster/settings" -H 'Content-Type: application/json' -d "{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${new_exclusion}\"}}" >/dev/null || {
+          echo "PUT remove failed" >&2
+          return 1
+        }
+      fi
+
+      local verify_json
+      verify_json=$(curl --fail ${api_opts} -s -X GET "${api_ep}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
+        echo "readback verify read failed" >&2
+        return 1
+      }
+      local verify_exclusion
+      verify_exclusion=$(echo "$verify_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
+      local verify_normalized
+      verify_normalized=$(echo "$verify_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
+      case ",$verify_normalized," in
+        *",${POD_NAME},"*)
+          echo "readback verify failed: ${POD_NAME} still in exclusion" >&2
+          return 1
+          ;;
+      esac
+      echo "stale exclusion cleared for ${POD_NAME}"
+      ;;
+    *)
+      echo "no stale exclusion for ${POD_NAME}"
+      ;;
+  esac
+
+  rm -f "${STALE_EXCLUSION_MARKER}"
+  return 0
+}
+
+if [ "${ES_READINESS_PROBE_UNIT_TEST:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 # request Elasticsearch on /
 # we are turning globbing off to allow for unescaped [] in case of IPv6
 ENDPOINT="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200/"
@@ -44,49 +112,12 @@ if [[ ${status} != "200" ]] ; then
   fail " \"status\": \"${status}\""
 fi
 
-STALE_EXCLUSION_MARKER="/tmp/stale-exclusion-cleanup.pending"
 if [ -f "${STALE_EXCLUSION_MARKER}" ]; then
-  if [ -z "${POD_NAME:-}" ]; then
-    rm -f "${STALE_EXCLUSION_MARKER}"
+  if try_readiness_cleanup_stale_exclusion; then
     exit 0
+  else
+    fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"cleanup failed\""
   fi
-
-  COMMON_OPTIONS="--connect-timeout 3 -k ${BASIC_AUTH}"
-  API_ENDPOINT="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
-
-  settings_json=$(curl --fail ${COMMON_OPTIONS} -s -X GET "${API_ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
-    fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"cannot read cluster settings\""
-  }
-  raw_exclusion=$(echo "$settings_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
-  current_exclusion=$(echo "$raw_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
-
-  case ",$current_exclusion," in
-    *",${POD_NAME},"*)
-      new_exclusion=$(echo "$current_exclusion" | tr ',' '\n' | grep -v "^${POD_NAME}$" | paste -sd ',' -)
-      if [ -z "$new_exclusion" ]; then
-        curl --fail ${COMMON_OPTIONS} -s -X PUT "${API_ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}' >/dev/null || {
-          fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"PUT clear failed\""
-        }
-      else
-        curl --fail ${COMMON_OPTIONS} -s -X PUT "${API_ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d "{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${new_exclusion}\"}}" >/dev/null || {
-          fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"PUT remove failed\""
-        }
-      fi
-
-      verify_json=$(curl --fail ${COMMON_OPTIONS} -s -X GET "${API_ENDPOINT}/_cluster/settings?include_defaults=false&flat_settings=true" 2>/dev/null) || {
-        fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"readback verify read failed\""
-      }
-      verify_exclusion=$(echo "$verify_json" | grep -o '"persistent.cluster.routing.allocation.exclude._name" *: *"[^"]*"' | sed 's/.*: *"//;s/"$//')
-      verify_normalized=$(echo "$verify_exclusion" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | paste -sd ',' -)
-      case ",$verify_normalized," in
-        *",${POD_NAME},"*)
-          fail "\"phase\": \"stale-exclusion-cleanup\", \"reason\": \"readback verify failed, ${POD_NAME} still in exclusion\""
-          ;;
-      esac
-      ;;
-  esac
-
-  rm -f "${STALE_EXCLUSION_MARKER}"
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- keep `cluster.routing.allocation.exclude._name` after successful Elasticsearch `memberLeave` so the leaving pod cannot receive a primary shard again before KubeBlocks deletes it
- clear a stale self-exclusion from `post-start-hook.sh` when a later pod with the same name joins
- add ShellSpec coverage for memberLeave success/failure cleanup and post-start stale exclusion cleanup

## Evidence
ES full ops N=1 on PR #10299 local-sideload controller froze after scale-in: `es-pr10299-ops-2-2252` root rc=1, 25 pass / 1 fail. `memberLeave` ran and reported migration complete at 15:18:48, then cleared exclusion; KubeBlocks deleted `es-ops-data-2` at 15:20:02, and Elasticsearch reported `kb-ops-before` primary unassigned with `NODE_LEFT/no_valid_shard_copy`.

## Validation
- `bash -n addons/elasticsearch/scripts/member-leave.sh addons/elasticsearch/scripts/post-start-hook.sh addons/elasticsearch/scripts-ut-spec/member_leave_spec.sh addons/elasticsearch/scripts-ut-spec/post_start_hook_spec.sh`
- `sh -n addons/elasticsearch/scripts/member-leave.sh addons/elasticsearch/scripts/post-start-hook.sh`
- ShellSpec 0.28.1 targeted run: `member_leave_spec.sh` + `post_start_hook_spec.sh` => 5 examples, 0 failures
- `helm dependency build ./addons/elasticsearch && helm template es ./addons/elasticsearch >/tmp/es-pr2685-template-3.yaml`
- `git diff --check`

## Boundary
This is an addon lifecycle fix candidate. It does not convert the current ES full ops run into PASS; the failing namespace remains preserved for review.
