### PR TITLE
mariadb: alpha.110 P0a URGENT — skip primary_local_root_write_ready syncerctl-writecheck on reconcile-repair-begin path

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1560,7 +1560,113 @@ type: application
 # close the fresh-create leak as architectural cleanup — alpha.109
 # does not require it because the production-FATAL path is the
 # secondary-restart path, and that is now closed.
-version: 1.1.1-alpha.109
+#
+# alpha.110 P0a URGENT (Jack 15:15 Round 1c-G 2nd PRODUCT-level FAIL
+# § 5.3 strict halt + Helen 15:20 TL ratify + Rocco 15:17 cosign +
+# Lily 15:19 strong +1 + Edward 15:22 controller-facing 5-項监听 100%
+# triggered + 15:25-15:34 Direction A→D→E narrow chain + Helen 15:34
+# TL pick Direction E + Helen 15:51 + Edward 15:51 + Rocco 15:53 +
+# Lily 15:54 4-cosign LGTM on Direction E patch design):
+#
+# Round 1c-G 2nd surfaced the EXACT Round 1c-E mechanism that alpha.108
+# + alpha.109 did NOT cover: chart `reconcile_sql_listener_for_syncer_
+# primary_once` repair loop fires `runtime-primary-listener-reconcile-
+# repair-begin` every ~3s while syncer-role=primary and chart markers
+# OUT-OF-SYNC (`.primary-read-write-ready` MISSING OR `.remote-root-
+# fence-role` PRESENT OR `master.info` PRESENT). Each iteration calls
+# `expose_sql_listener_for_primary_role` → `set_primary_read_write` →
+# `primary_write_gates_ready` → `primary_local_root_write_ready` →
+# `/tools/syncerctl --host 127.0.0.1 --port 3601 writecheck` → syncer
+# INSERT into kubeblocks.kb_health_check → **1 binlog event per fire**.
+# Round 1c-G 2nd mdb-async-10271 pod-0 fired 18 iterations in 2.5min,
+# accumulating 18 orphan events under pod-0's local domain. Post-
+# reconfigure switchover (pod-0 becomes secondary), pod-0's GTID is
+# 18 events ahead of primary → alpha.60 fail-closed detects divergence
+# → emits `.replication-divergence-pending` → HA permanent refuse
+# follow → role probe timeout → Cluster Failed within 22min. Round
+# 1c-G 2nd evidence pack:
+#   `artifacts/task442-r1g-2nd-fail-snapshot-1510.tar.gz`
+#   sha256 725907b959bec72523846be2598a57223b8b5819833fce5aa7702ff093b1453b
+#
+# This is NOT a syncer privilege issue. syncer uses MARIADB_INTERNAL_ROOT
+# (== kb_internal_root) which HAS BINLOG ADMIN per alpha.108 P0a B2 +
+# alpha.68 v2 grant matrix. syncer's WriteCheck deliberately writes to
+# binlog as part of replication health-check design — kb_health_check
+# IS supposed to replicate to secondaries for replication health
+# verification (alpha.99 Helen 2026-05-25 sealed: "kb_health_check is
+# owned by syncer (engines/mariadb/manager.go WriteCheck /
+# GetOpTimestamp)" + "syncerctl writecheck path is cluster-wide write
+# verification"). The problem is chart-side loop firing rate × per-
+# iteration binlog event accumulation; in the repair path (state-drift
+# detected) the writecheck is redundant — the state-drift is a chart
+# marker reconciliation issue, not a write-ready verification need.
+#
+# alpha.110 P0a URGENT Direction E (TL pick per Helen 15:34, smallest
+# scope per Jack 15:26 Direction E recommendation + Rocco 15:25 +
+# 15:54 cosign + Edward 15:51 cosign + Lily 15:54 cosign): skip
+# `primary_local_root_write_ready` syncerctl-writecheck step when
+# `expose_sql_listener_for_primary_role` is called from the
+# reconcile-repair-begin path (label has "-no-writecheck" suffix per
+# Rocco 15:53 stricter pattern). Implementation:
+#   1. `primary_write_gates_ready` (cmpd-replication-merged.yaml:610-614
+#      + cmpd-semisync.yaml:450-454): add case `*-no-writecheck` that
+#      skips `primary_local_root_write_ready` and preserves
+#      `primary_internal_root_write_ready` (kb_addon_write_probe addon-
+#      owned with explicit SET sql_log_bin=0 — NOT orphan event source).
+#   2. `set_primary_read_write` (cmpd-replication-merged.yaml:661 +
+#      cmpd-semisync.yaml:468): accept label parameter and pass through
+#      to all unlock/fail/primary_write_gates_ready calls.
+#   3. `expose_sql_listener_for_primary_role` (cmpd-replication-merged.yaml:
+#      1853/1872 + cmpd-semisync.yaml:1614/1631): pass label through to
+#      `set_primary_read_write`.
+#   4. `reconcile_sql_listener_for_syncer_primary_once` (cmpd-replication-
+#      merged.yaml:1922 + cmpd-semisync.yaml:1693): call with label
+#      "syncer-promoted-primary-existing-listener-no-writecheck" so the
+#      repair path triggers the skip case in `primary_write_gates_ready`.
+#
+# Happy-path writecheck PRESERVED for normal primary promotion (line
+# 1942 syncer-promoted-primary / 2134 primary-service-route / 2218
+# stale-slave-no-primary / 2383 default-pod0-primary, plus the
+# semisync template equivalents). None of these labels contain
+# "-no-writecheck" suffix, so they continue to run
+# `primary_local_root_write_ready` writecheck for replication health
+# verification (alpha.99 design intent preserved). Marker emit + role
+# probe + read_only management + lock/unlock logic all preserved in
+# `set_primary_read_write` happy path — only the writecheck step is
+# skipped on the repair path.
+#
+# alpha.110 P0e (former P0d, parallel, controller-side, Edward + Lily
+# pair, Helen 15:24 RATIFIED): KB controller OpsRequest condition
+# surface "DownstreamProgressionFailed" with structured reason for
+# alpha.60 fail-closed scenarios — orthogonal layer to alpha.110 P0a,
+# does not depend on chart-side closure but benefits from it.
+#
+# Acceptance protocol (Helen 15:52 sealed):
+# - T1.0' delta-count over observation window (alpha.108 inherited)
+# - T1.1 / T1.1b / T1.2 privilege boundary (alpha.108 inherited)
+# - T1.3 NEW: Reconfigure cycle reconcile-repair-begin loop verify —
+#   trigger reconfigure cycle on fresh cluster, verify post-CM4:
+#   pod-0 prestop-watchdog.log shows `runtime-primary-listener-reconcile-
+#   repair-begin` lines AND accompanying `primary-write-gates-ready
+#   label=...-no-writecheck reason=skip-writecheck-repair-path` lines,
+#   `.replication-divergence-pending` NOT emit, sql-listener-fence.log
+#   binlog event count delta = 0 over reconcile cycle window,
+#   Cluster Updating → Running ≤ 240s.
+# - T1.4 NEW: mdb-async-10271 frozen anchor cross-cluster regression —
+#   apply alpha.110 chart to mdb-async-10271 equivalent cluster + trigger
+#   CM4 → verify NO `.replication-divergence-pending` emit + cluster
+#   recovers Running.
+# - T1.5 NEW: happy-path writecheck preservation — fresh-create cluster
+#   bootstrap normal primary promotion paths run `primary_local_root_
+#   write_ready` (label without "-no-writecheck"), kb_health_check
+#   INSERT happens as designed for replication health verification.
+#
+# Direction B (root-cause why chart markers go OUT-OF-SYNC during
+# reconfigure cycle) deferred to alpha.111 backlog candidate per Lily
+# 15:45 sealed; alpha.110 P0a Direction E closes the production-FATAL
+# orphan event source mechanism, Direction B addresses the marker
+# state-drift root cause architectural sustainability.
+version: 1.1.1-alpha.110
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -608,7 +608,40 @@ spec:
               return 1
             }
             primary_write_gates_ready() {
+              # alpha.110 P0a URGENT Direction E (Jack 15:26 + Helen TL 15:34 sealed +
+              # Edward 15:51 + Rocco 15:53 + Lily 15:54 4-cosign LGTM):
+              # Skip primary_local_root_write_ready syncerctl-writecheck step on
+              # reconcile-repair-begin path. Root cause: chart-side
+              # reconcile_sql_listener_for_syncer_primary_once fires
+              # `runtime-primary-listener-reconcile-repair-begin` every ~3s while
+              # syncer-role=primary but chart markers OUT-OF-SYNC; each iteration's
+              # writecheck INSERTs into kb_health_check generating 1 binlog event
+              # per fire → cumulative orphan events on local domain → post-
+              # reconfigure switchover GTID divergence → alpha.60 fail-closed →
+              # HA permanent refuse follow → cluster stuck Updating. Round 1c-G
+              # 2nd mdb-async-10271 saw 18 events accumulate in 2.5min loop fire
+              # window.
+              #
+              # alpha.110 P0a URGENT Direction E preserves alpha.99 Helen
+              # 2026-05-25 design intent (syncer's WriteCheck deliberately writes
+              # to binlog for replication health verification): happy-path
+              # writecheck still runs on normal primary promotion paths (line
+              # 1942/2134/2218/2383 callers use labels without "-no-writecheck"
+              # suffix). Only the reconcile-repair-begin path passes label with
+              # "-no-writecheck" suffix (per Rocco 15:53 stricter suffix-anchored
+              # pattern), triggering this case to skip the writecheck step while
+              # preserving primary_internal_root_write_ready (kb_addon_write_probe
+              # addon-owned + explicit SET sql_log_bin=0 per line 596-602 — NOT
+              # orphan event source) + marker emit + role probe + read_only +
+              # role transition logic in set_primary_read_write happy path.
               local label="${1:-primary-write-gates-ready}"
+              case "${label}" in
+                *-no-writecheck)
+                  prestop_watchdog_log "primary-write-gates-ready label=${label} reason=skip-writecheck-repair-path"
+                  primary_internal_root_write_ready "${label}" || return 1
+                  return 0
+                  ;;
+              esac
               primary_local_root_write_ready "${label}" || return 1
               primary_internal_root_write_ready "${label}" || return 1
             }
@@ -626,42 +659,47 @@ spec:
               prestop_watchdog_log "primary-read-write ${reason} rc=1"
             }
             set_primary_read_write() {
+              # alpha.110 P0a URGENT Direction E (Jack 15:26 + 4-cosign sealed):
+              # accept label parameter so callers can pass "-no-writecheck" suffix
+              # through to primary_write_gates_ready for repair-path skip.
+              # Default label preserves alpha.109 and earlier behavior.
+              local label="${1:-primary-read-write}"
               if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
                 prestop_watchdog_log "skip-primary-read-write reason=prestop-fence-started"
                 mark_replication_pending
                 return 1
               fi
-              if ! unlock_local_root_writes "primary-read-write"; then
+              if ! unlock_local_root_writes "${label}"; then
                 rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-                prestop_watchdog_log "primary-read-write local-root-unlock rc=1"
+                prestop_watchdog_log "primary-read-write local-root-unlock rc=1 label=${label}"
                 return 1
               fi
-              if ! unlock_remote_root_writes "primary-read-write"; then
-                fail_primary_read_write_gate "primary-read-write" "remote-root-unlock"
+              if ! unlock_remote_root_writes "${label}"; then
+                fail_primary_read_write_gate "${label}" "remote-root-unlock"
                 return 1
               fi
               if "${LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
-                if ! primary_write_gates_ready "primary-read-write"; then
-                  fail_primary_read_write_gate "primary-read-write" "write-gate"
+                if ! primary_write_gates_ready "${label}"; then
+                  fail_primary_read_write_gate "${label}" "write-gate"
                   return 1
                 fi
                 rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
                 touch {{ .Values.dataMountPath }}/.primary-read-write-ready
-                prestop_watchdog_log "primary-read-write rc=0"
+                prestop_watchdog_log "primary-read-write rc=0 label=${label}"
                 return 0
               fi
               if "${LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
-                if ! primary_write_gates_ready "primary-read-write"; then
-                  fail_primary_read_write_gate "primary-read-write" "write-gate"
+                if ! primary_write_gates_ready "${label}"; then
+                  fail_primary_read_write_gate "${label}" "write-gate"
                   return 1
                 fi
                 rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
                 touch {{ .Values.dataMountPath }}/.primary-read-write-ready
-                prestop_watchdog_log "primary-read-write rc=0"
+                prestop_watchdog_log "primary-read-write rc=0 label=${label}"
                 return 0
               fi
-              fail_primary_read_write_gate "primary-read-write" "read-only-open"
-              prestop_watchdog_log "primary-read-write rc=1"
+              fail_primary_read_write_gate "${label}" "read-only-open"
+              prestop_watchdog_log "primary-read-write rc=1 label=${label}"
               return 1
             }
             mark_replication_pending() {
@@ -1850,7 +1888,7 @@ spec:
               if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
                 "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
-                if set_primary_read_write; then
+                if set_primary_read_write "${label}"; then
                   touch {{ .Values.dataMountPath }}/.sql-listener-ready
                   prestop_watchdog_log "sql-listener-primary-existing-reconciled label=${label}"
                   return 0
@@ -1869,7 +1907,7 @@ spec:
               fi
               "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
               "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
-              if ! set_primary_read_write; then
+              if ! set_primary_read_write "${label}"; then
                 mark_replication_pending
                 prestop_watchdog_log "sql-listener-primary-expose-failed label=${label}"
                 return 1
@@ -1919,7 +1957,18 @@ spec:
                   return 0
                 fi
                 prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role}"
-                expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener" || return 1
+                # alpha.110 P0a URGENT Direction E: pass "-no-writecheck" suffix
+                # to skip primary_local_root_write_ready syncerctl-writecheck in
+                # the repair path. Each loop iteration's writecheck INSERTs into
+                # kb_health_check generating 1 binlog event per fire; in Round
+                # 1c-G 2nd this fired 18 times in 2.5min on mdb-async-10271 pod-0
+                # accumulating 18 orphan events that caused post-reconfigure
+                # switchover GTID divergence + alpha.60 fail-closed. Skipping the
+                # writecheck here removes the orphan event source while preserving
+                # primary_internal_root_write_ready (kb_addon_write_probe addon-
+                # owned with explicit SET sql_log_bin=0) + marker emit + role
+                # probe + read_only management + lock/unlock logic.
+                expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener-no-writecheck" || return 1
                 mark_replication_ready
                 prestop_watchdog_log "runtime-primary-listener-reconcile-repair-complete role=${role}"
                 return 0

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -448,7 +448,17 @@ spec:
               return 1
             }
             primary_write_gates_ready() {
+              # alpha.110 P0a URGENT Direction E mirror (see cmpd-replication-merged.yaml
+              # for full design narrative + 4-cosign LGTM chain). Skip writecheck
+              # on repair path when label ends with "-no-writecheck" suffix.
               local label="${1:-primary-write-gates-ready}"
+              case "${label}" in
+                *-no-writecheck)
+                  prestop_watchdog_log "primary-write-gates-ready label=${label} reason=skip-writecheck-repair-path"
+                  primary_internal_root_write_ready "${label}" || return 1
+                  return 0
+                  ;;
+              esac
               primary_local_root_write_ready "${label}" || return 1
               primary_internal_root_write_ready "${label}" || return 1
             }
@@ -466,42 +476,44 @@ spec:
               prestop_watchdog_log "primary-read-write ${reason} rc=1"
             }
             set_primary_read_write() {
+              # alpha.110 P0a URGENT Direction E mirror: accept label parameter.
+              local label="${1:-primary-read-write}"
               if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
                 prestop_watchdog_log "skip-primary-read-write reason=prestop-fence-started"
                 mark_replication_pending
                 return 1
               fi
-              if ! unlock_local_root_writes "primary-read-write"; then
+              if ! unlock_local_root_writes "${label}"; then
                 rm -f {{ .Values.dataMountPath }}/.primary-read-write-ready
-                prestop_watchdog_log "primary-read-write local-root-unlock rc=1"
+                prestop_watchdog_log "primary-read-write local-root-unlock rc=1 label=${label}"
                 return 1
               fi
-              if ! unlock_remote_root_writes "primary-read-write"; then
-                fail_primary_read_write_gate "primary-read-write" "remote-root-unlock"
+              if ! unlock_remote_root_writes "${label}"; then
+                fail_primary_read_write_gate "${label}" "remote-root-unlock"
                 return 1
               fi
               if "${LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
-                if ! primary_write_gates_ready "primary-read-write"; then
-                  fail_primary_read_write_gate "primary-read-write" "write-gate"
+                if ! primary_write_gates_ready "${label}"; then
+                  fail_primary_read_write_gate "${label}" "write-gate"
                   return 1
                 fi
                 rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
                 touch {{ .Values.dataMountPath }}/.primary-read-write-ready
-                prestop_watchdog_log "primary-read-write rc=0"
+                prestop_watchdog_log "primary-read-write rc=0 label=${label}"
                 return 0
               fi
               if "${LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
-                if ! primary_write_gates_ready "primary-read-write"; then
-                  fail_primary_read_write_gate "primary-read-write" "write-gate"
+                if ! primary_write_gates_ready "${label}"; then
+                  fail_primary_read_write_gate "${label}" "write-gate"
                   return 1
                 fi
                 rm -f {{ .Values.dataMountPath }}/.remote-root-fence-role
                 touch {{ .Values.dataMountPath }}/.primary-read-write-ready
-                prestop_watchdog_log "primary-read-write rc=0"
+                prestop_watchdog_log "primary-read-write rc=0 label=${label}"
                 return 0
               fi
-              fail_primary_read_write_gate "primary-read-write" "read-only-open"
-              prestop_watchdog_log "primary-read-write rc=1"
+              fail_primary_read_write_gate "${label}" "read-only-open"
+              prestop_watchdog_log "primary-read-write rc=1 label=${label}"
               return 1
             }
             mark_replication_pending() {
@@ -1609,7 +1621,7 @@ spec:
               if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
                 "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
                 "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
-                if set_primary_read_write; then
+                if set_primary_read_write "${label}"; then
                   touch {{ .Values.dataMountPath }}/.sql-listener-ready
                   prestop_watchdog_log "sql-listener-primary-existing-reconciled label=${label}"
                   return 0
@@ -1628,7 +1640,7 @@ spec:
               fi
               "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
               "${LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_master_enabled=1;" 2>/dev/null || true
-              if ! set_primary_read_write; then
+              if ! set_primary_read_write "${label}"; then
                 mark_replication_pending
                 prestop_watchdog_log "sql-listener-primary-expose-failed label=${label}"
                 return 1
@@ -1678,7 +1690,9 @@ spec:
                   return 0
                 fi
                 prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role}"
-                expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener" || return 1
+                # alpha.110 P0a URGENT Direction E mirror (see cmpd-replication-merged.yaml
+                # for full design narrative + 4-cosign LGTM chain).
+                expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener-no-writecheck" || return 1
                 mark_replication_ready
                 prestop_watchdog_log "runtime-primary-listener-reconcile-repair-complete role=${role}"
                 return 0


### PR DESCRIPTION
## Summary

Round 1c-G 2nd PRODUCT-level FAIL on `mdb-async-10271` surfaced the exact Round 1c-E mechanism that alpha.108 + alpha.109 P0a did NOT close: chart-side `reconcile_sql_listener_for_syncer_primary_once` repair loop fires `runtime-primary-listener-reconcile-repair-begin` every ~3s while syncer-role=primary and chart markers OUT-OF-SYNC. Each iteration's `primary_local_root_write_ready` calls `/tools/syncerctl writecheck` → syncer INSERT into `kubeblocks.kb_health_check` → 1 binlog event per fire. Round 1c-G 2nd accumulated 18 orphan events in 2.5min → post-reconfigure switchover GTID divergence → alpha.60 fail-closed → cluster Failed within 22min.

**This is NOT a syncer privilege issue.** syncer uses `MARIADB_INTERNAL_ROOT` (== `kb_internal_root`) which HAS BINLOG ADMIN. syncer's WriteCheck deliberately writes to binlog by design (alpha.99 Helen 2026-05-25 sealed: `kb_health_check` IS supposed to replicate to secondaries for replication health verification). The problem is chart-side loop firing rate × per-iteration binlog event accumulation; in the repair path the writecheck is redundant — state-drift is a chart marker reconciliation issue, not a write-ready verification need.

This PR (alpha.110 P0a URGENT Direction E) skips `primary_local_root_write_ready` syncerctl-writecheck when `expose_sql_listener_for_primary_role` is called from the reconcile-repair-begin path. Implementation via label parameter passthrough through 4 functions, with the repair call site passing a label with `-no-writecheck` suffix (Rocco 15:53 stricter suffix-anchored pattern). `primary_write_gates_ready` checks the label suffix and skips the writecheck while preserving `primary_internal_root_write_ready` (`kb_addon_write_probe` addon-owned with explicit `SET sql_log_bin=0` — NOT orphan event source).

Happy-path writecheck preserved for normal primary promotion (4 chart call sites × 2 templates), continues to run `primary_local_root_write_ready` writecheck for replication health verification (alpha.99 design intent preserved). Marker emit + role probe + read_only management + lock/unlock logic all preserved in `set_primary_read_write` happy path.

Files modified:
- `addons/mariadb/Chart.yaml`: bump to `1.1.1-alpha.110` + verbatim narrative
- `addons/mariadb/templates/cmpd-replication-merged.yaml`: 4 changes (primary_write_gates_ready case skip, set_primary_read_write accept label, expose_sql_listener_for_primary_role pass label, reconcile_sql_listener_for_syncer_primary_once call with -no-writecheck suffix)
- `addons/mariadb/templates/cmpd-semisync.yaml`: parallel mirror

## Apply-timing dimension (sediment lesson)

alpha.107/108/109 three cycles all framed the orphan event problem as "chart function SQL identity" without considering the cumulative "chart function frequency firing in repair loop" dimension. alpha.99 in-code comment was already explicit that syncerctl-writecheck binlog writes are by design, but sediment carry-over across three cycles never connected the loop-fire-rate × cumulative-events recurrence path. Direction E is the framework-dogfooded mode-15 lesson applied: re-read in-code ownership/design comments between cycles and verify root-cause attribution at the actual loop-firing layer, not just single-call SQL identity layer.

## Cosign matrix (cross-team共担, 15:51-15:54)

- ✅ Helen TL ratification on Direction E patch design + T-P0a URGENT.1-5 acceptance criteria
- ✅ Edward controller-facing LGTM + CmpD/lifecycleActions/exec/roleProbe 4-tuple zero-change + alpha.110 P0e cross-link orthogonality preserved
- ✅ Rocco SQL/shell LGTM + happy-path writecheck preserved + state-drift skip narrow accurate + `-no-writecheck` suffix-anchored stricter pattern (adopted)
- ✅ Lily Configure 专线 + Doc B 主笔 LGTM + Configure 接口 zero-change + alpha.108 P0a pattern continuity + mode 15 framework dogfooded application 真活 worked example

## Evidence anchor

- Round 1c-G 2nd frozen evidence pack: `artifacts/task442-r1g-2nd-fail-snapshot-1510.tar.gz` sha256 `725907b959bec72523846be2598a57223b8b5819833fce5aa7702ff093b1453b`
- mdb-async-10271 cluster KEPT in stuck Updating for live evidence + frozen anchor cross-cluster regression substrate for T1.4
- mdb-async-11221 + mdb-async-12851 + mdb-async-10271 三 frozen anchors preserved end-to-end through Round 1c-E + 1c-F + 1c-G 2nd cycles

## Direction B + alpha.111 backlog candidate

Direction B (root-cause why chart markers go OUT-OF-SYNC during reconfigure cycle — `.primary-read-write-ready` MISSING / `.remote-root-fence-role` PRESENT / `master.info` PRESENT triggers) deferred to alpha.111 backlog candidate per Lily 15:45 sealed. alpha.110 P0a Direction E closes the production-FATAL orphan event source mechanism; Direction B addresses the marker state-drift root cause architectural sustainability.

## alpha.110 P0e parallel work

alpha.110 P0e (KB controller-side OpsRequest condition surface for `DownstreamProgressionFailed` reason): Edward + Lily controller-side pair, parallel work, per Helen 15:24 ratified parallel-with-P0a 升格. Edward 16:07 posted initial proposal full content for Lily controller-side pair-with-Edward review + cosign. Does not block this P0a Direction E PR.

## Test plan

- [ ] 4-cosign re-anchor on PR head sha `a79e1fd8ea5534a0efb014555d961bacb04b191d` per sub-3b commit-to-launch protocol (與 alpha.108/109 P0a same pattern)
- [ ] Pre-merge T0: 7-face frozen baseline preservation (mdb-async-11221 + mdb-async-12851 + mdb-async-10271 untouched)
- [ ] Pre-merge T1.0': delta-count over observation window (alpha.108 inherited)
- [ ] Pre-merge T1.1 / T1.1b / T1.2: privilege boundary (alpha.108 inherited)
- [ ] **Pre-merge T1.3 NEW**: Reconfigure cycle reconcile-repair-begin loop verify on fresh cluster — trigger CM4 reconfigure, verify pod-0 post-restart prestop-watchdog.log shows `runtime-primary-listener-reconcile-repair-begin` lines AND accompanying `primary-write-gates-ready label=...-no-writecheck reason=skip-writecheck-repair-path` lines, `.replication-divergence-pending` NOT emit, sql-listener-fence.log binlog event count delta = 0 over reconcile cycle window, Cluster Updating → Running ≤ 240s
- [ ] **Pre-merge T1.4 NEW**: mdb-async-10271 frozen anchor cross-cluster regression replay — apply alpha.110 chart to equivalent cluster + trigger CM4 → verify NO `.replication-divergence-pending` emit + cluster recovers Running
- [ ] **Pre-merge T1.5 NEW**: happy-path writecheck preservation — verify on fresh-create cluster bootstrap, `primary-write-gates-ready` runs `primary_local_root_write_ready` (no "-no-writecheck" in label) → kb_health_check INSERT happens as designed
- [ ] helm lint + helm template render (already verified locally)
- [ ] Self-merge after 4-cosign re-anchor on PR head sha
- [ ] IDC re-pin alpha.110 via helm upgrade (rev 45 → rev 46)
- [ ] Round 1c-H launch (4 topology N=1 stop-on-first-fail) on alpha.110 chart with T-P0a.1-5 + T-P0e.1-5 acceptance criteria once P0e merged + sub-3d 4 anchors cross-verify