### PR TITLE
mariadb: alpha.114 v2 — account model Phase A Path C declarative-only

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1789,7 +1789,155 @@ type: application
 # Already evidenced by 2026-05-28 fake-CmpD probe on KB controller
 # 1.0.3-beta.6 (skill `## 已知未知` section); no new evidence pack
 # needed.
-version: 1.1.1-alpha.113
+#
+# alpha.114 v2 (Helen 2026-06-01 — design review issue 3 / account
+# model Phase A Path C declarative-only).
+#
+# Background: alpha.110 declared only `root` as systemAccount, but
+# chart `ensure_internal_local_admin` (cmpd-semisync.yaml + cmpd-
+# replication-merged.yaml) and initdb (cmpd.yaml) inline-created
+# `kb_internal_root` (181 refs across 11 files) and `kb_replicator`
+# (81 refs across 5 files). KB controller had no model of these
+# accounts — no Secret materialization, no lifecycle hook,
+# no accountProvision plumbing. Design review (2026-05-31 weston-
+# requested audit) flagged this as issue 3.
+#
+# Phase A Path C scope (declarative-only, byte-identical runtime):
+# Declare `kb_internal_root` and `kb_replicator` as systemAccounts
+# with `initAccount: true` and `passwordGenerationPolicy`. KB
+# controller materializes per-account Secrets (KB-managed random
+# password) and registers account presence + lifecycle plumbing only.
+# Because the new systemAccounts have no `secretRef`,
+# `transformer_component_account.go:160-174` `buildAccountHash` short-
+# circuits (account.SecretRef == nil) and does NOT write a hash
+# annotation; cond.Message hash tracking and DB-side password drift
+# handling are DEFERRED to Phase B (which declares secretRef +
+# statement.create + statement.update). NO statement.create. NO
+# credentialVarRef env on the new accounts. NO chart watchdog /
+# initdb / script changes. All 16+ chart consumers of
+# MARIADB_ROOT_PASSWORD for kb_internal_root / kb_replicator
+# credentials continue working unchanged. Runtime behavior is
+# byte-identical to alpha.110.
+#
+# Path C rationale (over earlier candidate paths):
+#   - Path A naive (cluster.spec systemAccount.secretRef.name = KB-
+#     managed root Secret name) fails: componentAccountTransformer
+#     processes createSet in alphabetical order (kb_internal_root <
+#     kb_replicator < root); getPasswordFromSecret lookups for
+#     kb_internal_root hit NotFound on the root Secret which has not
+#     yet been committed to the apiserver in the same DAG. Result:
+#     infinite reconcile retry loop. Verified against
+#     transformer_component_account.go buildAccountSecret /
+#     getPasswordFromSecret path on KB main `8ee04938`.
+#   - Path A.1 (chart renders shared credentials Secret consumed by
+#     all three accounts) changes root account password ownership
+#     from KB-managed random to chart-managed — architectural shift
+#     outside Phase A scope.
+#   - Path B (full 16+ script sweep + credentialVarRef + watchdog
+#     password switch in one PR) atomic but large blast radius;
+#     deferred to Phase B as a separate atomic PR.
+#
+# Path C delivers the KB lifecycle hook in this PR without any
+# runtime behavior change, isolating the actual credential ownership
+# migration (16+ chart/script touchpoints) to a single atomic
+# Phase B PR.
+#
+# Topology coverage:
+#   - cmpd.yaml (standalone): kb_internal_root declared
+#   - cmpd-semisync.yaml: kb_internal_root + kb_replicator declared
+#   - cmpd-replication-merged.yaml: kb_internal_root + kb_replicator
+#     declared
+#   - cmpd-replication.yaml: UNCHANGED (zero kb_internal_root /
+#     kb_replicator references in this topology)
+#   - cmpd-galera.yaml: UNCHANGED (galera uses
+#     wsrep_sst_auth=root cluster-wide as engine-native auth model;
+#     no chart-managed kb_internal_root / kb_replicator path
+#     exists to declare against)
+#
+# Behavior delta vs alpha.110:
+#   (a) NEW KubeBlocks-managed Secrets:
+#       <cluster>-<comp>-account-kb_internal_root (3 topologies) and
+#       <cluster>-<comp>-account-kb_replicator (2 topologies). These
+#       Secrets are populated with KB-generated random passwords and
+#       are NOT consumed by any chart path during Phase A. They are
+#       lifecycle placeholders only.
+#   (b) NO env injection (no credentialVarRef on the new accounts).
+#       Pods see no new env. The existing `MARIADB_ROOT_PASSWORD`
+#       env (from credentialVarRef name: root) is unchanged.
+#   (c) NO chart watchdog / initdb / scripts code change.
+#   (d) initAccount: true semantics:
+#       transformer_component_account_provision.go:161-167 skips
+#       statement.create exec when initAccount is true; the
+#       placeholder Secret still materializes via
+#       componentAccountTransformer.
+#   (e) Phase A KB Secret password values do NOT match the actual
+#       DB-side password of `kb_internal_root` / `kb_replicator`
+#       (which remains MARIADB_ROOT_PASSWORD per existing chart).
+#       This is intentional and safe for Phase A because alpha.110
+#       does not expose these accounts to any external consumer
+#       (kbcli / Service binding / external tooling); chart-internal
+#       callers continue using MARIADB_ROOT_PASSWORD directly.
+#
+# Migration safety: alpha.110 → alpha.114 is fully additive.
+# Existing `root` systemAccount unchanged. New Secret objects
+# materialize but are not referenced by any chart path. No SQL DDL
+# fires. No behavior delta on any reconcile path. Rollback = revert
+# the systemAccounts declarations; KB will garbage-collect the
+# unreferenced Secret objects.
+#
+# Phase B (separate future PR, after one alpha cycle of Phase A
+# stable observation):
+#   - Add `mariadb.<topology>.spec.vars` helpers injecting
+#     KB_INTERNAL_ROOT_PASSWORD and KB_REPLICATOR_PASSWORD via
+#     credentialVarRef with optional: false safety contract.
+#   - Switch chart watchdog `ensure_internal_local_admin` password
+#     source from MARIADB_ROOT_PASSWORD to KB_INTERNAL_ROOT_PASSWORD
+#     / KB_REPLICATOR_PASSWORD across cmpd-semisync.yaml and
+#     cmpd-replication-merged.yaml.
+#   - Switch standalone initdb 01-kb-internal-root.sh password
+#     literal to KB_INTERNAL_ROOT_PASSWORD.
+#   - Update all 16+ chart-side credential collocations:
+#     INTERNAL_LOCAL and SOCK_CLI/TCP_CLI shell arrays
+#     (cmpd-semisync.yaml + cmpd-replication-merged.yaml);
+#     scripts/replication-roleprobe.sh (4 sites);
+#     scripts/replication-switchover.sh (12+ sites).
+#   - Set initAccount: false + statement.create with alpha.81 narrow
+#     allowlist (REPLICATION CLIENT + SLAVE MONITOR + REPLICATION
+#     MASTER ADMIN + kubeblocks.kb_health_check narrow table grants
+#     + SELECT mysql.user on @'%' for kb_internal_root; REPLICATION
+#     SLAVE on @'%' for kb_replicator). NO admin-bypass.
+#   - Add statement.update body (idempotent re-apply: CREATE IF NOT
+#     EXISTS + ALTER IDENTIFIED BY + ALTER ACCOUNT UNLOCK + REVOKE
+#     ALL + GRANT specific + FLUSH PRIVILEGES) so Secret rotation,
+#     DB user manual deletion, and privilege drift all converge via
+#     the same path.
+#   - Phase B is atomic single-PR: KB Secret password value, chart
+#     credential consumption, and DB-side user password all converge
+#     in one merge.
+#
+# Numbering: alpha.111 reserved for the P0a URGENT FLUSH PRIVILEGES
+# wrap PR, alpha.112 for the honest 60s memberJoin timeoutSeconds +
+# galera single-shot PR, alpha.113 for the replication memberJoin
+# single-shot bootstrap-or-defer PR. Integration owner reconciles
+# the version chain at merge time.
+#
+# Controller-side source-line citations (KB main `8ee04938`):
+#   - SystemAccount API: componentdefinition_types.go:1187-1239
+#   - initAccount semantics (skip provision exec):
+#     transformer_component_account_provision.go:161-167
+#   - placeholder Secret materialization:
+#     transformer_component_account.go:106-114 + createAccount
+#     line 119-130
+#   - accountProvision retry semantics (per-reconcile fire-and-retry):
+#     transformer_component_account_provision.go:103-134
+#   - createSet alphabetical ordering (root processed after kb_*):
+#     transformer_component_account.go:88 setDiff + sets.List
+#
+# Test plan: helm dependency build + helm template PASS for all 5
+# cmpd files; rendered systemAccounts blocks verified per topology.
+# IDC vcluster live verification deferred to next alpha-cycle deploy
+# alongside PR #2701 / .112 / .113.
+version: 1.1.1-alpha.114
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -836,6 +836,63 @@ systemAccounts:
 {{- end -}}
 
 {{/*
+System accounts for semisync + replication-merged topologies (Phase A account-model RFC; design review issue 3 from 2026-05-31 audit).
+
+Phase A scope is DECLARATIVE ONLY. kb_internal_root and kb_replicator are declared as KubeBlocks-managed systemAccounts with `initAccount: true` so KB controller materializes a placeholder Secret per account and tracks the lifecycle hook, but does NOT execute `accountProvision.statement.create` SQL against the engine. Per `transformer_component_account_provision.go:161-167`, `initAccount: true` short-circuits the provision exec path.
+
+DB-side runtime behavior is byte-identical to alpha.110: chart's `ensure_internal_local_admin` (cmpd-semisync.yaml + cmpd-replication-merged.yaml) and initdb (cmpd.yaml) continue to inline-create + maintain kb_internal_root and kb_replicator using `${MARIADB_ROOT_PASSWORD}`. The narrow alpha.81 @'%' grant allowlist (REPLICATION CLIENT + SLAVE MONITOR + REPLICATION MASTER ADMIN + narrow table grants + SELECT mysql.user for kb_internal_root; REPLICATION SLAVE for kb_replicator) is enforced by chart watchdog and unchanged.
+
+Phase A's only behavior delta is that KB controller now materializes a Secret per declared account and tracks `Component.status.conditions[SystemAccountProvision]`. The KB-managed Secret password is random (per passwordGenerationPolicy below) and INTENTIONALLY DIFFERENT from the DB-side password (= MARIADB_ROOT_PASSWORD). No external consumer reads these two Secrets in Phase A; alpha.110 also did not expose them.
+
+Phase B (separate future PR) will switch the chart to source the kb_internal_root / kb_replicator password from these Secrets via `credentialVarRef`, define `statement.create` + `statement.update` for real KB-driven provision, and sweep all 16+ script call sites in `ensure_internal_local_admin`, `replication-roleprobe.sh`, and `replication-switchover.sh` to use `${KB_INTERNAL_ROOT_PASSWORD}` / `${KB_REPLICATOR_PASSWORD}` atomically. Phase B's full grant contract design is captured in the addon-side RFC catalog.
+*/}}
+{{- define "mariadb.semisync.spec.systemAccounts" -}}
+systemAccounts:
+  - name: root
+    initAccount: true
+    passwordGenerationPolicy:
+      length: 10
+      numDigits: 3
+      numSymbols: 4
+      letterCase: MixedCases
+  - name: kb_internal_root
+    initAccount: true
+    passwordGenerationPolicy:
+      length: 32
+      numDigits: 16
+      numSymbols: 0
+      letterCase: MixedCases
+  - name: kb_replicator
+    initAccount: true
+    passwordGenerationPolicy:
+      length: 32
+      numDigits: 16
+      numSymbols: 0
+      letterCase: MixedCases
+{{- end -}}
+
+{{/*
+System accounts for standalone topology (Phase A account-model RFC). Same declarative-only scope as the semisync helper above. Standalone declares only kb_internal_root because there is no replication (single-node).
+*/}}
+{{- define "mariadb.standalone.spec.systemAccounts" -}}
+systemAccounts:
+  - name: root
+    initAccount: true
+    passwordGenerationPolicy:
+      length: 10
+      numDigits: 3
+      numSymbols: 4
+      letterCase: MixedCases
+  - name: kb_internal_root
+    initAccount: true
+    passwordGenerationPolicy:
+      length: 32
+      numDigits: 16
+      numSymbols: 0
+      letterCase: MixedCases
+{{- end -}}
+
+{{/*
 Common vars for replication and galera
 */}}
 {{- define "mariadb.spec.vars" -}}

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -134,7 +134,7 @@ spec:
   volumes:
     - name: data
       needSnapshot: true
-  {{- include "mariadb.replication.spec.systemAccounts" . | nindent 2 }}
+  {{- include "mariadb.semisync.spec.systemAccounts" . | nindent 2 }}
   {{- include "mariadb.spec.vars" . | nindent 2 }}
   lifecycleActions:
     roleProbe:

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -67,7 +67,7 @@ spec:
   volumes:
     - name: data
       needSnapshot: true
-  {{- include "mariadb.replication.spec.systemAccounts" . | nindent 2 }}
+  {{- include "mariadb.semisync.spec.systemAccounts" . | nindent 2 }}
   {{- include "mariadb.spec.vars" . | nindent 2 }}
   lifecycleActions:
     roleProbe:

--- a/addons/mariadb/templates/cmpd.yaml
+++ b/addons/mariadb/templates/cmpd.yaml
@@ -140,11 +140,4 @@ spec:
   volumes:
     - name: data
       needSnapshot: true
-  systemAccounts:
-    - name: root
-      initAccount: true
-      passwordGenerationPolicy:
-        length: 10
-        numDigits: 3
-        numSymbols: 4
-        letterCase: MixedCases
+  {{- include "mariadb.standalone.spec.systemAccounts" . | nindent 2 }}


### PR DESCRIPTION
## Summary

v2 redesign per 3-reviewer converged feedback. Phase A account model RFC (design review issue 3) is reduced to a **Path C declarative-only** scope: declare `kb_internal_root` and `kb_replicator` as KubeBlocks-managed `systemAccounts` with `initAccount: true` and `passwordGenerationPolicy`, but ship **zero runtime behavior change**. KB controller materializes per-account Secrets and registers the lifecycle hook; chart `ensure_internal_local_admin` + initdb + all 16+ script consumers of `${MARIADB_ROOT_PASSWORD}` for these accounts continue to operate unchanged.

The real credential ownership migration (chart watchdog + initdb + 16+ scripts → `${KB_INTERNAL_ROOT_PASSWORD}` / `${KB_REPLICATOR_PASSWORD}` env via `credentialVarRef`, with `initAccount: false` + `statement.create` + `statement.update`) lands as **Phase B** in a separate atomic PR after one alpha cycle of Phase A stable observation.

## Why Path C (not v1's Path A nor full-sweep B)

- **v1 Path A** (declare systemAccounts + switch chart watchdog password source + add credentialVarRef env) was a partial password-source switch. `INTERNAL_LOCAL` / `SOCK_CLI` / `TCP_CLI` shell arrays (in cmpd-semisync.yaml + cmpd-replication-merged.yaml) AND `scripts/replication-roleprobe.sh` (4 sites) AND `scripts/replication-switchover.sh` (12+ sites) were left unconverted. After the first watchdog reconcile ALTERs `kb_internal_root` to the KB-managed password, the unconverted sites would auth-fail → cluster never converges.
- **Path A.2** (cluster.spec systemAccount.secretRef → KB-managed root Secret) fails on `componentAccountTransformer` chicken-and-egg: createSet processes alphabetically (`kb_internal_root` < `root`), so `getPasswordFromSecret` hits NotFound on the root Secret which has not been committed in the same reconcile DAG → infinite retry.
- **Path B** (full 16+ script sweep + credentialVarRef + watchdog password switch + statement.create + statement.update in one PR) is atomic but large blast radius. Deferred to a separate atomic PR after Phase A stable observation.
- **Path C** (this PR): only the systemAccount declarations + `initAccount: true`. KB lifecycle hook delivered, zero runtime delta, blast radius minimal.

## Scope

| topology | change |
|---|---|
| `cmpd.yaml` (standalone) | switch to `mariadb.standalone.spec.systemAccounts` helper: root + kb_internal_root, all `initAccount: true` |
| `cmpd-semisync.yaml` | switch to `mariadb.semisync.spec.systemAccounts` helper: root + kb_internal_root + kb_replicator, all `initAccount: true` |
| `cmpd-replication-merged.yaml` | same as semisync |
| `cmpd-replication.yaml` | **UNCHANGED** — zero kb_internal_root references |
| `cmpd-galera.yaml` | **UNCHANGED** — galera uses `wsrep_sst_auth=root` cluster-wide (engine-native auth model) |

Diff stat: **+204 / -11 across 5 files** (Chart.yaml comment +145; _helpers.tpl +57 two new defines; three cmpd files only the helper include line switched).

## Behavior delta vs alpha.110

- (a) NEW KubeBlocks-managed Secrets: `<cluster>-<comp>-account-kb_internal_root` (3 topologies) and `<cluster>-<comp>-account-kb_replicator` (2 topologies), populated with KB-generated random passwords. **These Secrets are NOT consumed by any chart path during Phase A** — they are lifecycle placeholders only.
- (b) NO env injection. No `credentialVarRef` on the new accounts. Pods see no new env. Existing `MARIADB_ROOT_PASSWORD` env (from `credentialVarRef name: root`) unchanged.
- (c) NO chart watchdog / initdb / script code change.
- (d) `initAccount: true` semantics: `transformer_component_account_provision.go:161-167` skips `statement.create` exec when `initAccount` is true; the placeholder Secret still materializes via `componentAccountTransformer`.
- (e) Phase A KB Secret password values do NOT match the actual DB-side password of `kb_internal_root` / `kb_replicator` (which remains `MARIADB_ROOT_PASSWORD`). This is intentional and safe because alpha.110 does not expose these accounts to any external consumer (kbcli / Service binding / external tooling); chart-internal callers continue using `MARIADB_ROOT_PASSWORD`.

## Migration safety

alpha.110 → alpha.114 is fully additive:

- Existing `root` systemAccount unchanged.
- New Secret objects materialize but are not referenced by any chart path.
- No SQL DDL fires from KB controller (`initAccount: true` short-circuit).
- No behavior delta on any reconcile path.
- Rollback = revert the systemAccount declarations; KB will garbage-collect the unreferenced Secret objects.

## Phase B (out of scope; future PR)

- Add `mariadb.<topology>.spec.vars` helpers injecting `KB_INTERNAL_ROOT_PASSWORD` + `KB_REPLICATOR_PASSWORD` via `credentialVarRef` with `optional: false`.
- Switch chart watchdog `ensure_internal_local_admin` password source from `${MARIADB_ROOT_PASSWORD}` to `${KB_INTERNAL_ROOT_PASSWORD}` / `${KB_REPLICATOR_PASSWORD}` across cmpd-semisync.yaml + cmpd-replication-merged.yaml.
- Switch standalone initdb `01-kb-internal-root.sh` password literal.
- Update all 16+ chart-side credential collocations: INTERNAL_LOCAL + SOCK_CLI/TCP_CLI shell arrays + `replication-roleprobe.sh` (4 sites) + `replication-switchover.sh` (12+ sites).
- Set `initAccount: false` + `statement.create` with alpha.81 narrow allowlist (REPLICATION CLIENT + SLAVE MONITOR + REPLICATION MASTER ADMIN + narrow table grants + SELECT mysql.user on `@'%'` for kb_internal_root; REPLICATION SLAVE on `@'%'` for kb_replicator). NO admin-bypass.
- Add `statement.update` body for idempotent re-apply (CREATE IF NOT EXISTS + ALTER IDENTIFIED BY + ALTER ACCOUNT UNLOCK + REVOKE ALL + GRANT specific + FLUSH PRIVILEGES) covering Secret rotation, DB user manual deletion, and privilege drift.

## Test plan

- [x] `helm dependency build` PASS
- [x] `helm template` PASS for all 5 cmpd files
- [x] Rendered systemAccounts verified per topology (standalone: root + kb_internal_root; semisync + replication-merged: root + kb_internal_root + kb_replicator; pure replication + galera: root only). All `initAccount: true`.
- [x] Rendered output contains ZERO `KB_INTERNAL_ROOT_PASSWORD` / `KB_REPLICATOR_PASSWORD` env (Path C correctness: no env injection in Phase A).
- [x] Companion kubeblocks-tests PR #135 adds offline render-time assertions verifying the same topology shapes (`PASS=25 FAIL=0` against this chart).
- [ ] CI: chart helm-check + shellspec (auto-runs on push). Pre-existing shellspec failures unrelated to this PR's diff.
- [ ] IDC vcluster live verification: **deferred** to next alpha-cycle deploy alongside PR #2701/.112/.113 per Hard Rule 24 (no local tests; live verification on integration owner's deploy cycle).

## Related PRs and integration ordering

- PR #2701 alpha.111 (P0a URGENT FLUSH PRIVILEGES wrap) — `Chart.yaml` conflicts. cmpd.yaml semantic conflict (sql_log_bin wrap in #2701) is no longer present in v2 — Path C reverted the v1 initdb password source switch so cmpd.yaml standalone initdb body remains alpha.110-byte-identical.
- PR #2702 alpha.112 (honest 60s memberJoin timeoutSeconds + galera single-shot) — `Chart.yaml` conflicts.
- PR #2712 alpha.113 (replication memberJoin single-shot bootstrap-or-defer) — `Chart.yaml` conflicts.

Recommended integration order: `#2701 → #2702 → #2712 → #2714` with rebase at each step, OR a single integration branch outputting alpha.114. Pure `Chart.yaml` conflicts only; no semantic conflicts in v2.

## Controller-side source-line citations

- SystemAccount API: `componentdefinition_types.go:1187-1239`
- initAccount semantics (skip provision exec): `transformer_component_account_provision.go:161-167`
- Placeholder Secret materialization: `transformer_component_account.go:106-114` + createAccount line 119-130
- accountProvision retry semantics: `transformer_component_account_provision.go:103-134`
- createSet alphabetical ordering: `transformer_component_account.go:88` setDiff + sets.List
