### PR TITLE
fix(redis): truncate redis.conf before build to prevent duplicate loadmodule on container restart

### DIFF
--- a/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
@@ -768,6 +768,9 @@ start_redis_server() {
 
 # build redis cluster configuration redis.conf
 build_redis_conf() {
+  # Truncate before building to guarantee a clean slate on every container start.
+  # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+  > "$redis_real_conf"
   load_redis_template_conf
   build_redis_cluster_service_port
   build_redis_tls_config

--- a/addons/redis/redis-cluster-scripts/redis-cluster5-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster5-server-start.sh
@@ -639,6 +639,9 @@ start_redis_server() {
 
 # build redis cluster configuration redis.conf
 build_redis_conf() {
+  # Truncate before building to guarantee a clean slate on every container start.
+  # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+  > "$redis_real_conf"
   load_redis_template_conf
   build_redis_cluster_service_port
   build_announce_ip_and_port

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-server-start.sh
@@ -709,6 +709,9 @@ start_redis_server() {
 
 # build redis cluster configuration redis.conf
 build_redis_conf() {
+  # Truncate before building to guarantee a clean slate on every container start.
+  # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+  > "$redis_real_conf"
   load_redis_template_conf
   build_redis_cluster_service_port
   build_redis_tls_config

--- a/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
@@ -44,6 +44,42 @@ Describe "Redis Cluster Server Start Bash Script Tests"
     End
   End
 
+  Describe "build_redis_conf()"
+    Context "when redis.conf already contains stale loadmodule from CONFIG REWRITE"
+      setup() {
+        # Simulate a redis.conf that was written by CONFIG REWRITE after a prior run.
+        # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+        echo "loadmodule /opt/redis-stack/lib/redisearch.so" > "$redis_real_conf"
+        echo "loadmodule /opt/redis-stack/lib/redistimeseries.so" >> "$redis_real_conf"
+        echo "" > "$redis_acl_file"
+        redis_template_conf="/etc/conf/redis.conf"
+        load_redis_template_conf() {
+          echo "include $redis_template_conf" >> "$redis_real_conf"
+        }
+        build_redis_cluster_service_port() { :; }
+        build_redis_tls_config() { :; }
+        build_announce_ip_and_port() { :; }
+        build_cluster_announce_info() { :; }
+        rebuild_redis_acl_file() { :; }
+        build_redis_default_accounts() { :; }
+      }
+      Before "setup"
+
+      un_setup() {
+        rm -f "$redis_real_conf"
+      }
+      After "un_setup"
+
+      It "truncates stale loadmodule lines before building new config"
+        When call build_redis_conf
+        The status should be success
+        The contents of file "$redis_real_conf" should not include "loadmodule /opt/redis-stack/lib/redisearch.so"
+        The contents of file "$redis_real_conf" should not include "loadmodule /opt/redis-stack/lib/redistimeseries.so"
+        The contents of file "$redis_real_conf" should include "include $redis_template_conf"
+      End
+    End
+  End
+
   Describe "build_redis_default_accounts()"
     Context 'when all environment variables exist'
       setup() {

--- a/addons/redis/scripts-ut-spec/redis_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_start_spec.sh
@@ -63,6 +63,45 @@ Describe "Redis Start Bash Script Tests"
     End
   End
 
+  Describe "build_redis_conf()"
+    Context "when redis.conf already contains stale loadmodule from CONFIG REWRITE"
+      setup() {
+        # Simulate a redis.conf that was written by CONFIG REWRITE after a prior run.
+        # This reproduces the CrashLoopBackOff trigger: emptyDir survives container
+        # restart, so the file is not empty when the script runs again.
+        # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+        echo "loadmodule /opt/redis-stack/lib/redisearch.so" > "$redis_real_conf"
+        echo "loadmodule /opt/redis-stack/lib/redistimeseries.so" >> "$redis_real_conf"
+        echo "" > "$redis_acl_file"
+        redis_template_conf="/etc/conf/redis.conf"
+        load_redis_template_conf() {
+          echo "include $redis_template_conf" >> "$redis_real_conf"
+        }
+        build_announce_ip_and_port() { :; }
+        build_redis_service_port() { :; }
+        build_redis_tls_config() { :; }
+        build_replicaof_config() { :; }
+        rebuild_redis_acl_file() { :; }
+        build_redis_default_accounts() { :; }
+      }
+      Before "setup"
+
+      un_setup() {
+        rm -f "$redis_real_conf"
+      }
+      After "un_setup"
+
+      It "truncates stale loadmodule lines before building new config"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        When call build_redis_conf
+        The status should be success
+        The contents of file "$redis_real_conf" should not include "loadmodule /opt/redis-stack/lib/redisearch.so"
+        The contents of file "$redis_real_conf" should not include "loadmodule /opt/redis-stack/lib/redistimeseries.so"
+        The contents of file "$redis_real_conf" should include "include $redis_template_conf"
+      End
+    End
+  End
+
   Describe "build_redis_default_accounts()"
     Context 'when all environment variables exist'
       setup() {

--- a/addons/redis/scripts/redis-start.sh
+++ b/addons/redis/scripts/redis-start.sh
@@ -381,6 +381,15 @@ parse_redis_announce_addr() {
 
 # build redis.conf
 build_redis_conf() {
+  # Truncate before building to guarantee a clean slate on every container start.
+  # /etc/redis/ is an emptyDir that survives container restarts (but not pod
+  # deletion). Without this truncation, CONFIG REWRITE (triggered by Sentinel)
+  # writes 'loadmodule' back into redis.conf; on the next container restart the
+  # accumulated 'loadmodule' line stays in the file, and start_redis_server()
+  # also passes --loadmodule via CLI, causing the module to load twice.
+  # Redis exits on the second load attempt → CrashLoopBackOff.
+  # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+  > "$redis_real_conf"
   load_redis_template_conf
   build_announce_ip_and_port
   build_redis_service_port

--- a/addons/redis/scripts/redis5-start.sh
+++ b/addons/redis/scripts/redis5-start.sh
@@ -320,6 +320,9 @@ parse_redis_announce_addr() {
 
 # build redis.conf
 build_redis_conf() {
+  # Truncate before building to guarantee a clean slate on every container start.
+  # See: https://github.com/apecloud/kubeblocks-addons/issues/2686
+  > "$redis_real_conf"
   load_redis_template_conf
   build_announce_ip_and_port
   build_redis_service_port


### PR DESCRIPTION
## Summary

Fixes https://github.com/apecloud/kubeblocks-addons/issues/2686

### Root Cause

`/etc/redis/` is mounted as an **emptyDir** — it survives **container restarts** (same Pod), but resets on **pod deletion**. The `build_redis_conf()` function in all redis start scripts appended to `redis.conf` without truncating first.

When Sentinel triggers `CONFIG REWRITE` (on replication events, config changes, etc.), Redis writes the current runtime config — including `--loadmodule` CLI args — back into `/etc/redis/redis.conf`. On the next container restart, the emptyDir still holds this CONFIG REWRITE'd file. `build_redis_conf()` then appends another `include` line to the already-dirty file, and `start_redis_server()` unconditionally passes `--loadmodule` again. Redis tries to load each module twice, exits on the second attempt, and enters **CrashLoopBackOff**.

### Fix

Add `> "$redis_real_conf"` at the top of `build_redis_conf()` in every affected script. This truncates the file to empty before building, so every container start begins from a clean slate regardless of what prior runs or CONFIG REWRITE left behind.

### Files Changed

- `addons/redis/scripts/redis-start.sh` — replication mode (primary affected)
- `addons/redis/scripts/redis5-start.sh` — Redis 5 replication mode
- `addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh`
- `addons/redis/redis-cluster-scripts/redis-cluster5-server-start.sh`
- `addons/redis/redis-cluster-scripts/redis-cluster6-server-start.sh`

### Verification

**Crash path (before fix):**
```
1. Pod starts → emptyDir empty → redis.conf: "include /etc/conf/redis.conf"
2. Redis starts with --loadmodule redisearch.so (CLI)
3. Sentinel triggers CONFIG REWRITE → redis.conf gets "loadmodule redisearch.so ..." appended
4. Container crashes, kubelet restarts container (same Pod, emptyDir preserved)
5. build_redis_conf() appends "include ..." to dirty redis.conf (still has loadmodule line)
6. start_redis_server() passes --loadmodule again → double load → crash → CrashLoopBackOff
```

**After fix:** Step 4→5 truncates `redis.conf` first, so step 6 only loads modules once.

**Confirmed in production:** ACK Singapore, KubeBlocks redis@v1.0.3, Redis 7.4.7, replication mode with Sentinel, 2026-05-28.

### Test Plan

- [ ] Deploy redis replication mode with redis-stack-server image
- [ ] Verify `redis.conf` only contains expected content after startup
- [ ] Trigger `CONFIG REWRITE` manually: `redis-cli CONFIG REWRITE`
- [ ] Verify `redis.conf` gets `loadmodule` written back
- [ ] Force a container restart (e.g. `kill 1` inside container)
- [ ] Verify Redis starts successfully without CrashLoopBackOff
- [ ] Verify all modules load once (check `MODULE LIST`)