### PR TITLE
Fix Redis cluster reconfigure action container

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -187,9 +187,10 @@ redis-account.sh: |-
 {{- end }}
 
 {{- define "redis.config.reconfigureAction" -}}
+{{- $container := .container | default "redis" -}}
 reconfigure:
   exec:
-    container: redis
+    container: {{ $container }}
     targetPodSelector: All
     command:
       - /bin/sh

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -91,7 +91,7 @@ spec:
       namespace: {{ $.Release.Namespace }}
       volumeName: redis-cluster-config
       externalManaged: true
-      {{- include "redis.config.reconfigureAction" $ | nindent 6 }}
+      {{- include "redis.config.reconfigureAction" (dict "container" "redis-cluster") | nindent 6 }}
   scripts:
     - name: redis-cluster-scripts
       template: {{ include "redisCluster.scriptsTemplate" $ }}

--- a/addons/redis/templates/cmpd-redis.yaml
+++ b/addons/redis/templates/cmpd-redis.yaml
@@ -86,7 +86,7 @@ spec:
       namespace: {{ $.Release.Namespace }}
       volumeName: redis-config
       externalManaged: true
-      {{- include "redis.config.reconfigureAction" $ | nindent 6 }}
+      {{- include "redis.config.reconfigureAction" (dict "container" "redis") | nindent 6 }}
   scripts:
     - name: redis-scripts
       template: {{ include "redis.scriptsTemplate" $ }}


### PR DESCRIPTION
## Summary
- make the Redis reconfigure action helper accept a container name
- render normal Redis config reconfigure actions with `container: redis`
- render Redis Cluster config reconfigure actions with `container: redis-cluster`

## Why
On KubeBlocks main / Redis chart `1.2.0-alpha.0`, Redis Cluster creation hit controller errors:

`build kb-agent container failed: only one exec container is allowed in lifecycle actions`

The Redis Cluster ComponentDefinition uses lifecycle actions in the `redis-cluster` container, but the shared config reconfigure action was hardcoded to `container: redis`. The Redis test suite now includes static S06 to catch this render shape.

## Validation
Validated with the Redis test suite in `kubeblocks-tests` on dedicated vcluster `redis-topology-main-vc`:
- focused cluster rerun passed `5 PASS / 0 FAIL / 0 SKIP`
- fresh full Redis suite passed `93 PASS / 0 FAIL / 0 SKIP`
- live ComponentDefinition readback: `redis-cluster-config.reconfigure.exec.container=redis-cluster`

Evidence index: `/Users/wei/.slock/agents/27018600-fd49-4895-8785-bcc2a308c32a/artifacts/redis-topology-main-vc/20260531T2120-kb-install/EVIDENCE-INDEX.md`
