### PR TITLE
mariadb: alpha.108 P0a — restore BINLOG ADMIN on user-facing root @localhost+@127.0.0.1 to close sql_log_bin=0 wrap silent-fail

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1312,7 +1312,113 @@ type: application
 # Reaper + helper are topology-neutral; semisync/replication-merged
 # benefit uniformly without engine-specific code changes.
 # syncer / image baseline unchanged from alpha.106.
-version: 1.1.1-alpha.107
+#
+# alpha.108 v1 (Jack 2026-05-29) — close 6-alpha silent-fail in
+# chart-internal `SET SESSION sql_log_bin=0` wrap mechanism.
+#
+# Root cause (Round 1c-E acceptance evidence):
+# Chart functions wrapping DDL with `SET SESSION sql_log_bin=0;
+# ... SET SESSION sql_log_bin=1;` write SQL via `${LOCAL[@]}`
+# (user-facing root). Since alpha.64 hardening, user-facing root
+# has neither SUPER nor BINLOG ADMIN. The `SET SESSION
+# sql_log_bin=0` statement silently fails with `ERROR 1227
+# (42000) Access denied; you need (at least one of) the BINLOG
+# ADMIN privilege(s)`. `mariadb -e` continues to the next
+# statement on default binlog state, so the subsequent
+# CREATE USER / GRANT / REVOKE / ALTER USER statements emit
+# binlog events with server_id=this pod. Accumulated across
+# `set_local_root_account_state`, `set_remote_root_account_state`,
+# `grant_optional_local_root_privileges`,
+# `grant_optional_remote_root_privileges`, and the
+# prestop-fence path, ~45 silent-fail × ~5.5 DDL ≈ 248 orphan
+# events accumulated on pod-1 during the Round 1c-E async
+# VScale rolling restart window. Pod-1 then hit alpha.60
+# fail-closed protection (`.replication-divergence-pending`),
+# never published a valid role, and the VScale OpsRequest stayed
+# at progress 1/2 indefinitely. Evidence sha
+# 1d3554cd483bcf4eef9a96ce982b7341c6dce6a316f4e51b2731b1548f53b43f.
+# Historical context: alpha.69 v1 5.D-r2 RED documented this
+# same ERROR 1227 pattern for the kb_health_check probe path,
+# and alpha.70 v1 fixed *only* the probe path by delegating it
+# to `syncerctl writecheck` via the syncer-held internal admin
+# connection. The same fix pattern was not generalized to other
+# `${LOCAL[@]}` sites, and the architectural class went 6 alpha
+# generations unfixed until Round 1c-E acceptance surfaced it.
+#
+# alpha.64 hardening sub-boundary (corrected scope precision):
+# alpha.64 hardening rationale was: prevent user-facing root from
+# bypassing `@@global.read_only=ON`. The privilege that performs
+# that bypass is SUPER (and READ_ONLY ADMIN). The privilege that
+# was *also* dropped in the same alpha.64 commit, BINLOG ADMIN,
+# does NOT bypass read_only; it controls only
+# `SET SESSION sql_log_bin=*` and related binlog options.
+# alpha.108 P0a corrects the boundary as follows:
+#
+#   - user-facing root @'%' (remote)   → SUPER ✗, BINLOG ADMIN ✗,
+#                                         READ_ONLY ADMIN ✗
+#     (full alpha.64 hardening retained; remote root cannot bypass
+#      read_only or control binlog).
+#   - user-facing root @'localhost'    → SUPER ✗, BINLOG ADMIN ✓,
+#                                         READ_ONLY ADMIN ✗
+#     (read_only bypass still blocked; chart-internal
+#      sql_log_bin=0 wrap now takes effect).
+#   - user-facing root @'127.0.0.1'    → SUPER ✗, BINLOG ADMIN ✓,
+#                                         READ_ONLY ADMIN ✗
+#     (same as @'localhost').
+#
+# Configure-line contract: chart-internal SQL via socket/loopback
+# is trusted with binlog control (BINLOG ADMIN); remote root
+# remains fully hardened per the original alpha.64 intent.
+# K8s pod network boundary (pod-local unix socket + loopback)
+# means an external user cannot reach the @'localhost' or
+# @'127.0.0.1' grant; the BINLOG ADMIN restoration does not
+# widen the externally-reachable privilege set.
+#
+# Doc B reference (see kubeblocks-addon-docs once published):
+#   - Rule 5 sub-1.B 10th trap: source-intent envelope ≠
+#     runtime-effect payload, mediated by access-control
+#     privilege requirements.
+#   - Rule 5 sub-1.B 11th trap: security hardening grant-set
+#     envelope ≠ minimum-necessary privilege payload (alpha.64
+#     bundled drop should have been narrowed to SUPER + READ_ONLY
+#     ADMIN per minimum-necessary principle).
+#
+# Scope of this PR (alpha.108 P0a):
+#   1. CMPD_SECONDARY_FENCE_GRANT_BODY_LOCAL: new constant adding
+#      `BINLOG ADMIN` to CMPD_SECONDARY_FENCE_GRANT_BODY; used by
+#      set_local_root_account_state which iterates @'localhost' and
+#      @'127.0.0.1'. set_remote_root_account_state still uses the
+#      original CMPD_SECONDARY_FENCE_GRANT_BODY for @'%' targets.
+#   2. CMPD_EXPLICIT_PRIMARY_GRANT_BODY_LOCAL: same pattern; new
+#      _LOCAL variant for @'localhost' / @'127.0.0.1' usage.
+#   3. Defense-in-depth: swap `${LOCAL[@]}` → `${INTERNAL_LOCAL[@]}`
+#      in post-INTERNAL_LOCAL-ready chart functions
+#      (set_local_root_account_state, set_remote_root_account_state,
+#      grant_optional_local_root_privileges,
+#      grant_optional_remote_root_privileges)
+#      in cmpd-replication-merged.yaml + cmpd-semisync.yaml mirror.
+#      Even if a future hardening pass removes BINLOG ADMIN from
+#      @'localhost' / @'127.0.0.1' again, chart-internal DDL
+#      stays on INTERNAL_LOCAL (kb_internal_root) which retains
+#      BINLOG ADMIN per grant_internal_admin_runtime_privileges.
+#
+# Pre-merge acceptance anchor (sub-3d direct-runtime verify):
+# Deploy this chart into a fresh test pod and confirm
+# `grep -c "ERROR 1227" /var/lib/mysql/log/sql-listener-fence.log`
+# returns 0 throughout the startup window. Post-merge acceptance:
+# Round 1c-F fresh 4 topology N=1 stop-on-first-fail with this
+# chart pinned. T1.2 negative regression assertion (Rocco
+# 2026-05-29 10:26): external connection to user-facing root
+# @'%' attempting `SET SESSION sql_log_bin=0` MUST still emit
+# ERROR 1227 — verifying that the BINLOG ADMIN restoration is
+# host-scoped (alpha.64 hardening boundary preserved on @'%').
+#
+# syncer / image baseline unchanged from alpha.107. cmpd-
+# replication.yaml and cmpd.yaml (standalone) unchanged: those
+# topologies' chart-internal SQL paths either do not exercise
+# the affected functions or already use kb_internal_root for
+# their bootstrap path.
+version: 1.1.1-alpha.108
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1418,6 +1418,45 @@ type: application
 # topologies' chart-internal SQL paths either do not exercise
 # the affected functions or already use kb_internal_root for
 # their bootstrap path.
+#
+# Known residual: initial cluster bootstrap chicken-and-egg
+# (Lily 2026-05-29 10:41 documentation refinement, not addressed
+# in alpha.108 P0a):
+# `grant_internal_admin_runtime_privileges` (which GRANTS
+# BINLOG ADMIN etc. to kb_internal_root@'localhost' and
+# kb_internal_root@'127.0.0.1') must itself run as ROOT_LOCAL
+# (user-facing root via socket) before kb_internal_root exists.
+# Its first invocation on a fresh pod therefore still produces
+# ~14 BINLOG ADMIN-related GRANT events on the local binlog
+# under the user-facing root identity (whose sql_log_bin=0 wrap
+# is still ineffective at that point, since BINLOG ADMIN has not
+# yet been granted). These events are confined to the initial
+# cluster bootstrap window — pre-first-rolling-restart and
+# pre-any-secondary-following-the-primary — and they are
+# written to the eventual primary's binlog from cluster T0,
+# before any secondary joins. They therefore do NOT produce
+# server_id-divergence orphan events of the kind that triggered
+# the Round 1c-E failure (which required a transient primary
+# role on a future secondary). The pattern does NOT recur during
+# VScale / CM4 / T6 cycles, because after wait_for_internal_local_admin
+# promotes LOCAL=INTERNAL_LOCAL, all subsequent chart functions
+# use the kb_internal_root identity that has BINLOG ADMIN.
+# A future alpha could close this residual by, e.g.:
+#   (a) docker-entrypoint initdb-time pre-grant of BINLOG ADMIN
+#       to user-facing root @'localhost' (chart then revokes
+#       after promotion), or
+#   (b) `RESET MASTER` at GTID position 0 immediately before
+#       `grant_internal_admin_runtime_privileges` writes (clears
+#       the bootstrap binlog so no events remain), or
+#   (c) delegating the GRANT-BINLOG-ADMIN-to-kb_internal_root
+#       sequence to a syncer-internal init path analogous to
+#       alpha.70's `syncerctl writecheck` model.
+# alpha.108 P0a explicitly does NOT address this residual; Round
+# 1c-F acceptance evidence validates only the recurring-VScale-
+# orphan path. Doc B Rule 5 sub-1.A application: do NOT read
+# "alpha.108 P0a Round 1c-F PASS" as "all chart-internal DDL is
+# binlog-suppressed under every condition" — the initial-bootstrap
+# path remains a known scope exclusion until a future alpha.
 version: 1.1.1-alpha.108
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -340,6 +340,60 @@ spec:
             # "there is another switchover unfinished" axis).
             CMPD_EXPLICIT_PRIMARY_GRANT_BODY="SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, CREATE USER"
             CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN"
+            # alpha.108 P0a (Jack 2026-05-29): @localhost / @'127.0.0.1' variants
+            # restore BINLOG ADMIN to user-facing root @socket+loopback so the
+            # chart-internal `SET SESSION sql_log_bin=0; ...; SET SESSION
+            # sql_log_bin=1;` wrap mechanism in `set_local_root_account_state`
+            # / `set_remote_root_account_state` / `grant_optional_local_root_
+            # privileges` / `grant_optional_remote_root_privileges` actually
+            # takes effect. Background: from alpha.64 (security hardening to
+            # drop user-facing root admin-bypass) through alpha.107, the chart
+            # author's intended `sql_log_bin=0` wrap was structurally
+            # ineffective on ${LOCAL[@]} (= ROOT_LOCAL at bootstrap, user-
+            # facing root via socket) because user-facing root lost BINLOG
+            # ADMIN, so `SET SESSION sql_log_bin=0` returned ERROR 1227
+            # (Access denied; you need (at least one of) the BINLOG ADMIN
+            # privilege(s) for this operation) and `mariadb -e` silently
+            # continued to the subsequent CREATE USER / ALTER USER /
+            # REVOKE / GRANT / FLUSH PRIVILEGES statements WITH binlog
+            # enabled — each statement writing one binlog event with
+            # server_id=this_pod, accumulating as orphan events on the pod's
+            # local binlog. The bug was tracked indirectly through 5 alpha-
+            # test rounds (1c-A through 1c-E); Round 1c-E acceptance run
+            # finally surfaced the silent failure pattern directly via
+            # `grep "ERROR 1227" sql-listener-fence.log` (45 instances on
+            # frozen scene `mdb-async-11221`, sha
+            # 1d3554cd483bcf4eef9a96ce982b7341c6dce6a316f4e51b2731b1548f53b43f).
+            # Quantitative accounting: 45 silent-fail × ~5.5 DDL/fail ≈ 248
+            # orphan events matched the observed `gtid_binlog_pos` delta
+            # `2-2-248` (primary) vs `2-2-249` (pod-1 secondary) within 8%
+            # noise (FLUSH PRIVILEGES row-event variance + LOCK→LOCK same-
+            # state short-circuit + reconcile-repair mid-loop interruption).
+            #
+            # Security boundary preservation (per Helen TL 10:21 + Lily Doc B
+            # 主笔 10:20 alpha.64 hardening sub-boundary wording precision):
+            # BINLOG ADMIN is privilege-orthogonal to SUPER. SUPER allows
+            # `SET GLOBAL read_only=0` bypass and a broader admin-bypass set;
+            # BINLOG ADMIN allows ONLY `SET SESSION sql_log_bin=*` + a small
+            # set of binlog log-control statements; it does NOT bypass
+            # `@@global.read_only=1`. Restoring BINLOG ADMIN to user-facing
+            # root @'localhost' + @'127.0.0.1' therefore does NOT re-introduce
+            # the read_only bypass risk that alpha.64 hardening was designed
+            # to prevent. alpha.64 hardening boundary is preserved:
+            #   - user-facing root @'%' (remote): SUPER + BINLOG ADMIN +
+            #     READ_ONLY ADMIN remain dropped (unchanged from alpha.64)
+            #   - user-facing root @'localhost' + @'127.0.0.1' (socket /
+            #     loopback): SUPER + READ_ONLY ADMIN remain dropped; BINLOG
+            #     ADMIN restored to support chart-internal sql_log_bin=0 wrap
+            #
+            # Host-scope rationale: chart-internal SQL operations connect via
+            # unix socket or `127.0.0.1` loopback only (`${LOCAL[@]}` =
+            # `(mariadb ... -S "${SOCK}" ...)`). External users reaching the
+            # cluster via Service routing cannot reach the socket or
+            # loopback; @'%' remains the only attack surface for remote
+            # privilege escalation, and alpha.64 hardening on @'%' is intact.
+            CMPD_EXPLICIT_PRIMARY_GRANT_BODY_LOCAL="${CMPD_EXPLICIT_PRIMARY_GRANT_BODY}, BINLOG ADMIN"
+            CMPD_SECONDARY_FENCE_GRANT_BODY_LOCAL="${CMPD_SECONDARY_FENCE_GRANT_BODY}, BINLOG ADMIN"
             # Best-effort monitor privileges (read-only). These never bypass
             # read_only and are safe on user-facing root in any state. Tier A
             # by Jack 10:05: failure here is allowed to log + continue.
@@ -1116,7 +1170,12 @@ spec:
               local label="$3"
               local privilege
               for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do
-                if "${LOCAL[@]}" -e "
+                # alpha.108 P0a (Jack 2026-05-29): defense-in-depth wrapper
+                # swap ${LOCAL[@]} → ${INTERNAL_LOCAL[@]} (kb_internal_root)
+                # so sql_log_bin=0 wrap works regardless of any future
+                # hardening pass that might re-trim BINLOG ADMIN from
+                # user-facing root @'localhost'/@'127.0.0.1'.
+                if "${INTERNAL_LOCAL[@]}" -e "
                   SET SESSION sql_log_bin=0;
                   GRANT ${privilege} ON *.* TO '${user}'@'${host}';
                   FLUSH PRIVILEGES;
@@ -1146,14 +1205,23 @@ spec:
                   # READ_ONLY ADMIN / BINLOG ADMIN / CONNECTION ADMIN. SUPER
                   # bypassed @@global.read_only=ON, defeating the very fence
                   # this LOCK path was supposed to enforce.
-                  mode="read-replication-admin-only-no-bypass"
+                  #
+                  # alpha.108 P0a (Jack 2026-05-29): use _LOCAL variant of
+                  # CMPD_SECONDARY_FENCE_GRANT_BODY which adds BINLOG ADMIN.
+                  # BINLOG ADMIN is host-scoped to @localhost+@'127.0.0.1' so
+                  # the chart-internal sql_log_bin=0 wrap below actually
+                  # takes effect (alpha.64 unintentionally bundled BINLOG
+                  # ADMIN drop with SUPER drop; BINLOG ADMIN is privilege-
+                  # orthogonal to SUPER and does NOT bypass @@global.read_only=1
+                  # — see CMPD_*_LOCAL constant comments above).
+                  mode="read-replication-admin-only-no-bypass-with-binlog-admin"
                   sql="
                     SET SESSION sql_log_bin=0;
                     CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
                     REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
-                    GRANT ${CMPD_SECONDARY_FENCE_GRANT_BODY} ON *.* TO '${user}'@'${host}';
+                    GRANT ${CMPD_SECONDARY_FENCE_GRANT_BODY_LOCAL} ON *.* TO '${user}'@'${host}';
                     FLUSH PRIVILEGES;
                     SET SESSION sql_log_bin=1;
                   "
@@ -1163,19 +1231,37 @@ spec:
                   # aligned with switchover.sh's SWITCHOVER_EXPLICIT_PRIMARY_GRANT_BODY.
                   # GRANT ALL PRIVILEGES bundled SUPER/READ_ONLY ADMIN/BINLOG
                   # ADMIN which let user-facing root bypass read_only.
-                  mode="primary-write-no-bypass"
+                  #
+                  # alpha.108 P0a (Jack 2026-05-29): use _LOCAL variant for
+                  # same reason as the LOCK branch above (host-scoped BINLOG
+                  # ADMIN restoration to close the 6-alpha sql_log_bin=0 silent
+                  # failure pattern).
+                  mode="primary-write-no-bypass-with-binlog-admin"
                   sql="
                     SET SESSION sql_log_bin=0;
                     CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
                     REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
-                    GRANT ${CMPD_EXPLICIT_PRIMARY_GRANT_BODY} ON *.* TO '${user}'@'${host}' WITH GRANT OPTION;
+                    GRANT ${CMPD_EXPLICIT_PRIMARY_GRANT_BODY_LOCAL} ON *.* TO '${user}'@'${host}' WITH GRANT OPTION;
                     FLUSH PRIVILEGES;
                     SET SESSION sql_log_bin=1;
                   "
                 fi
-                if "${LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                # alpha.108 P0a (Jack 2026-05-29): defense-in-depth wrapper
+                # swap from ${LOCAL[@]} (which begins as ROOT_LOCAL = user-
+                # facing root and stays that way until wait_for_internal_
+                # local_admin promotes it) to ${INTERNAL_LOCAL[@]} (=
+                # kb_internal_root with full admin privileges). Even though
+                # the host-scoped CMPD_*_LOCAL GRANT BODY change above is
+                # the primary mechanism that closes the sql_log_bin=0 silent
+                # failure, using INTERNAL_LOCAL here adds a second
+                # independent layer of protection (a future hardening pass
+                # that accidentally drops BINLOG ADMIN from user-facing root
+                # @'localhost' would no longer regress this fix; reviewer
+                # sees explicit kb_internal_root identity rather than the
+                # bootstrap-time ambiguous LOCAL identity).
+                if "${INTERNAL_LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
                   if [ "${state}" = "LOCK" ]; then
                     rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
                   fi
@@ -1237,7 +1323,12 @@ spec:
                   SET SESSION sql_log_bin=1;
                 "
               fi
-              if "${LOCAL[@]}" -e "${sql}" \
+              # alpha.108 P0a (Jack 2026-05-29): defense-in-depth wrapper
+              # swap ${LOCAL[@]} → ${INTERNAL_LOCAL[@]} so sql_log_bin=0
+              # wrap works on this @'%' grant path even if the @'%'
+              # alpha.64 hardening (BINLOG ADMIN dropped, intentionally
+              # retained by alpha.108) is ever further tightened.
+              if "${INTERNAL_LOCAL[@]}" -e "${sql}" \
                 >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
                 prestop_watchdog_log "remote-root-account-${state} mode=${mode} label=${label} host=${host} rc=0 tier=required"
                 return 0
@@ -1265,8 +1356,13 @@ spec:
               #
               # alpha.64 v3 (Jack 11:14 live-gate RED): inline QUOTED list to
               # preserve multi-word priv name semantics; see constant block.
+              #
+              # alpha.108 P0a (Jack 2026-05-29): defense-in-depth wrapper
+              # swap ${LOCAL[@]} → ${INTERNAL_LOCAL[@]} so sql_log_bin=0
+              # wrap works regardless of which alpha generation user-facing
+              # root @'%' grant set takes.
               for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do
-                if "${LOCAL[@]}" -e "
+                if "${INTERNAL_LOCAL[@]}" -e "
                   SET SESSION sql_log_bin=0;
                   GRANT ${privilege} ON *.* TO '${user}'@'${host}';
                   FLUSH PRIVILEGES;

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -232,6 +232,18 @@ spec:
             # "there is another switchover unfinished" axis).
             CMPD_EXPLICIT_PRIMARY_GRANT_BODY="SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, CREATE USER"
             CMPD_SECONDARY_FENCE_GRANT_BODY="SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SLAVE MONITOR, REPLICATION MASTER ADMIN"
+            # alpha.108 P0a (Jack 2026-05-29): @localhost / @'127.0.0.1'
+            # variants restore BINLOG ADMIN to support chart-internal
+            # `SET SESSION sql_log_bin=0` wrap mechanism. See full rationale
+            # in cmpd-replication-merged.yaml (sister template) constant
+            # block comments + Chart.yaml alpha.108 v1 annotated note.
+            # Summary: alpha.64 unintentionally bundled BINLOG ADMIN drop
+            # with SUPER drop; BINLOG ADMIN is privilege-orthogonal to
+            # SUPER and does NOT bypass @@global.read_only=1. Host-scoping
+            # to @'localhost' + @'127.0.0.1' preserves alpha.64 hardening
+            # boundary for @'%' (remote, unchanged).
+            CMPD_EXPLICIT_PRIMARY_GRANT_BODY_LOCAL="${CMPD_EXPLICIT_PRIMARY_GRANT_BODY}, BINLOG ADMIN"
+            CMPD_SECONDARY_FENCE_GRANT_BODY_LOCAL="${CMPD_SECONDARY_FENCE_GRANT_BODY}, BINLOG ADMIN"
             # Best-effort monitor privileges (read-only). These never bypass
             # read_only and are safe on user-facing root in any state. Tier A
             # by Jack 10:05: failure here is allowed to log + continue.
@@ -997,8 +1009,11 @@ spec:
               local host="$2"
               local label="$3"
               local privilege
+              # alpha.108 P0a (Jack 2026-05-29): defense-in-depth wrapper
+              # swap ${LOCAL[@]} → ${INTERNAL_LOCAL[@]} (see sister template
+              # cmpd-replication-merged.yaml + Chart.yaml note).
               for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do
-                if "${LOCAL[@]}" -e "
+                if "${INTERNAL_LOCAL[@]}" -e "
                   SET SESSION sql_log_bin=0;
                   GRANT ${privilege} ON *.* TO '${user}'@'${host}';
                   FLUSH PRIVILEGES;
@@ -1024,40 +1039,38 @@ spec:
               for host in localhost 127.0.0.1; do
                 if [ "${state}" = "LOCK" ]; then
                   # alpha.64 v1 (Jack 09:35 RED): drop SUPER (admin bypass).
-                  # Use CMPD_SECONDARY_FENCE_GRANT_BODY which excludes SUPER /
-                  # READ_ONLY ADMIN / BINLOG ADMIN / CONNECTION ADMIN. SUPER
-                  # bypassed @@global.read_only=ON, defeating the very fence
-                  # this LOCK path was supposed to enforce.
-                  mode="read-replication-admin-only-no-bypass"
+                  # alpha.108 P0a (Jack 2026-05-29): use _LOCAL variant which
+                  # adds BINLOG ADMIN (host-scoped @localhost+@'127.0.0.1' only,
+                  # @'%' unchanged). See sister template + Chart.yaml note.
+                  mode="read-replication-admin-only-no-bypass-with-binlog-admin"
                   sql="
                     SET SESSION sql_log_bin=0;
                     CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
                     REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
-                    GRANT ${CMPD_SECONDARY_FENCE_GRANT_BODY} ON *.* TO '${user}'@'${host}';
+                    GRANT ${CMPD_SECONDARY_FENCE_GRANT_BODY_LOCAL} ON *.* TO '${user}'@'${host}';
                     FLUSH PRIVILEGES;
                     SET SESSION sql_log_bin=1;
                   "
                 else
                   # alpha.64 v1: replace GRANT ALL PRIVILEGES with explicit
-                  # primary grant body (CMPD_EXPLICIT_PRIMARY_GRANT_BODY)
-                  # aligned with switchover.sh's SWITCHOVER_EXPLICIT_PRIMARY_GRANT_BODY.
-                  # GRANT ALL PRIVILEGES bundled SUPER/READ_ONLY ADMIN/BINLOG
-                  # ADMIN which let user-facing root bypass read_only.
-                  mode="primary-write-no-bypass"
+                  # primary grant body.
+                  # alpha.108 P0a: use _LOCAL variant (host-scoped BINLOG ADMIN).
+                  mode="primary-write-no-bypass-with-binlog-admin"
                   sql="
                     SET SESSION sql_log_bin=0;
                     CREATE USER IF NOT EXISTS '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' IDENTIFIED BY '${password}';
                     ALTER USER '${user}'@'${host}' ACCOUNT UNLOCK;
                     REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${user}'@'${host}';
-                    GRANT ${CMPD_EXPLICIT_PRIMARY_GRANT_BODY} ON *.* TO '${user}'@'${host}' WITH GRANT OPTION;
+                    GRANT ${CMPD_EXPLICIT_PRIMARY_GRANT_BODY_LOCAL} ON *.* TO '${user}'@'${host}' WITH GRANT OPTION;
                     FLUSH PRIVILEGES;
                     SET SESSION sql_log_bin=1;
                   "
                 fi
-                if "${LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
+                # alpha.108 P0a (Jack 2026-05-29): wrapper swap (defense-in-depth).
+                if "${INTERNAL_LOCAL[@]}" -e "${sql}" >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
                   if [ "${state}" = "LOCK" ]; then
                     rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
                   fi
@@ -1119,7 +1132,8 @@ spec:
                   SET SESSION sql_log_bin=1;
                 "
               fi
-              if "${LOCAL[@]}" -e "${sql}" \
+              # alpha.108 P0a (Jack 2026-05-29): wrapper swap (defense-in-depth).
+              if "${INTERNAL_LOCAL[@]}" -e "${sql}" \
                 >> {{ .Values.dataMountPath }}/log/sql-listener-fence.log 2>&1; then
                 prestop_watchdog_log "remote-root-account-${state} mode=${mode} label=${label} host=${host} rc=0 tier=required"
                 return 0
@@ -1147,8 +1161,9 @@ spec:
               #
               # alpha.64 v3 (Jack 11:14 live-gate RED): inline QUOTED list to
               # preserve multi-word priv name semantics; see constant block.
+              # alpha.108 P0a (Jack 2026-05-29): wrapper swap (defense-in-depth).
               for privilege in "BINLOG MONITOR" "SLAVE MONITOR"; do
-                if "${LOCAL[@]}" -e "
+                if "${INTERNAL_LOCAL[@]}" -e "
                   SET SESSION sql_log_bin=0;
                   GRANT ${privilege} ON *.* TO '${user}'@'${host}';
                   FLUSH PRIVILEGES;


### PR DESCRIPTION
## Summary

Round 1c-E acceptance on alpha.107 surfaced a 6-alpha-generation latent silent failure in the chart-internal `SET SESSION sql_log_bin=0` wrap mechanism. The `${LOCAL[@]}` (user-facing root) connection lost BINLOG ADMIN in alpha.64 hardening, so the wrap silently fails with ERROR 1227 and the subsequent CREATE USER / GRANT / REVOKE / ALTER USER statements emit binlog events with `server_id=this pod`, accumulating as orphan events that trigger alpha.60 fail-closed protection on rolling restart.

**Direct evidence (frozen scene `mdb-async-11221`, sha `1d3554cd483bcf4eef9a96ce982b7341c6dce6a316f4e51b2731b1548f53b43f`)**: `sql-listener-fence.log` contains **45 instances** of `ERROR 1227 (42000) ... BINLOG ADMIN privilege(s)`. Quantitative accounting: 45 silent-fails × ~5.5 DDL/fail ≈ 248 orphan events — matches observed pod-1 `gtid_binlog_pos 2-2-249` vs primary pod-0 `2-2-248` within 8% noise.

## Root mechanism: sub-1.B 10th + 11th trap

- **trap 10**: chart-source `SET SESSION sql_log_bin=0` envelope ≠ runtime-effect payload (privilege check rejects SET, binlog stays enabled).
- **trap 11**: alpha.64 hardening grant-set envelope ≠ minimum-necessary privilege payload. alpha.64 dropped SUPER + BINLOG ADMIN as a bundle to prevent `read_only` bypass; BINLOG ADMIN is privilege-orthogonal to SUPER and does not bypass `read_only`. The bundled drop was an over-extension of the minimum-necessary boundary.

## Fix (B2 + Class A defense-in-depth, per Helen TL pick)

1. **Host-scoped `_LOCAL` constant variants** in `cmpd-replication-merged.yaml` and `cmpd-semisync.yaml`:
   - `CMPD_SECONDARY_FENCE_GRANT_BODY_LOCAL` = base + `BINLOG ADMIN`
   - `CMPD_EXPLICIT_PRIMARY_GRANT_BODY_LOCAL` = base + `BINLOG ADMIN`
   Used by `set_local_root_account_state` (iterates `@'localhost'` + `@'127.0.0.1'`). `set_remote_root_account_state` (`@'%'`) still uses the original constants — **alpha.64 hardening on `@'%'` is intact**.

2. **Defense-in-depth wrapper swap `${LOCAL[@]}` → `${INTERNAL_LOCAL[@]}`** in four chart functions:
   - `set_local_root_account_state`
   - `set_remote_root_account_state`
   - `grant_optional_local_root_privileges`
   - `grant_optional_remote_root_privileges`

3. Chart.yaml bump `1.1.1-alpha.107` → `1.1.1-alpha.108` with full annotated note.

## Security boundary preservation table

| Identity | SUPER | BINLOG ADMIN | READ_ONLY ADMIN |
|---|---|---|---|
| user-facing root `@'%'` | ✗ | ✗ | ✗ (alpha.64 unchanged) |
| user-facing root `@'localhost'` | ✗ | **✓ (NEW)** | ✗ |
| user-facing root `@'127.0.0.1'` | ✗ | **✓ (NEW)** | ✗ |

K8s pod network boundary (pod-local unix socket + loopback) ensures external users cannot reach `@'localhost'` or `@'127.0.0.1'` grants; the BINLOG ADMIN restoration does not widen the externally-reachable privilege set.

## Doc B context

This PR closes the structural root cause for **alpha-line orphan event taxonomy entry 4** (Round 1c-E discovery). The Chart.yaml note documents the alpha.64 hardening sub-boundary re-precision (per-host privilege scope table) and references Doc B Rule 5 sub-1.B 10th/11th traps for cross-link.

## Test plan

- [x] Local `helm lint` PASS
- [x] Local `helm template` render PASS — confirms `CMPD_*_LOCAL` constants render with `, BINLOG ADMIN` suffix at host-scoped sites
- [x] `bash -n` (no shell script changes, only YAML inline shell — covered by helm template)
- [ ] **Pre-merge acceptance (sub-3d direct-runtime anchor)**: deploy chart to fresh test pod and verify `grep -c "ERROR 1227" /var/lib/mysql/log/sql-listener-fence.log` = 0 throughout startup window
- [ ] **Pre-merge T1.2 negative regression (Rocco 10:26 sealed)**: external connection to user-facing root `@'%'` attempting `SET SESSION sql_log_bin=0` MUST still emit ERROR 1227 (verifies host-scoped BINLOG ADMIN, alpha.64 boundary intact)
- [ ] Cross-team focused review (Helen TL + Lily Configure 专线 + Rocco SQL/shell + Edward controller-facing)
- [ ] Self-merge after cosigns
- [ ] Helen IDC re-pin alpha.107 → alpha.108 on `mariadb-test5` vcluster
- [ ] **Round 1c-F**: fresh 4 topology N=1 stop-on-first-fail (standalone / async / semisync / galera) on alpha.108 — the actual release acceptance gate
- [ ] `mdb-async-11221` frozen anchor preserved until Round 1c-F PASS

## Refs

- Round 1c-E FAIL frozen evidence: sha256 `1d3554cd483bcf4eef9a96ce982b7341c6dce6a316f4e51b2731b1548f53b43f`
- alpha.107 squash merge: `40ad17b4de9852d31ffb06cf9ea9813b2c990447`
- alpha.69 v1 5.D-r2 historical anchor (chart-author documented partial fix): see `cmpd-replication-merged.yaml` line 450-475 comment block
- Round 1c-E discussion thread: `#kubeblocks-controller:ef37ac53` (Helen TL 10:21 B2 + Class A combined PR pick; Lily 10:24 verbatim Chart.yaml wording; Rocco 10:19 quantitative anchor + 10:26 T1.2 sealed)
