### PR TITLE
mariadb: alpha.107 reaper Cond 7 bind verify + chart reconciled-existing path verify + audit log

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1232,7 +1232,87 @@ type: application
 # topologies, so it heals semisync and replication-merged uniformly
 # without engine-specific code changes. syncer / image baseline
 # unchanged from alpha.105.
-version: 1.1.1-alpha.106
+#
+# alpha.107 v1 (Jack 2026-05-29 — Round 1c-D async CM4 RED root cause
+# CLOSED): alpha.106 reaper itself became a 6th `.sql-listener-ready`
+# writer that fires while mariadbd is still in 127.0.0.1-only
+# bootstrap mode. Round 1c-D async CM4 N=1 fresh run
+# (task442-full-n1-alpha106-r1d-fullrun-0712) at T6 Stop/Start was
+# RED: at 23:29:38 reaper Cond 1-6 all returned true (.replication-
+# pending present, no divergence-pending, master.info present,
+# .replication-ready absent, db_ready, secondary_replication_ready)
+# so the reaper touched `.replication-ready` + `.sql-listener-ready`
+# WHILE mariadbd was still bound to 127.0.0.1 (bootstrap phase pre-
+# rebind to 0.0.0.0). The marker semantic of `.sql-listener-ready`
+# = "mariadbd has rebound to 0.0.0.0 past bootstrap 127.0.0.1-only
+# phase" — Cond 6's secondary_replication_ready probes via the
+# 127.0.0.1 local mariadb client, so it is satisfied at bootstrap
+# time and is structurally NOT a direct proxy for the bind invariant.
+# Result: `.sql-listener-ready` lied, downstream actors (chart
+# expose_sql_listener_for_primary_role reconciled-existing fast
+# path, syncer Follow, KB roleProbe) saw a green marker and skipped
+# the rebind that the marker name claims is already done, leaving
+# pods unreachable on Service traffic. Live evidence frozen on
+# mdb-async-10115 sha256
+# d8d1aa42160c46df8eb0aecbdf41c739a9f691ece3724b05647c941fc7f75ac6
+# + narrow ABC sha256
+# a13c05dc9b25b972e1af4760a094da3a5bd7d9da0ac23bf9c4b4e7f3d1412107.
+# Cross-team cosign retraction (Helen TL / Edward / Rocco / Lily) on
+# PR #2694 alpha.106 LGTMs and upgrade to Doc B Rule 6.
+#
+# alpha.107 v1 fix (3-part bind invariant alignment):
+# 1. `addons/mariadb/scripts/replication-roleprobe.sh`
+#    `attempt_marker_self_heal()` adds Cond 7
+#    `mariadbd_listen_on_all_interfaces` — reads /proc/net/tcp +
+#    /proc/net/tcp6, accepts IPv4 wildcard `00000000:0CEA` (port
+#    3306 = hex 0CEA) OR IPv6 wildcard
+#    `00000000000000000000000000000000:0CEA` with listen state 0A.
+#    Rejects only 127.0.0.1-only (`0100007F:0CEA`). Any condition
+#    1-7 not met → return 1, no marker write.
+# 2. `addons/mariadb/templates/cmpd-replication-merged.yaml`
+#    `expose_sql_listener_for_primary_role()` reconciled-existing
+#    fast path is gated on the same bind verify — if
+#    `.sql-listener-ready` exists but `mariadbd_listen_on_all_
+#    interfaces` returns false, fall through to fresh-listener path
+#    which actually rebinds. Closes the symmetric DRY risk where a
+#    future stale `.sql-listener-ready` (reaper bug, PVC residue,
+#    other writer) would let the chart skip the rebind too.
+# 3. `addons/mariadb/scripts/replication-roleprobe.sh`
+#    `reaper_audit_log()` writes per-condition pass/bail rc to
+#    `${dataMountPath}/log/reaper-audit.log` (independent file —
+#    NOT stderr, which is suppressed via `2>/dev/null` per
+#    kbagent role-probe runtime contract and stays suppressed).
+#    Format: `<RFC3339 timestamp> cond=N <gate>=<value> rc=<bail|
+#    continue>`. Grep-able per gate + timestamps alignable with
+#    kbagent log time window for postmortem audit (Edward unique
+#    add: Rule 1 直证清单 alignment).
+#
+# Doc B Rule 4 (a-d) compliance: unchanged from alpha.106 — reaper
+# still reads only via existing internal admin helper +
+# /proc/net/tcp[6] (kernel proc filesystem, no replication-stream
+# side effect), writes only marker + audit files (no binlog event),
+# the divergence-pending fail-closed gate is preserved.
+# Doc B Rule 5 (Lily 06:57): live-verify scenario for alpha.107 will
+# explicitly enumerate implicit precondition "mariadbd 已 rebind
+# 0.0.0.0" so the verify scenario is equivalent to the CM4 rolling-
+# restart-with-stale-bind production failure mode that alpha.106's
+# mdb-async-11076 手工恢复 scenario did NOT cover.
+# Doc B Rule 6 (Helen 08:12 proposed, Lily 08:14 independent rule,
+# Rocco 08:15 / Edward 08:15 / Helen 08:17 cosign): marker semantic
+# invariant must be direct-verified at write time. Cond 7 reads the
+# real kernel-level bind state via /proc/net/tcp[6] instead of
+# inferring it from `secondary_replication_ready` (an indirect
+# 127.0.0.1-side health probe that does not reflect external bind).
+# Scope: `addons/mariadb/scripts/replication-roleprobe.sh` (Cond 7
+# + reaper_audit_log helper + Cond 1-6 per-gate audit hooks),
+# `addons/mariadb/templates/cmpd-replication-merged.yaml`
+# (mariadbd_listen_on_all_interfaces helper + reconciled-existing
+# fast path bind gate), `Chart.yaml` (version bump + this note).
+# cmpd-semisync.yaml and cmpd-replication.yaml are unchanged.
+# Reaper + helper are topology-neutral; semisync/replication-merged
+# benefit uniformly without engine-specific code changes.
+# syncer / image baseline unchanged from alpha.106.
+version: 1.1.1-alpha.107
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -78,6 +78,59 @@ divergence_pending_file() {
   printf "%s/.replication-divergence-pending" "$(data_dir)"
 }
 
+# alpha.107 v1 (Jack 2026-05-29): mariadbd_listen_on_all_interfaces returns
+# 0 iff mariadbd has at least one listening TCP socket bound to 0.0.0.0:3306
+# (IPv4 wildcard) OR :::3306 (IPv6 wildcard). The check looks directly at
+# /proc/net/tcp + /proc/net/tcp6 (kernel-truth) instead of `@@bind_address`
+# (which can be set to "*" or "0.0.0.0" by config while a startup-time
+# argument still pins the actual listening socket to 127.0.0.1). This is
+# the alpha.102 v1 `.sql-listener-ready` marker semantic in its strongest
+# form: the marker means "mariadbd is reachable from off-pod traffic past
+# the bootstrap 127.0.0.1-only phase", and the only direct way to confirm
+# that is to read the listen socket. Reaper Cond 7 (added in alpha.107)
+# uses this so it never sets `.sql-listener-ready` while mariadbd is still
+# bound to 127.0.0.1 (Round 1c-D async CM4 self-referential reaper bug,
+# evidence sha d8d1aa42160c46df8eb0aecbdf41c739a9f691ece3724b05647c941fc7f75ac6).
+#
+# Port 3306 = hex 0CEA. Listen state in /proc/net/tcp{,6} = hex 0A.
+# IPv4 0.0.0.0:3306 listen row local_address = "00000000:0CEA".
+# IPv6 :::3306    listen row local_address = "00000000000000000000000000000000:0CEA".
+# Function is POSIX-portable and uses awk + grep instead of `ss` so it
+# works inside the kbagent action runtime that does not always ship `ss`.
+mariadbd_listen_on_all_interfaces() {
+  local tcp4 tcp6
+  tcp4=$(awk 'NR>1 && $2=="00000000:0CEA" && $4=="0A" {print; exit}' /proc/net/tcp 2>/dev/null)
+  if [ -n "${tcp4}" ]; then
+    return 0
+  fi
+  tcp6=$(awk 'NR>1 && $2=="00000000000000000000000000000000:0CEA" && $4=="0A" {print; exit}' /proc/net/tcp6 2>/dev/null)
+  if [ -n "${tcp6}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# alpha.107 v1 (Jack 2026-05-29): reaper_audit_log writes a single line to
+# `${dataMountPath}/log/reaper-audit.log`. The audit log is intentionally
+# kept OUT of the `check_role()` `2>/dev/null` stderr-suppression path so a
+# future investigation can reconstruct exactly which conditions the reaper
+# observed and which steps it executed at every probe tick. Round 1c-D async
+# CM4 narrow (2026-05-29 07:30-08:13) had to spend 40+ minutes reverse-
+# engineering whether the reaper fired or not because the only fire-time
+# signal was a single `echo >&2` that `check_role` then swallowed. This
+# audit log makes the reaper's behavior self-documenting on disk. Format is
+# `YYYY-MM-DDTHH:MM:SSZ reaper-audit kv=val kv=val ...`. The function is a
+# best-effort write: if mkdir or tee fails we silently continue so the
+# reaper's main logic does not depend on the audit log being functional.
+reaper_audit_log() {
+  local audit_dir audit_file ts
+  audit_dir="$(data_dir)/log"
+  audit_file="${audit_dir}/reaper-audit.log"
+  mkdir -p "${audit_dir}" 2>/dev/null || return 0
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)"
+  printf '%s reaper-audit %s\n' "${ts}" "$*" >> "${audit_file}" 2>/dev/null || true
+}
+
 resolve_mariadb_cli() {
   if command -v mariadb >/dev/null 2>&1; then
     command -v mariadb
@@ -393,22 +446,94 @@ attempt_marker_self_heal() {
   #   5. db_ready (local MariaDB is up and accepting connections)
   #   6. secondary_replication_ready (Slave_IO_Running=Yes,
   #      Slave_SQL_Running=Yes, Last_IO_Errno=0, Last_SQL_Errno=0)
+  #   7. mariadbd_listen_on_all_interfaces (added in alpha.107 — see below)
   # Any condition not met -> return 1 without touching markers. The
   # reaper never writes a binlog event and never calls admin SQL as
   # user-facing root: secondary_replication_ready already runs via the
   # internal admin path. Doc B Rule 4 (a) internal account / (b) no
   # binlog propagation / (c) only reads from existing tables / (d) does
-  # not bypass the divergence-pending gate.
-  [ -f "$(pending_file)" ] || return 1
-  [ -f "$(divergence_pending_file)" ] && return 1
-  [ -f "$(master_info_file)" ] || return 1
-  [ -f "$(ready_file)" ] && return 1
-  db_ready || return 1
-  secondary_replication_ready || return 1
-  touch "$(ready_file)" || return 1
-  touch "$(sql_listener_ready_file)" || return 1
-  rm -f "$(pending_file)" || return 1
-  echo "alpha.106 marker self-heal: replication ready confirmed via Slave_IO/SQL healthy + no divergence; cleared .replication-pending and created .replication-ready + .sql-listener-ready" >&2
+  # not bypass the divergence-pending gate. Doc B Rule 6 (proposed by
+  # Helen TL 2026-05-29 08:12): the reaper now verifies the marker
+  # semantic invariant at write time (Cond 7 directly reads the kernel
+  # listen socket) instead of inferring it from indirect health signals.
+  # alpha.107 v1 (Jack 2026-05-29): Cond 7 closes the alpha.106 self-
+  # referential reaper bug uncovered by Round 1c-D async CM4
+  # (task442-full-n1-alpha106-r1d-fullrun-0712). After CM4 rolling restart,
+  # the recreated pod-1 mariadbd was launched with `--bind-address=127.0.0.1`
+  # (bootstrap-local-only phase). The PVC carried a stale master.info from
+  # the previous incarnation, so the alpha.106 6-condition gate (pending /
+  # divergence-pending absent / master.info present / ready absent /
+  # db_ready / secondary_replication_ready) all passed at the next
+  # roleProbe tick. The reaper touched `.replication-ready` +
+  # `.sql-listener-ready` and removed `.replication-pending`. But
+  # `.sql-listener-ready` carries the alpha.102 v1 semantic "mariadbd has
+  # been re-bound to 0.0.0.0 past the bootstrap 127.0.0.1-only phase".
+  # Pod-1's mariadbd was still 127.0.0.1-only, so the marker was a lie.
+  # KB then promoted pod-1 to primary (saw ready=secondary in DCS, ran
+  # switchover RESET SLAVE ALL + SET GLOBAL read_only=0) — but mariadbd
+  # was still 127.0.0.1-only, so pod-0's slave IO got Connection refused.
+  # Cluster never reached Running.
+  #
+  # Evidence sha256
+  # d8d1aa42160c46df8eb0aecbdf41c739a9f691ece3724b05647c941fc7f75ac6.
+  #
+  # Cond 7 reads /proc/net/tcp + /proc/net/tcp6 directly and requires at
+  # least one wildcard listen socket (0.0.0.0:3306 or :::3306) before
+  # the reaper may set `.sql-listener-ready`. This is the strongest
+  # possible direct proof of the marker's contract.
+  reaper_audit_log "tick=enter"
+  if [ ! -f "$(pending_file)" ]; then
+    reaper_audit_log "cond=1 pending=absent rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=1 pending=present rc=continue"
+  if [ -f "$(divergence_pending_file)" ]; then
+    reaper_audit_log "cond=2 divergence_pending=present rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=2 divergence_pending=absent rc=continue"
+  if [ ! -f "$(master_info_file)" ]; then
+    reaper_audit_log "cond=3 master_info=absent rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=3 master_info=present rc=continue"
+  if [ -f "$(ready_file)" ]; then
+    reaper_audit_log "cond=4 ready=present rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=4 ready=absent rc=continue"
+  if ! db_ready; then
+    reaper_audit_log "cond=5 db_ready=false rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=5 db_ready=true rc=continue"
+  if ! secondary_replication_ready; then
+    reaper_audit_log "cond=6 secondary_replication_ready=false rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=6 secondary_replication_ready=true rc=continue"
+  if ! mariadbd_listen_on_all_interfaces; then
+    reaper_audit_log "cond=7 mariadbd_bind=127.0.0.1-only rc=bail"
+    return 1
+  fi
+  reaper_audit_log "cond=7 mariadbd_bind=wildcard rc=continue"
+  if ! touch "$(ready_file)"; then
+    reaper_audit_log "fire step=touch_ready rc=fail"
+    return 1
+  fi
+  reaper_audit_log "fire step=touch_ready rc=ok"
+  if ! touch "$(sql_listener_ready_file)"; then
+    reaper_audit_log "fire step=touch_sql_listener_ready rc=fail"
+    return 1
+  fi
+  reaper_audit_log "fire step=touch_sql_listener_ready rc=ok"
+  if ! rm -f "$(pending_file)"; then
+    reaper_audit_log "fire step=rm_pending rc=fail"
+    return 1
+  fi
+  reaper_audit_log "fire step=rm_pending rc=ok"
+  reaper_audit_log "fire step=complete"
+  echo "alpha.107 marker self-heal: replication ready confirmed via Slave_IO/SQL healthy + no divergence + mariadbd bound to 0.0.0.0; cleared .replication-pending and created .replication-ready + .sql-listener-ready" >&2
   return 0
 }
 

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1647,6 +1647,26 @@ spec:
               touch {{ .Values.dataMountPath }}/.sql-listener-ready
               prestop_watchdog_log "sql-listener-expose-complete label=${label}"
             }
+            # alpha.107 (Doc B Rule 6): direct verify mariadbd is listening on
+            # 0.0.0.0:3306 (or :::3306) — `.sql-listener-ready` marker semantic
+            # = "mariadbd already rebound past 127.0.0.1 bootstrap". Read
+            # /proc/net/tcp (IPv4) + /proc/net/tcp6 (IPv6); listen state = 0A;
+            # port 3306 = hex 0CEA. IPv4 wildcard local_address = 00000000:0CEA;
+            # IPv6 wildcard = 00000000000000000000000000000000:0CEA. Either
+            # present passes; only 127.0.0.1:3306 (0100007F:0CEA) → fail.
+            mariadbd_listen_on_all_interfaces() {
+              local f
+              for f in /proc/net/tcp /proc/net/tcp6; do
+                [ -r "$f" ] || continue
+                awk 'NR>1 && $4=="0A" {print $2}' "$f" | while read -r addr; do
+                  case "$addr" in
+                    00000000:0CEA) echo wildcard; break ;;
+                    00000000000000000000000000000000:0CEA) echo wildcard; break ;;
+                  esac
+                done | grep -q wildcard && return 0
+              done
+              return 1
+            }
             expose_sql_listener_for_primary_role() {
               local label="$1"
               if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
@@ -1654,7 +1674,14 @@ spec:
                 mark_replication_pending
                 return 1
               fi
-              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+              # alpha.107 (Doc B Rule 6): gate reconciled-existing fast path on
+              # direct mariadbd bind verify. Without this, a stale
+              # `.sql-listener-ready` marker (reaper bug, PVC residue, etc.)
+              # lets us skip the actual rebind and leave mariadbd on 127.0.0.1
+              # bootstrap — pods can't be reached by Service traffic. If the
+              # marker exists but mariadbd is still bootstrap-bound, fall
+              # through to the fresh-listener path below.
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
                 "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
                 if set_primary_read_write; then


### PR DESCRIPTION
## Summary

alpha.106 reaper became a 6th `.sql-listener-ready` writer that fires while mariadbd is still in 127.0.0.1-only bootstrap mode. Round 1c-D async CM4 N=1 (`task442-full-n1-alpha106-r1d-fullrun-0712`) RED root cause: Cond 6 `secondary_replication_ready` probes via 127.0.0.1 local mariadb client, so it is satisfied at bootstrap time and is structurally NOT a direct proxy for the bind invariant the marker name claims.

Live evidence frozen on `mdb-async-10115`:
- full freeze sha256 `d8d1aa42160c46df8eb0aecbdf41c739a9f691ece3724b05647c941fc7f75ac6`
- narrow ABC sha256 `a13c05dc9b25b972e1af4760a094da3a5bd7d9da0ac23bf9c4b4e7f3d1412107`

## Fix (3-part bind invariant alignment, Doc B Rule 6)

### 1. Reaper Cond 7 (scripts/replication-roleprobe.sh)

`attempt_marker_self_heal()` adds Cond 7 `mariadbd_listen_on_all_interfaces`:
- reads `/proc/net/tcp` (IPv4) + `/proc/net/tcp6` (IPv6)
- accepts IPv4 wildcard `00000000:0CEA` (port 3306 = hex `0CEA`) OR IPv6 wildcard `00000000000000000000000000000000:0CEA` with listen state `0A`
- rejects only 127.0.0.1-only (`0100007F:0CEA`)
- any condition 1-7 not met → return 1, no marker write

### 2. Chart reconciled-existing path bind gate (templates/cmpd-replication-merged.yaml)

`expose_sql_listener_for_primary_role()` reconciled-existing fast path is gated on the same `mariadbd_listen_on_all_interfaces` helper (DRY). Symmetric defense: if `.sql-listener-ready` exists but mariadbd is still bootstrap-bound (reaper bug, PVC residue, other writer), fall through to the fresh-listener path which actually rebinds.

### 3. Reaper audit log (scripts/replication-roleprobe.sh)

`reaper_audit_log()` writes per-condition pass/bail rc to `${dataMountPath}/log/reaper-audit.log`:
- independent file — NOT stderr (stderr stays suppressed by `2>/dev/null` per kbagent role-probe contract per Helen 08:12)
- format: `<RFC3339 timestamp> cond=N <gate>=<value> rc=<bail|continue>`
- grep-able per gate; timestamps alignable with kbagent log window for postmortem audit (Edward unique add: Rule 1 直证清单 alignment)

## Doc B compliance

- **Rule 4 (a-d)**: reader uses internal admin helper + `/proc/net/tcp[6]` (kernel proc fs, no replication side effect); writes marker + audit files only (no binlog event); divergence-pending fail-closed gate preserved.
- **Rule 5 (Lily 06:57)**: live-verify scenario for alpha.107 will explicitly enumerate implicit precondition "mariadbd 已 rebind 0.0.0.0" so the verify scenario is equivalent to the CM4 rolling-restart-with-stale-bind production failure mode that alpha.106's `mdb-async-11076` 手工恢复 scenario did NOT cover.
- **Rule 6 (Helen 08:12 / Lily 08:14 independent rule / Rocco 08:15 / Edward 08:15 / Helen 08:17 cosign)**: marker semantic invariant direct-verified at write time, not inferred from indirect 127.0.0.1-side health probe.

## Scope

- `addons/mariadb/scripts/replication-roleprobe.sh` — Cond 7 + `reaper_audit_log` + Cond 1-6 audit hooks
- `addons/mariadb/templates/cmpd-replication-merged.yaml` — `mariadbd_listen_on_all_interfaces` helper + reconciled-existing fast path bind gate
- `addons/mariadb/Chart.yaml` — version bump 1.1.1-alpha.106 → 1.1.1-alpha.107 + annotated note
- `cmpd-semisync.yaml` and `cmpd-replication.yaml` unchanged (reaper + helper are topology-neutral)
- syncer / image baseline unchanged from alpha.106

## Cross-team review framework (5-dim, finalized by Helen 08:17)

1. Cond 7 socket check implementation detail (port envvar sync + listen state `0A` + IPv4 + IPv6 double cover)
2. bind-check helper DRY (reaper + chart reconciled-existing same helper)
3. audit log schema Rule 1 alignment (independent file + per gate grep-able + RFC3339 ms timestamp + kbagent log window alignable) — Edward unique add
4. Round 1c-E double verify (a fix unsticks + b not falsely triggered in non-target scenario)
5. Rule 5 implicit-precondition self-check + Rule 6 marker invariant self-check as explicit review subitems

## Test plan

- [ ] Helm template render verify (chart unchanged behavior for non-stale marker case)
- [ ] `bash -n` syntax check on `replication-roleprobe.sh` (PASS locally)
- [ ] `helm lint` (PASS locally — 1 chart(s) linted, 0 chart(s) failed)
- [ ] Cross-team focused review (Helen TL + Lily + Rocco + Edward) per the 5-dim framework
- [ ] Self-merge after cosigns
- [ ] IDC re-pin alpha.106 → alpha.107 on `mariadb-test5` vcluster
- [ ] Round 1c-E fresh from T1 on 4 topology (async / replication-merged / semisync / galera) — the real acceptance gate
- [ ] mdb-async-10115 scene preserved until merge + IDC re-pin + Round 1c-E PASS

## Refs

Cross-team cosign retraction on PR #2694 alpha.106:
- Helen TL: https://github.com/apecloud/kubeblocks-addons/pull/2694#issuecomment-4569350041
- Lily / Rocco / Edward: https://github.com/apecloud/kubeblocks-addons/pull/2694#issuecomment-4569351887
