### PR TITLE
fix(mysql): configure proxysql for mgr writes

### DIFF
--- a/addons/mysql/config/proxysql.tpl
+++ b/addons/mysql/config/proxysql.tpl
@@ -55,7 +55,7 @@ mysql_query_rules=
 		flagIN=0
 		apply=1
 		rule_id=1
-		destination_hostgroup=2
+		destination_hostgroup=1
 		match_digest="^SELECT.*FOR UPDATE$"
 		negate_match_pattern=0
 		active=1
@@ -65,20 +65,10 @@ mysql_query_rules=
 		active=1
 		re_modifiers="CASELESS"
 		negate_match_pattern=0
-		destination_hostgroup=3
+		destination_hostgroup=2
 		flagIN=0
 		match_digest="^SELECT"
 		rule_id=2
-	},
-	{
-		re_modifiers="CASELESS"
-		destination_hostgroup=2
-		active=1
-		rule_id=3
-		match_digest=".*"
-		apply=1
-		negate_match_pattern=0
-		flagIN=0
 	}
 )
 

--- a/addons/mysql/scripts/configure-proxysql.sh
+++ b/addons/mysql/scripts/configure-proxysql.sh
@@ -63,6 +63,95 @@ function wait_for_mysql() {
     fi
 }
 
+function get_writable_mysql_server() {
+    local server
+    local super_read_only
+
+    IFS=',' read -ra servers <<< "$MYSQL_FQDNS"
+    for server in "${servers[@]}"; do
+        super_read_only=$(mysql_exec ${MYSQL_ROOT_USER} ${MYSQL_ROOT_PASSWORD} ${server} ${MYSQL_PORT} "select @@global.super_read_only;" 2>/dev/null || true)
+        if [[ "$super_read_only" == "0" || "$super_read_only" == "OFF" ]]; then
+            echo "$server"
+            return 0
+        fi
+    done
+
+    echo "$BACKEND_SERVER"
+}
+
+function is_group_replication_backend() {
+    local server="$1"
+    local group_name
+
+    group_name=$(mysql_exec ${MYSQL_ROOT_USER} ${MYSQL_ROOT_PASSWORD} ${server} ${MYSQL_PORT} "select @@global.group_replication_group_name;" 2>/dev/null || true)
+    [[ -n "$group_name" && "$group_name" != "NULL" ]]
+}
+
+function init_group_replication_monitor_view() {
+    local server="$1"
+    local query
+
+    query=$(cat <<'SQL'
+CREATE DATABASE IF NOT EXISTS sys;
+USE sys;
+DROP VIEW IF EXISTS gr_member_routing_candidate_status;
+DROP FUNCTION IF EXISTS gr_member_in_primary_partition;
+DROP FUNCTION IF EXISTS gr_transactions_to_cert;
+CREATE FUNCTION gr_member_in_primary_partition() RETURNS VARCHAR(3) DETERMINISTIC READS SQL DATA
+RETURN (
+  SELECT IF(
+    MEMBER_STATE = 'ONLINE'
+    AND (
+      (
+        SELECT COUNT(*)
+        FROM performance_schema.replication_group_members
+        WHERE MEMBER_STATE != 'ONLINE'
+      ) >= (
+        (
+          SELECT COUNT(*)
+          FROM performance_schema.replication_group_members
+        ) / 2
+      ) = 0
+    ),
+    'YES',
+    'NO'
+  )
+  FROM performance_schema.replication_group_members
+    JOIN performance_schema.replication_group_member_stats rgms USING (member_id)
+  WHERE rgms.MEMBER_ID = @@SERVER_UUID
+);
+CREATE FUNCTION gr_transactions_to_cert() RETURNS INT DETERMINISTIC NO SQL
+RETURN 0;
+CREATE VIEW gr_member_routing_candidate_status AS
+SELECT
+  sys.gr_member_in_primary_partition() AS viable_candidate,
+  IF(
+    (
+      SELECT GROUP_CONCAT(variable_value ORDER BY variable_name)
+      FROM performance_schema.global_variables
+      WHERE variable_name IN ('read_only', 'super_read_only')
+    ) != 'OFF,OFF',
+    'YES',
+    'NO'
+  ) AS read_only,
+  (
+    SELECT COUNT_TRANSACTIONS_REMOTE_IN_APPLIER_QUEUE
+    FROM performance_schema.replication_group_member_stats
+    WHERE MEMBER_ID = @@SERVER_UUID
+  ) AS transactions_behind,
+  sys.gr_transactions_to_cert() AS transactions_to_cert;
+GRANT SELECT ON sys.gr_member_routing_candidate_status TO 'proxysql'@'%';
+GRANT EXECUTE ON FUNCTION sys.gr_member_in_primary_partition TO 'proxysql'@'%';
+GRANT SELECT ON performance_schema.replication_group_members TO 'proxysql'@'%';
+GRANT SELECT ON performance_schema.replication_group_member_stats TO 'proxysql'@'%';
+GRANT SELECT ON performance_schema.global_variables TO 'proxysql'@'%';
+SQL
+)
+
+    log "INFO" "Initializing ProxySQL Group Replication monitor objects on $server"
+    mysql_exec ${MYSQL_ROOT_USER} ${MYSQL_ROOT_PASSWORD} ${server} ${MYSQL_PORT} "$query" $opt
+}
+
 # if test by shellspec include, just return 0
 if [ "${__SOURCED__:+x}" ]; then
   return 0
@@ -72,7 +161,8 @@ fi
 log "$MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $BACKEND_SERVER $MYSQL_PORT"
 wait_for_mysql $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $BACKEND_SERVER $MYSQL_PORT
 
-mysql_version=$(mysql_exec $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $BACKEND_SERVER $MYSQL_PORT  'select @@version')
+writable_mysql_server=$(get_writable_mysql_server)
+mysql_version=$(mysql_exec $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $writable_mysql_server $MYSQL_PORT  'select @@version')
 
 # echo "mysql version $mysql_version"
 # if [[ $mysql_version == *"8"* ]]; then
@@ -83,8 +173,11 @@ mysql_version=$(mysql_exec $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $BACKEND_SERVER
 #     log "Unsupported mysql version"
 # fi
 
-log "connecting to mysql $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $BACKEND_SERVER $MYSQL_PORT"
-mysql_exec $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $BACKEND_SERVER $MYSQL_PORT "$additional_sys_query" $opt
+log "connecting to mysql $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $writable_mysql_server $MYSQL_PORT"
+if is_group_replication_backend "$writable_mysql_server"; then
+    init_group_replication_monitor_view "$writable_mysql_server"
+fi
+mysql_exec $MYSQL_ROOT_USER $MYSQL_ROOT_PASSWORD $writable_mysql_server $MYSQL_PORT "$additional_sys_query" $opt
 
 # wait for proxysql process to run
 wait_for_mysql admin ${PROXYSQL_ADMIN_PASSWORD} 127.0.0.1 6032
@@ -106,6 +199,12 @@ select * from runtime_proxysql_servers;
 
 mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "$configuration_sql"
 
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_users (username,password) values ('$MYSQL_ROOT_USER','$MYSQL_ROOT_PASSWORD');LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;"
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert into mysql_replication_hostgroups ( writer_hostgroup, reader_hostgroup, comment) values (1,2,'proxy');load mysql servers to runtime;save mysql servers to disk;"
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "select * from main.runtime_mysql_replication_hostgroups; select * from main.mysql_replication_hostgroups; select * from mysql_replication_hostgroups;"
+mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "delete from mysql_query_rules;insert into mysql_query_rules (rule_id,active,match_digest,destination_hostgroup,apply,re_modifiers) values (1,1,'^SELECT.*FOR UPDATE$',1,1,'CASELESS'),(2,1,'^SELECT',2,1,'CASELESS');LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
+mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_users (username,password,default_hostgroup) values ('$MYSQL_ROOT_USER','$MYSQL_ROOT_PASSWORD',1);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;"
+if is_group_replication_backend "$writable_mysql_server"; then
+    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_group_replication_hostgroups (writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) values (1,4,2,3,1,1,0,100,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
+    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "select * from runtime_mysql_group_replication_hostgroups; select * from mysql_group_replication_hostgroups;"
+else
+    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_replication_hostgroups (writer_hostgroup,reader_hostgroup,comment) values (1,2,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
+    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "select * from main.runtime_mysql_replication_hostgroups; select * from main.mysql_replication_hostgroups; select * from mysql_replication_hostgroups;"
+fi

--- a/addons/mysql/scripts/configure-proxysql.sh
+++ b/addons/mysql/scripts/configure-proxysql.sh
@@ -96,6 +96,7 @@ CREATE DATABASE IF NOT EXISTS sys;
 USE sys;
 DROP VIEW IF EXISTS gr_member_routing_candidate_status;
 DROP FUNCTION IF EXISTS gr_member_in_primary_partition;
+DROP FUNCTION IF EXISTS gr_transactions_behind;
 DROP FUNCTION IF EXISTS gr_transactions_to_cert;
 CREATE FUNCTION gr_member_in_primary_partition() RETURNS VARCHAR(3) DETERMINISTIC READS SQL DATA
 RETURN (
@@ -120,6 +121,12 @@ RETURN (
     JOIN performance_schema.replication_group_member_stats rgms USING (member_id)
   WHERE rgms.MEMBER_ID = @@SERVER_UUID
 );
+CREATE FUNCTION gr_transactions_behind() RETURNS INT DETERMINISTIC READS SQL DATA
+RETURN (
+  SELECT COUNT_TRANSACTIONS_REMOTE_IN_APPLIER_QUEUE
+  FROM performance_schema.replication_group_member_stats
+  WHERE MEMBER_ID = @@SERVER_UUID
+);
 CREATE FUNCTION gr_transactions_to_cert() RETURNS INT DETERMINISTIC NO SQL
 RETURN 0;
 CREATE VIEW gr_member_routing_candidate_status AS
@@ -134,14 +141,11 @@ SELECT
     'YES',
     'NO'
   ) AS read_only,
-  (
-    SELECT COUNT_TRANSACTIONS_REMOTE_IN_APPLIER_QUEUE
-    FROM performance_schema.replication_group_member_stats
-    WHERE MEMBER_ID = @@SERVER_UUID
-  ) AS transactions_behind,
+  sys.gr_transactions_behind() AS transactions_behind,
   sys.gr_transactions_to_cert() AS transactions_to_cert;
 GRANT SELECT ON sys.gr_member_routing_candidate_status TO 'proxysql'@'%';
 GRANT EXECUTE ON FUNCTION sys.gr_member_in_primary_partition TO 'proxysql'@'%';
+GRANT EXECUTE ON FUNCTION sys.gr_transactions_behind TO 'proxysql'@'%';
 GRANT SELECT ON performance_schema.replication_group_members TO 'proxysql'@'%';
 GRANT SELECT ON performance_schema.replication_group_member_stats TO 'proxysql'@'%';
 GRANT SELECT ON performance_schema.global_variables TO 'proxysql'@'%';


### PR DESCRIPTION
Fixes #2640

Summary:
- route SELECT FOR UPDATE to the writer hostgroup and normal SELECT traffic to the reader hostgroup
- set the MySQL user default hostgroup to writer and refresh persisted ProxySQL query rules on startup
- initialize Group Replication monitor objects and hostgroups only when the backend is Group Replication
- avoid direct system-variable references in the ProxySQL Group Replication monitor view

Validation:
- bash -n addons/mysql/scripts/configure-proxysql.sh
- helm lint addons/mysql
- helm template mysql addons/mysql --namespace kb-system --show-only templates/configmap-proxysql.yaml --show-only templates/scripts.yaml
- shellspec --shell bash --load-path shellspec addons/mysql/scripts-ut-spec/configre_proxysql_spec.sh