### PR TITLE
fix(mariadb): pin reconfigure action image

### DIFF
--- a/addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
@@ -478,6 +478,26 @@ Describe "alpha.86 reconfigureAction.persisted semisync gates"
     End
   End
 
+  Describe "Reconfigure action execution surface"
+    # `exec.container` shares the MariaDB container resources, but the
+    # action process itself runs in the action runtime. The reconfigure
+    # script calls the `mariadb` CLI, so pin the action image to the
+    # MariaDB image while keeping `container: mariadb` for shared mounts.
+    It "base reconfigureAction declares the MariaDB exec image"
+      When call extract_base_helper_body
+      The status should be success
+      The output should include 'container: mariadb'
+      The output should include 'image: {{ include "mariadb.image" . }}'
+    End
+
+    It "persisted reconfigureAction declares the MariaDB exec image"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include 'container: mariadb'
+      The output should include 'image: {{ include "mariadb.image" . }}'
+    End
+  End
+
   Describe "Regression: KB-managed config has NO !includedir (alpha.84 v1 parser FAIL)"
     It "config/mariadb-semisync.tpl does NOT contain !includedir (mariadbd loads via --defaults-extra-file instead)"
       # alpha.84 v1 put !includedir into KB-managed my.cnf, which KB
@@ -488,7 +508,7 @@ Describe "alpha.86 reconfigureAction.persisted semisync gates"
       The output should equal "0"
     End
 
-    It "config/mariadb-semisync.tpl content remains pure INI (no `!` directives)"
+    It "config/mariadb-semisync.tpl content remains pure INI (no bang directives)"
       When call grep -c '^!' "${SEMISYNC_CFG}"
       The status should be failure
       The output should equal "0"

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -247,6 +247,7 @@ ComponentDefinition reconfigure action for MariaDB
 reconfigure:
   exec:
     container: mariadb
+    image: {{ include "mariadb.image" . }}
     command:
       - /bin/sh
       - -c
@@ -455,6 +456,7 @@ parse smoke REMOVED in alpha.88 after dry-run blocker (Jack msg
 reconfigure:
   exec:
     container: mariadb
+    image: {{ include "mariadb.image" . }}
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Summary

Fixes the MariaDB reconfigure action execution surface exposed by full acceptance `task442-full-n1-2320`.

The reconfigure script calls the `mariadb` CLI. `exec.container: mariadb` shares the MariaDB container resources, but the action still runs from the action runtime. Pinning `exec.image` to the MariaDB image makes the CLI available while keeping `container: mariadb` for shared mounts.

## Evidence

- Failing run: `task442-full-n1-2320`, standalone T4 reconfigure timeout after 600s.
- Error: `MariaDB client is unavailable in current reconfigure runtime`.
- Frozen evidence sha256: `b951adc61a495a3539ebf61e1e781f412e8f4161ca64685e7db73cb3e5d2baea`.
- Controller-side contract check: `exec.container` does not mean the action process enters the business container; `exec.image` is required when the action needs binaries from a specific image.

## Changes

- Add `exec.image: {{ include "mariadb.image" . }}` to both MariaDB reconfigure action helpers.
- Add ShellSpec coverage that both base and persisted reconfigure helpers declare `container: mariadb` and the MariaDB exec image.

## Validation

- `helm dependency build addons/mariadb`
- `helm lint addons/mariadb`
- `helm template mariadb-alpha102 addons/mariadb --namespace kb-system`
- `bash -n addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh`
- `git diff --check`

## CI Status

- Passing after the latest push: `shell-check`, `generate-files`, `check-addons-cluster-helm`.
- Failing checks are inherited from the parent PR branch rather than newly introduced by this patch: older MariaDB ShellSpec expectations still pin alpha.90-era assertions, and chart image checks fail on pre-existing public image availability issues such as MariaDB/syncer images.

## Re-pin Evidence Required After Merge

Official acceptance must use a new candidate package and capture:

- rendered CmpD evidence that both reconfigure helpers include `exec.image` and keep `exec.container: mariadb`;
- live action runtime evidence for image/imageID plus `mariadb` CLI path and version;
- Round 1 restart from T1 in the approved IDC vcluster.

## Boundary

This PR is a candidate fix only. Official acceptance must re-pin this child PR commit and restart Round 1 from T1 in the approved IDC vcluster.
