### PR TITLE
fix(redis): make cluster shard lifecycle actions retry-safe

### DIFF
--- a/addons/clickhouse/README.md
+++ b/addons/clickhouse/README.md
@@ -830,6 +830,30 @@ spec:
 
 ```
 
+```yaml
+# cat examples/clickhouse/keeper-switchover-specified-instance.yaml
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: keeper-switchover
+  namespace: demo
+spec:
+  # Specifies the name of the Cluster resource that this operation is targeting.
+  clusterName: clickhouse-cluster
+  type: Switchover
+  # Lists Switchover objects, each specifying a Component to perform the switchover operation.
+  switchover:
+    # Specifies the name of the Component.
+  - componentName: ch-keeper
+    # Specifies the instance whose role will be transferred.
+    # A typical usage is to transfer the leader role in a consensus system.
+    instanceName: "clickhouse-cluster-ch-keeper-0"
+    # ClickHouse Keeper switchover currently requires candidateName.
+    # Need to ensure the candidate instance has caught up with quorum logs.
+    candidateName: "clickhouse-cluster-ch-keeper-1"
+
+```
+
 ```bash
 kubectl apply -f examples/clickhouse/keeper-switchover-specified-instance.yaml
 ```
@@ -1554,7 +1578,7 @@ spec:
                 storage: 10Gi
   shardings:
     - name: clickhouse
-      shards: 3
+      shards: 2
       template:
         name: clickhouse
         componentDef: clickhouse-1
@@ -1847,6 +1871,7 @@ metadata:
 type: Opaque
 data:
   password: cGFzc3dvcmQxMjM=  # 'password123' in base64
+
 ```
 
 ```bash

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -436,8 +436,8 @@ fix_cluster_slots() {
     fix_command="redis-cli $REDIS_CLI_TLS_CMD --cluster fix $node_endpoint_with_port -p $cluster_service_port --cluster-yes -a $REDIS_DEFAULT_PASSWORD"
     logging_mask_fix_command="${fix_command/$REDIS_DEFAULT_PASSWORD/********}"
   fi
-  echo "fix Redis Cluster slots command: $logging_mask_fix_command" >&2
-  if ! $fix_command; then
+  echo "fix Redis Cluster slots command: yes yes | $logging_mask_fix_command" >&2
+  if ! yes yes | $fix_command; then
     set_xtrace_when_ut_mode_false
     echo "Failed to fix Redis Cluster slots for $node_endpoint_with_port" >&2
     return 1

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -410,10 +410,73 @@ check_slots_covered() {
   fi
   set_xtrace_when_ut_mode_false
   if contains "$check" "All 16384 slots covered"; then
+    if contains "$check" "[ERR]" || \
+       contains "$check" "[WARNING] The following slots are open" || \
+       contains "$check" "has slots in importing state" || \
+       contains "$check" "has slots in migrating state"; then
+      echo "Redis Cluster slots are covered but cluster check is not stable:" >&2
+      echo "$check" >&2
+      return 1
+    fi
     return 0
+  fi
+  echo "Redis Cluster slots are not fully covered:" >&2
+  echo "$check" >&2
+  return 1
+}
+
+fix_cluster_slots() {
+  local node_endpoint_with_port="$1"
+  local cluster_service_port="$2"
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    fix_command="redis-cli $REDIS_CLI_TLS_CMD --cluster fix $node_endpoint_with_port -p $cluster_service_port --cluster-yes"
+    logging_mask_fix_command="$fix_command"
   else
+    fix_command="redis-cli $REDIS_CLI_TLS_CMD --cluster fix $node_endpoint_with_port -p $cluster_service_port --cluster-yes -a $REDIS_DEFAULT_PASSWORD"
+    logging_mask_fix_command="${fix_command/$REDIS_DEFAULT_PASSWORD/********}"
+  fi
+  echo "fix Redis Cluster slots command: $logging_mask_fix_command" >&2
+  if ! $fix_command; then
+    set_xtrace_when_ut_mode_false
+    echo "Failed to fix Redis Cluster slots for $node_endpoint_with_port" >&2
     return 1
   fi
+  set_xtrace_when_ut_mode_false
+  return 0
+}
+
+count_node_slots() {
+  local cluster_node="$1"
+  local cluster_node_port="$2"
+  local node_cluster_id="$3"
+  local cluster_nodes_info
+  cluster_nodes_info=$(get_cluster_nodes_info "$cluster_node" "$cluster_node_port")
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Failed to get cluster nodes info in count_node_slots" >&2
+    return 1
+  fi
+
+  echo "$cluster_nodes_info" | awk -v node_id="$node_cluster_id" '
+    $1 == node_id {
+      count = 0
+      for (i = 9; i <= NF; i++) {
+        if ($i ~ /^[0-9]+$/) {
+          count += 1
+        } else if ($i ~ /^[0-9]+-[0-9]+$/) {
+          split($i, range, "-")
+          count += range[2] - range[1] + 1
+        }
+      }
+      print count
+      found = 1
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }'
 }
 
 # check if the cluster has been initialized

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -428,6 +428,8 @@ check_slots_covered() {
 fix_cluster_slots() {
   local node_endpoint_with_port="$1"
   local cluster_service_port="$2"
+  local fix_yes_input
+  local fix_yes_count
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
     fix_command="redis-cli $REDIS_CLI_TLS_CMD --cluster fix $node_endpoint_with_port -p $cluster_service_port --cluster-yes"
@@ -436,8 +438,14 @@ fix_cluster_slots() {
     fix_command="redis-cli $REDIS_CLI_TLS_CMD --cluster fix $node_endpoint_with_port -p $cluster_service_port --cluster-yes -a $REDIS_DEFAULT_PASSWORD"
     logging_mask_fix_command="${fix_command/$REDIS_DEFAULT_PASSWORD/********}"
   fi
-  echo "fix Redis Cluster slots command: yes yes | $logging_mask_fix_command" >&2
-  if ! yes yes | $fix_command; then
+  fix_yes_input=""
+  fix_yes_count=0
+  while [ "$fix_yes_count" -lt 128 ]; do
+    fix_yes_input="${fix_yes_input}yes\n"
+    fix_yes_count=$((fix_yes_count + 1))
+  done
+  echo "fix Redis Cluster slots command: printf yes... | $logging_mask_fix_command" >&2
+  if ! printf "%b" "$fix_yes_input" | $fix_command; then
     set_xtrace_when_ut_mode_false
     echo "Failed to fix Redis Cluster slots for $node_endpoint_with_port" >&2
     return 1

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -143,6 +143,23 @@ find_exist_available_node() {
   echo ""
 }
 
+fix_unstable_cluster_and_defer() {
+  local node_with_port="$1"
+  local node_port
+  node_port=$(echo "$node_with_port" | cut -d':' -f2)
+  if check_slots_covered "$node_with_port" "$node_port"; then
+    return 0
+  fi
+
+  echo "Redis Cluster is not stable; run cluster fix and defer lifecycle action for retry." >&2
+  if fix_cluster_slots "$node_with_port" "$node_port"; then
+    echo "Redis Cluster fix completed; defer current lifecycle action so the next retry observes the fixed state." >&2
+  else
+    echo "Redis Cluster fix failed; defer current lifecycle action for operator-visible retry." >&2
+  fi
+  return 1
+}
+
 extract_pod_name_prefix() {
   local pod_name="$1"
   # shellcheck disable=SC2001
@@ -781,6 +798,10 @@ scale_out_redis_cluster_shard() {
     return 1
   fi
 
+  if [ ${#other_component_nodes[@]} -gt 0 ]; then
+    fix_unstable_cluster_and_defer "${other_component_nodes[0]}" || return 1
+  fi
+
   # check the current component shard whether is already scaled out
   if [ ${#scale_out_shard_default_primary_node[@]} -eq 0 ]; then
     echo "Failed to generate primary nodes when scaling out" >&2
@@ -793,10 +814,11 @@ scale_out_redis_cluster_shard() {
   current_primary_joined=false
   if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
     if check_current_shard_other_nodes_are_joined "$primary_node_fqdn" "$primary_node_port"; then
-      echo "The current component shard is already scaled out, no need to scale out again."
-      return 0
+      echo "The current component shard primary and replicas already joined the cluster."
+      current_primary_joined=true
+    else
+      current_primary_joined=true
     fi
-    current_primary_joined=true
   fi
 
   # find the exist available node which is not in the current component
@@ -855,20 +877,49 @@ scale_out_redis_cluster_shard() {
   local all_comp_pod_count
   local shard_count
   local slots_per_shard
+  local current_slots
+  local remaining_slots
+  local reshard_slots
+  local reshard_batch_size
   total_slots=16384
   current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
   all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
   shard_count=$((all_comp_pod_count / current_comp_pod_count))
   slots_per_shard=$((total_slots / shard_count))
-  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$slots_per_shard"; then
+  current_slots=$(count_node_slots "$primary_node_fqdn" "$primary_node_port" "$mapping_primary_cluster_id")
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Failed to count current shard primary slots before scale out reshard" >&2
+    return 1
+  fi
+  remaining_slots=$((slots_per_shard - current_slots))
+  if [ "$remaining_slots" -le 0 ]; then
+    if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
+      echo "Redis cluster scale out shard already owns $current_slots slots and cluster is stable"
+      return 0
+    fi
+    fix_unstable_cluster_and_defer "$primary_node_with_port" || return 1
+  fi
+
+  reshard_batch_size=${REDIS_CLUSTER_RESHARD_BATCH_SIZE:-1024}
+  reshard_slots=$remaining_slots
+  if [ "$ut_mode" = "false" ] && [ "$remaining_slots" -gt "$reshard_batch_size" ]; then
+    reshard_slots=$reshard_batch_size
+  fi
+
+  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$reshard_slots"; then
     echo "Redis cluster scale out shard reshard successfully"
   else
     echo "Failed to scale out shard reshard" >&2
     return 1
   fi
 
-  # TODO: rebalance the cluster
-  return 0
+  if [ "$reshard_slots" -lt "$remaining_slots" ]; then
+    echo "Redis cluster scale out shard moved $reshard_slots/$remaining_slots remaining slots; defer for retry" >&2
+    return 1
+  fi
+
+  check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"
 }
 
 sync_acl_for_redis_cluster_shard() {
@@ -942,7 +993,14 @@ scale_in_redis_cluster_shard() {
 
   # init information for the other components and pods
   init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$KB_CLUSTER_POD_FQDN_LIST" "$KB_CLUSTER_COMPONENT_LIST"
+  if [ ${#other_component_nodes[@]} -gt 0 ]; then
+    fix_unstable_cluster_and_defer "${other_component_nodes[0]}" || return 1
+  fi
   available_node=$(find_exist_available_node)
+  if is_empty "$available_node"; then
+    echo "No stable available Redis Cluster node found before scaling in shard" >&2
+    return 1
+  fi
   available_node_fqdn=$(echo "$available_node" | awk -F ':' '{print $1}')
   available_node_port=$(echo "$available_node" | awk -F ':' '{print $2}')
   get_current_comp_nodes_for_scale_in "$available_node_fqdn" "$available_node_port"

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -858,7 +858,7 @@ scale_out_redis_cluster_shard() {
       scale_out_shard_secondary_node=$scale_out_shard_secondary_node_with_port
     fi
     echo "primary_node_with_port: $primary_node_with_port, primary_node_fqdn: $primary_node_fqdn, mapping_primary_cluster_id: $mapping_primary_cluster_id"
-    if check_node_in_cluster "$primary_node_fqdn" "$primary_node_with_port" "$scale_out_shard_secondary_node"; then
+    if check_node_in_cluster "$primary_node_fqdn" "$primary_node_port" "$scale_out_shard_secondary_node"; then
       echo "Secondary node $secondary_pod_name already joined the cluster, skip replicating to primary"
       continue
     fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -821,18 +821,18 @@ scale_out_redis_cluster_shard() {
     fi
   fi
 
-  # find the exist available node which is not in the current component
-  available_node=$(find_exist_available_node)
-  if is_empty "$available_node"; then
-    echo "No exist available node found or cluster status is not ok" >&2
-    return 1
-  fi
-
-  # Forget fail node when cluster is ok
-  # forget_fail_node_when_cluster_is_ok "${available_node%%:*}" "${available_node##*:}"
-
   # add the primary node for the current shard
   if [ "$current_primary_joined" = false ]; then
+    # find the exist available node which is not in the current component
+    available_node=$(find_exist_available_node)
+    if is_empty "$available_node"; then
+      echo "No exist available node found or cluster status is not ok" >&2
+      return 1
+    fi
+
+    # Forget fail node when cluster is ok
+    # forget_fail_node_when_cluster_is_ok "${available_node%%:*}" "${available_node##*:}"
+
     local scale_out_shard_default_primary
     for primary_pod_name in "${!scale_out_shard_default_primary_node[@]}"; do
       scale_out_shard_default_primary="${scale_out_shard_default_primary_node[$primary_pod_name]}"

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
@@ -161,6 +161,23 @@ find_exist_available_node() {
   echo ""
 }
 
+fix_unstable_cluster_and_defer() {
+  local node_with_port="$1"
+  local node_port
+  node_port=$(echo "$node_with_port" | cut -d':' -f2)
+  if check_slots_covered "$node_with_port" "$node_port"; then
+    return 0
+  fi
+
+  echo "Redis Cluster is not stable; run cluster fix and defer lifecycle action for retry." >&2
+  if fix_cluster_slots "$node_with_port" "$node_port"; then
+    echo "Redis Cluster fix completed; defer current lifecycle action so the next retry observes the fixed state." >&2
+  else
+    echo "Redis Cluster fix failed; defer current lifecycle action for operator-visible retry." >&2
+  fi
+  return 1
+}
+
 extract_pod_name_prefix() {
   local pod_name="$1"
   # shellcheck disable=SC2001
@@ -779,6 +796,10 @@ scale_out_redis_cluster_shard() {
     return 1
   fi
 
+  if [ ${#other_component_nodes[@]} -gt 0 ]; then
+    fix_unstable_cluster_and_defer "${other_component_nodes[0]}" || return 1
+  fi
+
   # check the current component shard whether is already scaled out
   if [ ${#scale_out_shard_default_primary_node[@]} -eq 0 ]; then
     echo "Failed to generate primary nodes when scaling out" >&2
@@ -791,10 +812,11 @@ scale_out_redis_cluster_shard() {
   current_primary_joined=false
   if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
     if check_current_shard_other_nodes_are_joined "$primary_node_fqdn" "$primary_node_port"; then
-      echo "The current component shard is already scaled out, no need to scale out again."
-      return 0
+      echo "The current component shard primary and replicas already joined the cluster."
+      current_primary_joined=true
+    else
+      current_primary_joined=true
     fi
-    current_primary_joined=true
   fi
 
   # find the exist available node which is not in the current component
@@ -848,20 +870,49 @@ scale_out_redis_cluster_shard() {
   local all_comp_pod_count
   local shard_count
   local slots_per_shard
+  local current_slots
+  local remaining_slots
+  local reshard_slots
+  local reshard_batch_size
   total_slots=16384
   current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
   all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
   shard_count=$((all_comp_pod_count / current_comp_pod_count))
   slots_per_shard=$((total_slots / shard_count))
-  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$slots_per_shard"; then
+  current_slots=$(count_node_slots "$primary_node_fqdn" "$primary_node_port" "$mapping_primary_cluster_id")
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Failed to count current shard primary slots before scale out reshard" >&2
+    return 1
+  fi
+  remaining_slots=$((slots_per_shard - current_slots))
+  if [ "$remaining_slots" -le 0 ]; then
+    if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
+      echo "Redis cluster scale out shard already owns $current_slots slots and cluster is stable"
+      return 0
+    fi
+    fix_unstable_cluster_and_defer "$primary_node_with_port" || return 1
+  fi
+
+  reshard_batch_size=${REDIS_CLUSTER_RESHARD_BATCH_SIZE:-1024}
+  reshard_slots=$remaining_slots
+  if [ "$ut_mode" = "false" ] && [ "$remaining_slots" -gt "$reshard_batch_size" ]; then
+    reshard_slots=$reshard_batch_size
+  fi
+
+  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$reshard_slots"; then
     echo "Redis cluster scale out shard reshard successfully"
   else
     echo "Failed to scale out shard reshard" >&2
     return 1
   fi
 
-  # TODO: rebalance the cluster
-  return 0
+  if [ "$reshard_slots" -lt "$remaining_slots" ]; then
+    echo "Redis cluster scale out shard moved $reshard_slots/$remaining_slots remaining slots; defer for retry" >&2
+    return 1
+  fi
+
+  check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"
 }
 
 sync_acl_for_redis_cluster_shard() {
@@ -934,7 +985,14 @@ scale_in_redis_cluster_shard() {
 
   # init information for the other components and pods
   init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$KB_CLUSTER_POD_FQDN_LIST" "$KB_CLUSTER_COMPONENT_LIST"
+  if [ ${#other_component_nodes[@]} -gt 0 ]; then
+    fix_unstable_cluster_and_defer "${other_component_nodes[0]}" || return 1
+  fi
   available_node=$(find_exist_available_node)
+  if is_empty "$available_node"; then
+    echo "No stable available Redis Cluster node found before scaling in shard" >&2
+    return 1
+  fi
   available_node_fqdn=$(echo "$available_node" | awk -F ':' '{print $1}')
   available_node_port=$(echo "$available_node" | awk -F ':' '{print $2}')
   get_current_comp_nodes_for_scale_in "$available_node_fqdn" "$available_node_port"

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
@@ -851,7 +851,7 @@ scale_out_redis_cluster_shard() {
   for secondary_pod_name in "${!scale_out_shard_default_other_nodes[@]}"; do
     scale_out_shard_secondary_node="${scale_out_shard_default_other_nodes[$secondary_pod_name]}"
     echo "primary_node_with_port: $primary_node_with_port, primary_node_fqdn: $primary_node_fqdn, mapping_primary_cluster_id: $mapping_primary_cluster_id"
-    if check_node_in_cluster "$primary_node_fqdn" "$primary_node_with_port" "$secondary_pod_name"; then
+    if check_node_in_cluster "$primary_node_fqdn" "$primary_node_port" "$secondary_pod_name"; then
       echo "Secondary node $secondary_pod_name already joined the cluster, skip replicating to primary"
       continue
     fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
@@ -819,18 +819,18 @@ scale_out_redis_cluster_shard() {
     fi
   fi
 
-  # find the exist available node which is not in the current component
-  available_node=$(find_exist_available_node)
-  if is_empty "$available_node"; then
-    echo "No exist available node found or cluster status is not ok" >&2
-    return 1
-  fi
-
-  # Forget fail node when cluster is ok
-  forget_fail_node_when_cluster_is_ok "${available_node%%:*}" "${available_node##*:}"
-
   # add the primary node for the current shard
   if [ "$current_primary_joined" = "false" ]; then
+    # find the exist available node which is not in the current component
+    available_node=$(find_exist_available_node)
+    if is_empty "$available_node"; then
+      echo "No exist available node found or cluster status is not ok" >&2
+      return 1
+    fi
+
+    # Forget fail node when cluster is ok
+    forget_fail_node_when_cluster_is_ok "${available_node%%:*}" "${available_node##*:}"
+
     local scale_out_shard_default_primary
     for primary_pod_name in "${!scale_out_shard_default_primary_node[@]}"; do
       scale_out_shard_default_primary="${scale_out_shard_default_primary_node[$primary_pod_name]}"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -139,6 +139,32 @@ Describe "Redis Cluster Common Bash Script Tests"
     End
   End
 
+  Describe "fix_cluster_slots()"
+    setup() {
+      export REDIS_DEFAULT_PASSWORD=""
+      export REDIS_CLI_TLS_CMD=""
+    }
+    Before "setup"
+
+    un_setup() {
+      unset REDIS_DEFAULT_PASSWORD
+      unset REDIS_CLI_TLS_CMD
+    }
+    After "un_setup"
+
+    It "answers redis-cli cluster fix confirmation non-interactively"
+      redis-cli() {
+        local answer=""
+        read -r answer || true
+        [ "$answer" = "yes" ]
+      }
+
+      When call fix_cluster_slots "redis-0:6379" "6379"
+      The status should be success
+      The error should include "yes yes | redis-cli"
+    End
+  End
+
   Describe "get_cluster_announce_ip()"
     It "gets cluster announce IP successfully"
       get_cluster_nodes_info() {

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -161,7 +161,7 @@ Describe "Redis Cluster Common Bash Script Tests"
 
       When call fix_cluster_slots "redis-0:6379" "6379"
       The status should be success
-      The error should include "yes yes | redis-cli"
+      The error should include "printf yes... | redis-cli"
     End
   End
 

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1185,6 +1185,14 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 1
       }
 
+      fix_unstable_cluster_and_defer() {
+        return 0
+      }
+
+      count_node_slots() {
+        echo "0"
+      }
+
       find_exist_available_node() {
         echo "10.42.0.3:6379"
       }

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1282,6 +1282,10 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 0
       }
 
+      check_slots_covered() {
+        return 0
+      }
+
       forget_fail_node_when_cluster_is_ok() {
         return 0
       }
@@ -1329,6 +1333,10 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 1
       }
 
+      check_slots_covered() {
+        return 0
+      }
+
       setup() {
         export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
@@ -1373,6 +1381,10 @@ Describe "Redis Cluster Manage Bash Script Tests"
 
       scale_in_shard_del_node() {
         return 1
+      }
+
+      check_slots_covered() {
+        return 0
       }
 
       setup() {

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1142,6 +1142,13 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 0
       }
 
+      check_node_in_cluster() {
+        if [ "$2" != "6379" ]; then
+          echo "unexpected check_node_in_cluster port: $2" >&2
+        fi
+        return 1
+      }
+
       secondary_replicated_to_primary() {
         return 1
       }
@@ -1164,6 +1171,7 @@ Describe "Redis Cluster Manage Bash Script Tests"
         When call scale_out_redis_cluster_shard
         The status should be failure
         The error should include "Failed to scale out shard secondary node redis-shard-98x-1"
+        The error should not include "unexpected check_node_in_cluster port"
         The stdout should include "Redis cluster scale out shard primary node redis-shard-98x-0 successfully"
         The stdout should include "primary_node_with_port: 10.42.0.1:6379, primary_node_fqdn: 10.42.0.1, mapping_primary_cluster_id: cluster_id_123"
       End
@@ -1205,6 +1213,13 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 0
       }
 
+      check_node_in_cluster() {
+        if [ "$2" != "6379" ]; then
+          echo "unexpected check_node_in_cluster port: $2" >&2
+        fi
+        return 1
+      }
+
       scale_out_shard_reshard() {
         return 1
       }
@@ -1235,6 +1250,7 @@ Describe "Redis Cluster Manage Bash Script Tests"
         When call scale_out_redis_cluster_shard
         The status should be failure
         The error should include "Failed to scale out shard reshard"
+        The error should not include "unexpected check_node_in_cluster port"
         The stdout should include "Redis cluster scale out shard secondary node redis-shard-98x-1 successfully"
       End
     End

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1005,8 +1005,15 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 0
       }
 
+      count_node_slots() {
+        echo "16384"
+      }
+
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard-98x"
+        export CURRENT_SHARD_POD_NAME_LIST="redis-shard-98x-0,redis-shard-98x-1"
+        export KB_CLUSTER_POD_NAME_LIST="redis-shard-98x-0,redis-shard-98x-1"
         export KB_CLUSTER_POD_FQDN_LIST="redis-shard-98x-0,redis-shard-98x-1"
         export SERVICE_PORT="6379"
       }
@@ -1022,7 +1029,8 @@ Describe "Redis Cluster Manage Bash Script Tests"
       It "returns success when the current component shard is already scaled out"
         When call scale_out_redis_cluster_shard
         The status should be success
-        The output should include "The current component shard is already scaled out, no need to scale out again."
+        The output should include "The current component shard primary and replicas already joined the cluster."
+        The output should include "Redis cluster scale out shard already owns 16384 slots and cluster is stable"
       End
     End
 

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -130,7 +130,16 @@ redis-cluster-scripts-template-{{ .Chart.Version }}
 {{- end -}}
 
 {{- define "redis7.image" -}}
-{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+{{- $registry := .Values.image.registry | default "docker.io" -}}
+{{- $repository := .Values.image.repository -}}
+{{- $tag := .Values.image.tag.major7.minor72 -}}
+{{- range .Values.redisVersions -}}
+{{- if eq .major "7" -}}
+{{- $repository = .repository | default $repository -}}
+{{- $tag = .defaultImageTag | default $tag -}}
+{{- end -}}
+{{- end -}}
+{{ $registry }}/{{ $repository }}:{{ $tag }}
 {{- end }}
 
 {{- define "redisTwemproxy.repository" -}}

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -468,13 +468,21 @@ spec:
           - redis
           - getrole
     postProvision:
-      timeoutSeconds: 900
+      # kbagent caps lifecycle action calls at 60s; keep this below the cap
+      # and let retryPolicy re-enter the idempotent postProvision action.
+      timeoutSeconds: 50
       exec:
         container: redis-cluster
         command:
           - /bin/bash
           - -c
-          - /scripts/{{ $redisClusterManageScripts }} --post-provision  > /tmp/post-provision.log 2>&1
+          - |
+            log=/tmp/post-provision.log
+            : > "$log"
+            /scripts/{{ $redisClusterManageScripts }} --post-provision > "$log" 2>&1
+            rc=$?
+            cat "$log" >&2 || true
+            exit "$rc"
         ## all lifecycle actions share the same env
         env:
           - name: CURRENT_POD_NAME

--- a/addons/redis/templates/opsdefinition-account.yaml
+++ b/addons/redis/templates/opsdefinition-account.yaml
@@ -60,7 +60,7 @@ spec:
         podSpec:
           containers:
             - name: redis-account-ops
-              image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+              image: {{ include "redis7.image" . }}
               imagePullPolicy: IfNotPresent
               command:
                 - bash
@@ -130,7 +130,7 @@ spec:
         podSpec:
           containers:
             - name: redis-account-ops
-              image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+              image: {{ include "redis7.image" . }}
               imagePullPolicy: IfNotPresent
               command:
                 - bash
@@ -216,7 +216,7 @@ spec:
         podSpec:
           containers:
             - name: redis-account-ops
-              image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+              image: {{ include "redis7.image" . }}
               imagePullPolicy: IfNotPresent
               command:
                 - bash

--- a/addons/redis/templates/shardingdefinition.yaml
+++ b/addons/redis/templates/shardingdefinition.yaml
@@ -19,17 +19,25 @@ spec:
       shared: true
   lifecycleActions:
     shardRemove:
-      timeoutSeconds: 900
+      # kbagent caps lifecycle action calls at 60s; keep this below the cap
+      # and let retryPolicy re-enter the idempotent shardRemove action.
+      timeoutSeconds: 50
       exec:
         container: redis-cluster
         command:
           - /bin/bash
           - -c
           - |
+            log=/tmp/pre-terminate.log
+            : > "$log"
             if [ "$LEGACY_REDIS" == "true" ]; then
-               /scripts/redis-cluster6-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
+               script=/scripts/redis-cluster6-manage.sh
             else
-               /scripts/redis-cluster-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
+               script=/scripts/redis-cluster-manage.sh
             fi
+            "$script" --pre-terminate > "$log" 2>&1
+            rc=$?
+            cat "$log" >&2 || true
+            exit "$rc"
       retryPolicy:
         maxRetries: 10


### PR DESCRIPTION
## Summary
- keep Redis Cluster postProvision/shardRemove action timeout below the kbagent 60s cap and echo action logs back to stderr
- reject Redis Cluster checks that still have ERR/open/importing/migrating slots instead of treating `All 16384 slots covered` as sufficient
- make scale-out reshard move slots in bounded batches and defer via retry; run cluster fix before scale-out/scale-in when open slots are detected

## Evidence
- Fresh full first red on kubeblocks-tests #126 head `83df821`: `cluster-day2 C03`, runner `224/1/0`; kbagent `/tmp/pre-terminate.log` showed `Please fix your cluster problems before rebalancing` after postProvision was killed during reshard.
- `bash -n addons/redis/redis-cluster-scripts/redis-cluster-manage.sh addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh addons/redis/redis-cluster-scripts/redis-cluster-common.sh`
- `helm template redis addons/redis >/tmp/redis-chart-render.yaml`
- `./redis/run-tests.sh -t static --addons-repo /Users/wei/ApeCloud/kubeblocks-addons` from kubeblocks-tests branch = `35/0/0`

## Not run
- Redis shellspec: `shellspec` is not installed on this machine.