### PR TITLE
mariadb: alpha.111 P0a URGENT Phase 2 — wrap unwrapped FLUSH PRIVILEGES sites to close orphan binlog source

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1666,7 +1666,34 @@ type: application
 # 15:45 sealed; alpha.110 P0a Direction E closes the production-FATAL
 # orphan event source mechanism, Direction B addresses the marker
 # state-drift root cause architectural sustainability.
-version: 1.1.1-alpha.110
+#
+# alpha.111 P0a URGENT Phase 2 (root cause): Round 1c-H Track A async
+# CM4 surfaced alpha.110 P0a Direction E scope-completeness GAP — the
+# Direction E label-anchored skip closed the syncerctl-writecheck
+# orphan path in the runtime reconcile-repair watchdog loop, but a
+# SEPARATE chart code path was emitting orphan binlog events. Jack
+# mysqlbinlog dump on Round 1c-H Track A frozen anchor mdb-async-9391
+# pod-0 @11:30:06Z identified the orphan event content as a bare
+# `FLUSH PRIVILEGES;` statement emitted on the eventual demoted-primary
+# pod's local binlog via `replication-switchover.sh:1264` post-DCS
+# root revoke summary path (the per-priv REVOKE statements above
+# wrap in SET SESSION sql_log_bin=0, but the FINAL summary FLUSH
+# at line 1264 was unwrapped). Phase 2 fix wraps the FLUSH PRIVILEGES
+# in SET SESSION sql_log_bin=0/1 bracket. Also wraps cmpd.yaml:59
+# initdb script FLUSH PRIVILEGES for chart-wide audit completeness
+# (bootstrap-only, not orphan source, hygiene wrap only). Evidence
+# chain: Helen 20:14 causality hypothesis (ERROR 1227 != orphan source
+# per MariaDB CLI stop-on-first-error semantic) + Rocco 20:26 chart
+# code self-documentation cross-anchor (cmpd-replication-merged.yaml
+# 1010-1016 chart comment) + Jack 20:23 GTID divergence direct evidence
+# (pod-0 1-1-154 vs pod-1 1-1-153) + Jack 20:37 mysqlbinlog SMOKING
+# GUN content (orphan SQL = FLUSH PRIVILEGES) + Helen 20:46 worktree
+# audit + Rocco 20:48 parallel chart grep独 convergence on same site
+# = sextuple cross-anchor sealing. Pre-merge T-pre.NEW protocol:
+# `mysqlbinlog --start-datetime --stop-datetime <local-binlog>` on
+# demoted-primary post-switchover must observe ZERO domain-1
+# FLUSH PRIVILEGES events.
+version: 1.1.1-alpha.111
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1259,9 +1259,23 @@ EOF_HOSTS
     log_switchover_error "Switchover failed: post-DCS root revoke summary revoked=${total_revoked} already_fenced=${total_already_fenced} failed_hosts=${total_failed_hosts}; fail-closed"
     return 1
   fi
+  # alpha.111 P0a URGENT Phase 2 root cause fix: wrap FLUSH PRIVILEGES in
+  # SET SESSION sql_log_bin=0/1 to prevent orphan binlog event emission on
+  # demoted-primary post-switchover binlog. Round 1c-H Track A async CM4
+  # evidence (Jack mysqlbinlog dump on mdb-async-9391 pod-0 @11:30:06Z)
+  # identified a domain-1 FLUSH PRIVILEGES event that became orphan post-CM4
+  # switchover (pod-1 promoted primary at domain-1 seq=153, pod-0 demoted
+  # secondary had local domain-1 seq=154 — the extra event was this bare
+  # FLUSH PRIVILEGES emit). kb_internal_root has BINLOG ADMIN per alpha.66+
+  # so SET sql_log_bin=0 succeeds; FLUSH PRIVILEGES still executes against
+  # local mysql.user but emit to binlog suppressed.
   out=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
     --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
-    -P3306 -h127.0.0.1 -N -s -e "FLUSH PRIVILEGES;" 2>&1)
+    -P3306 -h127.0.0.1 -N -s -e "
+      SET SESSION sql_log_bin=0;
+      FLUSH PRIVILEGES;
+      SET SESSION sql_log_bin=1;
+    " 2>&1)
   rc=$?
   if [ "${rc}" -ne 0 ]; then
     log_switchover_error "Switchover failed: post-DCS root revoke: FLUSH PRIVILEGES failed rc=${rc} out=${out}; fail-closed"

--- a/addons/mariadb/templates/cmpd.yaml
+++ b/addons/mariadb/templates/cmpd.yaml
@@ -47,7 +47,16 @@ spec:
             cat > /docker-entrypoint-initdb.d/01-kb-internal-root.sh <<'INITDB_EOF'
             #!/bin/bash
             set -eu
+            # alpha.111 P0a URGENT Phase 2 hygiene wrap: bracket all binlog-
+            # affecting DDL/DCL in SET SESSION sql_log_bin=0/1 per chart-wide
+            # FLUSH PRIVILEGES wrap audit completeness pattern. This initdb
+            # script runs ONCE at cluster T0 (mariadbd fresh datadir init)
+            # BEFORE any secondary joins, so unwrapped emit was historically
+            # not orphan source — but wrap maintained for chart-wide hygiene
+            # consistency and to prevent future regressions if invocation
+            # path expands.
             mariadb -h localhost -u root -p"${MARIADB_ROOT_PASSWORD}" <<-SQL
+              SET SESSION sql_log_bin=0;
               CREATE USER IF NOT EXISTS 'kb_internal_root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               ALTER USER 'kb_internal_root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               ALTER USER 'kb_internal_root'@'localhost' ACCOUNT UNLOCK;
@@ -57,6 +66,7 @@ spec:
               ALTER USER 'kb_internal_root'@'127.0.0.1' ACCOUNT UNLOCK;
               GRANT ALL PRIVILEGES ON *.* TO 'kb_internal_root'@'127.0.0.1' WITH GRANT OPTION;
               FLUSH PRIVILEGES;
+              SET SESSION sql_log_bin=1;
             SQL
             INITDB_EOF
             chmod +x /docker-entrypoint-initdb.d/01-kb-internal-root.sh


### PR DESCRIPTION
## Summary

alpha.111 P0a URGENT Phase 2 — wrap two unwrapped FLUSH PRIVILEGES sites in `SET SESSION sql_log_bin=0/1` brackets to close orphan binlog event source identified by Round 1c-H Track A async CM4 acceptance evidence on Round 1c-G 2nd mechanism recurrence on alpha.110 chart.

- **Phase 2 root cause fix**: `scripts/replication-switchover.sh:1264` — wrap bare `FLUSH PRIVILEGES;` at the end of post-DCS root revoke summary path (the per-priv REVOKE statements above wrap correctly; this final summary FLUSH was missed). Identity is `kb_internal_root` which has BINLOG ADMIN per alpha.66+ design, so `SET sql_log_bin=0` succeeds and FLUSH runs without binlog emit.
- **Phase 2 hygiene wrap**: `templates/cmpd.yaml:59` — wrap the initdb `/docker-entrypoint-initdb.d/01-kb-internal-root.sh` heredoc CREATE USER / GRANT / FLUSH PRIVILEGES sequence in `SET sql_log_bin=0/1`. Bootstrap-only path (runs at cluster T0 before any secondary joins), not orphan source today per chicken-and-egg framing, wrap for chart-wide audit completeness and to prevent future regression if invocation path expands.
- **Chart version**: bumped to `1.1.1-alpha.111`.

Phase 1 (alpha.108 B2 swap audit completion — ROOT_LOCAL-first fallback patterns in 4 chart functions) is **not** in this PR; tracked as hygiene cleanup follow-up child PR. Per chart-wide audit those patterns produce ERROR 1227 noise in fence log but are not the orphan binlog event source (MariaDB CLI `-e` stop-on-first-error semantic prevents subsequent GRANT/FLUSH execution when `SET sql_log_bin=0` itself fails — also documented in `cmpd-replication-merged.yaml` lines 1010-1016 chart comment).

## Direct evidence (sextuple cross-anchor)

1. **TL first-principles causality hypothesis**: `ERROR 1227` in `sql-listener-fence.log` is a health signal but **not** the orphan source per MariaDB CLI `-e` default stop-on-first-error semantic; subsequent CREATE/GRANT in the failed batch do not execute, so wrapped ROOT_LOCAL-first patterns do not emit binlog when `SET sql_log_bin=0` itself fails.
2. **Chart code self-documentation cross-anchor**: `cmpd-replication-merged.yaml` lines 1010-1016 chart comment block explicitly acknowledges non-atomic DDL + stop-on-first-error behavior.
3. **GTID divergence direct evidence** (`mdb-async-9391` Round 1c-H Track A frozen anchor):

   ```
   pod-0:  @@gtid_binlog_pos = 1-1-154, 2-2-381
   pod-1:  @@gtid_binlog_pos = 1-1-153, 2-2-2264   (post-CM4 promoted primary)
   ```

   The extra `1-1-154` event on pod-0 is the orphan that triggered alpha.60 fail-closed at 11:36:33Z post-CM4 switchover.

4. **mysqlbinlog SMOKING GUN content** (pod-0 local binlog at 11:30:06Z):

   ```
   #260529 11:30:06 server id 1  end_log_pos 58630  GTID 1-1-154
   SET @@session.gtid_domain_id=1
   SET @@session.server_id=1
   SET @@session.gtid_seq_no=154
   # at 58630
   #260529 11:30:06 server id 1  end_log_pos 58709  Query thread_id=776 xid=0
   SET TIMESTAMP=1780054206
   FLUSH PRIVILEGES                                  <-- orphan SQL
   /*!*/;
   ```

   Statement-based replication of FLUSH PRIVILEGES, not in any `SET sql_log_bin=0` wrap.

5. **Chart-side worktree audit**: chart-wide grep + read confirms 19 FLUSH PRIVILEGES sites total — only 2 unwrapped: `scripts/replication-switchover.sh:1264` (post-DCS root revoke summary, the orphan source) and `templates/cmpd.yaml:59` (bootstrap-only initdb, not orphan source today but wrap for consistency).
6. **Independent peer convergence**: parallel chart grep on same code site within 9 minutes of mysqlbinlog evidence handoff, 5/5 attribute match (SOLO unwrapped + kb_internal_root identity + post-DCS path + statement-based emit + 11:30:06Z timing).

## Test plan

Pre-merge T-pre acceptance protocol (must be applied per topology against Round 1c-I launch on alpha.111-pinned cluster):

- [ ] **T-pre.0** (first-principles acceptance gate): post-CM4 cycle, `kubectl -n <ns> exec <pod> -c mariadb -- ls -la /var/lib/mysql/.replication-divergence-pending` MUST return file-not-found (canonical data root path, **not** `/var/lib/mysql/log/` subdir which produced the false-PASS evidence in earlier pre-merge T runs).
- [ ] **T-pre.NEW** (orphan source absence): post-switchover, `mysqlbinlog --start-datetime --stop-datetime <local-binlog>` on demoted-primary MUST observe ZERO domain-1 `FLUSH PRIVILEGES` events.
- [ ] **T1.X** (cross-cluster regression): apply on `mdb-async-9391` 4th frozen anchor (Round 1c-H Track A live cluster preserved), trigger CM4 reconfigure cycle, verify cluster reaches `phase=Running` post-CM4 within bounded budget AND verify divergence-pending marker absence + binlog FLUSH PRIVILEGES absence.
- [ ] **T0** (7-face frozen baseline preservation): mdb-async-11221 + mdb-async-12851 + mdb-async-10271 + mdb-async-9391 restart counters preserved 0/0 through PR pre-merge cycle.
- [ ] **Helm template render**: `helm template addons/mariadb` succeeds (template-only syntactic verify).

## Related

- Parent dev branch: `feat/mariadb-alpha37-semisync-fencing-pr` (long-running MariaDB addon integration target)
- Previous related PRs in chain: #2696 (alpha.108 B2 swap), #2697 (alpha.109 sentinel), #2700 (alpha.110 P0a URGENT Direction E)
- Follow-up child PR: alpha.111 Phase 1 ROOT_LOCAL-first swap (hygiene cleanup, non-blocking)
