### PR TITLE
mariadb: alpha.115 — fix passwordGenerationPolicy.numDigits violating CRD Maximum=8 (surfaced by alpha.114 first live deploy)

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1937,7 +1937,46 @@ type: application
 # cmpd files; rendered systemAccounts blocks verified per topology.
 # IDC vcluster live verification deferred to next alpha-cycle deploy
 # alongside PR #2701 / .112 / .113.
-version: 1.1.1-alpha.114
+#
+# alpha.115 v1 (Helen 2026-06-01 — schema validation hotfix surfaced by
+# IDC vcluster first live deploy of the alpha.114 Path C systemAccount
+# declarations).
+#
+# Problem: alpha.114 declared `kb_internal_root` and `kb_replicator`
+# with `passwordGenerationPolicy.numDigits: 16`. KubeBlocks
+# ComponentDefinition CRD constrains `numDigits` to `Maximum=8`
+# (per `apis/apps/v1/types.go:443-449` `+kubebuilder:validation:Maximum=8`).
+# `helm template` only renders the chart; CRD validation runs on the
+# controller side when the ComponentDefinition object is applied. The
+# alpha.114 ShellSpec render gate (kubeblocks-tests PR #135) and the
+# author's own `helm template` checks therefore did not catch the
+# constraint; the constraint surfaced at first live `helm upgrade`
+# against an IDC vcluster as:
+#
+#     ComponentDefinition.apps.kubeblocks.io "mariadb-replication-merged-
+#     1.1.1-alpha.114" is invalid:
+#     [spec.systemAccounts[1].passwordGenerationPolicy.numDigits: Invalid
+#     value: 16: ... should be less than or equal to 8,
+#      spec.systemAccounts[2].passwordGenerationPolicy.numDigits: Invalid
+#     value: 16: ... should be less than or equal to 8]
+#
+# Fix: change `numDigits: 16` → `numDigits: 8` at the 3 occurrences in
+# `_helpers.tpl` (`mariadb.semisync.spec.systemAccounts`
+# kb_internal_root and kb_replicator entries, and
+# `mariadb.standalone.spec.systemAccounts` kb_internal_root entry).
+# `length: 32` is preserved (Maximum=32 per the same struct).
+# `numSymbols: 0` is already within Maximum=8.
+#
+# No SQL change. No CmpD spec change beyond the field value adjustment.
+# No script change. No watchdog change.
+#
+# Lesson captured for the code-review cycle catalog: addon-side
+# `helm template` + ShellSpec render gates do NOT validate CRD schema
+# constraints. Any new value placed on a CRD-validated field must be
+# cross-checked against the corresponding `+kubebuilder:validation:*`
+# annotation in `apis/apps/v1/`. The "value within shape" check is a
+# separate review dimension from "field shape is correct".
+version: 1.1.1-alpha.115
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -862,14 +862,14 @@ systemAccounts:
     initAccount: true
     passwordGenerationPolicy:
       length: 32
-      numDigits: 16
+      numDigits: 8
       numSymbols: 0
       letterCase: MixedCases
   - name: kb_replicator
     initAccount: true
     passwordGenerationPolicy:
       length: 32
-      numDigits: 16
+      numDigits: 8
       numSymbols: 0
       letterCase: MixedCases
 {{- end -}}
@@ -890,7 +890,7 @@ systemAccounts:
     initAccount: true
     passwordGenerationPolicy:
       length: 32
-      numDigits: 16
+      numDigits: 8
       numSymbols: 0
       letterCase: MixedCases
 {{- end -}}


### PR DESCRIPTION
## Summary

Hotfix child PR for alpha.114 Path C systemAccount declarations. Surfaced by IDC vcluster first live deploy of alpha.114: `passwordGenerationPolicy.numDigits: 16` violates KubeBlocks ComponentDefinition CRD `+kubebuilder:validation:Maximum=8` constraint.

`helm template` rendering does not enforce CRD validation; constraint surfaces only at live `helm upgrade` against an actual KB controller.

## Failure observed at live deploy

```
ComponentDefinition.apps.kubeblocks.io "mariadb-replication-merged-1.1.1-alpha.114" is invalid:
[spec.systemAccounts[1].passwordGenerationPolicy.numDigits: Invalid value: 16: ... should be less than or equal to 8,
 spec.systemAccounts[2].passwordGenerationPolicy.numDigits: Invalid value: 16: ... should be less than or equal to 8]
```

## Fix

3 occurrences in `_helpers.tpl`, `numDigits: 16 → 8`:
- `mariadb.semisync.spec.systemAccounts` kb_internal_root
- `mariadb.semisync.spec.systemAccounts` kb_replicator
- `mariadb.standalone.spec.systemAccounts` kb_internal_root

`length: 32` preserved (Maximum=32). `numSymbols: 0` unchanged (Maximum=8).

No SQL change. No CmpD shape change. No script change. No watchdog change. Chart.yaml bump alpha.114 → alpha.115 plus comment block documenting the lesson.

## Lesson

addon-side `helm template` and ShellSpec render gates do not validate CRD schema constraints. Any new value placed on a CRD-validated field must be cross-checked against the corresponding `+kubebuilder:validation:*` annotation in `apis/apps/v1/`. The "value within shape" check is a separate review dimension from "field shape is correct" — the alpha.114 cosign cycle verified `credentialVarRef` field shape against `componentdefinition_types.go` but did not cross-walk `PasswordConfig` field-value constraints (`types.go:443-449` `Maximum=8`).

## Test plan

- [x] `helm dependency build` PASS
- [x] `helm template` PASS for all 5 cmpd files; rendered `numDigits = 8` verified in semisync + replication-merged + standalone systemAccounts blocks; replication + galera unchanged (no kb_internal_root / kb_replicator declared there)
- [ ] CI: chart helm-check + shellspec (auto-runs on push)
- [ ] IDC vcluster live `helm upgrade` from alpha.111 → alpha.115 PASS (the failure mode this hotfix addresses; verification driven by parallel live-test lane)

## Self-merge

Per `autonomous-addon-development-loop` Rule 7, this is a child PR with base = `feat/mariadb-alpha37-semisync-fencing-pr` (development branch). After 3-team cosign, self-merge into the development branch.