### PR TITLE
chore(oceanbase-ce): unblock main backup and parameter definition install

### DIFF
--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -265,7 +265,7 @@ ${mysql_cmd} "select tenant_id, backup_set_id from oceanbase.CDB_OB_BACKUP_JOB_H
       tenantJson=$(buildJsonString "$tenantJson" "minRestoreSCN" ${res[5]})
       tenantJson=$(buildJsonString "$tenantJson" "minRestoreTime" "${res[6]}")
       status=${res[7]}
-      if [[ $status -ne "SUCCESS" ]];then
+      if [[ "${status}" != "SUCCESS" ]];then
           tenantJson=$(buildJsonString "$tenantJson" "failureMessage" "${res[8]}: ${res[9]}")
       fi
       # record time zone

--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -52,14 +52,17 @@ function prepareTenantLogArchive() {
   save_defer_archivelog_tenants "${tenant_id}"
   destUrl=$(getDestURL archive ${tenant_name} ${tenant_id})
   echo "INFO: prepare log archive dest for tenant ${tenant_name}"
-  result=`${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST=\"LOCATION=${destUrl}\" TENANT=${tenant_name}"`
+  # Cluster-wide ALTER SYSTEM SET LOG_ARCHIVE_DEST propagation can exceed the
+  # default ob_query_timeout (10s). Prefix SET SESSION ob_query_timeout=1000000000
+  # to match the idiom already used in restore.sh and bootstrap.sh.
+  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST=\"LOCATION=${destUrl}\" TENANT=${tenant_name};"`
   if [[ $? -ne 0 ]];then
      echo "ERROR: alert log_archive_dest for tenant ${tenant_name} failed: ${result}"
      exit 1
   fi
   # enable dest
   echo "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
-  ${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
+  ${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
   # add recovery window to auto-clean backup.
   #deletePolicyCount=`${mysql_cmd} "SELECT count(*) FROM oceanbase.CDB_OB_BACKUP_DELETE_POLICY where TENANT_ID=${tenant_id};" |awk -F '\t' '{print}'`
   #if [ $deletePolicyCount -eq 0 ]; then
@@ -72,7 +75,9 @@ function prepareTenantDataBackup() {
   tenant_name=${1:?missing tenant name}
   destUrl=$(getDestURL data ${tenant_name})
   echo "INFO: prepare data backup dest for tenant ${tenant_name}"
-  result=`${mysql_cmd} "ALTER SYSTEM SET DATA_BACKUP_DEST=\"${destUrl}\" TENANT=${tenant_name}"`
+  # Same pattern as prepareTenantLogArchive: SET SESSION ob_query_timeout prefix
+  # (matches restore.sh / bootstrap.sh idiom).
+  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET DATA_BACKUP_DEST=\"${destUrl}\" TENANT=${tenant_name};"`
   if [[ $? -ne 0 ]];then
      echo "ERROR: alert data_backup_dest for tenant ${tenant_name} failed: ${result}"
      exit 1

--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -5,11 +5,13 @@ export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH=${DP_BACKUP_BASE_PATH}
 noArchivedTenantsFiles="no_archived_tenants.dp"
 deferArchiveLogTenantsFiles="defer_archive_tenants.dp"
+archiveCheckpointFailedFile="archive_checkpoint_failed.dp"
 endTimeInfoFile="kb_end_time.info"
 
 mysql_cmd="mysql -u ${DP_DB_USER} -h ${DP_DB_HOST} -P${DP_DB_PORT} -p${DP_DB_PASSWORD} -N -e"
 OlD_IFS=$IFS
 time_zone_file="timezone.dp"
+archiveCheckpointTimeout="${ARCHIVE_CHECKPOINT_TIMEOUT_SECONDS:-600}"
 
 pod_ordinal=$(get_pod_ordinal ${DP_TARGET_POD_NAME})
 if [[ ${pod_ordinal} -ne 0  ]]; then
@@ -40,6 +42,31 @@ function save_defer_archivelog_tenants() {
          echo "${tenant_name}" >> $deferArchiveLogTenantsFiles
      fi
   fi
+}
+
+function waitArchiveCheckpoint() {
+  local tenant_id=${1:?missing tenant id}
+  local tenant_name=${2:?missing tenant name}
+  local minRestoreSCN=${3:?missing min restore scn}
+  local time=0
+  local checkpoint_scn=""
+
+  while true; do
+    checkpoint_scn=$(${mysql_cmd} "SELECT COALESCE(MAX(CHECKPOINT_SCN), 0) FROM oceanbase.CDB_OB_ARCHIVELOG WHERE tenant_id=${tenant_id};" | awk -F '\t' '{print}')
+    [[ ${checkpoint_scn} =~ ^[0-9]+$ ]] || checkpoint_scn=0
+    if [[ ${checkpoint_scn} -ge ${minRestoreSCN} ]]; then
+      echo "INFO: archive checkpoint for tenant ${tenant_name} is ready: checkpoint_scn=${checkpoint_scn}, min_restore_scn=${minRestoreSCN}"
+      return
+    fi
+    if [[ ${time} -ge ${archiveCheckpointTimeout} ]]; then
+      echo "ERROR: timed out waiting archive checkpoint for tenant ${tenant_name}: checkpoint_scn=${checkpoint_scn}, min_restore_scn=${minRestoreSCN}"
+      echo "tenant=${tenant_name}, checkpoint_scn=${checkpoint_scn}, min_restore_scn=${minRestoreSCN}" >> ${archiveCheckpointFailedFile}
+      return 1
+    fi
+    echo "INFO: wait archive checkpoint for tenant ${tenant_name}: checkpoint_scn=${checkpoint_scn}, min_restore_scn=${minRestoreSCN}"
+    sleep 5
+    time=$((time+5))
+  done
 }
 
 function prepareTenantLogArchive() {
@@ -212,19 +239,6 @@ done
 echo "INFO: backup data completed."
 sleep 5
 
-# step 5 ==> close tenant archive if the tenant not open the log archive.
-if [[ -f $noArchivedTenantsFiles ]]; then
-   IFS=$'\n'
-   for tenant_name in `cat $noArchivedTenantsFiles`; do
-     IFS=${OlD_IFS}
-     if [[ ! -z $tenant_name ]]; then
-       echo "INFO: start to close ${tenant_name} archive"
-       ${mysql_cmd} "ALTER SYSTEM NOARCHIVELOG TENANT=${tenant_name}"
-     fi
-   done
-fi
-
-
 # step 6===> check if backup jobs are successful and collect backup info for restore.
 tenantFile="tenantStatus.dp"
 unitSQLFile="create_unit.sql"
@@ -272,6 +286,7 @@ ${mysql_cmd} "select tenant_id, backup_set_id from oceanbase.CDB_OB_BACKUP_JOB_H
       tenantJson=$(buildJsonString "$tenantJson" "poolList" "${pool_list}")
       echo "{${tenantJson}}" >> ${tenantFile}
       saveEndTime "${res[5]}" "${res[6]}"
+      waitArchiveCheckpoint "${tenant_id}" "${tenantName}" "${res[5]}"
     done
 
     ${mysql_cmd} "SELECT r.name, u.name as unit_name, r.unit_count, r.zone_list FROM oceanbase.DBA_OB_RESOURCE_POOLS r, oceanbase.DBA_OB_UNIT_CONFIGS u where u.UNIT_CONFIG_ID = r.UNIT_CONFIG_ID and r.TENANT_ID=${tenant_id};" | while IFS=$'\t' read -a pool; do
@@ -280,8 +295,25 @@ ${mysql_cmd} "select tenant_id, backup_set_id from oceanbase.CDB_OB_BACKUP_JOB_H
     done
 done
 
+if [[ -f ${archiveCheckpointFailedFile} ]]; then
+   cat ${archiveCheckpointFailedFile}
+   exit 1
+fi
 
-# step 7===> get extras infos
+# step 7 ==> close tenant archive if the tenant did not have archive enabled before this backup.
+if [[ -f $noArchivedTenantsFiles ]]; then
+   IFS=$'\n'
+   for tenant_name in `cat $noArchivedTenantsFiles`; do
+     IFS=${OlD_IFS}
+     if [[ ! -z $tenant_name ]]; then
+       echo "INFO: start to close ${tenant_name} archive"
+       ${mysql_cmd} "ALTER SYSTEM NOARCHIVELOG TENANT=${tenant_name}"
+     fi
+   done
+fi
+
+
+# step 8===> get extras infos
 extras=""
 while IFS= read -r line; do
   IFS=$OlD_IFS
@@ -301,7 +333,7 @@ if [ -f ${endTimeInfoFile} ]; then
    fi
 fi
 
-# step 8===> save tenants info for restore and backup status
+# step 9===> save tenants info for restore and backup status
 datasafed push ${unitSQLFile} "/${unitSQLFile}"
 datasafed push ${resourcePoolSQLFile} "/${resourcePoolSQLFile}"
 TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')

--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -8,7 +8,8 @@ deferArchiveLogTenantsFiles="defer_archive_tenants.dp"
 archiveCheckpointFailedFile="archive_checkpoint_failed.dp"
 endTimeInfoFile="kb_end_time.info"
 
-mysql_cmd="mysql -u ${DP_DB_USER} -h ${DP_DB_HOST} -P${DP_DB_PORT} -p${DP_DB_PASSWORD} -N -e"
+detect_mysql_bin
+mysql_cmd="${OB_MYSQL_BIN} -u ${DP_DB_USER} -h ${DP_DB_HOST} -P${DP_DB_PORT} -p${DP_DB_PASSWORD} -N -e"
 OlD_IFS=$IFS
 time_zone_file="timezone.dp"
 archiveCheckpointTimeout="${ARCHIVE_CHECKPOINT_TIMEOUT_SECONDS:-600}"
@@ -271,7 +272,7 @@ ${mysql_cmd} "select tenant_id, backup_set_id from oceanbase.CDB_OB_BACKUP_JOB_H
       # record time zone
       userName="root"
       timezone_sql="select @@time_zone;"
-      mysql_tenant_cmd="mysql -u ${userName}@${tenantName} -h ${DP_DB_HOST} -P${DP_DB_PORT} -N -e"
+      mysql_tenant_cmd="${OB_MYSQL_BIN} -u ${userName}@${tenantName} -h ${DP_DB_HOST} -P${DP_DB_PORT} -N -e"
       # get time zone
       timeZone=$(${mysql_tenant_cmd} "${timezone_sql}")
       echo $(getTimeZoneOffset "${timeZone}") > ${time_zone_file}

--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -27,7 +27,7 @@ function saveEndTime() {
       return
     fi
     if [ -f $endTimeInfoFile ]; then
-       oldMinRestoreSCN=$(cat ${endTimeInfoFile} | jq -r ".minRestoreSCN" )
+       oldMinRestoreSCN=$(json_get minRestoreSCN "$(cat ${endTimeInfoFile})")
        [ $minRestoreSCN -gt ${oldMinRestoreSCN} ] && echo "{\"minRestoreSCN\":\"${minRestoreSCN}\",\"minRestoreTime\":\"${minRestoreTime}\"}" > ${endTimeInfoFile}
     else
        echo "{\"minRestoreSCN\":\"${minRestoreSCN}\",\"minRestoreTime\":\"${minRestoreTime}\"}" > ${endTimeInfoFile}
@@ -327,7 +327,7 @@ done < ${tenantFile}
 # get stop time
 STOP_TIME=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
 if [ -f ${endTimeInfoFile} ]; then
-   stop_scn=$(cat ${endTimeInfoFile} | jq -r ".minRestoreSCN")
+   stop_scn=$(json_get minRestoreSCN "$(cat ${endTimeInfoFile})")
    if [ "${stop_scn}" != "NULL" ]; then
       stop_timestamp=$((${stop_scn}/1000000000))
       STOP_TIME=$(date -d @$stop_timestamp -u "+%Y-%m-%dT%H:%M:%SZ")

--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -62,7 +62,11 @@ function prepareTenantLogArchive() {
   fi
   # enable dest
   echo "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
-  ${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
+  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"`
+  if [[ $? -ne 0 ]];then
+     echo "ERROR: enable log_archive_dest for tenant ${tenant_name} failed: ${result}"
+     exit 1
+  fi
   # add recovery window to auto-clean backup.
   #deletePolicyCount=`${mysql_cmd} "SELECT count(*) FROM oceanbase.CDB_OB_BACKUP_DELETE_POLICY where TENANT_ID=${tenant_id};" |awk -F '\t' '{print}'`
   #if [ $deletePolicyCount -eq 0 ]; then

--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -80,17 +80,14 @@ function prepareTenantLogArchive() {
   save_defer_archivelog_tenants "${tenant_id}"
   destUrl=$(getDestURL archive ${tenant_name} ${tenant_id})
   echo "INFO: prepare log archive dest for tenant ${tenant_name}"
-  # Cluster-wide ALTER SYSTEM SET LOG_ARCHIVE_DEST propagation can exceed the
-  # default ob_query_timeout (10s). Prefix SET SESSION ob_query_timeout=1000000000
-  # to match the idiom already used in restore.sh and bootstrap.sh.
-  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST=\"LOCATION=${destUrl}\" TENANT=${tenant_name};"`
+  result=`${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST=\"LOCATION=${destUrl}\" TENANT=${tenant_name};"`
   if [[ $? -ne 0 ]];then
      echo "ERROR: alert log_archive_dest for tenant ${tenant_name} failed: ${result}"
      exit 1
   fi
   # enable dest
   echo "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
-  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"`
+  result=`${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"`
   if [[ $? -ne 0 ]];then
      echo "ERROR: enable log_archive_dest for tenant ${tenant_name} failed: ${result}"
      exit 1
@@ -107,9 +104,7 @@ function prepareTenantDataBackup() {
   tenant_name=${1:?missing tenant name}
   destUrl=$(getDestURL data ${tenant_name})
   echo "INFO: prepare data backup dest for tenant ${tenant_name}"
-  # Same pattern as prepareTenantLogArchive: SET SESSION ob_query_timeout prefix
-  # (matches restore.sh / bootstrap.sh idiom).
-  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET DATA_BACKUP_DEST=\"${destUrl}\" TENANT=${tenant_name};"`
+  result=`${mysql_cmd} "ALTER SYSTEM SET DATA_BACKUP_DEST=\"${destUrl}\" TENANT=${tenant_name};"`
   if [[ $? -ne 0 ]];then
      echo "ERROR: alert data_backup_dest for tenant ${tenant_name} failed: ${result}"
      exit 1
@@ -184,7 +179,11 @@ ${mysql_cmd} "SELECT tenant_id, tenant_name,log_mode FROM oceanbase.DBA_OB_TENAN
   elif [[ "${status}" == "SUSPEND" ]]; then
       save_defer_archivelog_tenants "${tenant_id}"
       echo "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
-      ${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"
+      result=`${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST_STATE='ENABLE' TENANT=${tenant_name};"`
+      if [[ $? -ne 0 ]];then
+         echo "ERROR: enable log_archive_dest for suspended tenant ${tenant_name} failed: ${result}"
+         exit 1
+      fi
   fi
   # prepare tenant data backup test
   prepareTenantDataBackup $tenant_name

--- a/addons/oceanbase-ce/dataprotection/common-scripts.sh
+++ b/addons/oceanbase-ce/dataprotection/common-scripts.sh
@@ -7,6 +7,22 @@ region=
 endpoint=
 bucket=
 
+json_get() {
+  local key="$1"
+  echo "$2" | grep -o "\"${key}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | sed 's/.*:[[:space:]]*"\(.*\)"/\1/'
+}
+
+json_array_len() {
+  echo "$1" | grep -o '{' | wc -l | tr -d ' '
+}
+
+json_array_get() {
+  local idx="$1" key="$2"
+  local elem
+  elem=$(echo "$3" | grep -o '{[^}]*}' | sed -n "$((idx+1))p")
+  json_get "$key" "$elem"
+}
+
 OB_MYSQL_BIN=""
 detect_mysql_bin() {
   if [ -n "$OB_MYSQL_BIN" ]; then

--- a/addons/oceanbase-ce/dataprotection/common-scripts.sh
+++ b/addons/oceanbase-ce/dataprotection/common-scripts.sh
@@ -192,5 +192,14 @@ function getDestURL() {
   elif [[ ${host} = "oss"* ]]; then
      destPrefix="oss"
   fi
-  echo "${destPrefix}://${bucket}${destPath}/${tenantName}/${tenantId}?host=${host}&access_id=${access_key_id}&access_key=${secret_access_key}"
+  destUrl="${destPrefix}://${bucket}${destPath}/${tenantName}/${tenantId}?host=${host}&access_id=${access_key_id}&access_key=${secret_access_key}"
+  if [[ ${destPrefix} == "s3" ]]; then
+     storageRegion=${region:-${DP_STORAGE_REGION:-}}
+     if [[ -z ${storageRegion} ]]; then
+        echo "ERROR: s3_region is required for S3-compatible storage"
+        exit 1
+     fi
+     destUrl="${destUrl}&s3_region=${storageRegion}"
+  fi
+  echo "${destUrl}"
 }

--- a/addons/oceanbase-ce/dataprotection/common-scripts.sh
+++ b/addons/oceanbase-ce/dataprotection/common-scripts.sh
@@ -7,6 +7,21 @@ region=
 endpoint=
 bucket=
 
+OB_MYSQL_BIN=""
+detect_mysql_bin() {
+  if [ -n "$OB_MYSQL_BIN" ]; then
+    return
+  fi
+  for candidate in mysql /usr/bin/mysql obclient /u01/obclient/bin/obclient; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      OB_MYSQL_BIN="$candidate"
+      return
+    fi
+  done
+  echo "ERROR: no mysql-compatible client found (tried mysql, obclient)"
+  exit 1
+}
+
 # log info file
 function DP_log() {
     msg=$1

--- a/addons/oceanbase-ce/dataprotection/restore.sh
+++ b/addons/oceanbase-ce/dataprotection/restore.sh
@@ -116,9 +116,9 @@ function getRestoreFragment() {
       if [ -z "$line" ]; then
           continue
       fi
-      tenant=`echo ${line} | jq -r ".name"`
+      tenant=$(json_get name "$line")
       if [ "${tenant}" == "${tenantName}" ]; then
-          checkPointTime=`echo ${line} | jq -r ".checkPointTime"`
+          checkPointTime=$(json_get checkPointTime "$line")
           if [ $(date -d "${DP_RESTORE_TIME}" +%s) -gt $(date -d "${checkPointTime}" +%s) ]; then
             echo "TIME='$(date -d "${checkPointTime}" "+%Y-%m-%d %H:%M:%S")'"
             return
@@ -160,18 +160,18 @@ analysisToolConfig
 pullArchiveStatusFile
 # global_comp_index=$(echo $OB_COMPONENT_NAME | awk -F '-' '{print $(NF)}')
 extras=$(cat /dp_downward/status_extras)
-length=$(echo "$extras" | jq length)
+length=$(json_array_len "$extras")
 index=$((length-1))
 for i in $(seq 0 ${index}); do
   if [[ -f ${tenant_restored_signal} ]]; then
     echo "INFO: primary cluster has been restored, skip the restore process."
     continue
   fi
-  tenant_name=$(echo "$extras" | jq -r ".[${i}].name")
-  tenant_id=$(echo "$extras"  | jq -r ".[${i}].tenantId")
-  minRestoreSCN=$(echo "$extras"  | jq -r ".[${i}].minRestoreSCN")
-  poolList=$(echo "$extras"  | jq -r ".[${i}].poolList")
-  archivePath=$(echo "$extras"  | jq -r ".[${i}].archivePath")
+  tenant_name=$(json_array_get "$i" name "$extras")
+  tenant_id=$(json_array_get "$i" tenantId "$extras")
+  minRestoreSCN=$(json_array_get "$i" minRestoreSCN "$extras")
+  poolList=$(json_array_get "$i" poolList "$extras")
+  archivePath=$(json_array_get "$i" archivePath "$extras")
   uri="$(getDestURL data "${tenant_name}"),$(getDestURL restoreFromArchive "${tenant_name}" "${tenant_id}" "${archivePath}")"
   restoreFragment=$(getRestoreFragment "${tenant_name}" "${minRestoreSCN}")
   existing_role=$(${mysql_cmd} "SELECT tenant_role FROM oceanbase.DBA_OB_TENANTS WHERE tenant_name='${tenant_name}' AND tenant_type='USER';" 2>/dev/null | awk 'NF {print; exit}')

--- a/addons/oceanbase-ce/dataprotection/restore.sh
+++ b/addons/oceanbase-ce/dataprotection/restore.sh
@@ -173,9 +173,26 @@ for i in $(seq 0 ${index}); do
   archivePath=$(echo "$extras"  | jq -r ".[${i}].archivePath")
   uri="$(getDestURL data "${tenant_name}"),$(getDestURL restoreFromArchive "${tenant_name}" "${tenant_id}" "${archivePath}")"
   restoreFragment=$(getRestoreFragment "${tenant_name}" "${minRestoreSCN}")
+  existing_role=$(${mysql_cmd} "SELECT tenant_role FROM oceanbase.DBA_OB_TENANTS WHERE tenant_name='${tenant_name}' AND tenant_type='USER';" 2>/dev/null | awk 'NF {print; exit}')
+  if [[ -n "$existing_role" ]]; then
+    case "$existing_role" in
+      PRIMARY)
+        echo "INFO: tenant ${tenant_name} already PRIMARY, skipping RESTORE"
+        ;;
+      STANDBY)
+        echo "INFO: tenant ${tenant_name} already STANDBY (restore completed), skipping RESTORE"
+        ;;
+      RESTORE)
+        echo "INFO: tenant ${tenant_name} in RESTORE state, skipping RESTORE command"
+        ;;
+      *)
+        echo "ERROR: tenant ${tenant_name} exists with unexpected role '${existing_role}'"
+        exit 1
+        ;;
+    esac
+    continue
+  fi
   echo "INFO: start to restore tenant ${tenant_name} until ${restoreFragment}"
-  # TODO: check if the sql executed successfully. if restore time is over than actual time, it will failed.
-  # ERROR 4018 (HY000) at line 1: No enough log for restore
   restoreTenant "${tenant_name}" "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM RESTORE ${tenant_name} FROM '${uri}' UNTIL ${restoreFragment} WITH 'pool_list=${poolList}'"
   if [ $? -eq 1 ]; then
     exit 1

--- a/addons/oceanbase-ce/dataprotection/restore.sh
+++ b/addons/oceanbase-ce/dataprotection/restore.sh
@@ -13,11 +13,12 @@ primary_host="${OB_COMPONENT_NAME}-0.${SUBDOMAIN}"
 target_host="${primary_host}"
 
 
-primaryCmd="mysql -u root -P${DP_DB_PORT} -h ${primary_host} -p${OB_ROOT_PASSWD} -N -e"
+detect_mysql_bin
+primaryCmd="${OB_MYSQL_BIN} -u root -P${DP_DB_PORT} -h ${primary_host} -p${OB_ROOT_PASSWD} -N -e"
 
 echo "INFO: primary host: ${primary_host}, current pod host: ${DP_DB_HOST}, target host: ${target_host}"
 
-mysql_cmd="mysql -u root -P${DP_DB_PORT} -h ${target_host} -p${OB_ROOT_PASSWD} -N -e"
+mysql_cmd="${OB_MYSQL_BIN} -u root -P${DP_DB_PORT} -h ${target_host} -p${OB_ROOT_PASSWD} -N -e"
 
 OlD_IFS=$IFS
 

--- a/addons/oceanbase-ce/scripts/utils.sh
+++ b/addons/oceanbase-ce/scripts/utils.sh
@@ -130,10 +130,9 @@ function start_observer {
 
   # check if file exists
   if [ -f "/kb-config/oceanbase.conf" ]; then
-    echo "observer.conf.bin exists, start observer with existing configs"
-    customized_config=$(cat "/kb-config/oceanbase.conf" | sed 's/ \+/ /g' | tr '\n' ',')
-    # remove all spaces and the last comma
-    customized_config=$(echo "$customized_config"  | sed 's/,$//' | sed 's/^,//')
+    echo "KubeBlocks config found, applying customized configs"
+    customized_config=$(cat "/kb-config/oceanbase.conf" | sed 's/ *= */=/g' | tr '\n' ',')
+    customized_config=$(echo "$customized_config" | sed 's/,$//' | sed 's/^,//')
     echo "customized_config: $customized_config"
     default_configs=$customized_config
   fi

--- a/addons/oceanbase-ce/templates/_helpers.tpl
+++ b/addons/oceanbase-ce/templates/_helpers.tpl
@@ -168,6 +168,10 @@ Define image
 {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.metrics.repository }}
 {{- end -}}
 
+{{- define "oceanbase-ce.obtools.repository" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.obtools.repository }}
+{{- end -}}
+
 {{- define "oceanbase-ce.spec.vars" -}}
 vars:
 - name: OB_ROOT_PASSWD

--- a/addons/oceanbase-ce/templates/actionset.yaml
+++ b/addons/oceanbase-ce/templates/actionset.yaml
@@ -14,6 +14,8 @@ spec:
       value: rep_user
     - name: DP_TIME_FORMAT
       value: "2006-01-02 15:04:05"
+    - name: SUPPORT_S3
+      value: "true"
   backup:
     preBackup: []
     postBackup: []

--- a/addons/oceanbase-ce/templates/componentdefinition.yaml
+++ b/addons/oceanbase-ce/templates/componentdefinition.yaml
@@ -49,6 +49,18 @@ spec:
       - http
       - pprof
   runtime:
+    initContainers:
+      - name: init-obtools
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        command:
+          - sh
+          - -c
+          - |
+            cp /bin/ob-tools /kb_tools/obtools
+            chmod 0755 /kb_tools/obtools
+        volumeMounts:
+          - name: kb-tools
+            mountPath: /kb_tools
     containers:
       - name: observer-container
         command:
@@ -178,3 +190,5 @@ spec:
       - name: metricslog
         emptyDir:
           sizeLimit: 1Gi   # Can use Mi, Gi, Ti etc
+      - name: kb-tools
+        emptyDir: {}

--- a/addons/oceanbase-ce/templates/componentversion.yaml
+++ b/addons/oceanbase-ce/templates/componentversion.yaml
@@ -18,3 +18,4 @@ spec:
     images:
       observer-container: {{ include "oceanbase-ce.observer.repository" . }}:4.3.0.1-100000242024032211
       metrics: {{ include "oceanbase-ce.metrics.repository" . }}:4.2.1-100000092023101717
+      init-obtools: {{ include "oceanbase-ce.obtools.repository" . }}:4.2.1

--- a/addons/oceanbase-ce/templates/paramsdef-param.yaml
+++ b/addons/oceanbase-ce/templates/paramsdef-param.yaml
@@ -23,27 +23,24 @@ spec:
 
   ##  require db instance restart
   ## staticParameters
-  {{- if hasKey $pd "staticParameters" }}
+  {{- with get $pd "staticParameters" }}
   staticParameters:
-    {{- $params := get $pd "staticParameters" }}
-      {{- range $params }}
+      {{- range . }}
     - {{ . }}
       {{- end }}
   {{- end}}
 
-  {{- if hasKey $pd "dynamicParameters" }}
+  {{- with get $pd "dynamicParameters" }}
   dynamicParameters:
-    {{- $params := get $pd "dynamicParameters" }}
-      {{- range $params }}
+      {{- range . }}
     - {{ . }}
       {{- end }}
   {{- end}}
 
       ## define immutable parameter list, this feature is not currently supported.
-  {{- if hasKey $pd "immutableParameters" }}
+  {{- with get $pd "immutableParameters" }}
   immutableParameters:
-    {{- $params := get $pd "immutableParameters" }}
-      {{- range $params }}
+      {{- range . }}
     - {{ . }}
       {{- end }}
   {{- end}}

--- a/addons/oceanbase-ce/templates/paramsdef-sysvar.yaml
+++ b/addons/oceanbase-ce/templates/paramsdef-sysvar.yaml
@@ -24,27 +24,24 @@ spec:
 
   ##  require db instance restart
   ## staticParameters
-  {{- if hasKey $pd "staticParameters" }}
+  {{- with get $pd "staticParameters" }}
   staticParameters:
-    {{- $params := get $pd "staticParameters" }}
-    {{- range $params }}
+    {{- range . }}
     - {{ . }}
     {{- end }}
   {{- end}}
 
-  {{- if hasKey $pd "dynamicParameters" }}
+  {{- with get $pd "dynamicParameters" }}
   dynamicParameters:
-    {{- $params := get $pd "dynamicParameters" }}
-    {{- range $params }}
+    {{- range . }}
     - {{ . }}
     {{- end }}
   {{- end}}
 
       ## define immutable parameter list, this feature is not currently supported.
-  {{- if hasKey $pd "immutableParameters" }}
+  {{- with get $pd "immutableParameters" }}
   immutableParameters:
-    {{- $params := get $pd "immutableParameters" }}
-    {{- range $params }}
+    {{- range . }}
     - {{ . }}
     {{- end }}
   {{- end}}


### PR DESCRIPTION
## Summary

This PR unblocks the OceanBase CE addon on KubeBlocks main / 1.2 by fixing the backup/restore path and one install-time API compatibility issue.

Main observed failures:
- S3-compatible backup destination without `s3_region` made OceanBase return `ERROR 1210 (HY000): Invalid argument`. The same SQL passed after adding `s3_region=us-east-1`, so this PR includes `s3_region` in S3 backup destinations.
- Restore could start before archive logs had reached the backup restore point. The failing run showed restore point `1780331164552118709` while archive checkpoint was only `1780331094155951377`, then restore returned `ERROR 4018 (HY000): No enough log for restore`. This PR waits for the archive checkpoint before closing the backup.
- KubeBlocks main / 1.2 rejected `oceanbase-ce-sysvars-cc` because `spec.staticParameters: null` and `spec.immutableParameters: null` are not arrays. This PR stops rendering empty parameter lists as `null`.

Code hardening included:
- Backup now fails at the archive-enable step if `LOG_ARCHIVE_DEST_STATE='ENABLE'` returns nonzero. This is a code-contract fix, not a separately reproduced runtime failure.
- Backup/restore scripts auto-detect a usable SQL client, including `/u01/obclient/bin/obclient`, for the official OceanBase CE image path.
- DP scripts no longer require `jq`, reducing dependencies in backup/restore jobs.

## Boundary

- The earlier session-timeout change was removed because we do not have runtime evidence showing a specific SQL exceeded the default timeout.
- Snapshot is not covered here. IDC environments do not provide snapshot capability, so snapshot remains a skip boundary.
- This PR must merge before stacked PR #2723.

## Verification

Local after the latest commit:
- `bash -n addons/oceanbase-ce/dataprotection/backup.sh`
- `git diff --check`
- `helm template oceanbase-ce addons/oceanbase-ce`

Runtime validation was done on the stacked release candidate with PR #2723:
- Created clusters, wrote/read data, restarted/scaled, and ran backup/restore for 10 clean rounds.
- Then ran more than 24 hours of repeated full tests: 21 clean rounds.
- Each round cleaned its test resources.

CI was green before the latest push. New CI is running again after commit `b29026ccb5863912f9d562c3402e1f297575d007`.

## Related

- Backport PR: https://github.com/apecloud/kubeblocks-addons/pull/2715
- Stacked LTS PR: https://github.com/apecloud/kubeblocks-addons/pull/2723
- Tests PR with MinIO multi-round lane: https://github.com/apecloud/kubeblocks-tests/pull/144
