### PR TITLE
fix(mariadb): rewrite fence verifier to read-only privilege query (alpha.105)

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1135,7 +1135,45 @@ type: application
 # existing inline startup SQL block (`cmpd-replication-merged.yaml`).
 # No script content changes outside the entrypoint wrapper.
 # syncer/image baseline unchanged from alpha.103.
-version: 1.1.1-alpha.104
+# alpha.105 v1 (Jack 2026-05-29): rewrite `verify_post_dcs_local_root_
+# write_fenced` in `addons/mariadb/scripts/replication-switchover.sh`
+# from a destructive INSERT probe to a read-only privilege query.
+# Round 1c-B (task442-full-n1-alpha104-r1c-fullrun-0428) async CM4
+# uncovered a self-referential bug: the alpha.59-104 verifier issued
+# `INSERT INTO kubeblocks.kb_post_dcs_fence_probe` as user-facing root
+# to test whether read_only=ON rejects user-facing writes. When the
+# fence had a real gap (`apply_post_dcs_root_revoke` only strips
+# READ_ONLY ADMIN / SUPER / BINLOG ADMIN, leaving base INSERT on
+# user-facing root), the INSERT succeeded, was binlogged on the
+# demoted primary, and the new primary — already promoted in DCS —
+# never replicated it. That single INSERT became a permanent orphan
+# event (pod-0 gtid_binlog_pos=1-1-175 vs pod-1=1-1-174,2-2-N) and
+# the subsequent rejoin path hit GTID divergence fail-closed, locking
+# pod-0 as a stuck orphan. The verifier was both the source and the
+# detector of the very bug it was supposed to enforce.
+# Live evidence: both pods of mdb-async-10255 hold a
+# `kb_post_dcs_fence_probe` row with ts=1780001450 (2026-05-28
+# 20:50:50Z, the verifier's own write); evidence pack sha256
+# a48ab90d13da5740a7899ba6e28657671534352f9c6000bd15b32bcf048275c9.
+# Fix: the verifier now connects as MARIADB_INTERNAL_ROOT_USER
+# (kb_internal_root) and emits `SHOW GRANTS FOR 'root'@'%' /
+# 'root'@'127.0.0.1' / 'root'@'localhost'`, then scans the combined
+# output for any of READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL
+# PRIVILEGES. Presence of any → fence not enforced (FAIL); absence
+# on all three hosts → fence enforced (PASS). 1141 (no such grant)
+# is accepted as PASS for that host. The query is purely read-only:
+# zero binlog events, zero data mutation, zero replication side
+# effects. Satisfies the four-part diagnostic-isolation contract
+# (Doc B Rule 4 a/b/c/d): (a) internal account, (b) suppresses
+# binlog propagation by performing no writes at all, (c) reads from
+# system tables only, (d) the diagnostic account does not bypass the
+# gate under test (the gate is "does user-facing root carry bypass
+# grants?", the diagnostic just reads grants).
+# Scope: only `addons/mariadb/scripts/replication-switchover.sh`
+# `verify_post_dcs_local_root_write_fenced()` body + Chart.yaml.
+# No other addon script content changes. syncer/image baseline
+# unchanged from alpha.104.
+version: 1.1.1-alpha.105
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1327,45 +1327,60 @@ verify_post_dcs_local_root_write_fenced() {
   # this verifier, but the bootstrap-time ensure_internal_local_admin path
   # in cmpd-replication-merged.yaml still creates it so legacy callers and
   # diagnostics that inspect it (e.g. case appendices) keep working.
-  local out rc
+  # alpha.105 v2 R1 fix (Helen TL review): a single `mariadb -e "stmt1;
+  # stmt2; stmt3"` invocation short-circuits on the first error (default
+  # client behavior) and reports a non-zero exit. If any of the per-host
+  # SHOW GRANTS hits 1141 (no such grant), later host queries never run
+  # and earlier host output is still attached to the same `out` capture.
+  # A naïve `case rc!=0 in *1141* return 0` would then false-PASS even
+  # when an earlier host already revealed a bypass-class grant. Switch to
+  # per-host loop: one mariadb invocation per host, classify each
+  # independently, fail the moment any host shows bypass, count 1141 as
+  # "no account on that host", and only PASS when no host showed bypass
+  # AND at least one host returned a usable grant list (or all hosts are
+  # 1141 — host set is genuinely empty).
+  local rc host_count=0 missing_count=0
   if [ -z "${MARIADB_CLIENT_BIN}" ] || [ ! -x "${MARIADB_CLIENT_BIN}" ]; then
     log_switchover_error "Switchover failed: post-DCS local-root write fence verification cannot run without MARIADB_CLIENT_BIN"
     return 1
   fi
-  out=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
-    --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
-    -P3306 -h127.0.0.1 -N -s -e "
-      SHOW GRANTS FOR 'root'@'%';
-      SHOW GRANTS FOR 'root'@'127.0.0.1';
-      SHOW GRANTS FOR 'root'@'localhost';
-    " 2>&1)
-  rc=$?
-  if [ "${rc}" -ne 0 ]; then
-    case "${out}" in
-      *1141*)
-        log_switchover_info "Switchover post-DCS local-root write fence verified via read-only privilege query: no user-facing root account present (1141 from SHOW GRANTS)"
-        return 0
-        ;;
-    esac
-    log_switchover_error "Switchover failed: post-DCS local-root write fence verification SHOW GRANTS failed rc=${rc} out=${out}"
-    return 1
-  fi
-  # MariaDB emits dynamic privileges as plain space-separated text in SHOW
-  # GRANTS output (e.g. "GRANT READ_ONLY ADMIN ON *.* TO ..."). The case
-  # patterns below intentionally match the literal grant tokens. None of
-  # the non-bypass grants the chart leaves on user-facing root after
-  # alpha.83 (SELECT / RELOAD / PROCESS / REPLICATION SLAVE / BINLOG
-  # MONITOR / REPLICATION MASTER ADMIN / SLAVE MONITOR / PROXY) trigger
-  # these patterns. ALL PRIVILEGES catches the defensive "did the revoke
-  # step run at all" failure mode where the chart bootstrap script crashed
-  # before narrowing root.
-  case "${out}" in
-    *"READ_ONLY ADMIN"*|*"READ ONLY ADMIN"*|*"BINLOG ADMIN"*|*" SUPER "*|*" SUPER,"*|*"GRANT SUPER "*|*"ALL PRIVILEGES"*)
-      log_switchover_error "Switchover failed: post-DCS local-root write fence not enforced; user-facing root still holds a read_only-bypass privilege (READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL PRIVILEGES). grants=${out}"
+  for host in '%' '127.0.0.1' 'localhost'; do
+    host_count=$((host_count + 1))
+    local out
+    out=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+      --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
+      -P3306 -h127.0.0.1 -N -s -e "SHOW GRANTS FOR 'root'@'${host}';" 2>&1)
+    rc=$?
+    if [ "${rc}" -ne 0 ]; then
+      case "${out}" in
+        *1141*)
+          missing_count=$((missing_count + 1))
+          log_switchover_info "Switchover post-DCS local-root write fence verification: 'root'@'${host}' absent (1141), skipping"
+          continue
+          ;;
+      esac
+      log_switchover_error "Switchover failed: post-DCS local-root write fence verification SHOW GRANTS FOR 'root'@'${host}' failed rc=${rc} out=${out}"
       return 1
-      ;;
-  esac
-  log_switchover_info "Switchover post-DCS local-root write fence verified via read-only privilege query: user-facing root carries no read_only-bypass privilege on any of @%/@127.0.0.1/@localhost"
+    fi
+    # Word-boundary match: avoid false hits on SUPER inside other words
+    # and on tokens whose name happens to share a prefix with the bypass
+    # set (SLAVE MONITOR / REPLICATION MASTER ADMIN / BINLOG MONITOR are
+    # all NON-bypass grants present on the alpha.83 narrowed root and
+    # must not trip this scan). `grep -E` keeps the regex compact and
+    # the patterns explicit. "SUPER" is matched only when surrounded
+    # by `[, ]` (privilege list separator) or sitting at start/end of
+    # the line. ALL PRIVILEGES is matched as a defensive catch-all in
+    # case the chart bootstrap revoke step never ran.
+    if printf '%s\n' "${out}" | grep -qE '(READ_ONLY ADMIN|READ ONLY ADMIN|BINLOG ADMIN|(^|[, ])SUPER([, ]|$)|ALL PRIVILEGES)'; then
+      log_switchover_error "Switchover failed: post-DCS local-root write fence not enforced; 'root'@'${host}' still holds a read_only-bypass privilege (READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL PRIVILEGES). grants=${out}"
+      return 1
+    fi
+  done
+  if [ "${missing_count}" -eq "${host_count}" ]; then
+    log_switchover_info "Switchover post-DCS local-root write fence verified via read-only privilege query: no user-facing root account present on any of @%/@127.0.0.1/@localhost (all hosts 1141)"
+    return 0
+  fi
+  log_switchover_info "Switchover post-DCS local-root write fence verified via read-only privilege query: user-facing root carries no read_only-bypass privilege on any present host (checked=${host_count}, missing=${missing_count})"
   return 0
 }
 

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1277,76 +1277,96 @@ EOF_HOSTS
 }
 
 verify_post_dcs_local_root_write_fenced() {
-  # alpha.59 design-contract close-out: setting @@global.read_only=ON is not
-  # enough on its own. Per Jack 19:45 review, the action must also prove that
-  # a user-facing root INSERT against this pod's localhost is actually rejected
-  # by the read-only fence (server error 1290 or "read-only" message). This
-  # closes the "non-empty contract field unenforced at write site" hole that
-  # the alpha.58 contract had: alpha.58 only set the marker without ever
-  # observing a denied write.
+  # alpha.105 (Jack 2026-05-29) verifier rewrite — destructive write check
+  # removed; replaced with read-only privilege query against user-facing root
+  # accounts. Reason: the alpha.59-104 verifier body issued an INSERT into
+  # kubeblocks.kb_post_dcs_fence_probe as user-facing root to test whether
+  # @@global.read_only=ON actually rejects user-facing writes. Under a real
+  # bypass condition (post-DCS root revoke ran but only stripped READ_ONLY
+  # ADMIN / SUPER / BINLOG ADMIN, leaving INSERT/UPDATE/DELETE on
+  # user-facing root), this INSERT SUCCEEDED, was binlogged on the demoted
+  # primary, and the new primary (already promoted in DCS) never replicated
+  # it back. That single INSERT became a permanent orphan event and the
+  # subsequent rejoin attempt hit GTID divergence fail-closed — the verifier
+  # itself was the source of the orphan it then detected. Live reproduction
+  # task442-full-n1-alpha104-r1c-fullrun-0428 async CM4 confirmed the
+  # self-referential cycle: pod-0 binlog gtid_binlog_pos=1-1-175, pod-1
+  # gtid_binlog_pos=1-1-174,2-2-N, both `kubeblocks.kb_post_dcs_fence_probe`
+  # rows show ts=20:50:50Z (the verifier's own write). Evidence sha256
+  # a48ab90d13da5740a7899ba6e28657671534352f9c6000bd15b32bcf048275c9.
   #
-  # alpha.75 v1 verifier contract fix (Helen TL + Jack XP review):
-  # alpha.74 v1 switchover idle-state N=1 RED revealed an inherited contract
-  # drift between alpha.61 v3 secondary fence (REVOKE ALL + GRANT non-bypass
-  # minimum list, NO BINLOG ADMIN) and this verifier's preamble. The previous
-  # body ran "SET SESSION sql_log_bin=0" + "CREATE DATABASE IF NOT EXISTS"
-  # + "CREATE TABLE IF NOT EXISTS" BEFORE the actual INSERT, all as
-  # user-facing root. After alpha.60 demote, user-facing root has lost
-  # BINLOG ADMIN -> "SET SESSION sql_log_bin=0" errors out with rc=1 stderr
-  # "ERROR 1227 (42000) Access denied; you need (at least one of) the
-  # BINLOG ADMIN privilege(s) for this operation". This 1227 was being
-  # reported as the verifier failure even though the actual fence behaviour
-  # (read_only=ON rejecting root INSERT) was never reached: the preamble
-  # contaminated the test purpose ("verify read_only fence" -> "verify root
-  # has BINLOG ADMIN / DDL privilege").
+  # The verifier purpose stands: confirm user-facing root cannot bypass the
+  # post-DCS read_only=ON fence. The new implementation enumerates SHOW
+  # GRANTS for root@'%' / root@'127.0.0.1' / root@'localhost' (the same
+  # host set apply_post_dcs_root_revoke iterates) and scans for any of the
+  # read_only-bypass privileges that the revoke step claims to have removed
+  # (READ_ONLY ADMIN / BINLOG ADMIN / SUPER, plus a defensive ALL
+  # PRIVILEGES match). If any bypass-class privilege is still granted, the
+  # fence is by definition not enforced; otherwise the contract holds. The
+  # query produces zero binlog events and zero observable side effects on
+  # data, replication topology, or DCS state, eliminating the self-pollution
+  # path. The session connects as MARIADB_INTERNAL_ROOT_USER (kb_internal_
+  # root) because user-facing root@'localhost' is the very subject under
+  # test and may itself have been narrowed past SELECT on mysql.* — using
+  # the internal admin keeps the query unambiguously read-only at the
+  # privilege-system level (per Lily Doc B Rule 4(d): "诊断账号不得拥有
+  # 可绕过被测 gate 的特权" — true here because the diagnostic is
+  # SHOW GRANTS, not the gate operation itself).
   #
-  # alpha.75 v1 fix:
-  #   - probe table provisioning moved to bootstrap-time
-  #     ensure_internal_local_admin in cmpd-semisync.yaml; INTERNAL_LOCAL
-  #     handles DDL with sql_log_bin=0 so it is binlog-replay-safe across pods
-  #   - this verifier body strips the preamble; runs ONLY the user-facing
-  #     root INSERT against the existing probe table
-  #   - acceptance contract narrows: rc=0 FAIL; rc=1 with 1146/1227/1044 FAIL
-  #     (must NOT be confused with read_only fence closed); rc=1 with
-  #     1290/read-only PASS
-  # Jack XP 8-class checklist & ShellSpec hard gates enforce these.
+  # Acceptance contract (rewrite):
+  #   - rc=0 + grants contain no READ_ONLY ADMIN / BINLOG ADMIN / SUPER /
+  #     ALL PRIVILEGES on any of the three root hosts                 → PASS
+  #   - rc=0 + grants contain any bypass-class privilege               → FAIL
+  #     (fence not enforced; user-facing root can still bypass read_only)
+  #   - rc!=0 with 1141 (no such grant — root@host absent)             → PASS
+  #     (host carries no user-facing root at all; nothing to bypass)
+  #   - rc!=0 otherwise (1044 access denied, connection failure, etc.) → FAIL
+  #     (verifier could not observe; do not infer fence state)
+  #
+  # The kubeblocks.kb_post_dcs_fence_probe table is no longer required by
+  # this verifier, but the bootstrap-time ensure_internal_local_admin path
+  # in cmpd-replication-merged.yaml still creates it so legacy callers and
+  # diagnostics that inspect it (e.g. case appendices) keep working.
   local out rc
   if [ -z "${MARIADB_CLIENT_BIN}" ] || [ ! -x "${MARIADB_CLIENT_BIN}" ]; then
     log_switchover_error "Switchover failed: post-DCS local-root write fence verification cannot run without MARIADB_CLIENT_BIN"
     return 1
   fi
-  out=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+  out=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
     --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
     -P3306 -h127.0.0.1 -N -s -e "
-      INSERT INTO kubeblocks.kb_post_dcs_fence_probe(probe_id, ts)
-        VALUES ('post_dcs_fence', UNIX_TIMESTAMP())
-        ON DUPLICATE KEY UPDATE ts=VALUES(ts);
+      SHOW GRANTS FOR 'root'@'%';
+      SHOW GRANTS FOR 'root'@'127.0.0.1';
+      SHOW GRANTS FOR 'root'@'localhost';
     " 2>&1)
   rc=$?
-  if [ "${rc}" -eq 0 ]; then
-    log_switchover_error "Switchover failed: post-DCS local-root write fence not enforced; user-facing root INSERT succeeded after read_only=ON"
+  if [ "${rc}" -ne 0 ]; then
+    case "${out}" in
+      *1141*)
+        log_switchover_info "Switchover post-DCS local-root write fence verified via read-only privilege query: no user-facing root account present (1141 from SHOW GRANTS)"
+        return 0
+        ;;
+    esac
+    log_switchover_error "Switchover failed: post-DCS local-root write fence verification SHOW GRANTS failed rc=${rc} out=${out}"
     return 1
   fi
+  # MariaDB emits dynamic privileges as plain space-separated text in SHOW
+  # GRANTS output (e.g. "GRANT READ_ONLY ADMIN ON *.* TO ..."). The case
+  # patterns below intentionally match the literal grant tokens. None of
+  # the non-bypass grants the chart leaves on user-facing root after
+  # alpha.83 (SELECT / RELOAD / PROCESS / REPLICATION SLAVE / BINLOG
+  # MONITOR / REPLICATION MASTER ADMIN / SLAVE MONITOR / PROXY) trigger
+  # these patterns. ALL PRIVILEGES catches the defensive "did the revoke
+  # step run at all" failure mode where the chart bootstrap script crashed
+  # before narrowing root.
   case "${out}" in
-    *1290*|*read-only*|*"read only"*|*"--read-only"*)
-      log_switchover_info "Switchover post-DCS local-root write fence verified: user-facing root INSERT rejected (rc=${rc})"
-      return 0
-      ;;
-    *1146*)
-      log_switchover_error "Switchover failed: post-DCS local-root write fence verification probe table missing (Error 1146); bootstrap-time ensure_internal_local_admin must create kubeblocks.kb_post_dcs_fence_probe (alpha.75 v1 contract)"
-      return 1
-      ;;
-    *1227*)
-      log_switchover_error "Switchover failed: post-DCS local-root write fence verification implementation error rc=${rc} (Error 1227 BINLOG ADMIN); verifier body must NOT need BINLOG ADMIN; remove any sql_log_bin manipulation (alpha.75 v1 regression guard) out=${out}"
-      return 1
-      ;;
-    *1044*)
-      log_switchover_error "Switchover failed: post-DCS local-root write fence verification got Error 1044 access denied; verifier body must NOT need DDL/database-level grants beyond INSERT on the existing probe table (alpha.75 v1 regression guard) out=${out}"
+    *"READ_ONLY ADMIN"*|*"READ ONLY ADMIN"*|*"BINLOG ADMIN"*|*" SUPER "*|*" SUPER,"*|*"GRANT SUPER "*|*"ALL PRIVILEGES"*)
+      log_switchover_error "Switchover failed: post-DCS local-root write fence not enforced; user-facing root still holds a read_only-bypass privilege (READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL PRIVILEGES). grants=${out}"
       return 1
       ;;
   esac
-  log_switchover_error "Switchover failed: post-DCS local-root write fence verification got unexpected error rc=${rc} out=${out}"
-  return 1
+  log_switchover_info "Switchover post-DCS local-root write fence verified via read-only privilege query: user-facing root carries no read_only-bypass privilege on any of @%/@127.0.0.1/@localhost"
+  return 0
 }
 
 fence_current_primary_local_writes_after_dcs() {


### PR DESCRIPTION
## Summary

Rewrites `verify_post_dcs_local_root_write_fenced()` in `addons/mariadb/scripts/replication-switchover.sh` from a destructive `INSERT` probe into a read-only privilege query. Bumps MariaDB addon chart to `1.1.1-alpha.105`.

## Why — self-referential bug

Round 1c-B (`task442-full-n1-alpha104-r1c-fullrun-0428`) async CM4 uncovered a **self-referential** bug in the fence verifier:

1. The alpha.59-104 verifier issued
   ```sql
   INSERT INTO kubeblocks.kb_post_dcs_fence_probe(probe_id, ts)
     VALUES ('post_dcs_fence', UNIX_TIMESTAMP())
     ON DUPLICATE KEY UPDATE ts=VALUES(ts);
   ```
   as **user-facing root** to test whether `read_only=ON` rejects user-facing writes.
2. `apply_post_dcs_root_revoke()` only strips `READ_ONLY ADMIN / SUPER / BINLOG ADMIN` (the admin-bypass dynamic privileges). It does **not** revoke base `INSERT/UPDATE/DELETE`, which user-facing root retains during the bootstrap window.
3. So the `INSERT` succeeded, was binlogged on the demoted primary, and the new primary — already promoted in DCS — never replicated it.
4. That single `INSERT` became a permanent orphan event (`pod-0 gtid_binlog_pos=1-1-175` vs `pod-1=1-1-174,2-2-N`). The subsequent rejoin path hit GTID divergence fail-closed, locking pod-0 as a stuck orphan.
5. The verifier was both the source and the detector of the bug it was supposed to enforce.

### Live evidence

- Both pods of `mdb-async-10255` hold a `kb_post_dcs_fence_probe` row with `ts=1780001450` = 2026-05-28T20:50:50Z — the verifier's own write.
- Evidence pack `artifacts/task442-full-n1-alpha104-r1c-fullrun-0428-async-cm4-fail-freeze-0522.tar.gz` sha256 `a48ab90d13da5740a7899ba6e28657671534352f9c6000bd15b32bcf048275c9`.
- `switchover-action.log` chain: prepare ✓ → dcs ✓ → apply_post_dcs_root_revoke ran (revoked=9) → verify INSERT succeeded (fence broken) → exit 1.
- Controller fire-and-forget hook ignored exit 1; KB delete pod-0 was downstream of the orphan, not its cause.

This closes the 5/27 alpha.60 fence verifier "unrooted" open item.

## Fix — read-only privilege query

The verifier now:
1. Connects as `MARIADB_INTERNAL_ROOT_USER` (`kb_internal_root`).
2. Emits `SHOW GRANTS FOR 'root'@'%' / 'root'@'127.0.0.1' / 'root'@'localhost'`.
3. Scans the combined output for any of `READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL PRIVILEGES`.
4. Returns PASS if none present on any host; FAIL if any present. `1141` (no such grant — root@host absent) accepted as PASS for that host.

Zero binlog events, zero data mutation, zero replication side effects.

### Doc B Rule 4 compliance

Satisfies the four-part diagnostic-isolation contract proposed by @Lily / cross-team consensus:

- **(a) internal account**: connects as `kb_internal_root`, not user-facing root
- **(b) suppresses binlog propagation**: by performing no writes at all
- **(c) reads from system tables only**: `SHOW GRANTS` is metadata-only
- **(d) does not bypass the gate under test**: the gate is "does user-facing root carry bypass grants?" The diagnostic just reads grants; `kb_internal_root`'s own bypass privileges are immaterial because the test target is `root@host`, not `kb_internal_root`

## Test plan

- [x] `bash -n` on rewritten verifier — PASS
- [x] `helm dependency build` + `helm lint` on chart with alpha.105 bump — PASS
- [x] Live diagnostic on `mdb-async-10255` pod-0 confirms current `root@host` grants contain no bypass privileges and `INSERT INTO kubeblocks.kb_health_check` is correctly rejected with `1290 read-only`. The new verifier query against the same pod returns PASS (no bypass-class grants in `SHOW GRANTS`).
- [ ] IDC `mariadb-test5` helm upgrade to alpha.105 — awaits @Helen
- [ ] Round 1c-C from T1 (standalone → async → semisync → galera) N=1 — Jack
- [ ] Round 1c-C closeout per Lily/Rocco/Edward direct-proof discipline: controller log shows `succeed to call switchover action` not `failed to call switchover action, ignore it` during async/semisync rolling restarts; no `replication-divergence-pending` markers; no orphan events in pod-0 `gtid_binlog_pos` vs pod-1

## Related

- Triggering evidence: `artifacts/task442-full-n1-alpha104-r1c-fullrun-0428-async-cm4-fail-freeze-0522.tar.gz` sha256 `a48ab90d13da5740a7899ba6e28657671534352f9c6000bd15b32bcf048275c9`
- Cross-team narrow timeline (Doc B case appendix material): `#mariadb:672b2193` + `#kubeblocks-controller:ef37ac53` 05:22-06:00
- Parent PR #2633
- Predecessor child PRs in the same dev branch:
  - PR #2689 (`fix(mariadb): pin reconfigure action image`)
  - PR #2690 (`bump(mariadb): 1.1.1-alpha.103 pin reconfigure action image`)
  - PR #2691 (`fix(mariadb): provision kb_internal_root in standalone CmpD (alpha.104)`)
- Per Helen TL decision (option L4b-i, read-only privilege query); L4a/L4c rejected (user-facing CRUD revoke pollutes consumer contract; DCS in-flight flush is unnecessarily heavy)
- Cross-team consensus: chart-side fix only; InstanceSet fire-and-forget switchover hook does **not** need a controller-side change for this case (orphan precedes the controller ignore decision)
