### PR TITLE
bump(mariadb): 1.1.1-alpha.103 pin reconfigure action image

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1082,7 +1082,29 @@ type: application
 # syncer-side double-stop fix is in apecloud/syncer branch
 # helen/mariadb-demote-pause-writecheck, image
 # apecloud/syncer:mariadb-fullfix-20260526-v5).
-version: 1.1.1-alpha.102
+# alpha.103 v1 (Jack 2026-05-29): pin reconfigure action image (PR #2689,
+# squash-merged as 91f98ad38439b65e4b9a8d48528d4d688fa33bb6). The
+# `mariadb.config.reconfigureAction` and `.persisted` helpers now emit
+# `exec.image: {{ include "mariadb.image" . }}` in addition to the
+# existing `exec.container: mariadb`. task442-full-n1-2320 acceptance
+# Round 1 standalone T4 reconfigure was timing out at 600s because
+# kbagent action runtime did not have the mariadb CLI in PATH and the
+# previous `exec.container: mariadb` alone did not bring the CLI into
+# the runtime (see kubeblocks-addon-docs PR #382 contract guard:
+# `exec.container` shares mounts/resources, it does not exec inside
+# the target container's filesystem). Bumping the chart version is
+# mandatory: CmpD spec is immutable per Helm, so the patched
+# reconfigure exec must land under a new ComponentDefinition name.
+# Patch-head pre-validation on `mariadb-1.1.1-alpha.102-pr2689`
+# isolated CmpD passed in IDC mariadb-test5: OpsRequest Reconfiguring
+# `max_connections=200` succeeded in ~15-30s (vs alpha.102 600s
+# timeout) and live `SHOW VARIABLES LIKE 'max_connections'` returned
+# 200 (evidence sha256
+# e16cda074db48a7195790474b5d04b0c5bcc8f9d0ca8cb6c9035b609e7b9a6d6).
+# No script content changes, no CmpD shape changes beyond the new
+# reconfigure exec.image field; syncer/image baseline unchanged from
+# alpha.102.
+version: 1.1.1-alpha.103
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add


### PR DESCRIPTION
## Summary

Bumps MariaDB addon chart to `1.1.1-alpha.103` to ship the reconfigure action image fix from PR #2689 (squash-merged as `91f98ad38439b65e4b9a8d48528d4d688fa33bb6`) under a new CmpD name. CmpD spec is immutable per Helm, so the patched `reconfigure.exec.image` field must land on a fresh chart version rather than be applied in-place on `alpha.102`.

## Why a new chart version is mandatory

- `alpha.102` 上 `mariadb-1.1.1-alpha.102` CmpD 已经发布到 IDC `mariadb-test5`，Helm 视 CmpD spec 为 immutable。
- 之前在 `task442-full-n1-fix1-2351` 尝试直接 helm-upgrade 修改 alpha.102 CmpD 的 reconfigure exec，触发 `Unavailable: immutable fields can't be updated`（evidence sha256 `a16be1e3887f286d79f296f559e3c9c4e052bc5c4831128293491b737b4a39a5`）。
- 用新版本号让 KubeBlocks 创建新的 CmpD `mariadb-1.1.1-alpha.103` 而不是 mutate 旧 CmpD。

## Patch-head pre-validation

Evidence sha256 `e16cda074db48a7195790474b5d04b0c5bcc8f9d0ca8cb6c9035b609e7b9a6d6`，IDC `mariadb-test5` 上隔离 CmpD `mariadb-1.1.1-alpha.102-pr2689` PASS:

- OpsRequest Reconfiguring `max_connections=200` 在 ~15-30s Succeed（vs alpha.102 的 600s timeout）
- live `SHOW VARIABLES LIKE 'max_connections'` = 200，证明 reconfigure action 真跑过
- 相同 controller (`pr-10252-1c8723184`)、相同 vcluster、相同 DB image；唯一差别 = chart 加 `exec.image`

## Scope

- 只改 `addons/mariadb/Chart.yaml` 版本号与对应版本说明注释；
- 不动 templates / scripts / CmpD shape 之外的任何字段；
- syncer / image / paramsdef baseline 与 alpha.102 一致。

## Test plan

- [x] `helm dependency build` PASS
- [x] `helm lint` PASS
- [x] PR #2689 commit `4c8cd5bd5` patch-head pre-validation PASS (sha `e16cda07...`)
- [ ] Helm release upgrade to alpha.103 in IDC `mariadb-test5` — 等 @Helen 在 `#mariadb` 拍板
- [ ] Rule 13 N=1 official acceptance Round 1 standalone → async → semisync → galera from T1 — 在 IDC re-pin 之后
- [ ] N=2 / N=10 / chaos / soak 路径 — Round 1 PASS 之后按 Helen 2026-05-28 20:14 节奏推进

## Related

- 父 PR #2633
- 触发现场：task442-full-n1-2320 evidence sha `b951adc61a495a3539ebf61e1e781f412e8f4161ca64685e7db73cb3e5d2baea`
- Lily/Rocco contract guard: kubeblocks-addon-docs PR #382
- Case appendix 草稿：`docs/cases/mariadb/mariadb-reconfigure-exec-container-without-image-task442-case.md`
- Post-merge restart runbook：`notes/task442-post-pr2689-restart-runbook.md`（agent-side）
