### PR TITLE
mariadb: alpha.112 — honest 60s timeoutSeconds on memberJoin + galera single-shot bootstrap-or-defer refactor

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1693,7 +1693,18 @@ type: application
 # `mysqlbinlog --start-datetime --stop-datetime <local-binlog>` on
 # demoted-primary post-switchover must observe ZERO domain-1
 # FLUSH PRIVILEGES events.
-version: 1.1.1-alpha.111
+#
+# alpha.112 honest-timeout: lifecycle action timeoutSeconds must match
+# kbagent's 60s hard cap. Galera memberJoin previously declared 3660s
+# (~61 minutes) and replication memberJoin declared 180s; both were silently
+# truncated to 60s by kbagent and the declared value misled operators.
+# This release reduces both to 60s and refactors galera-member-join.sh to
+# the single-shot bootstrap-or-defer pattern so each rc=1 with classified
+# "next-retry-safe: yes" lets the runtime re-fire until SST completes,
+# preserving long-running SST support under a 60s-per-call ceiling.
+# replication-member-join.sh refactor to the same pattern tracked
+# separately (TODO in cmpd-replication.yaml memberJoin block).
+version: 1.1.1-alpha.112
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/galera-member-join.sh
+++ b/addons/mariadb/scripts/galera-member-join.sh
@@ -1,28 +1,60 @@
 #!/bin/sh
-# Called by KubeBlocks when a new member is joining the Galera cluster.
-# Waits until galera-start.sh signals that this node has reached wsrep_local_state=4 (Synced).
+# Called by KubeBlocks runtime (controller / kbagent) when a member is joining
+# the Galera cluster. Single-shot bootstrap-or-defer pattern: each invocation
+# observes the synced marker once and decides whether to close the action or
+# defer to the next re-fire. Does NOT poll in-process — that would hit
+# kbagent's hardcoded 60s maxActionCallTimeout for any non-trivial Galera SST.
 #
-# NOTE: kbagent (which executes this script) has no mariadb binary.
-# galera-start.sh writes .galera-synced once wsrep_local_state=4 is detected via Unix socket.
-# This script simply checks for that file.
+# galera-start.sh runs inside the mariadb container's main entrypoint and
+# writes ${DATA_DIR}/.galera-synced after it observes wsrep_local_state=4
+# (Synced) via the Unix socket. This script only checks for that marker and
+# classifies the result for the next re-fire.
+#
+# Contract per skills/addon-lifecycle-single-shot-bootstrap-or-defer:
+#   - rc=0 == genuinely synced (positive observation of the marker file).
+#   - rc=1 with "next-retry-safe: yes" == still bootstrapping (SST in flight,
+#     galera-start.sh has not yet written the marker); the runtime will
+#     re-invoke this action and a future call will observe the marker.
+#   - rc=1 with "next-retry-safe: no" == operator-attention failure
+#     (DATA_DIR missing entirely == script preconditions broken).
 
 DATA_DIR="${DATA_DIR:-/var/lib/mysql}"
 SYNCED_FILE="${DATA_DIR}/.galera-synced"
-MAX_WAIT=3600
-INTERVAL=5
-elapsed=0
 
-echo "Waiting for Galera SST to complete on ${KB_JOIN_MEMBER_POD_NAME:-this node}..."
+galera_member_join_diagnose_not_ready() {
+    phase="$1"
+    ctx="$2"
+    retry_safe="$3"
+    {
+        echo "memberJoin diagnosis:"
+        echo "  action: galera-member-join"
+        echo "  phase: ${phase}"
+        echo "  cluster: ${KB_CLUSTER_NAME:-<unset>}"
+        echo "  pod: ${KB_JOIN_MEMBER_POD_NAME:-<unset>}"
+        echo "  data_dir: ${DATA_DIR}"
+        echo "  synced_marker: ${SYNCED_FILE}"
+        echo "${ctx}"
+        echo "  next-retry-safe: ${retry_safe}"
+    } >&2
+}
 
-while true; do
-  if [ -f "${SYNCED_FILE}" ]; then
-    echo "Node synced (${SYNCED_FILE} present). Member join complete."
-    exit 0
-  fi
-  if [ "$elapsed" -ge "$MAX_WAIT" ]; then
-    echo "Timeout waiting for node to sync after ${MAX_WAIT}s."
+if [ ! -d "${DATA_DIR}" ]; then
+    galera_member_join_diagnose_not_ready \
+        "data-dir-missing" \
+        "  data_dir_exists: no" \
+        "no"
     exit 1
-  fi
-  sleep "$INTERVAL"
-  elapsed=$((elapsed + INTERVAL))
-done
+fi
+
+if [ -f "${SYNCED_FILE}" ]; then
+    echo "Galera node synced (${SYNCED_FILE} present). Member join complete."
+    exit 0
+fi
+
+galera_member_join_diagnose_not_ready \
+    "sst-not-yet-synced" \
+    "  data_dir_exists: yes
+  synced_marker_present: no
+  hint: galera-start.sh writes this marker once wsrep_local_state reaches 4 (Synced); SST may still be in progress." \
+    "yes"
+exit 1

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -108,7 +108,15 @@ spec:
           - /bin/sh
           - /scripts/galera-roleprobe.sh
     memberJoin:
-      timeoutSeconds: 3660
+      # KB kbagent enforces a hardcoded maxActionCallTimeout of 60s
+      # (pkg/kbagent/service/action_utils.go); any value above 60 is silently
+      # truncated. Galera SST can run much longer than 60s, so the script uses
+      # the single-shot bootstrap-or-defer pattern: each invocation checks the
+      # .galera-synced marker (written by galera-start.sh once wsrep_local_state
+      # reaches 4 = Synced); if not yet synced, it exits 1 with a classified
+      # "next-retry-safe: yes" diagnose so the runtime re-fires until SST
+      # completes. The 60s declared here matches kbagent's actual cap.
+      timeoutSeconds: 60
       exec:
         container: mariadb
         command:

--- a/addons/mariadb/templates/cmpd-replication.yaml
+++ b/addons/mariadb/templates/cmpd-replication.yaml
@@ -68,7 +68,21 @@ spec:
           - /bin/sh
           - /scripts/replication-roleprobe.sh
     memberJoin:
-      timeoutSeconds: 180
+      # KB kbagent enforces a hardcoded maxActionCallTimeout of 60s
+      # (pkg/kbagent/service/action_utils.go); any value above 60 is silently
+      # truncated. The previous declared 180s was misleading — kbagent never
+      # honored more than 60s. The 60s declared here matches kbagent's actual
+      # cap.
+      #
+      # TODO(helen, alpha.112+): replication-member-join.sh still polls
+      # wait_for_primary up to 120s in-process, which will hit the 60s cap when
+      # the primary takes longer than ~55s to become reachable (e.g., scale-out
+      # against a slow primary). Refactor to the single-shot
+      # bootstrap-or-defer pattern (see skills/addon-lifecycle-single-shot-
+      # bootstrap-or-defer and the galera-member-join.sh rewrite in this PR
+      # for the reference shape) so each rc=1 with "next-retry-safe: yes"
+      # lets the runtime re-fire. Tracked separately to keep this PR scoped.
+      timeoutSeconds: 60
       exec:
         container: mariadb
         command:


### PR DESCRIPTION
## Summary

Closes Finding #1 from the 2026-05-31 MariaDB addon design review (@westonnnn requested at 16:03 in #mariadb).

- `cmpd-galera.yaml` `memberJoin.timeoutSeconds`: **3660 → 60** (with self-doc note)
- `cmpd-replication.yaml` `memberJoin.timeoutSeconds`: **180 → 60** (with self-doc note + TODO for script refactor)
- `galera-member-join.sh`: rewritten per `skills/addon-lifecycle-single-shot-bootstrap-or-defer` — no in-process polling loop, each invocation observes the marker once, exits 0 (synced) or exits 1 with classified `next-retry-safe: yes|no` for the runtime to re-fire
- `Chart.yaml`: version bump `1.1.1-alpha.110 → 1.1.1-alpha.112` (alpha.111 reserved for parallel child PR #2701)

## Why

`kbagent` enforces a hardcoded `maxActionCallTimeout` of 60s (`pkg/kbagent/service/action_utils.go`) — any `timeoutSeconds` value above 60 is silently truncated. The previous galera declaration (3660s = 61 minutes) and replication declaration (180s = 3 minutes) were misleading: operators reading the CmpD spec believed kbagent would wait that long, but the actual cap was 60s.

For galera this was **load-bearing**, not just cosmetic: `galera-member-join.sh` was a polling loop waiting up to 3600s for the `.galera-synced` marker (written by `galera-start.sh` once `wsrep_local_state` reaches 4 = Synced). For any non-trivial SST (large state-snapshot-transfer or slow network), kbagent killed the polling action at 60s before SST completed, breaking scale-out.

The `cmpd-replication.yaml` switchover action at line 85-90 already documents the 60s cap in a self-doc note — memberJoin lacked the same acknowledgment.

## What the fix does

1. **`cmpd-galera.yaml` memberJoin**: timeout 3660 → 60, with explanatory block citing kbagent's cap and the new bootstrap-or-defer pattern.

2. **`galera-member-join.sh` rewrite** per `skills/addon-lifecycle-single-shot-bootstrap-or-defer`:
   - removes the in-process polling loop
   - each invocation observes the `.galera-synced` marker once and exits
   - `rc=0` == genuinely synced (positive observation of the marker file)
   - `rc=1` with `next-retry-safe: yes` + classified diagnose helper output to stderr == still bootstrapping (SST in flight, galera-start.sh has not yet written the marker); runtime re-fires the action
   - `rc=1` with `next-retry-safe: no` == operator-attention failure (DATA_DIR missing entirely)
   - Long-running SST is supported: each re-fire takes <1s for the observation; the actual SST runs in the mariadb container's main entrypoint (`galera-start.sh`) and is not bound by the lifecycle action timeout.

3. **`cmpd-replication.yaml` memberJoin**: timeout 180 → 60, with explanatory block plus a `TODO(helen, alpha.112+)` noting that `replication-member-join.sh` still polls `wait_for_primary` up to 120s in-process and needs the same bootstrap-or-defer refactor. Tracked separately to keep this PR scoped — the replication script is 592 lines with substantial SQL setup logic, refactoring needs more care than galera's 28-line script.

4. **`Chart.yaml` version**: bumped `1.1.1-alpha.110 → 1.1.1-alpha.112` with honest-timeout release note. `alpha.111` is reserved for parallel child PR #2701 (FLUSH PRIVILEGES wrap); integration owner reconciles version chain at merge time.

5. `cmpd-semisync.yaml` and `cmpd-replication-merged.yaml` do not declare `memberJoin` and are not affected.

## Compatibility / migration

- Existing galera clusters: re-fired memberJoin during scale-out is observed behavior of the runtime per the precondition probe documented in the loaded skill (2026-05-28 fake-CmpD live probe confirmed runtime re-invokes classified rc=1 actions). No operator-visible behavior change beyond "scale-out now succeeds where previously SST-truncated at 60s".
- Existing replication clusters: timeout drops from 180s → 60s. **If primary takes 60s-180s to become reachable** (e.g. slow initial bootstrap), replication-member-join's `wait_for_primary 120` polling loop will now fail at 60s where it previously succeeded. The replication script refactor (TODO above) closes this gap; until that ships, operators with slow primaries should expect a one-cycle memberJoin retry from KB controller's reconcile.

## Test plan

- [x] `helm template addons/mariadb` succeeds (template-only syntactic verify locally).
- [ ] Galera scale-out on a vcluster (fresh mariadb-galera cluster, scale 1→3, observe new pod's memberJoin re-fires until `.galera-synced` appears, then closes). **Tracked separately as a Phase 1 follow-up** — this PR ships the contract correction; vcluster scale-out validation requires fresh galera cluster which is outside the current Phase 3 sub-3c proviso scope on the active integration branch.
- [ ] Replication scale-out: verify memberJoin still completes within 60s for the normal case (primary already up); confirm one-cycle retry for the slow-primary case noted above.
- [x] Static checks: `gofmt` N/A, `shellcheck` not run (no shellcheck CI on this repo); manual review of `galera-member-join.sh` for POSIX sh compliance (only sh builtins used, no bash-isms).

## Related

- Design review notes: `notes/mariadb-addon-design-review-20260531.md` (Helen agent workspace; can be pasted into a separate sediment doc PR on `kubeblocks-addon-docs` if useful).
- Sibling: PR #2701 (alpha.111 FLUSH PRIVILEGES wrap, parallel child on integration branch).
- Sibling: `apecloud/syncer` PR #170 (Phase 3 syncer-side `WriteCheck` binlog suppression — different orphan class, in flight).
- Skill reference: `skills/addon-lifecycle-single-shot-bootstrap-or-defer` for the pattern applied here.

## Hard Rule 6 self-merge gating

I do not self-merge. Awaiting @westonnnn or human maintainer signal.
