### PR TITLE
mariadb: write .replication-pending marker on every memberJoin rc=1 path (close roleProbe stuck-initializing window)

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
@@ -781,6 +781,110 @@ EOF
     End
   End
 
+  Describe "setup_replication() rc=1 paths MUST write .replication-pending marker (regression guard for roleProbe stuck-initializing window)"
+    setup_pending_guard() {
+      rm -f "${TEST_DIR}/.replication-ready" "${TEST_DIR}/.replication-pending" "${TEST_DIR}/.replication-divergence-pending"
+    }
+    BeforeEach "setup_pending_guard"
+
+    Context "fresh-pod CHANGE MASTER + START IO failed"
+      It "writes .replication-pending before returning failure"
+        primary_sql() {
+          case "$*" in
+            *"gtid_binlog_pos"*) echo "0-1-100" ;;
+          esac
+        }
+        local_sql() {
+          case "$*" in
+            *"gtid_slave_pos;"*) echo "" ;;
+            *"STOP SLAVE"*) return 1 ;;
+            *) : ;;
+          esac
+        }
+        When call setup_replication
+        The status should be failure
+        The path "${TEST_DIR}/.replication-pending" should be exist
+        The stderr should include "phase: change-master-or-start-io-failed"
+      End
+    End
+
+    Context "rejoining-pod CHANGE MASTER failed"
+      It "writes .replication-pending before returning failure"
+        primary_sql() {
+          case "$*" in
+            *"gtid_binlog_pos"*) echo "0-1-200" ;;
+          esac
+        }
+        local_sql() {
+          case "$*" in
+            *"gtid_slave_pos;"*) echo "0-1-150" ;;
+            *"STOP SLAVE"*) return 1 ;;
+            *) : ;;
+          esac
+        }
+        When call setup_replication
+        The status should be failure
+        The path "${TEST_DIR}/.replication-pending" should be exist
+        The stderr should include "phase: change-master-failed"
+      End
+    End
+
+    Context "SHOW SLAVE STATUS empty after successful CHANGE MASTER"
+      It "writes .replication-pending before returning failure"
+        primary_sql() {
+          case "$*" in
+            *"gtid_binlog_pos"*) echo "0-1-300" ;;
+          esac
+        }
+        local_sql() {
+          case "$*" in
+            *"gtid_slave_pos;"*) echo "0-1-250" ;;
+            *"STOP SLAVE"*) : ;;
+            *"SHOW SLAVE STATUS"*) echo "" ;;
+            *) : ;;
+          esac
+        }
+        When call setup_replication
+        The status should be failure
+        The path "${TEST_DIR}/.replication-pending" should be exist
+        The stderr should include "phase: slave-config-not-persisted"
+      End
+    End
+  End
+
+  Describe "main() rc=1 paths MUST write .replication-pending marker (regression guard for roleProbe stuck-initializing window)"
+    setup_main_guard() {
+      rm -f "${TEST_DIR}/.replication-ready" "${TEST_DIR}/.replication-pending" "${TEST_DIR}/.replication-divergence-pending"
+    }
+    BeforeEach "setup_main_guard"
+
+    Context "MARIADB_CLI unavailable"
+      It "writes .replication-pending before returning failure"
+        export MARIADB_CLI=""
+        When call main
+        The status should be failure
+        The path "${TEST_DIR}/.replication-pending" should be exist
+        The stderr should include "phase: mariadb-cli-unavailable"
+      End
+    End
+
+    Context "probe_primary_or_defer fails"
+      It "writes .replication-pending before returning failure"
+        local_sql() {
+          case "$*" in
+            *"SHOW SLAVE STATUS"*) echo "" ;;
+            *) : ;;
+          esac
+        }
+        is_slave_running() { return 1; }
+        probe_primary_or_defer() { return 1; }
+        When call main
+        The status should be failure
+        The path "${TEST_DIR}/.replication-pending" should be exist
+      End
+    End
+  End
+
   Describe "PRIMARY_HOST default contract"
     Context "when CLUSTER_DOMAIN is overridden"
       It "builds PRIMARY_HOST from CLUSTER_DOMAIN"

--- a/addons/mariadb/scripts/replication-member-join.sh
+++ b/addons/mariadb/scripts/replication-member-join.sh
@@ -621,8 +621,21 @@ main() {
   # each invocation either (a) closes positively with rc=0 (replication observably
   # running) or (b) defers with rc=1 + classified diagnose on stderr. No in-process
   # polling — kbagent caps every call to 60s and re-fires on rc=1 retry=yes.
+  #
+  # roleProbe-marker contract for every rc=1 path in this function: write
+  # `.replication-pending` so roleProbe (`replication-roleprobe.sh`) has an
+  # explicit "pod still configuring" signal. Without the marker, roleProbe's
+  # `not_ready()` path returns rc=1 with stdout `initializing` for every
+  # invocation; controller ignores those events; pod label is never written;
+  # KB never advances Component to Running. The cluster stays Creating until
+  # a memberJoin invocation either reaches `mark_replication_ready` or a
+  # downstream marker write. If memberJoin keeps re-firing through this
+  # function's early rc=1 paths (MARIADB_CLI missing, probe defer) without
+  # writing `.replication-pending`, the pod stays in the no-marker limbo
+  # forever and Cluster never converges.
   if [ -z "${MARIADB_CLI}" ]; then
     echo "MariaDB client is unavailable in current memberJoin runtime."
+    mark_replication_pending
     replication_member_join_diagnose_not_ready \
       "mariadb-cli-unavailable" \
       "  reason: neither \`mariadb\` on PATH nor ${MYSQL_CLIENT_DIR}/bin/mariadb is executable in current memberJoin runtime" \
@@ -641,7 +654,13 @@ main() {
     return 0
   fi
 
-  probe_primary_or_defer || return 1
+  if ! probe_primary_or_defer; then
+    # probe_primary_or_defer already emitted its own diagnose stderr; we add
+    # the marker write so roleProbe has an explicit pending signal during the
+    # primary-service-not-yet-reachable window.
+    mark_replication_pending
+    return 1
+  fi
 
   # Guard: if the primary service routes to this pod, this pod IS the primary.
   # Do not configure replication — the startup command already handled it.

--- a/addons/mariadb/scripts/replication-member-join.sh
+++ b/addons/mariadb/scripts/replication-member-join.sh
@@ -511,6 +511,7 @@ CHANGE MASTER TO
 START SLAVE IO_THREAD;
 "; then
       echo "CHANGE MASTER TO or START SLAVE IO_THREAD failed. Keeping roleProbe pending."
+      mark_replication_pending
       replication_member_join_diagnose_not_ready \
         "change-master-or-start-io-failed" \
         "  branch: fresh-pod (empty gtid_slave_pos)
@@ -548,6 +549,7 @@ CHANGE MASTER TO
 START SLAVE;
 "; then
       echo "CHANGE MASTER TO failed. Keeping roleProbe pending."
+      mark_replication_pending
       replication_member_join_diagnose_not_ready \
         "change-master-failed" \
         "  branch: rejoining-pod (local gtid_slave_pos preserved)
@@ -559,6 +561,7 @@ START SLAVE;
   fi
   if [ -z "$(local_sql -e "SHOW SLAVE STATUS;" 2>/dev/null)" ]; then
     echo "CHANGE MASTER TO did not store slave config. Keeping roleProbe pending."
+    mark_replication_pending
     replication_member_join_diagnose_not_ready \
       "slave-config-not-persisted" \
       "  reason: SHOW SLAVE STATUS empty immediately after CHANGE MASTER TO" \


### PR DESCRIPTION
## Summary

addon-api 05a roleProbe contract review surfaced a convergence-blocking gap in `replication-member-join.sh`: rc=1 paths in both `main()` and `setup_replication()` do not consistently write `.replication-pending`, which lets the pod fall into a no-marker limbo where `replication-roleprobe.sh` cannot emit a usable role signal.

After peer review (3-team review per `autonomous-addon-development-loop` Rule 7 cosign cadence), v2 expands the fix to a full atomic sweep across all rc=1 paths plus a ShellSpec regression guard so the pattern cannot regress silently.

## The gap

`replication-roleprobe.sh` uses filesystem markers as the authority during bootstrap:

- `.replication-ready` present → publish `secondary` or `primary` based on `master.info`.
- `.replication-pending` present → `not_ready()` with stdout `initializing` + rc=1 (controller treats as "still configuring", waits for next probe).
- **Neither marker present** → same `not_ready()` branch → `initializing` rc=1 → controller ignores the event.

If memberJoin retries through any rc=1 path without writing `.replication-pending`, the pod stays in the no-marker limbo: roleProbe events are ignored every cycle, pod label is never written, Component never advances to Running, Cluster stays Creating until memberJoin reaches a marker write or fails permanently.

## Mechanism alignment with recent fresh-create convergence failures

Recent fresh-create attempts saw clusters stuck Creating for the entire runner budget before timeout. Mechanism that matches:

1. New pod starts; `PRIMARY_HOST` service has no endpoint yet.
2. memberJoin runs `probe_primary_or_defer` → returns 1 retry=yes (correct single-shot bootstrap-or-defer behavior).
3. memberJoin exits 1 without writing `.replication-pending`.
4. roleProbe sees no markers → `initializing` rc=1 → ignored.
5. kbagent re-fires memberJoin → steps 2-4 repeat.
6. Cluster stays Creating indefinitely.

Same shape applies to the other rc=1 paths in `setup_replication`: a SQL execution failure inside `CHANGE MASTER TO + START SLAVE` leaves the script in the same no-marker exit state.

## Fix scope

After this PR, every rc=1 path in both `main()` and `setup_replication()` writes one of:

- `mark_replication_pending` (most paths)
- `mark_replication_divergence_pending` (only the GTID-divergence-confirmed path; written inside `fail_closed_for_gtid_divergence`)

### `main()` rc=1 paths (both newly fixed)

| path | marker write added |
|---|---|
| `MARIADB_CLI` unavailable | `mark_replication_pending` before diagnose + return 1 |
| `probe_primary_or_defer` fail | one-liner `|| return 1` converted to explicit if-block that writes `mark_replication_pending` before return 1 |

### `setup_replication()` rc=1 paths (3 newly fixed in v2; others already covered)

| path | v2 change |
|---|---|
| `fail_closed_for_gtid_divergence` returns truthy | unchanged — called function writes divergence marker internally |
| fresh-pod `CHANGE MASTER + START SLAVE IO_THREAD` failed | **added `mark_replication_pending`** |
| fresh-pod `prepare_fresh_replica_for_sql_thread_start` failed | unchanged — called function writes marker internally |
| fresh-pod `START SLAVE SQL_THREAD` failed | unchanged — marker already inline |
| rejoining-pod `CHANGE MASTER + START SLAVE` failed | **added `mark_replication_pending`** |
| `SHOW SLAVE STATUS` empty after CHANGE MASTER | **added `mark_replication_pending`** |
| GTID 1950 out-of-order transient | unchanged — marker already inline |
| slave-not-yet-ready-for-rejoin fallback | unchanged — marker already inline |

## ShellSpec regression guard (v2)

Two new `Describe` blocks (`setup_replication() rc=1 paths MUST write .replication-pending marker` + `main() rc=1 paths MUST write .replication-pending marker`) with 5 test cases that assert each rc=1 path writes `.replication-pending` on failure. Future PRs adding a new rc=1 path without the marker write will fail these tests.

## Behavior delta

- Every rc=1 path through `main()` and `setup_replication()` now writes `.replication-pending` (directly or via the called function's internal write).
- No rc=0 path is touched.
- No SQL change, no grant change, no CmpD spec change, no chart watchdog change.

## addon-api contract anchor

`docs/addon-api/05a-lifecycle-roles-and-probe.md`:

> `memberJoin` 和 `memberLeave` 要能重复执行或安全失败，且不要依赖可能已删除的 peer service。

The safely-fail half requires roleProbe to remain in a consistent observable state across memberJoin rc=1 invocations. This PR closes the gap that violated that contract.

## Test plan

- [x] `bash -n` on script + spec PASS
- [ ] CI: shell-check + chart helm-check + shellspec (auto-runs on push). New regression-guard ShellSpec asserts marker write on all 5 rc=1 paths.
- [ ] Integration-deploy verification: rerun the recent Phase 3 retest scenario on the development branch candidate package after this PR self-merges. Expect cluster to reach Running within the normal create budget instead of stuck Creating until timeout.

## Self-merge

Per `autonomous-addon-development-loop` Rule 7, this is a child PR with base = `feat/mariadb-alpha37-semisync-fencing-pr` (development branch). After 3-team cosign closes, self-merge into the development branch. Final merge of the development branch into target (release/main) goes through integration owner.
