### PR TITLE
fix(mariadb): use published syncer default

### DIFF
--- a/addons/mariadb/values.yaml
+++ b/addons/mariadb/values.yaml
@@ -13,9 +13,10 @@ image:
       tag: v0.14.0
   syncer:
     repository: apecloud/syncer
-    # alpha.23: patched syncer for semisync switchover old-primary rejoin.
-    # Built linux/amd64 and distributed by sideload with IfNotPresent.
-    tag: mariadb-switchover-follow-alpha23-20260506-1005-amd64
+    # Keep the chart default on a published syncer tag. Candidate or
+    # engine-specific syncer builds must be supplied explicitly by values
+    # override during validation, not baked into the release chart default.
+    tag: 0.6.7
 
 ## @param componentServiceVersion define default serviceVersion of each Component
 defaultServiceVersion:


### PR DESCRIPTION
## Summary

- replace the MariaDB chart default syncer tag with published `apecloud/syncer:0.6.7`
- keep candidate or engine-specific syncer builds as explicit values overrides instead of release chart defaults
- leave PR #2710 README-only; this PR handles the syncer image-supply part separately

## Validation

- `git diff --check origin/feat/mariadb-alpha37-semisync-fencing-pr..HEAD`
- `helm dependency build addons/mariadb`
- `helm template mariadb addons/mariadb --show-only templates/cmpv.yaml | rg "init-syncer|syncer:0\\.6\\.7|mariadb-switchover-follow" -n`

Rendered `init-syncer` now points to `docker.io/apecloud/syncer:0.6.7` for every MariaDB release entry, and the old sideload-only tag is no longer rendered.

## CI note

Mason is handling image supply for `apecloud/mariadb:11.8.4` and `apecloud/mariadb:12.0.2` to Docker Hub + ACR. This PR only fixes the syncer default image reference.
