### PR TITLE
fix(mariadb): self-heal stuck-pending markers + raise retry budget (alpha.106)

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1173,7 +1173,66 @@ type: application
 # `verify_post_dcs_local_root_write_fenced()` body + Chart.yaml.
 # No other addon script content changes. syncer/image baseline
 # unchanged from alpha.104.
-version: 1.1.1-alpha.105
+# alpha.106 v1 (Jack 2026-05-29): self-heal stuck-pending markers
+# after a Stop/Start cycle where pod-0 startup probes pod-1 before
+# pod-1's mariadbd has finished accepting connections. Round 1c-C
+# (task442-full-n1-alpha105-r1c-fullrun-0617) async T6 Stop/Start
+# exposed a different chart bug than alpha.105 fixed: when both
+# pods are stopped and started together, pod-0 startup at
+# 22:43:38 polled pod-1:3306 for the alpha.92 bounded 60s budget
+# (default) and never saw it listen, so the script dropped into
+# block_existing_datadir_self_election_without_primary, wrote
+# `.replication-pending`, and exited. After pod-1 came up the
+# slave IO/SQL threads (started manually as kb_internal_root in
+# diagnosis) caught up cleanly with no GTID divergence, but no
+# actor — startup, HA syncer, switchover — ever flipped the
+# `.replication-pending` -> `.replication-ready` markers, so
+# roleProbe kept publishing `initializing` and the cluster never
+# reached Running. Live verification on mdb-async-11076 confirmed
+# the markers were the sole gate: `touch .replication-ready +
+# .sql-listener-ready; rm .replication-pending` -> roleProbe
+# immediately published `secondary`, KB published the role label,
+# cluster moved Failed -> Running in <15s. Evidence sha256
+# 154cb8735a4d5efe203303c36e779ed5b4617835571c4690313fb5a50a833b82.
+# Fix path C = A + B:
+# A. `addons/mariadb/templates/cmpd-replication-merged.yaml`
+#    raises the alpha.92 MARIADB_NO_PRIMARY_RETRY_BUDGET_SECONDS
+#    default from 60s -> 180s. Stays well under the InstanceSet
+#    startupProbe budget (failureThreshold 60 * periodSeconds 10 =
+#    600s) so it does not push pod-0 past KB NotReady. This reduces
+#    how often the reaper fires and shortens the visible "Cluster
+#    Failed" window on first roleProbe tick. Does not address the
+#    underlying race; only widens it.
+# B. `addons/mariadb/scripts/replication-roleprobe.sh` adds
+#    `attempt_marker_self_heal()` and calls it at the top of
+#    check_role. The reaper observes the live replication state and
+#    clears `.replication-pending` + creates `.replication-ready` +
+#    `.sql-listener-ready` only when ALL strict conditions hold:
+#    (1) .replication-pending exists, (2) .replication-divergence-
+#    pending does NOT exist (preserves the alpha.60 / Round 1c-B
+#    GTID divergence fail-closed protection), (3) master.info
+#    exists (we are configured as a secondary, not in initial
+#    bootstrap), (4) .replication-ready missing (otherwise nothing
+#    to heal), (5) db_ready (local mariadbd up), (6)
+#    secondary_replication_ready (Slave_IO_Running=Yes,
+#    Slave_SQL_Running=Yes, Last_IO_Errno=0, Last_SQL_Errno=0).
+#    Any condition not met -> return 1, no marker write.
+# Doc B Rule 4 (a-d) compliance: (a) reads only via existing
+# internal admin helper, (b) writes only marker files outside the
+# replication stream (no binlog event), (c) reads from existing
+# tables, (d) the diagnostic does not bypass the divergence-pending
+# gate that detects the bug class the alpha.60 fix protects against.
+# Doc B Rule 5 (Lily 06:57 proposed): live-verified the fix layer
+# on the frozen scene before the PR; the markers ARE the sole gate.
+# Scope: `addons/mariadb/templates/cmpd-replication-merged.yaml`
+# (A budget bump), `addons/mariadb/scripts/replication-roleprobe.sh`
+# (B reaper + helper), `Chart.yaml` (version bump + this note).
+# cmpd-semisync.yaml and cmpd-replication.yaml are unchanged; the B
+# reaper in replication-roleprobe.sh is used by all replication
+# topologies, so it heals semisync and replication-merged uniformly
+# without engine-specific code changes. syncer / image baseline
+# unchanged from alpha.105.
+version: 1.1.1-alpha.106
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -67,6 +67,17 @@ master_info_file() {
   printf "%s/master.info" "$(data_dir)"
 }
 
+# alpha.106 v1 (Jack 2026-05-29): divergence_pending_file marker is written
+# by fail_closed_for_gtid_divergence in cmpd-replication-merged.yaml and
+# cmpd-semisync.yaml when the chart's startup-after-restart path detects a
+# GTID divergence between local datadir and primary. The marker file is the
+# fail-safe authority: while it is present, do not auto-heal. The reaper
+# below explicitly bails when it sees this marker so the alpha.60 / Round
+# 1c-B style orphan-event protection is preserved.
+divergence_pending_file() {
+  printf "%s/.replication-divergence-pending" "$(data_dir)"
+}
+
 resolve_mariadb_cli() {
   if command -v mariadb >/dev/null 2>&1; then
     command -v mariadb
@@ -351,7 +362,65 @@ primary_read_write_ready() {
   return 1
 }
 
+attempt_marker_self_heal() {
+  # alpha.106 v1 (Jack 2026-05-29): defensive marker reaper for the
+  # stuck-pending-after-recovery state surfaced by Round 1c-C async T6
+  # Stop/Start (task442-full-n1-alpha105-r1c-fullrun-0617). When both pods
+  # are stopped and started together, pod-0 startup probes pod-1:3306
+  # before pod-1's mariadbd has finished accepting connections. The
+  # cmpd-replication-merged.yaml alpha.92 bounded retry (default 60s) can
+  # expire if pod-1 takes longer than that to come up; the startup script
+  # then drops into block_existing_datadir_self_election_without_primary,
+  # which writes `.replication-pending` and never returns to clear it.
+  # After pod-1 becomes reachable, the slave IO/SQL threads catch up
+  # cleanly but no actor (startup, HA syncer, switchover) ever flips the
+  # markers back to ready, so roleProbe keeps publishing `initializing`
+  # and the cluster never reaches Running. Live verification on
+  # mdb-async-11076 confirmed that touching `.replication-ready` +
+  # `.sql-listener-ready` and removing `.replication-pending` causes
+  # roleProbe to immediately publish `secondary` and the cluster to
+  # converge to Running (evidence sha
+  # 154cb8735a4d5efe203303c36e779ed5b4617835571c4690313fb5a50a833b82).
+  #
+  # The reaper observes the live replication state and clears the pending
+  # marker only when ALL strict conditions hold:
+  #   1. .replication-pending exists
+  #   2. .replication-divergence-pending does NOT exist (do not mask the
+  #      alpha.60 / Round 1c-B style GTID divergence fail-closed)
+  #   3. master.info exists (we are configured as a secondary; not in
+  #      initial bootstrap or self-election path)
+  #   4. .replication-ready missing (otherwise nothing to heal)
+  #   5. db_ready (local MariaDB is up and accepting connections)
+  #   6. secondary_replication_ready (Slave_IO_Running=Yes,
+  #      Slave_SQL_Running=Yes, Last_IO_Errno=0, Last_SQL_Errno=0)
+  # Any condition not met -> return 1 without touching markers. The
+  # reaper never writes a binlog event and never calls admin SQL as
+  # user-facing root: secondary_replication_ready already runs via the
+  # internal admin path. Doc B Rule 4 (a) internal account / (b) no
+  # binlog propagation / (c) only reads from existing tables / (d) does
+  # not bypass the divergence-pending gate.
+  [ -f "$(pending_file)" ] || return 1
+  [ -f "$(divergence_pending_file)" ] && return 1
+  [ -f "$(master_info_file)" ] || return 1
+  [ -f "$(ready_file)" ] && return 1
+  db_ready || return 1
+  secondary_replication_ready || return 1
+  touch "$(ready_file)" || return 1
+  touch "$(sql_listener_ready_file)" || return 1
+  rm -f "$(pending_file)" || return 1
+  echo "alpha.106 marker self-heal: replication ready confirmed via Slave_IO/SQL healthy + no divergence; cleared .replication-pending and created .replication-ready + .sql-listener-ready" >&2
+  return 0
+}
+
 check_role() {
+  # alpha.106 v1 (Jack 2026-05-29): try to self-heal stuck-pending markers
+  # before falling through to the existing pending/ready gate. The reaper
+  # returns success only when the strict five-condition pre-check passes
+  # (see attempt_marker_self_heal); otherwise it is a no-op and the
+  # original logic stands. We swallow any unexpected runtime error so the
+  # reaper never propagates a failure into the role-decision path.
+  attempt_marker_self_heal 2>/dev/null || true
+
   # Before the startup command finishes role selection, do not publish a role.
   # Publishing "secondary" here causes secondary -> primary label flips for
   # pod-0, and publishing "primary" before the pending marker exists causes

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1993,7 +1993,22 @@ spec:
                 # set_fail_closed_read_only + lock_local_root_writes
                 # in place via the startup-before-role-decision setup
                 # already done at lines 1927-1930.
-                no_primary_budget="${MARIADB_NO_PRIMARY_RETRY_BUDGET_SECONDS:-60}"
+                # alpha.106 (Jack 2026-05-29) Round 1c-C async T6
+                # Stop/Start exposed 60s is not enough when both pods are
+                # stopped and started together: pod-1 can take 70-100s
+                # from new containerCreating to "mariadbd ready for
+                # connections" under vcluster CPU/IO contention. With a
+                # 60s budget pod-0 falls through to
+                # block_existing_datadir_self_election_without_primary,
+                # writes `.replication-pending` and never returns. The
+                # alpha.106 reaper in replication-roleprobe.sh is the
+                # main self-heal path; extending this budget to 180s
+                # reduces how often the reaper has to fire and avoids
+                # the visible "Cluster Failed for N minutes" window on
+                # the first roleProbe tick. 180s is well under the
+                # InstanceSet startupProbe budget so it does not push
+                # pod-0 past KB's NotReady threshold.
+                no_primary_budget="${MARIADB_NO_PRIMARY_RETRY_BUDGET_SECONDS:-180}"
                 no_primary_deadline=$((SECONDS + no_primary_budget))
                 while [ $SECONDS -lt $no_primary_deadline ]; do
                   echo "pod-0 startup: no primary visible yet, polling every 5s for up to ${no_primary_budget}s before deciding (alpha.92 bounded rejoin retry)"


### PR DESCRIPTION
## Summary

Adds a self-healing marker reaper to `replication-roleprobe.sh` and raises the alpha.92 bounded-retry budget in `cmpd-replication-merged.yaml` from 60s → 180s. Bumps MariaDB addon chart to `1.1.1-alpha.106`.

## Why

Round 1c-C (`task442-full-n1-alpha105-r1c-fullrun-0617`) async T6 Stop/Start exposed a chart bug **different from** the alpha.105 fence-verifier fix:

1. When KB Stop/Start cycles both pods together, pod-0 startup probes pod-1:3306 before pod-1's `mariadbd` has finished accepting connections.
2. The alpha.92 bounded retry (60s default) can expire while pod-1 is still spinning up under vcluster CPU/IO contention.
3. pod-0 drops into `block_existing_datadir_self_election_without_primary`, writes `.replication-pending`, and exits.
4. After pod-1 becomes reachable the slave IO/SQL threads catch up cleanly with **no GTID divergence**, but **no actor** (startup, HA syncer, switchover) ever flips `.replication-pending` → `.replication-ready`.
5. roleProbe keeps publishing `initializing` and the cluster never reaches Running.

### Live evidence

Evidence pack `artifacts/task442-full-n1-alpha105-r1c-fullrun-0617-async-t6-fail-freeze-0648.tar.gz` sha256 `154cb8735a4d5efe203303c36e779ed5b4617835571c4690313fb5a50a833b82`:

- pod-0 `/var/lib/mysql/log/replication-no-primary-pending.log` at 22:44:59 shows `decision=no-primary-pending` + `Last_IO_Error: ... Connection refused`.
- Manual `STOP SLAVE; START SLAVE` as `kb_internal_root` recovered slave threads cleanly: `Slave_IO_Running=Yes`, `Slave_SQL_Running=Yes`.
- DCS leader cm clean: holder/leader = pod-1, no stale switchover state.
- **Live fix-layer verification (Doc B Rule 5)**: `touch .replication-ready + .sql-listener-ready; rm .replication-pending` → roleProbe immediately returned `secondary` rc=0 → KB published role label → Cluster Status `Failed` → `Running` in <15s.

## Fix — path C = A + B

### A. `cmpd-replication-merged.yaml` — raise bounded-retry budget

Change `MARIADB_NO_PRIMARY_RETRY_BUDGET_SECONDS` default from `60` to `180`. Stays well under the InstanceSet startupProbe budget (`failureThreshold 60 × periodSeconds 10 = 600s`), so it does not push pod-0 past KB NotReady. Reduces how often the reaper has to fire and shortens the visible "Cluster Failed" window on the first roleProbe tick. **Does not address the underlying race; only widens it.**

### B. `replication-roleprobe.sh` — self-healing marker reaper (main fix)

New `attempt_marker_self_heal()` called at the top of `check_role()`. The reaper observes live replication state and clears `.replication-pending` + creates `.replication-ready` + `.sql-listener-ready` only when **ALL** strict conditions hold:

| # | Condition | Why |
|---|---|---|
| 1 | `.replication-pending` exists | nothing to heal otherwise |
| 2 | `.replication-divergence-pending` does NOT exist | preserves alpha.60 / Round 1c-B GTID divergence fail-closed protection |
| 3 | `master.info` exists | we are configured as a secondary, not in initial bootstrap |
| 4 | `.replication-ready` missing | otherwise nothing to heal |
| 5 | `db_ready` | local mariadbd is up |
| 6 | `secondary_replication_ready` | `Slave_IO_Running=Yes`, `Slave_SQL_Running=Yes`, `Last_IO_Errno=0`, `Last_SQL_Errno=0` |

Any condition not met → return 1, no marker write.

### Doc B Rule 4 (a-d) compliance

| Rule | Compliance |
|---|---|
| (a) internal account | reads via existing `secondary_replication_ready` helper which uses the internal admin path |
| (b) suppresses binlog propagation | writes only marker files (no SQL writes; no INSERT/UPDATE/DELETE) |
| (c) isolated namespace | reads from existing replication-state tables only |
| (d) does not bypass the gate under test | the gate under test is "is replication healthy enough to clear pending?" — reaper checks gate inputs directly, does not run privileged SQL that would mask divergence |

### Doc B Rule 5 (Lily 06:57 proposed) compliance

The frozen Round 1c-C T6 scene `mdb-async-11076` was used for **fix-layer hypothesis pre-validation**: manually flipping the markers (`touch .replication-ready + .sql-listener-ready; rm .replication-pending`) on the live stuck cluster confirmed the markers were the sole gate (cluster reached Running in <15s) **before** the PR was written. The reaper's logic mirrors exactly that manual sequence with conservative guards.

## Scope

- `addons/mariadb/templates/cmpd-replication-merged.yaml` (A budget bump)
- `addons/mariadb/scripts/replication-roleprobe.sh` (B reaper + helper)
- `addons/mariadb/Chart.yaml` (version bump + annotated change note)

`cmpd-semisync.yaml` and `cmpd-replication.yaml` are **unchanged**; the B reaper lives in the shared `replication-roleprobe.sh` script, so it heals semisync and replication-merged uniformly without engine-specific code changes.

syncer / image baseline unchanged from alpha.105.

## Helen TL pre-PR review points covered

1. **Emit location identified**: `block_existing_datadir_self_election_without_primary` is in both `cmpd-replication-merged.yaml` (line 692) and `cmpd-semisync.yaml` (line 574); `cmpd-replication.yaml` does not have the path. The B reaper in the shared roleprobe script covers all topologies that import roleprobe (replication-merged, semisync, replication) without per-topology code changes.
2. **Retry budget vs startup probe**: 180s default is well under the 600s startupProbe budget; safe.
3. **Reaper trigger conditions strict**: six required checks listed above; cannot bypass the divergence-pending gate.
4. **Relation to alpha.105**: alpha.105 fixed `verify_post_dcs_local_root_write_fenced()` self-pollution (PR #2692); alpha.106 fixes the secondary-rejoin marker-stuck path. Two independent bugs, two independent PRs, two independent Chart bumps.
5. **Cleanup discipline**: `mdb-async-11076` normal-deleted (per Helen 06:55 approval); evidence sha already archived. Fresh Round 1c-D will exercise the real startup-after-restart path on alpha.106.

## Test plan

- [x] `bash -n` on rewritten roleprobe — PASS
- [x] `helm dependency build` + `helm lint` on chart with alpha.106 bump — PASS
- [x] Live verify on `mdb-async-11076` (Doc B Rule 5): markers are sole gate (PASS)
- [ ] IDC `mariadb-test5` helm upgrade to alpha.106 — awaits @Helen
- [ ] Round 1c-D from T1 fresh 4 topology — Jack
- [ ] Round 1c-D async T6 PASS — verifies reaper handles real Stop/Start
- [ ] Round 1c-D semisync / galera 4-topology completion

## Related

- Triggering evidence: `artifacts/task442-full-n1-alpha105-r1c-fullrun-0617-async-t6-fail-freeze-0648.tar.gz` sha256 `154cb8735a4d5efe203303c36e779ed5b4617835571c4690313fb5a50a833b82`
- Predecessor child PRs in this dev branch:
  - PR #2689 (`fix(mariadb): pin reconfigure action image`)
  - PR #2690 (`bump(mariadb): 1.1.1-alpha.103`)
  - PR #2691 (`fix(mariadb): provision kb_internal_root in standalone CmpD (alpha.104)`)
  - PR #2692 (`fix(mariadb): rewrite fence verifier to read-only privilege query (alpha.105)`)
- Cross-team Doc B Rule 5 acknowledgement: `#kubeblocks-controller:ef37ac53` 06:57 (Lily)
