### PR TITLE
mariadb: alpha.113 — single-shot bootstrap-or-defer refactor of replication-member-join.sh

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1704,7 +1704,68 @@ type: application
 # preserving long-running SST support under a 60s-per-call ceiling.
 # replication-member-join.sh refactor to the same pattern tracked
 # separately (TODO in cmpd-replication.yaml memberJoin block).
-version: 1.1.1-alpha.112
+#
+# alpha.113 v1 (Helen 2026-06-01 — single-shot bootstrap-or-defer
+# refactor of replication-member-join.sh, deferred follow-up to
+# alpha.112 / PR #2702 which only capped cmpd-replication.yaml
+# memberJoin timeoutSeconds 180→60 but explicitly left the script
+# refactor as TODO).
+#
+# Problem: the script's `wait_for_primary 120` polling loop was
+# silently truncated by kbagent's 60s maxActionCallTimeout. The
+# alpha.112 cmpd cap made the truncation honest in the spec but
+# did not change the script — every memberJoin invocation that hit
+# an unresponsive primary service still wasted 60s on an in-process
+# poll that the runtime would simply kill and retry.
+#
+# Fix (1 script + this Chart.yaml; cmpd-replication.yaml unchanged
+# because PR #2702 already capped its timeoutSeconds to 60):
+#   - scripts/replication-member-join.sh: replace `wait_for_primary`
+#     polling loop with single-shot `probe_primary_or_defer`
+#     (one PRIMARY_HOST SELECT 1 + one BOOTSTRAP_PRIMARY_HOST
+#     read_only fallback for pod-index>0). On miss, classify
+#     "primary-not-yet-reachable" with retry=yes and exit 1; the
+#     runtime re-fires.
+#   - Add per-action `replication_member_join_diagnose_not_ready`
+#     helper (Pin 1 of
+#     skills/addon-lifecycle-single-shot-bootstrap-or-defer), with
+#     action label baked in. Every rc=1 path in main / setup_replication
+#     now routes through this helper with a phase label and
+#     next-retry-safe classification:
+#       retry=no  → mariadb CLI missing; CHANGE MASTER TO failed;
+#                   START SLAVE SQL_THREAD failed; SHOW SLAVE STATUS
+#                   empty after CHANGE MASTER; fresh-replica prepare
+#                   failed; GTID divergence fail-closed; GTID
+#                   out-of-order WITH confirmed divergence.
+#       retry=yes → primary service not yet reachable; slave threads
+#                   not yet Yes/0/0 (catch-up in progress); GTID
+#                   out-of-order WITHOUT confirmed divergence (primary
+#                   truth still stabilizing).
+#   - rc=0 paths preserved verbatim: is_slave_running fast-path,
+#     is_self_primary guard, slave_status_is_ready_for_rejoin positive
+#     verify, post-repair re-verify. No new rc=0 path.
+#
+# Numbering: alpha.111 reserved for PR #2701 (P0a URGENT FLUSH
+# PRIVILEGES wrap, in flight) and alpha.112 reserved for PR #2702
+# (honest 60s timeoutSeconds on memberJoin + galera single-shot
+# refactor, in flight). Integration owner reconciles the chain at
+# merge time.
+#
+# Behavior preservation: all four existing rc=0 paths return rc=0 on
+# the same conditions as alpha.110. All existing rc=1 paths still
+# return rc=1; the only behavior delta is (a) the wait_for_primary
+# polling loop becomes a single-shot probe + retry=yes defer (under
+# kbagent's 60s cap this is equivalent to or better than the prior
+# in-process poll), and (b) every rc=1 path now emits classified
+# stderr that operator triage can read to distinguish transient
+# from operator-attention failures.
+#
+# Use-precondition (per skill): runtime re-invokes the action on a
+# subsequent attempt when the previous invocation returned rc=1.
+# Already evidenced by 2026-05-28 fake-CmpD probe on KB controller
+# 1.0.3-beta.6 (skill `## 已知未知` section); no new evidence pack
+# needed.
+version: 1.1.1-alpha.113
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1741,9 +1741,10 @@ type: application
 #                   not yet Yes/0/0 (catch-up in progress); GTID
 #                   out-of-order WITHOUT confirmed divergence (primary
 #                   truth still stabilizing).
-#   - rc=0 paths preserved verbatim: is_slave_running fast-path,
-#     is_self_primary guard, slave_status_is_ready_for_rejoin positive
-#     verify, post-repair re-verify. No new rc=0 path.
+#   - The 4 explicit positive-success rc=0 paths preserved verbatim:
+#     is_slave_running fast-path, is_self_primary guard,
+#     slave_status_is_ready_for_rejoin positive verify, post-repair
+#     re-verify. No new rc=0 path.
 #
 # Numbering: alpha.111 reserved for PR #2701 (P0a URGENT FLUSH
 # PRIVILEGES wrap, in flight) and alpha.112 reserved for PR #2702
@@ -1751,14 +1752,37 @@ type: application
 # refactor, in flight). Integration owner reconciles the chain at
 # merge time.
 #
-# Behavior preservation: all four existing rc=0 paths return rc=0 on
-# the same conditions as alpha.110. All existing rc=1 paths still
-# return rc=1; the only behavior delta is (a) the wait_for_primary
-# polling loop becomes a single-shot probe + retry=yes defer (under
-# kbagent's 60s cap this is equivalent to or better than the prior
-# in-process poll), and (b) every rc=1 path now emits classified
-# stderr that operator triage can read to distinguish transient
-# from operator-attention failures.
+# Behavior delta vs alpha.110 (acknowledged corrected bug, not pure
+# preservation — Jack peer review 2026-06-01 01:59 GH comment
+# 4587575867 caught the over-claim in PR #2712 v1):
+#
+#   (a) The wait_for_primary polling loop becomes a single-shot
+#       probe + retry=yes defer. Under kbagent's 60s cap this is
+#       equivalent to or better than the prior in-process poll, which
+#       was silently truncated at 60s and discarded partial state.
+#
+#   (b) Every rc=1 path now emits classified stderr that operator
+#       triage can read to distinguish transient (retry=yes) from
+#       operator-attention (retry=no) failures.
+#
+#   (c) CORRECTED IMPLICIT rc=0 BUG: alpha.110's `setup_replication`
+#       had a final `mark_replication_pending; echo "WARNING: ... not
+#       yet healthy"; }` branch with NO explicit `return 1`. Because
+#       the last statement in that branch was `echo`, the function
+#       returned the rc of `echo` (= 0), which propagated up through
+#       `main` so kbagent observed memberJoin = succeeded even when
+#       Slave_IO / Slave_SQL had not converged. The cluster eventually
+#       self-healed via roleProbe reading `.replication-pending`, but
+#       memberJoin was lying to the controller about its outcome.
+#       alpha.113 makes this branch an explicit `return 1` classified
+#       as `slave-not-yet-ready-for-rejoin` + retry=yes, so kbagent
+#       sees the true not-ready state and re-fires the action until
+#       slave IS ready. This is the correct single-shot bootstrap-
+#       or-defer behavior; it is also a semantic change vs alpha.110.
+#       Same `mark_replication_pending` marker write preserved for
+#       roleProbe interop. New ShellSpec assertion in
+#       scripts-ut-spec/replication_member_join_spec.sh covers this
+#       phase + retry-safe so the regression cannot reopen silently.
 #
 # Use-precondition (per skill): runtime re-invokes the action on a
 # subsequent attempt when the previous invocation returned rc=1.

--- a/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
@@ -448,6 +448,8 @@ EOF
         The path "${TEST_DIR}/.replication-pending" should be exist
         The path "${TEST_DIR}/.replication-divergence-pending" should be exist
         The output should include "GTID divergence detected"
+        The stderr should include "phase: gtid-divergence-fail-closed"
+        The stderr should include "next-retry-safe: no"
       End
 
       It "persists divergence decision evidence for later proof collection"
@@ -491,6 +493,8 @@ EOF
         The contents of file "${TEST_DIR}/.replication-divergence-pending" should include "branch=fail_closed_for_gtid_divergence"
         The contents of file "${TEST_DIR}/.replication-divergence-pending" should include "primary_resolved_endpoint=mdb-mariadb-1"
         The contents of file "${TEST_DIR}/.replication-divergence-pending" should include "primary_gtid_binlog_state=0-1-8550,0-2-8689"
+        The stderr should include "phase: gtid-divergence-fail-closed"
+        The stderr should include "next-retry-safe: no"
       End
 
       It "does not fail closed when primary sampling is unstable across retries"
@@ -581,6 +585,8 @@ EOF
         The path "${TEST_DIR}/.replication-pending" should be exist
         The path "${TEST_DIR}/.replication-divergence-pending" should not be exist
         The output should include "GTID out-of-order (1950) before primary truth stabilized"
+        The stderr should include "phase: gtid-out-of-order-transient"
+        The stderr should include "next-retry-safe: yes"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
@@ -583,6 +583,43 @@ EOF
         The output should include "GTID out-of-order (1950) before primary truth stabilized"
       End
     End
+
+    Context "when slave is not yet ready for rejoin (Slave_IO_Running still Connecting)"
+      It "returns failure with classified slave-not-yet-ready-for-rejoin retry=yes (alpha.110 implicit rc=0 bug fix)"
+        # Regression guard for alpha.110 implicit rc=0 bug: that release returned rc=0
+        # from this branch because the last statement was an echo (no explicit return 1).
+        # alpha.113 reclassifies as slave-not-yet-ready-for-rejoin + retry=yes so kbagent
+        # re-fires memberJoin until slave actually converges.
+        primary_sql() {
+          case "$*" in
+            *"gtid_binlog_pos"*) echo "0-1-100" ;;
+          esac
+        }
+        local_sql() {
+          case "$*" in
+            *"gtid_slave_pos;"*)   echo "" ;;
+            *"SHOW SLAVE STATUS"*) echo "some-slave-status-row" ;;
+            *) : ;;
+          esac
+        }
+        query_slave_status_verbose() {
+          cat <<'EOF'
+Slave_IO_Running: Connecting
+Slave_SQL_Running: No
+Last_IO_Errno: 0
+Last_SQL_Errno: 0
+EOF
+        }
+        When call setup_replication
+        The status should be failure
+        The path "${TEST_DIR}/.replication-pending" should be exist
+        The output should include "WARNING: replication rejoin not yet healthy"
+        The stderr should include "phase: slave-not-yet-ready-for-rejoin"
+        The stderr should include "next-retry-safe: yes"
+        The stderr should include "Slave_IO_Running: Connecting"
+        The stderr should include "Slave_SQL_Running: No"
+      End
+    End
   End
 
   Describe "replication_member_join_diagnose_not_ready()"

--- a/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
@@ -585,12 +585,119 @@ EOF
     End
   End
 
+  Describe "replication_member_join_diagnose_not_ready()"
+    Context "emits structured stderr with action label, phase, and retry-safe"
+      It "writes the action label, phase, and next-retry-safe to stderr"
+        export KB_CLUSTER_NAME="mdb-cluster"
+        export POD_NAME="mdb-mariadb-1"
+        ACTIVE_PRIMARY_HOST="mdb-mariadb.demo.svc.cluster.local"
+        When call replication_member_join_diagnose_not_ready "primary-not-yet-reachable" "  probe_primary_host: mdb-mariadb.demo.svc.cluster.local" "yes"
+        The status should be success
+        The stderr should include "action: replication-member-join"
+        The stderr should include "phase: primary-not-yet-reachable"
+        The stderr should include "cluster: mdb-cluster"
+        The stderr should include "pod: mdb-mariadb-1"
+        The stderr should include "probe_primary_host: mdb-mariadb.demo.svc.cluster.local"
+        The stderr should include "next-retry-safe: yes"
+      End
+
+      It "supports retry-safe: no for operator-attention failures"
+        When call replication_member_join_diagnose_not_ready "change-master-failed" "  master_host: pri" "no"
+        The status should be success
+        The stderr should include "phase: change-master-failed"
+        The stderr should include "next-retry-safe: no"
+      End
+    End
+  End
+
+  Describe "probe_primary_or_defer() single-shot"
+    Context "when PRIMARY_HOST accepts SELECT 1"
+      It "sets ACTIVE_PRIMARY_HOST and returns success"
+        host_sql() {
+          case "$1" in
+            "${PRIMARY_HOST}") return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+        ACTIVE_PRIMARY_HOST=""
+        When call probe_primary_or_defer
+        The status should be success
+        The variable ACTIVE_PRIMARY_HOST should eq "${PRIMARY_HOST}"
+      End
+    End
+
+    Context "when PRIMARY_HOST is unreachable on pod-0"
+      It "defers without trying bootstrap fallback and writes retry-safe: yes diagnose"
+        export POD_NAME="mdb-mariadb-0"
+        POD_INDEX="0"
+        host_sql() { return 1; }
+        ACTIVE_PRIMARY_HOST=""
+        When call probe_primary_or_defer
+        The status should be failure
+        The variable ACTIVE_PRIMARY_HOST should eq ""
+        The stderr should include "phase: primary-not-yet-reachable"
+        The stderr should include "next-retry-safe: yes"
+      End
+    End
+
+    Context "when PRIMARY_HOST unreachable on pod-1 and bootstrap primary is writable"
+      It "falls back to BOOTSTRAP_PRIMARY_HOST and returns success"
+        export POD_NAME="mdb-mariadb-1"
+        POD_INDEX="1"
+        host_sql() {
+          case "$*" in
+            *"${BOOTSTRAP_PRIMARY_HOST}"*"read_only"*) echo "0"; return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+        ACTIVE_PRIMARY_HOST=""
+        When call probe_primary_or_defer
+        The status should be success
+        The variable ACTIVE_PRIMARY_HOST should eq "${BOOTSTRAP_PRIMARY_HOST}"
+        The output should include "Using bootstrap primary"
+      End
+    End
+
+    Context "when neither PRIMARY_HOST nor bootstrap primary are reachable on pod-1"
+      It "defers with retry-safe: yes"
+        export POD_NAME="mdb-mariadb-1"
+        POD_INDEX="1"
+        host_sql() { return 1; }
+        ACTIVE_PRIMARY_HOST=""
+        When call probe_primary_or_defer
+        The status should be failure
+        The variable ACTIVE_PRIMARY_HOST should eq ""
+        The stderr should include "phase: primary-not-yet-reachable"
+        The stderr should include "next-retry-safe: yes"
+        The stderr should include "pod_index: 1"
+      End
+    End
+
+    Context "when PRIMARY_HOST unreachable on pod-1 but bootstrap primary is read_only"
+      It "defers because bootstrap is not writable (read_only != 0)"
+        export POD_NAME="mdb-mariadb-1"
+        POD_INDEX="1"
+        host_sql() {
+          case "$*" in
+            *"${BOOTSTRAP_PRIMARY_HOST}"*"read_only"*) echo "1"; return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+        ACTIVE_PRIMARY_HOST=""
+        When call probe_primary_or_defer
+        The status should be failure
+        The variable ACTIVE_PRIMARY_HOST should eq ""
+        The stderr should include "next-retry-safe: yes"
+      End
+    End
+  End
+
   Describe "main() self-primary guard"
     Context "when this pod is the primary"
       It "skips replication setup and exits 0"
         local_sql()         { echo "100"; }
         primary_sql()       { echo "100"; }
-        wait_for_primary()  { return 0; }
+        probe_primary_or_defer() { return 0; }
         When call main
         The status should be success
         The output should include "Already primary"
@@ -607,7 +714,7 @@ EOF
           esac
         }
         primary_sql()      { echo "100"; }
-        wait_for_primary() { return 0; }
+        probe_primary_or_defer() { return 0; }
         When call main
         The status should be success
         The output should include "Nothing to do"
@@ -615,14 +722,14 @@ EOF
     End
 
     Context "when PRIMARY_HOST is unreachable but slave is already running"
-      It "returns success without waiting for PRIMARY_HOST"
+      It "returns success without probing PRIMARY_HOST"
         local_sql() {
           case "$*" in
             *"SHOW SLAVE STATUS"*) echo "some-row" ;;
             *"Slave_running"*)     printf 'Slave_running\tON\n' ;;
           esac
         }
-        wait_for_primary() { echo "should-not-be-called"; return 1; }
+        probe_primary_or_defer() { echo "should-not-be-called"; return 1; }
         When call main
         The status should be success
         The output should include "Nothing to do"

--- a/addons/mariadb/scripts/replication-member-join.sh
+++ b/addons/mariadb/scripts/replication-member-join.sh
@@ -414,31 +414,46 @@ repair_kb_health_check_replication_error() {
   return 0
 }
 
-# Wait for the primary service endpoint to accept connections.
-wait_for_primary() {
-  local max_wait="${1:-120}" elapsed=0
-  echo "Waiting for primary (${PRIMARY_HOST}) to be reachable..."
-  while true; do
-    if host_sql "${PRIMARY_HOST}" -e "SELECT 1;" >/dev/null 2>&1; then
-      ACTIVE_PRIMARY_HOST="${PRIMARY_HOST}"
+# Per-action diagnose helper. Action label baked in.
+# Pin 1 of skills/addon-lifecycle-single-shot-bootstrap-or-defer.
+replication_member_join_diagnose_not_ready() {
+  local phase="$1" ctx="$2" retry_safe="$3"
+  {
+    echo "memberJoin diagnosis:"
+    echo "  action: replication-member-join"
+    echo "  phase: ${phase}"
+    echo "  cluster: ${KB_CLUSTER_NAME:-${CLUSTER_NAME:-<unset>}}"
+    echo "  pod: ${POD_NAME:-<unset>}"
+    echo "  primary_host: ${PRIMARY_HOST:-<unset>}"
+    echo "  active_primary_host: ${ACTIVE_PRIMARY_HOST:-<unset>}"
+    echo "${ctx}"
+    echo "  next-retry-safe: ${retry_safe}"
+  } >&2
+}
+
+# Single-shot probe of the primary service endpoint. No in-process polling —
+# the runtime re-fires this action on rc=1 retry=yes, which gives us a fresh
+# 60s window each time. If neither the headless primary service nor the
+# bootstrap pod-0 fallback is reachable, defer for the next re-fire.
+probe_primary_or_defer() {
+  if host_sql "${PRIMARY_HOST}" -e "SELECT 1;" >/dev/null 2>&1; then
+    ACTIVE_PRIMARY_HOST="${PRIMARY_HOST}"
+    return 0
+  fi
+  if [ -n "${POD_INDEX}" ] && [ "${POD_INDEX}" -gt 0 ] 2>/dev/null; then
+    local direct_read_only
+    direct_read_only=$(host_sql "${BOOTSTRAP_PRIMARY_HOST}" -e "SELECT @@global.read_only;" 2>/dev/null || echo "")
+    if [ "${direct_read_only}" = "0" ]; then
+      ACTIVE_PRIMARY_HOST="${BOOTSTRAP_PRIMARY_HOST}"
+      echo "Using bootstrap primary ${ACTIVE_PRIMARY_HOST} while primary service has no endpoint."
       return 0
     fi
-    if [ -n "${POD_INDEX}" ] && [ "${POD_INDEX}" -gt 0 ] 2>/dev/null; then
-      local direct_read_only
-      direct_read_only=$(host_sql "${BOOTSTRAP_PRIMARY_HOST}" -e "SELECT @@global.read_only;" 2>/dev/null || echo "")
-      if [ "${direct_read_only}" = "0" ]; then
-        ACTIVE_PRIMARY_HOST="${BOOTSTRAP_PRIMARY_HOST}"
-        echo "Using bootstrap primary ${ACTIVE_PRIMARY_HOST} while primary service has no endpoint."
-        return 0
-      fi
-    fi
-    if [ "$elapsed" -ge "$max_wait" ]; then
-      echo "Timeout waiting for primary. Exiting."
-      return 1
-    fi
-    sleep 3
-    elapsed=$((elapsed + 3))
-  done
+  fi
+  local ctx
+  ctx=$(printf '  probe_primary_host: %s (SELECT 1 unreachable)\n  probe_bootstrap_host: %s (read_only != 0 or unreachable)\n  pod_index: %s' \
+    "${PRIMARY_HOST}" "${BOOTSTRAP_PRIMARY_HOST}" "${POD_INDEX:-<unset>}")
+  replication_member_join_diagnose_not_ready "primary-not-yet-reachable" "${ctx}" "yes"
+  return 1
 }
 
 # Return 0 if the primary service currently routes to this pod (we are the primary).
@@ -472,6 +487,15 @@ setup_replication() {
   # Rejoining pod: preserve local gtid_slave_pos and catch up from the local replay point.
 
   if fail_closed_for_gtid_divergence; then
+    # fail_closed_for_gtid_divergence already echoes the "GTID divergence
+    # detected" line for operator visibility and writes the marker file;
+    # add classified stderr for triage.
+    replication_member_join_diagnose_not_ready \
+      "gtid-divergence-fail-closed" \
+      "  local_gtid_binlog_state: ${local_gtid:-<empty>}
+  primary_gtid_binlog_pos: ${master_gtid:-<empty>}
+  marker: .replication-divergence-pending written; rebuild/resync required" \
+      "no"
     return 1
   fi
 
@@ -487,14 +511,29 @@ CHANGE MASTER TO
 START SLAVE IO_THREAD;
 "; then
       echo "CHANGE MASTER TO or START SLAVE IO_THREAD failed. Keeping roleProbe pending."
+      replication_member_join_diagnose_not_ready \
+        "change-master-or-start-io-failed" \
+        "  branch: fresh-pod (empty gtid_slave_pos)
+  master_host: ${PRIMARY_HOST}" \
+        "no"
       return 1
     fi
     if ! prepare_fresh_replica_for_sql_thread_start "${local_gtid}"; then
+      replication_member_join_diagnose_not_ready \
+        "fresh-replica-prepare-failed" \
+        "  branch: fresh-pod
+  reason: failed to clear local kb_health_check table" \
+        "no"
       return 1
     fi
     if ! local_sql -e "START SLAVE SQL_THREAD;" 2>/dev/null; then
       mark_replication_pending
       echo "START SLAVE SQL_THREAD failed. Keeping roleProbe pending."
+      replication_member_join_diagnose_not_ready \
+        "start-slave-sql-thread-failed" \
+        "  branch: fresh-pod
+  marker: .replication-pending" \
+        "no"
       return 1
     fi
   else
@@ -509,11 +548,21 @@ CHANGE MASTER TO
 START SLAVE;
 "; then
       echo "CHANGE MASTER TO failed. Keeping roleProbe pending."
+      replication_member_join_diagnose_not_ready \
+        "change-master-failed" \
+        "  branch: rejoining-pod (local gtid_slave_pos preserved)
+  master_host: ${PRIMARY_HOST}
+  local_gtid_slave_pos: ${local_gtid}" \
+        "no"
       return 1
     fi
   fi
   if [ -z "$(local_sql -e "SHOW SLAVE STATUS;" 2>/dev/null)" ]; then
     echo "CHANGE MASTER TO did not store slave config. Keeping roleProbe pending."
+    replication_member_join_diagnose_not_ready \
+      "slave-config-not-persisted" \
+      "  reason: SHOW SLAVE STATUS empty immediately after CHANGE MASTER TO" \
+      "no"
     return 1
   fi
 
@@ -538,26 +587,53 @@ START SLAVE;
   fi
   if slave_status_has_gtid_out_of_order "${slave_status_verbose}"; then
     if fail_closed_for_gtid_divergence; then
+      replication_member_join_diagnose_not_ready \
+        "gtid-out-of-order-divergent" \
+        "  symptom: Last_SQL_Errno=1950 (out-of-order) + GTID divergence confirmed
+  marker: .replication-divergence-pending; rebuild/resync required" \
+        "no"
       return 1
     fi
     mark_replication_pending
     echo "WARNING: replication rejoin hit GTID out-of-order (1950) before primary truth stabilized; keeping roleProbe pending for retry"
+    replication_member_join_diagnose_not_ready \
+      "gtid-out-of-order-transient" \
+      "  symptom: Last_SQL_Errno=1950 (out-of-order) but no GTID divergence yet
+  hint: primary truth may still be stabilizing; runtime re-fires this action" \
+      "yes"
     return 1
   fi
   mark_replication_pending
   echo "WARNING: replication rejoin not yet healthy; keeping roleProbe pending until Slave_IO/Slave_SQL are Yes and Last_IO/Last_SQL_Errno are 0"
+  local ready_snapshot
+  ready_snapshot=$(printf '%s' "${slave_status_verbose}" | grep -E "Slave_IO_Running|Slave_SQL_Running|Last_IO_Errno|Last_SQL_Errno" | sed 's/^/    /')
+  replication_member_join_diagnose_not_ready \
+    "slave-not-yet-ready-for-rejoin" \
+    "  required: Slave_IO_Running=Yes AND Slave_SQL_Running=Yes AND Last_IO_Errno=0 AND Last_SQL_Errno=0
+  observed:
+${ready_snapshot}" \
+    "yes"
+  return 1
 }
 
 main() {
+  # Single-shot bootstrap-or-defer per skills/addon-lifecycle-single-shot-bootstrap-or-defer:
+  # each invocation either (a) closes positively with rc=0 (replication observably
+  # running) or (b) defers with rc=1 + classified diagnose on stderr. No in-process
+  # polling — kbagent caps every call to 60s and re-fires on rc=1 retry=yes.
   if [ -z "${MARIADB_CLI}" ]; then
     echo "MariaDB client is unavailable in current memberJoin runtime."
+    replication_member_join_diagnose_not_ready \
+      "mariadb-cli-unavailable" \
+      "  reason: neither \`mariadb\` on PATH nor ${MYSQL_CLIENT_DIR}/bin/mariadb is executable in current memberJoin runtime" \
+      "no"
     return 1
   fi
 
   # Skip if replication is already configured AND running.
-  # This fast-path must run before waiting on PRIMARY_HOST: after scale-out,
+  # This fast-path must run before probing PRIMARY_HOST: after scale-out,
   # startup may already have configured replication successfully while the
-  # memberJoin action is retried later. In that case, waiting on the primary
+  # memberJoin action is retried later. In that case, probing the primary
   # service again only keeps the control-plane stuck on MemberJoined=false.
   if is_slave_running; then
     echo "Replication already configured and running. Nothing to do."
@@ -565,7 +641,7 @@ main() {
     return 0
   fi
 
-  wait_for_primary 120 || return 1
+  probe_primary_or_defer || return 1
 
   # Guard: if the primary service routes to this pod, this pod IS the primary.
   # Do not configure replication — the startup command already handled it.


### PR DESCRIPTION
## Summary

Deferred follow-up to alpha.112 / PR #2702. PR #2702 capped `cmpd-replication.yaml` `memberJoin.timeoutSeconds` 180 → 60 to make the spec honest about kbagent's hardcoded 60s `maxActionCallTimeout`, but explicitly left the `replication-member-join.sh` script unchanged with a TODO to refactor it the same way as galera. This PR is that refactor **plus a corrected alpha.110 implicit rc=0 bug** that surfaced during the refactor (see "Behavior delta" below).

After this PR, `replication-member-join.sh` follows the same single-shot bootstrap-or-defer pattern documented in `skills/addon-lifecycle-single-shot-bootstrap-or-defer`: each invocation either positively closes (rc=0) or classifies its deferral on stderr (rc=1 + `next-retry-safe: yes|no`).

## Behavior delta vs alpha.110 — NOT pure preservation

PR v1 wording claimed "all rc=0 paths byte-identical" — that was over-claim and Jack caught it in peer review (GH comment 4587575867, 2026-06-01 01:59). The true delta:

1. **4 explicit positive-success rc=0 paths preserved verbatim**:
   - `is_slave_running` fast-path
   - `is_self_primary` guard
   - `slave_status_is_ready_for_rejoin` positive verify
   - Post-repair re-verify (`repair_kb_health_check_replication_error` → re-verify ready)

2. **Wait shape change** (`wait_for_primary` polling loop → `probe_primary_or_defer` single-shot). Under kbagent's 60s cap this is equivalent to or better than the prior in-process poll, which was silently truncated at 60s and discarded partial state.

3. **Classified stderr** on every rc=1 path via the new `replication_member_join_diagnose_not_ready` helper (`next-retry-safe: yes|no`).

4. **CORRECTED IMPLICIT rc=0 BUG**: alpha.110's `setup_replication` had a final `mark_replication_pending; echo "WARNING: ... not yet healthy"; }` branch with **no explicit `return 1`**. The function returned the rc of `echo` (= 0), which propagated up through `main()` so kbagent observed memberJoin = succeeded even when `Slave_IO` / `Slave_SQL` had not converged. The cluster eventually self-healed via `roleProbe` reading the `.replication-pending` marker, but memberJoin was lying to the controller. alpha.113 reclassifies this branch as explicit `return 1` with phase `slave-not-yet-ready-for-rejoin` + `retry=yes`, so kbagent re-fires memberJoin until slave is actually ready. This is the correct single-shot bootstrap-or-defer behavior; it is also a semantic change vs alpha.110. The `mark_replication_pending` marker write is preserved for `roleProbe` interop. A new ShellSpec assertion guards against this regression silently reopening.

## What changed

| file | change |
|---|---|
| `addons/mariadb/scripts/replication-member-join.sh` | Replace `wait_for_primary 120` polling loop with single-shot `probe_primary_or_defer`. Add per-action `replication_member_join_diagnose_not_ready` helper. Route every `rc=1` path through the helper with a classified phase + `next-retry-safe`. Make the not-yet-healthy branch explicit `return 1` (corrected implicit rc=0 bug). |
| `addons/mariadb/Chart.yaml` | 1.1.1-alpha.110 → 1.1.1-alpha.113. alpha.111 reserved for PR #2701, alpha.112 reserved for PR #2702; integration owner reconciles version chain at merge time. Comment block documents the three-part behavior delta (wait shape / classified stderr / corrected implicit rc=0 bug). |
| `addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh` | Stub renames (`wait_for_primary` → `probe_primary_or_defer`). 8 new test cases (1 not-ready-regression-guard + 2 for diagnose helper retry=yes/no + 5 for probe success/defer/fallback/bootstrap-read-only). |

`cmpd-replication.yaml` is intentionally unchanged — PR #2702 already capped it to 60s.

## Phase taxonomy

`rc=1` paths now emit classified `next-retry-safe`:

| Phase | retry-safe | Where it fires |
|---|---|---|
| `mariadb-cli-unavailable` | no | `main()` precondition: neither `mariadb` on PATH nor `${MYSQL_CLIENT_DIR}/bin/mariadb` executable |
| `primary-not-yet-reachable` | yes | `probe_primary_or_defer`: PRIMARY_HOST `SELECT 1` miss AND (pod-0 OR bootstrap fallback miss for pod-index>0) |
| `gtid-divergence-fail-closed` | no | `setup_replication`: `fail_closed_for_gtid_divergence` returned 0 (divergence detected, marker written) |
| `change-master-or-start-io-failed` | no | fresh-pod branch: `CHANGE MASTER TO + START SLAVE IO_THREAD` SQL failed |
| `fresh-replica-prepare-failed` | no | fresh-pod branch: failed to clear local `kb_health_check` table |
| `start-slave-sql-thread-failed` | no | fresh-pod branch: `START SLAVE SQL_THREAD` SQL failed |
| `change-master-failed` | no | rejoining-pod branch: `CHANGE MASTER TO + START SLAVE` SQL failed |
| `slave-config-not-persisted` | no | `SHOW SLAVE STATUS` empty immediately after CHANGE MASTER TO |
| `gtid-out-of-order-divergent` | no | post-START: `Last_SQL_Errno=1950` AND `fail_closed_for_gtid_divergence` confirmed divergence |
| `gtid-out-of-order-transient` | yes | post-START: `Last_SQL_Errno=1950` but no divergence yet (primary truth still stabilizing) |
| `slave-not-yet-ready-for-rejoin` | yes | **NEW classification of corrected alpha.110 implicit rc=0**: post-START: none of `Slave_IO_Running=Yes / Slave_SQL_Running=Yes / Last_IO_Errno=0 / Last_SQL_Errno=0` (catch-up in progress) |

## Pin 2 contract — what `rc=0` positively observes

`rc=0` is only emitted on these positive observations (4 paths, unchanged from alpha.110 by the explicit success branches):

1. `is_slave_running` — `SHOW SLAVE STATUS` non-empty AND `Slave_running=ON` (fast-path before primary probe).
2. `is_self_primary` — local `@@server_id` equals primary's `@@server_id` (this pod IS the primary, no replication setup needed).
3. `slave_status_is_ready_for_rejoin` — `Slave_IO_Running=Yes` AND `Slave_SQL_Running=Yes` AND `Last_IO_Errno=0` AND `Last_SQL_Errno=0`.
4. Post-repair re-verify — same as (3) after `repair_kb_health_check_replication_error`.

No `rc=0` path infers success from "no error token observed". The alpha.110 implicit rc=0 from the not-yet-healthy branch (which was not a positive observation) is removed by this PR.

## Bounded-wait budget

| step | window | rationale |
|---|---|---|
| `MARIADB_CLI` precondition | ~0s | env / file check |
| `is_slave_running` probe | ≤5s | 2 local SQL calls with `--connect-timeout=5` |
| `probe_primary_or_defer` PRIMARY_HOST | ≤5s | 1 `SELECT 1` with `--connect-timeout=5` |
| `probe_primary_or_defer` BOOTSTRAP_HOST | ≤5s | 1 `read_only` query (pod-index>0 only) |
| `is_self_primary` | ≤10s | 2 SQL calls |
| `setup_replication` SQL block | ≤15s | `STOP SLAVE` + `CHANGE MASTER TO` + `START SLAVE [IO/SQL]_THREAD` + `SHOW SLAVE STATUS` |
| `query_slave_status_verbose` final probe | ≤5s | 1 SQL call |
| **total worst case** | **≤45s** | leaves ≥15s buffer under kbagent's 60s `maxActionCallTimeout` |

No in-process `sleep` loops anywhere in the script after this PR.

## Use-precondition status

Re-invocation behavior on `rc=1` is evidenced by the 2026-05-28 fake-CmpD probe on KB controller `1.0.3-beta.6` (skill `## known unknowns` section). The probe demonstrated that a `memberJoin` action returning rc=1 is re-invoked by the runtime on the same pod until it returns rc=0. No new evidence pack required for this PR — it adopts the same pattern the galera-member-join refactor in PR #2702 adopted.

## Test plan

- [x] `bash -n addons/mariadb/scripts/replication-member-join.sh` PASS
- [x] `bash -n addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh` PASS
- [x] Manual source + `replication_member_join_diagnose_not_ready` + `probe_primary_or_defer` invocation: stderr shape matches expected
- [x] v1 peer review (Jack) caught implicit rc=0 over-claim; v2 commit `ae6ed2809` corrects framing and adds regression-guard ShellSpec test
- [ ] CI: shellspec full suite (auto-runs on push) — v2 includes the new not-ready-regression-guard
- [ ] CI: chart helm-check (auto-runs on push) — expected red on the pre-existing sideload-only syncer tag pattern (PR #2711 closes that source)
- [ ] IDC vcluster live verification: bundled with the next alpha-cycle deploy alongside PR #2701 / PR #2702 — the 4 explicit success paths are byte-identical to alpha.110 and the corrected implicit-rc=0 branch is now positively asserted by the new ShellSpec, so a standalone live-gate is not required.

## Related PRs

- PR #2701 (in flight): alpha.111 P0a URGENT FLUSH PRIVILEGES wrap — separate scope, independent.
- PR #2702 (in flight): alpha.112 honest 60s `memberJoin.timeoutSeconds` + galera single-shot refactor — this PR closes the explicit TODO that #2702 left for replication.

Reserved version numbering allows the three PRs to merge in any order without conflicting on Chart.yaml.
