### PR TITLE
test(mariadb): lock replication mode contract wording

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2054,11 +2054,9 @@ version: 1.1.1-alpha.110
 #   primary/secondary (plus `standalone` and `galera` unchanged).
 #   `async` and `semisync` are NOT listed: Option B is a breaking
 #   change; users with old Cluster CRs must actively migrate to
-#   `spec.topology=replication` plus a ComponentSpec parameter
-#   `replicationMode: async | semisync`. Auto-rebind by KB on a
-#   topology compDef rename is exploratory (verified in upgrade
-#   gate N=1) and is NOT promised in release notes (Jack design
-#   Gate 6 / Blocker 4).
+#   `spec.topology=replication`. Auto-rebind by KB on a topology
+#   compDef rename is exploratory (verified in upgrade gate N=1) and
+#   is NOT promised in release notes (Jack design Gate 6 / Blocker 4).
 # - Adds a new CmpD `mariadb-replication-merged-1.1.1-alpha.89`.
 #   Initially a near-verbatim copy of cmpd-semisync.yaml (semisync
 #   already has the most resilience layers: alpha.85 PD, alpha.88
@@ -2069,12 +2067,11 @@ version: 1.1.1-alpha.110
 #   to the new CmpD via the narrow regex `^mariadb-replication-merged-`
 #   (Jack design Gate 3 / Blocker 3 — no double-match against
 #   standalone / galera / old async / old semisync PDs).
-# - replicationMode source-of-truth is ComponentSpec parameter
-#   `replicationMode`, written by the user into the Cluster CR and
-#   resolved by KB into ComponentParameter / engine config; Helm-time
-#   only provides global defaults (Jack design Gate 2 / Blocker 2 —
-#   no per-cluster Helm rendering of mode-specific defaults). The
-#   parameter wiring is added in a subsequent commit.
+# - replication mode source-of-truth is the install/render-time Helm
+#   value `mariadb.replication.mode`, wired to the merged CmpD as
+#   `MARIADB_REPLICATION_MODE`. The current chart deliberately does
+#   not expose any per-Cluster mode parameter named `replicationMode`;
+#   runtime mode flip via OpsRequest reconfigure is deferred.
 # - Old `cmpd-replication.yaml` and `cmpd-semisync.yaml` still render
 #   so that any Cluster CR still referencing those CmpDs by name does
 #   not get an "unresolved compDef" error during upgrade. They are

--- a/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
@@ -40,6 +40,18 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
     printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "$(repo_root)"
   }
 
+  clusterdefinition_path() {
+    printf "%s/addons/mariadb/templates/clusterdefinition.yaml" "$(repo_root)"
+  }
+
+  chart_yaml_path() {
+    printf "%s/addons/mariadb/Chart.yaml" "$(repo_root)"
+  }
+
+  helper_path() {
+    printf "%s/addons/mariadb/templates/_helpers.tpl" "$(repo_root)"
+  }
+
   Describe "values.yaml declares replication.mode with empty default"
     It "declares a top-level replication block"
       When call grep -E '^replication:' "$(values_path)"
@@ -56,6 +68,35 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
     End
   End
 
+  Describe "replication topology contract wording stays aligned with the actual implementation"
+    # API-doc / MySQL-addon comparison guard (Jack 2026-06-01):
+    # MySQL exposes semisync as an explicit topology, while MariaDB's
+    # merged replication CmpD currently selects async/semisync through
+    # the install-time Helm value below. Do not document this as a
+    # per-Cluster ComponentSpec parameter unless the chart actually
+    # implements that contract end-to-end.
+
+    It "ClusterDefinition documents mariadb.replication.mode as the current mode source"
+      When call grep -q 'mariadb\.replication\.mode' "$(clusterdefinition_path)"
+      The status should be success
+    End
+
+    It "ClusterDefinition does not claim replicationMode is a ComponentSpec parameter"
+      When call grep -Eq 'ComponentSpec parameter[[:space:]]+`?replicationMode|`replicationMode[^`]*`[[:space:]]+ComponentSpec parameter' "$(clusterdefinition_path)"
+      The status should be failure
+    End
+
+    It "Chart.yaml does not claim replicationMode is the ComponentSpec source of truth"
+      When call grep -Eq 'replicationMode source-of-truth is ComponentSpec parameter|ComponentSpec parameter[[:space:]]+`replicationMode`' "$(chart_yaml_path)"
+      The status should be failure
+    End
+
+    It "_helpers.tpl documents the merged mode as install/render-time rather than per-Cluster"
+      When call grep -q 'Current mode selection is install/render-time only' "$(helper_path)"
+      The status should be success
+    End
+  End
+
   Describe "cmpd-replication-merged.yaml wires MARIADB_REPLICATION_MODE env from Helm value"
     It "declares a MARIADB_REPLICATION_MODE env entry in the merged CmpD"
       When call grep -c 'name: MARIADB_REPLICATION_MODE' "$(cmpd_merged_path)"
@@ -68,10 +109,6 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
       The status should be success
       The output should equal "1"
     End
-
-    helper_path() {
-      printf "%s/addons/mariadb/templates/_helpers.tpl" "$(repo_root)"
-    }
 
     It "_helpers.tpl declares the mariadb.replication.mode.validate helper"
       When call grep -c 'define "mariadb\.replication\.mode\.validate"' "$(helper_path)"

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -129,9 +129,12 @@ Define mariadb-replication-merged component definition name.
 alpha.89 v1 (Helen 2026-05-19, Jack design review non-blocking
 clarification) — new CmpD for topology merge (weston 2026-05-19
 14:12 Option B). The merged CmpD consolidates the old
-`mariadb-replication` (async) and `mariadb-semisync` CmpDs into one,
-selected at runtime by a `replicationMode: async | semisync`
-ComponentSpec parameter rather than by topology name.
+`mariadb-replication` (async) and `mariadb-semisync` CmpDs into one.
+Current mode selection is install/render-time only: the Helm value
+`mariadb.replication.mode` is validated by
+`mariadb.replication.mode.validate` and wired to the merged CmpD as
+`MARIADB_REPLICATION_MODE`. The current chart does not expose any
+per-Cluster mode parameter named `replicationMode`.
 
 The new CmpD name is `mariadb-replication-merged-{ChartVersion}`.
 It still starts with `mariadb-replication-`, but disambiguation from

--- a/addons/mariadb/templates/clusterdefinition.yaml
+++ b/addons/mariadb/templates/clusterdefinition.yaml
@@ -15,9 +15,12 @@ spec:
       default: true
     # `replication` is the single canonical primary/secondary topology
     # (alpha.89 — topology merge under weston 2026-05-19 Option B
-    # msg `d8ecfae7`). The async vs semisync behavior is selected by
-    # a ComponentSpec parameter `replicationMode: async | semisync`,
-    # not by the topology name.
+    # msg `d8ecfae7`). The async vs semisync behavior is currently
+    # selected at addon install/render time by the Helm value
+    # `mariadb.replication.mode`, which is wired to
+    # `MARIADB_REPLICATION_MODE` on the merged CmpD. It is NOT a
+    # per-Cluster topology selector. The current chart does not expose
+    # any user-facing mode parameter named `replicationMode`.
     #
     # Breaking change relative to alpha.88: the old `async` /
     # `semisync` topology names are NOT listed here. Existing Cluster


### PR DESCRIPTION
## Summary
- correct MariaDB merged replication topology comments so they match the implemented install-time `mariadb.replication.mode` path
- remove stale wording that described `replicationMode` as a per-Cluster ComponentSpec parameter
- extend the existing replication mode ShellSpec to guard this contract wording from drifting again

## Review basis
- addon API: user-selectable deployment shape must be represented clearly by ClusterDefinition topology; comments must not imply a per-Cluster API that the chart does not implement
- MySQL comparison: MySQL exposes semisync as an explicit topology, while current MariaDB uses one `replication` topology with install/render-time mode wiring

## Validation
- `sh -n addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh`
- `git diff --check`
- grep-equivalent assertions for the new guard conditions
- `helm dependency build addons/mariadb`
- `helm template test addons/mariadb`

## Boundary
This is a contract/comment/static-test guard only. It does not change rendered runtime resources, does not validate live K8s, and does not prove MariaDB runtime acceptance. Runtime lifecycle fixes remain in the separate MariaDB alpha chain PRs.