### PR TITLE
fix(mysql): suppress xtrace around accountProvision mysql -p<password> (secret hygiene)

### DIFF
--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -208,8 +208,19 @@ lifecycleActions:
         - |
           set -ex
           ALL_DB='*.*'
+          # Suppress xtrace AND errexit so the password-bearing expansion is not echoed
+          # to pod stderr. KB_ACCOUNT_STATEMENT itself contains CREATE USER ... IDENTIFIED
+          # BY '<password>' (account password), and the mysql -p${MYSQL_ROOT_PASSWORD}
+          # invocation contains the root password; both would land in `kubectl logs` if
+          # xtrace stayed on. errexit is suppressed too so accountProvision failure can be
+          # captured explicitly via $? -- if it stayed on, set -e would exit before the
+          # rc-save line on any non-zero result.
+          { previous_state=$(set +o); set +ex; } 2>/dev/null
           eval statement=\"${KB_ACCOUNT_STATEMENT}\"
           mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement}"
+          mysql_rc=$?
+          eval "$previous_state"
+          exit $mysql_rc
       targetPodSelector: Role
       matchingKey: primary
   roleProbe:

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -168,8 +168,19 @@ accountProvision:
       - |
         set -ex
         ALL_DB='*.*'
+        # Suppress xtrace AND errexit so the password-bearing expansion is not echoed
+        # to pod stderr. KB_ACCOUNT_STATEMENT itself contains CREATE USER ... IDENTIFIED
+        # BY '<password>' (account password), and the mysql -p${MYSQL_ROOT_PASSWORD}
+        # invocation contains the root password; both would land in `kubectl logs` if
+        # xtrace stayed on. errexit is suppressed too so accountProvision failure can be
+        # captured explicitly via $? -- if it stayed on, set -e would exit before the
+        # rc-save line on any non-zero result.
+        { previous_state=$(set +o); set +ex; } 2>/dev/null
         eval statement=\"${KB_ACCOUNT_STATEMENT}\"
         mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement};"
+        mysql_rc=$?
+        eval "$previous_state"
+        exit $mysql_rc
     targetPodSelector: Role
     matchingKey: primary
 roleProbe:


### PR DESCRIPTION
## Summary

- The MySQL addon accountProvision lifecycle action enables `set -ex` before invoking `mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD}`, so bash xtrace echoes the fully-expanded command (including the plaintext MYSQL_ROOT_PASSWORD) to the pod stderr. Anyone with `kubectl logs` access (operators, log shippers, monitoring) then sees the root password in cleartext.
- Fix: wrap only the password-bearing line with xtrace suppression while keeping `set -ex` active for the surrounding context; preserve the mysql exit code so accountProvision failure still surfaces to kbagent / KB controller.
- 2 sites in this repo:
  - `addons/mysql/templates/_helpers.tpl` line 212 (default MySQL CmpD)
  - `addons/mysql/templates/_orc.tpl` line 172 (orchestrator-managed CmpD)
- Companion PR in `apecloud-addons` `release-1.0`: https://github.com/apecloud/apecloud-addons/pull/1417

## Why surfaced now

Cross-engine audit run by William (MySQL TL) per `prep/cross-engine-mysql-audit-checklist-prep.md` Trap 1 (set -ex + password-bearing command pattern). Pattern originally caught in kingbase round 12c2 (Taylor evidence pack `5032d746` + Hazel surfacing); fix pattern reuses Hazel R13 commit `57f8fe1`.

## Boundary

- Hygiene/secret PR, independent of D1 implementation work -- does NOT wait for the weston "open D1 code" decision and does NOT constitute release acceptance.
- Per pair-review (Henry `e0d6a217`): narrow xtrace suppression preferred over wrapping the whole block; mysql rc preserved.

## Test plan

- [ ] Helm template render check (no breakage of YAML structure).
- [ ] Runtime verification owner: Freya (A1 first-round low-storage probe). Trigger accountProvision via kbagent on a fresh primary pod, then `kubectl logs <pod> -c mysql` and `kubectl logs <pod> -c kbagent` -- expect no plaintext `-p<password>` line. The non-password context (`set -ex`, `ALL_DB`, `eval statement`) should still echo.
- [ ] Runtime verification owner: Freya -- assert accountProvision still surfaces a non-zero exit on intentional fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)