### PR TITLE
fix(mariadb): provision kb_internal_root in standalone CmpD (alpha.104)

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1104,7 +1104,38 @@ type: application
 # No script content changes, no CmpD shape changes beyond the new
 # reconfigure exec.image field; syncer/image baseline unchanged from
 # alpha.102.
-version: 1.1.1-alpha.103
+# alpha.104 v1 (Jack 2026-05-29): provision kb_internal_root in
+# standalone CmpD. Round 1 acceptance task442-full-n1-alpha103-r1-0226
+# launched on alpha.103 and FAILED at standalone T4 reconfigure with
+# `ERROR 1045 (28000): Access denied for user 'kb_internal_root'@
+# '127.0.0.1' (using password: YES)`. Live MariaDB inspection on the
+# test pod confirmed only `root` and `healthcheck` users existed; the
+# chart-wide reconfigure helper in `_helpers.tpl` defaults to
+# `kb_internal_root` per the alpha.83 security-hardening convention,
+# but only `cmpd-replication-merged.yaml` / `cmpd-replication.yaml` /
+# `cmpd-semisync.yaml` / `cmpd-galera.yaml` actually CREATE that user
+# during their inline bootstrap; standalone CmpD `cmpd.yaml` did not.
+# The PR #2689 reconfigure CLI fix removed the prior "CLI not found"
+# wall and surfaced this pre-existing standalone gap. SQL `ERROR 1045`
+# from the server is the strongest evidence so far that PR #2689's
+# `exec.image` actually wires CLI -> server in the alpha.103 runtime
+# (action reaches authentication and fails there, not earlier).
+# Fix: standalone CmpD entrypoint wrapper now writes
+# `/docker-entrypoint-initdb.d/01-kb-internal-root.sh` before exec'ing
+# docker-entrypoint.sh. MariaDB's official entrypoint processes `*.sh`
+# in `/docker-entrypoint-initdb.d/` exactly once on fresh datadir init
+# and runs `CREATE USER IF NOT EXISTS` + `ALTER USER ... IDENTIFIED BY`
+# + `GRANT ALL PRIVILEGES`. Same `MARIADB_ROOT_PASSWORD` secret as
+# user-facing root (chart-wide convention: root and kb_internal_root
+# share the password).
+# Evidence: `artifacts/task442-full-n1-alpha103-r1-0226-t4-access-denied-freeze-0237.tar.gz`
+# sha256 e7b04d01139c3178ca4a5fad0caf3e1def9323dc28a68f92fb7d26a02966f332.
+# Scope: only standalone CmpD `templates/cmpd.yaml`; replication /
+# semisync / galera CmpDs already create kb_internal_root via their
+# existing inline startup SQL block (`cmpd-replication-merged.yaml`).
+# No script content changes outside the entrypoint wrapper.
+# syncer/image baseline unchanged from alpha.103.
+version: 1.1.1-alpha.104
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd.yaml
+++ b/addons/mariadb/templates/cmpd.yaml
@@ -26,6 +26,41 @@ spec:
           - bash
           - -c
           - |
+            # alpha.104 (Jack 2026-05-29): provision the internal admin
+            # account kb_internal_root before mariadbd starts. The shared
+            # reconfigure helper in _helpers.tpl uses kb_internal_root for
+            # dynamic SET GLOBAL (alpha.83 v1: user-facing root has SUPER
+            # stripped under the security hardening path used by the
+            # replication topologies). standalone topology previously did
+            # not create kb_internal_root, which the PR #2689 CLI fix
+            # exposed at task442-full-n1-alpha103-r1-0226 standalone T4
+            # reconfigure (`ERROR 1045 (28000): Access denied for user
+            # 'kb_internal_root'@'127.0.0.1' (using password: YES)`). The
+            # provisioning runs only on first-init (docker-entrypoint.sh
+            # processes /docker-entrypoint-initdb.d/*.sh exactly once when
+            # the datadir is fresh); CREATE USER IF NOT EXISTS + ALTER USER
+            # keep it idempotent if the script is re-run for any reason.
+            # Same MARIADB_ROOT_PASSWORD secret as the root account per the
+            # chart-wide convention (root and kb_internal_root share the
+            # password, no extra secret indirection).
+            mkdir -p /docker-entrypoint-initdb.d
+            cat > /docker-entrypoint-initdb.d/01-kb-internal-root.sh <<'INITDB_EOF'
+            #!/bin/bash
+            set -eu
+            mariadb -h localhost -u root -p"${MARIADB_ROOT_PASSWORD}" <<-SQL
+              CREATE USER IF NOT EXISTS 'kb_internal_root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              ALTER USER 'kb_internal_root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              ALTER USER 'kb_internal_root'@'localhost' ACCOUNT UNLOCK;
+              GRANT ALL PRIVILEGES ON *.* TO 'kb_internal_root'@'localhost' WITH GRANT OPTION;
+              CREATE USER IF NOT EXISTS 'kb_internal_root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              ALTER USER 'kb_internal_root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              ALTER USER 'kb_internal_root'@'127.0.0.1' ACCOUNT UNLOCK;
+              GRANT ALL PRIVILEGES ON *.* TO 'kb_internal_root'@'127.0.0.1' WITH GRANT OPTION;
+              FLUSH PRIVILEGES;
+            SQL
+            INITDB_EOF
+            chmod +x /docker-entrypoint-initdb.d/01-kb-internal-root.sh
+
             # Copy TLS certs to data dir (root:root 600 mounts are unreadable by mysql user)
             if [ "${TLS_ENABLED:-false}" = "true" ] && [ -d /etc/pki/mariadb-ssl ]; then
               mkdir -p /var/lib/mysql/tls


### PR DESCRIPTION
## Summary

Provisions `kb_internal_root` in the standalone CmpD so the chart-wide reconfigure helper can authenticate. Bumps MariaDB addon chart to `1.1.1-alpha.104`.

## Why

`task442-full-n1-alpha103-r1-0226` acceptance Round 1 launched on alpha.103 and **FAILED at standalone T4 reconfigure**:

```
action: udf-reconfigure-cmpd-mariadb-standalone-config
error: exit code: 1
stderr: Failed to set parameter long_query_time=5:
        ERROR 1045 (28000): Access denied for user
        'kb_internal_root'@'127.0.0.1' (using password: YES)
```

Live MariaDB inspection on the test pod `mdb-sa-1483-mariadb-0`:

```
SELECT User,Host,plugin FROM mysql.user;
-- Only: root@localhost, root@%, healthcheck@127.0.0.1/::1/localhost, mariadb.sys@localhost
-- kb_internal_root NOT PRESENT
```

The chart-wide reconfigure helper in `addons/mariadb/templates/_helpers.tpl` (`mariadb_exec`) defaults to `kb_internal_root` + `MARIADB_ROOT_PASSWORD` per the alpha.83 security-hardening convention. Replication / semisync / galera CmpDs all CREATE `kb_internal_root` during their inline bootstrap SQL block. Standalone CmpD `cmpd.yaml` did not — it only ran `docker-entrypoint.sh mariadbd` with no extra user provisioning.

The PR #2689 reconfigure CLI fix removed the prior "CLI not found" wall and surfaced this pre-existing standalone gap. The SQL `ERROR 1045` from the MariaDB server is also the strongest evidence so far that PR #2689's `exec.image` actually wires CLI → server in the alpha.103 runtime: the action reaches authentication and fails there, not earlier on CLI lookup or socket connect.

## Fix

`addons/mariadb/templates/cmpd.yaml` entrypoint wrapper now writes `/docker-entrypoint-initdb.d/01-kb-internal-root.sh` before `exec`'ing `docker-entrypoint.sh`. MariaDB's official entrypoint processes `*.sh` files in `/docker-entrypoint-initdb.d/` exactly once on fresh datadir init.

The init script runs:

```sql
CREATE USER IF NOT EXISTS 'kb_internal_root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
ALTER  USER                'kb_internal_root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
ALTER  USER                'kb_internal_root'@'localhost' ACCOUNT UNLOCK;
GRANT  ALL PRIVILEGES ON *.* TO 'kb_internal_root'@'localhost' WITH GRANT OPTION;
CREATE USER IF NOT EXISTS 'kb_internal_root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
ALTER  USER                'kb_internal_root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
ALTER  USER                'kb_internal_root'@'127.0.0.1' ACCOUNT UNLOCK;
GRANT  ALL PRIVILEGES ON *.* TO 'kb_internal_root'@'127.0.0.1' WITH GRANT OPTION;
FLUSH PRIVILEGES;
```

`CREATE USER IF NOT EXISTS` + `ALTER USER ... IDENTIFIED BY` keep it idempotent if the script is ever re-run. The shared `MARIADB_ROOT_PASSWORD` secret matches chart-wide convention (root and `kb_internal_root` share the same password — no extra secret indirection).

## Scope

- Only `addons/mariadb/templates/cmpd.yaml` (standalone) and `addons/mariadb/Chart.yaml` (version bump + annotated comment).
- Replication / semisync / galera CmpDs already create `kb_internal_root` via their existing inline startup SQL block, unchanged.
- No script content changes outside the entrypoint wrapper.
- syncer / image baseline unchanged from alpha.103.

## Per Helen TL decision

Option A (standalone CmpD provisions `kb_internal_root`, unify contract across all topologies) over option B (env override `MARIADB_INTERNAL_ROOT_USER=root` for standalone reconfigure action). Reasons (from `#mariadb:672b2193`):

- Shared helper is a single contract — all topologies must satisfy the prerequisite (`kb_internal_root` exists); standalone is the gap, not a special case.
- Consistent with alpha.83 / alpha.64 "root drop SUPER" security hardening (standard reconfigure runs as internal admin; user-facing root stays minimum-priv).
- Lower long-term cost than dual-contract maintenance.
- Does not depend on standalone root still having SUPER (implementation detail that future hardening may change).

## Test plan

- [x] `helm dependency build` PASS
- [x] `helm lint` PASS
- [x] `helm template --show-only templates/cmpd.yaml` renders the initdb script + reconfigure exec block correctly
- [ ] Helm upgrade to alpha.104 in IDC `mariadb-test5` — @Helen IDC re-pin
- [ ] Round 1 from T1 standalone → async → semisync → galera N=1 stop-on-first-fail — Jack starts after re-pin
- [ ] Per Lily/Rocco/Edward closeout: verify controller log shows `udf-reconfigure-cmpd-*` invoked + non-empty kbagent stdout/stderr + OpsRequest progress non-`-/-` (no patch-head shortcut this time)

## Related

- Triggering evidence: `artifacts/task442-full-n1-alpha103-r1-0226-t4-access-denied-freeze-0237.tar.gz` sha256 `e7b04d01139c3178ca4a5fad0caf3e1def9323dc28a68f92fb7d26a02966f332`
- Parent PR #2633
- PR #2689 (reconfigure CLI exec.image fix, merged squash `91f98ad3...`)
- PR #2690 (alpha.103 chart bump, merged squash `408bfb35...`)
- Lily/Rocco/Edward evidence-discipline retractions of patch-head LGTM: `#kubeblocks-controller:ef37ac53` 02:45-02:48
- Sediment plan post-Round-1-PASS (per Helen 02:47): Doc A "exec.container ≠ exec INTO container — engine CLI 依赖必须 exec.image" (Jack + Helen 主笔), Doc B "OpsRequest Succeed ≠ reconfigure action ran — 三方直证" (Lily 主笔)
