### PR TITLE
mariadb: alpha.109 P0a — sentinel + INTERNAL_LOCAL probe skip on grant_internal_admin_runtime_privileges secondary-restart path

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1457,7 +1457,110 @@ type: application
 # "alpha.108 P0a Round 1c-F PASS" as "all chart-internal DDL is
 # binlog-suppressed under every condition" — the initial-bootstrap
 # path remains a known scope exclusion until a future alpha.
-version: 1.1.1-alpha.108
+#
+# alpha.109 P0a (Jack 2026-05-29 12:08 Round 1c-F FAIL § 5.3 strict
+# halt + Helen 12:10 TL approve halt + retract + alpha.109 narrow
+# scope升格 + 12:17 TL pick NEW C+probe combo + 12:19 INTERNAL_LOCAL
+# self-query syntax sealed + Rocco 12:18 + Edward 12:19 + Lily 12:21
+# 4/4 cosign matrix complete):
+#
+# Round 1c-F empirically reversed the alpha.108 Known residual fold's
+# implicit claim "does NOT recur during VScale / CM4 / T6 cycles".
+# On Round 1c-F's first async-topology CM4 reconfigure cycle, pod-0
+# (which was secondary at the time) rolling-restarted, ran
+# `wait_for_internal_local_admin "startup-before-role-decision"` →
+# `grant_internal_admin_runtime_privileges`. Because that call sits
+# BEFORE the role-decision branches that run
+# `set_local_root_account_state` (which is where alpha.108 P0a B2
+# restored BINLOG ADMIN to user-facing root@localhost), root@localhost
+# at THAT point still had no BINLOG ADMIN. The multi-statement
+# wrapper `SET sql_log_bin=0; GRANT ...; SET sql_log_bin=1` silently
+# failed on the SET (ERROR 1227, 15 entries in sql-listener-fence.log
+# at 03:38:07Z on mdb-async-12851 pod-0), the GRANT ran with binlog
+# enabled, ~14 binlog events leaked under this pod's server_id, the
+# primary (pod-1) did not have those events, alpha.60 fail-closed
+# detected divergence and wrote `.replication-divergence-pending`
+# 9 seconds post-restart, HA refused to follow indefinitely, role
+# probe timed out, cluster transitioned to Failed within 22min.
+#
+# Apply-timing dimension (13th trap candidate, Jack 12:22 sediment):
+# alpha.108 B2 grant is logically in scope but its runtime apply
+# timing (role-decision-time, line ~1135 of cmpd-replication-merged.yaml)
+# is AFTER the chicken-and-egg path runs (startup-before-role-decision,
+# line 2041). Fix scope correct + apply timing wrong = effectively
+# no-op for the specific path that produced Round 1c-F's failure.
+#
+# alpha.109 P0a NEW C+probe combo (sealed Helen 12:17/12:19):
+# `grant_internal_admin_runtime_privileges` now starts with a
+# two-source-of-truth defense-in-depth skip path before falling
+# through to the original grant loop:
+#
+#   (1) Fast-path: sentinel file `.bootstrap-complete` from prior
+#       successful bootstrap. Read via single stat() — no SQL.
+#   (2) SQL probe fallback via INTERNAL_LOCAL identity self-query
+#       `SHOW GRANTS FOR CURRENT_USER()` substring match for
+#       `ALL PRIVILEGES` or `BINLOG ADMIN`. Rocco 12:18 picked
+#       INTERNAL_LOCAL self-query (NOT ROOT_LOCAL cross-user
+#       `SHOW GRANTS FOR 'kb_internal_root'@'localhost'`) to avoid
+#       the symmetric ERROR 1142 silent-fail trap that ROOT_LOCAL's
+#       possible missing SELECT on mysql.global_priv would induce.
+#       INTERNAL_LOCAL self-query is always allowed for self
+#       regardless of mysql DB privilege.
+#
+# Either path matches → skip the grant loop and touch the sentinel
+# for future fast-path. Neither path matches → run the original
+# grant loop (initial bootstrap path, acceptable leak on fresh-create
+# only because the secondary follows from the primary's GTID
+# position which already includes those events — mutual bootstrap
+# state, Rocco 10:39 sealed), then touch the sentinel after.
+#
+# Edward 12:19 cross-link: alpha.105 fence verifier rewrite
+# (Round 1c-C) established the "verifier MUST NOT self-fall-victim
+# to the same family trap" pattern. INTERNAL_LOCAL self-query is
+# the alpha.109 P0a application of that pattern at the probe layer.
+#
+# Acceptance protocol (Helen 12:13 + Rocco 12:15 + Jack 12:16 sealed):
+#   - T1.0' delta-count over observation window (inherited from
+#     alpha.108 Helen 12:02 sealed: capture ERROR 1227 count at
+#     T_start, wait ≥5min observation window with log mtime updating,
+#     capture T_end, expect delta = 0).
+#   - T1.1 / T1.1b / T1.2 privilege boundary verify (inherited from
+#     alpha.108: INTERNAL_LOCAL + user-facing root @localhost socket
+#     SET sql_log_bin=0 succeed; user-facing root @'%' SET
+#     sql_log_bin=0 still emit ERROR 1227 — alpha.64 hardening
+#     boundary on @'%' intact).
+#   - T1.4 NEW: fresh cluster CM4 secondary-restart path verify on
+#     alpha.109 chart. Pre-CM4 pod-0 sql-listener-fence.log baseline
+#     ERROR 1227 count, trigger CM4, wait pod-0 rolling restart
+#     complete, post-restart verify `.replication-divergence-pending`
+#     NOT emit + sentinel `.bootstrap-complete` present + post-restart
+#     ERROR 1227 delta = 0 + prestop-watchdog.log shows
+#     `internal-local-admin-runtime-privilege-skip ... reason=sentinel`
+#     or `reason=sql-probe` line.
+#   - T1.5 NEW: mdb-async-12851 frozen scenario cross-cluster
+#     regression replay. helm upgrade in-place to alpha.109 chart
+#     on a clean replica cluster matching mdb-async-12851's topology,
+#     then trigger equivalent CM4 reconfigure cycle, expect
+#     Cluster Updating → Running within 240s + no
+#     `.replication-divergence-pending` marker emission + no role
+#     probe timeout.
+#   - T1.5b NEW: PVC restore path verify. Simulate sentinel-missing
+#     + kb_internal_root already present (e.g. delete the sentinel
+#     file then restart the pod), expect SQL probe path skip the
+#     grant loop via INTERNAL_LOCAL `SHOW GRANTS FOR CURRENT_USER()`
+#     substring match + ERROR 1227 delta = 0 + sentinel re-touched.
+#
+# Doc B Rule 5 sub-1.A application: read alpha.109 P0a scope as
+# "chicken-and-egg residual closed for CM secondary-restart bootstrap
+# path via two-source-of-truth defense-in-depth skip" — initial
+# fresh-create bootstrap still leaks ~14 binlog events on the primary,
+# but those are inherited by the secondary's GTID position from T0,
+# so the leak does NOT produce server_id-divergence orphan events.
+# A future alpha (B3-style initdb-time create kb_internal_root) can
+# close the fresh-create leak as architectural cleanup — alpha.109
+# does not require it because the production-FATAL path is the
+# secondary-restart path, and that is now closed.
+version: 1.1.1-alpha.109
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -812,7 +812,76 @@ spec:
               printf "%s" "$1" | sed "s/'/''/g"
             }
             grant_internal_admin_runtime_privileges() {
+              # alpha.109 P0a (Jack 12:08 Round 1c-F FAIL § 5.3 halt + Helen 12:13/12:17/12:19
+              # TL pick NEW C+probe combo + Rocco 12:18 INTERNAL_LOCAL self-query syntax +
+              # Edward 12:19 Doc B Rule 6 cross-link + Lily 12:21 cosign): close the
+              # chicken-and-egg residual that Round 1c-F surfaced as production-FATAL on
+              # CM secondary-restart bootstrap.
+              #
+              # The grant loop below uses ROOT_LOCAL (root@localhost) as the SQL session
+              # to GRANT admin privileges to kb_internal_root. At bootstrap-time, before
+              # the role-decision branches run set_local_root_account_state (which
+              # alpha.108 P0a B2 restored BINLOG ADMIN to root@localhost via host-scoped
+              # _LOCAL grant body), root@localhost does NOT yet have BINLOG ADMIN. The
+              # multi-statement wrapper `SET SESSION sql_log_bin=0; GRANT ...; SET
+              # SESSION sql_log_bin=1` therefore silently fails on the SET (ERROR 1227),
+              # the GRANT runs WITH binlog enabled, and 14 DDL events (2 host × 7 privilege)
+              # leak into the local binlog. On a fresh-create primary that's
+              # tolerable because the secondary follows from primary's GTID position and
+              # inherits those events. On a CM secondary-restart with persistent PVC
+              # (kb_internal_root already has the privileges from a prior bootstrap),
+              # the leak is pure waste: 14 events emitted with this pod's server_id
+              # that the primary does NOT have, producing GTID divergence → alpha.60
+              # fail-closed marker `.replication-divergence-pending` → HA permanent
+              # follow rejection → role probe timeout → Cluster Failed. This is the
+              # exact mechanism Round 1c-F mdb-async-12851 hit on CM4 post-rolling-restart
+              # (pod-0 secondary, ERROR 1227 leak 9s post-restart, divergence-pending
+              # marker emitted, cluster Failed in 22min).
+              #
+              # alpha.109 P0a closes this via two-source-of-truth defense-in-depth:
+              # (1) Fast-path sentinel file `.bootstrap-complete` from prior successful
+              #     bootstrap. Read via single stat() — no SQL roundtrip.
+              # (2) SQL probe fallback via INTERNAL_LOCAL identity self-query
+              #     `SHOW GRANTS FOR CURRENT_USER()` substring match for ALL PRIVILEGES
+              #     or BINLOG ADMIN. Rocco 12:18 picked INTERNAL_LOCAL self-query
+              #     (not ROOT_LOCAL cross-user SHOW GRANTS) to avoid the symmetric
+              #     ERROR 1142 silent-fail trap that ROOT_LOCAL's possible missing
+              #     SELECT on mysql.global_priv would induce; INTERNAL_LOCAL self-query
+              #     is always allowed for self regardless of mysql DB privilege.
+              # Either path → skip the grant loop and touch the sentinel for future
+              # fast-path. Neither path → run the grant loop (initial bootstrap path,
+              # acceptable leak on fresh-create) and touch the sentinel after.
+              #
+              # Edward 12:19 cross-link: alpha.105 fence verifier rewrite (Round 1c-C)
+              # established the "verifier MUST NOT self-fall-victim to the same family
+              # trap" pattern; INTERNAL_LOCAL self-query is the alpha.109 P0a application
+              # of that pattern at the probe layer.
               local label="${1:-internal-local-admin-runtime-privileges}"
+              local sentinel="{{ .Values.dataMountPath }}/.bootstrap-complete"
+
+              # Fast-path: sentinel from prior successful bootstrap
+              if [ -f "${sentinel}" ]; then
+                prestop_watchdog_log "internal-local-admin-runtime-privilege-skip label=${label} reason=sentinel"
+                return 0
+              fi
+
+              # Defense-in-depth: SQL probe via INTERNAL_LOCAL identity self-query
+              # (Rocco 12:18 INTERNAL_LOCAL self-query, NOT ROOT_LOCAL cross-user query —
+              # avoids ERROR 1142 family silent-fail trap; Edward 12:19 Rule 6 verifier
+              # self-immunity application).
+              if "${INTERNAL_LOCAL[@]}" -BNe "SELECT 1" >/dev/null 2>&1 \
+                 && "${INTERNAL_LOCAL[@]}" -BNe "SHOW GRANTS FOR CURRENT_USER()" 2>/dev/null \
+                      | grep -qiE "(ALL PRIVILEGES|BINLOG[[:space:]]*ADMIN)"; then
+                touch "${sentinel}" 2>/dev/null || true
+                prestop_watchdog_log "internal-local-admin-runtime-privilege-skip label=${label} reason=sql-probe"
+                return 0
+              fi
+
+              # Initial bootstrap path (kb_internal_root not yet granted admin privileges).
+              # The 14-event leak in this path is acceptable on fresh-create because the
+              # secondary follows from primary's GTID position which includes the leak
+              # (mutual bootstrap state, Rocco 10:39 sealed). The leak does NOT recur on
+              # secondary-restart because the sentinel/probe fast-paths above will skip.
               local user host privilege sql
               user="$(sql_quote "${MARIADB_INTERNAL_ROOT_USER}")"
               for host in localhost 127.0.0.1; do
@@ -834,6 +903,7 @@ spec:
                   prestop_watchdog_log "internal-local-admin-runtime-privilege privilege=${privilege} label=${label} host=${host} rc=1"
                 done
               done
+              touch "${sentinel}" 2>/dev/null || true
             }
             ensure_internal_local_admin() {
               # alpha.66 v1 (Jack 12:18 alpha.65 v2 install/script live-gate

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -652,7 +652,31 @@ spec:
               printf "%s" "$1" | sed "s/'/''/g"
             }
             grant_internal_admin_runtime_privileges() {
+              # alpha.109 P0a (Jack 12:08 Round 1c-F FAIL § 5.3 halt + Helen 12:13/12:17/12:19
+              # TL pick NEW C+probe combo + Rocco 12:18 INTERNAL_LOCAL self-query syntax +
+              # Edward 12:19 Doc B Rule 6 cross-link + Lily 12:21 cosign): close the
+              # chicken-and-egg residual that Round 1c-F surfaced as production-FATAL on
+              # CM secondary-restart bootstrap. See cmpd-replication-merged.yaml for the
+              # full design narrative; this is the semisync template mirror.
               local label="${1:-internal-local-admin-runtime-privileges}"
+              local sentinel="{{ .Values.dataMountPath }}/.bootstrap-complete"
+
+              # Fast-path: sentinel from prior successful bootstrap
+              if [ -f "${sentinel}" ]; then
+                prestop_watchdog_log "internal-local-admin-runtime-privilege-skip label=${label} reason=sentinel"
+                return 0
+              fi
+
+              # Defense-in-depth: SQL probe via INTERNAL_LOCAL identity self-query
+              if "${INTERNAL_LOCAL[@]}" -BNe "SELECT 1" >/dev/null 2>&1 \
+                 && "${INTERNAL_LOCAL[@]}" -BNe "SHOW GRANTS FOR CURRENT_USER()" 2>/dev/null \
+                      | grep -qiE "(ALL PRIVILEGES|BINLOG[[:space:]]*ADMIN)"; then
+                touch "${sentinel}" 2>/dev/null || true
+                prestop_watchdog_log "internal-local-admin-runtime-privilege-skip label=${label} reason=sql-probe"
+                return 0
+              fi
+
+              # Initial bootstrap path
               local user host privilege sql
               user="$(sql_quote "${MARIADB_INTERNAL_ROOT_USER}")"
               for host in localhost 127.0.0.1; do
@@ -674,6 +698,7 @@ spec:
                   prestop_watchdog_log "internal-local-admin-runtime-privilege privilege=${privilege} label=${label} host=${host} rc=1"
                 done
               done
+              touch "${sentinel}" 2>/dev/null || true
             }
             ensure_internal_local_admin() {
               # alpha.66 v1 (Jack 12:18 alpha.65 v2 install/script live-gate


### PR DESCRIPTION
## Summary

Round 1c-F mdb-async-12851 (async topology, alpha.108 chart) hit a hard FAIL on the first CM4 reconfigure cycle: pod-0 (secondary after CM4) rolling-restarted, bootstrap path emitted `.replication-divergence-pending` 9 seconds post-restart, HA refused follow indefinitely, role probe timed out, cluster transitioned to Failed within 22min. Root cause is the **chicken-and-egg residual** that alpha.108 P0a's Chart.yaml fold described as "does NOT recur during VScale / CM4 / T6 cycles" — that claim is empirically wrong on secondary-restart paths.

alpha.108 P0a's B2 BINLOG ADMIN restoration to user-facing `root@localhost` runs inside `set_local_root_account_state`, which executes **after** role-decision. But `grant_internal_admin_runtime_privileges` runs **before** role-decision via `wait_for_internal_local_admin "startup-before-role-decision"`. At that earlier point root@localhost has no BINLOG ADMIN, so its multi-statement `SET sql_log_bin=0; GRANT ...; SET sql_log_bin=1` silently fails on the SET (ERROR 1227), the GRANT executes with binlog enabled, and ~14 DDL events leak under this pod's `server_id`. On a CM secondary-restart with persistent PVC, those events are not on the primary → GTID divergence → alpha.60 fail-closed → permanent stuck.

Apply-timing dimension (13th trap candidate, sediment hold): fix scope correct + apply-timing wrong = effectively no-op for the specific trigger path.

This PR adds a two-source-of-truth defense-in-depth skip at the head of `grant_internal_admin_runtime_privileges`:

1. **Fast-path sentinel** `.bootstrap-complete` — single `stat()`, no SQL roundtrip.
2. **SQL probe fallback** via INTERNAL_LOCAL identity self-query `SHOW GRANTS FOR CURRENT_USER()` substring match for `ALL PRIVILEGES` or `BINLOG ADMIN`. INTERNAL_LOCAL self-query is always allowed for self regardless of `mysql` DB privilege — chosen over ROOT_LOCAL cross-user `SHOW GRANTS FOR 'kb_internal_root'@'localhost'` to avoid the symmetric ERROR 1142 silent-fail trap. This is the alpha.105 fence verifier rewrite ("verifier MUST NOT self-fall-victim to the same family trap") pattern at the probe layer.

Either path matches → skip the grant loop and touch the sentinel. Neither matches → run the original grant loop (initial fresh-create only; the resulting 14-event leak is acceptable because the secondary follows from the primary's GTID position that includes them — mutual bootstrap state) and touch the sentinel after.

Chart.yaml documents the full design narrative + 4-cosign matrix + T1.0' / T1.1 / T1.1b / T1.2 (alpha.108 inherited) / T1.4 / T1.5 / T1.5b acceptance protocol. CmpD / lifecycleActions / exec / roleProbe contract: zero change. 2 templates mirror change (`cmpd-replication-merged.yaml` + `cmpd-semisync.yaml`).

## Cosign matrix (cross-team共担, 12:13-12:21)

- ✅ Helen TL pick + LGTM (NEW C+probe combo with INTERNAL_LOCAL syntax)
- ✅ Rocco SQL/shell LGTM + INTERNAL_LOCAL syntax recommendation
- ✅ Edward controller-facing LGTM + Doc B Rule 6 cross-link
- ✅ Lily Configure专线 + Doc B 主笔 LGTM

## Evidence anchor

- Round 1c-F frozen evidence pack: `artifacts/task442-round-1c-f-fail-snapshot-1205.tar.gz` sha256 `839f327c4983d8744302fa3e8318888ec786b631bdc318a167a945aed515025b`
- mdb-async-12851 Failed state preserved for T1.5 cross-cluster regression replay
- mdb-async-11221 Round 1c-E frozen anchor preserved

## Test plan

- [ ] Pre-merge T0: 7-face frozen baseline preservation verify (mdb-async-11221 + mdb-async-12851 untouched)
- [ ] Pre-merge T1.0': delta-count over observation window on fresh cluster (alpha.108 inherited)
- [ ] Pre-merge T1.1 / T1.1b / T1.2: privilege boundary verify on fresh cluster (alpha.108 inherited)
- [ ] Pre-merge T1.4 NEW: fresh cluster CM4 secondary-restart path verify — post-restart sentinel present, ERROR 1227 delta = 0, no `.replication-divergence-pending`, prestop-watchdog.log shows skip line
- [ ] Pre-merge T1.5 NEW: cross-cluster regression replay equivalent to mdb-async-12851 CM4 cycle on alpha.109 chart — Cluster Updating → Running within 240s, no marker emission, no role probe timeout
- [ ] Pre-merge T1.5b NEW: PVC restore path verify — simulate sentinel missing + kb_internal_root present, expect SQL probe path skip + ERROR 1227 delta = 0
- [ ] helm lint + helm template render (already verified locally)
- [ ] Self-merge after 4-cosign re-anchor on PR head sha per sub-3b commit-to-launch protocol
- [ ] IDC re-pin alpha.109 via helm upgrade
- [ ] Round 1c-G 4 topology N=1 stop-on-first-fail launch (含 secondary-restart path 强制 sub-3a 三轴 orthogonal coverage)