### PR TITLE
chore(rabbitmq): start replicas in parallel

### DIFF
--- a/addons/rabbitmq/templates/cmpd.yaml
+++ b/addons/rabbitmq/templates/cmpd.yaml
@@ -11,6 +11,7 @@ spec:
   description: RabbitMQ is a reliable and mature messaging and streaming broker.
   serviceKind: rabbitmq
   serviceVersion: {{ .Values.componentServiceVersion.rabbitmq }}
+  podManagementPolicy: Parallel
   services:
     - name: default
       spec:


### PR DESCRIPTION
## Summary

- Add podManagementPolicy: Parallel to RabbitMQ ComponentDefinition

OrderedReady pod management causes permanent deadlock during Stop/Start for N>=3 clusters: pod 0 starts first but cannot form Raft quorum alone, blocking subsequent pods from ever starting. Parallel policy starts all replicas simultaneously so quorum can reform.

## Evidence

A/B proof on vcluster with chaos_stopstart suite (SS01-SS06):
- **OrderedReady (main)**: SS04 Start deadlocks - pod 0 cannot form quorum alone, cluster never recovers
- **Parallel (this PR)**: SS04 PASS - all 3 pods start simultaneously, quorum recovered, no committed message loss

N=2 ALL PASS (26/0/0). Run artifacts: artifacts/chaos-stopstart-pr2718-run{1,2}-*.tar.gz

## Test plan

- [x] chaos_stopstart N=2 PASS (26/0/0)
- [ ] smoke + day2 on PR branch (Ava executing)
- [ ] chaos_stopstart N=3 after merge