### PR TITLE
chore(zookeeper): render dynamic config on hscale

### DIFF
--- a/addons/zookeeper/README.md
+++ b/addons/zookeeper/README.md
@@ -114,6 +114,18 @@ kubectl apply -f examples/zookeeper/cluster.yaml
 
 ### Horizontal scaling
 
+The Zookeeper component supports 1 to 6 replicas. Pods whose ordinal is `0`,
+`1`, or `2` are rendered and joined as voting `participant` members; ordinals
+`3` and above are rendered and joined as non-voting `observer` members.
+
+> [!NOTE]
+> For clusters created with older chart revisions that marked
+> `zookeeper-dynamic-config` as externally managed, verify the live Component
+> no longer carries a Component-level external config override before relying on
+> this chart's generated dynamic config during horizontal scaling. If such an
+> override remains, remove that stale override or recreate the Component through
+> the upgraded chart before treating horizontal scaling as validated.
+
 #### Scale-out
 
 Horizontal scaling out cluster by adding ONE more `OBSERVER` replica:

--- a/addons/zookeeper/config/zookeeper-dynamic.tpl
+++ b/addons/zookeeper/config/zookeeper-dynamic.tpl
@@ -5,7 +5,7 @@
   {{- $name := index (splitList "." $fqdn) 0 }}
   {{- $tokens := splitList "-" $name }}
   {{- $ordinal := index $tokens (sub (len $tokens) 1) }}
-  {{- if ge $i 3 }}
+  {{- if ge (int $ordinal) 3 }}
     {{- printf "server.%s=%s:2888:3888:observer\n" $ordinal $fqdn }}
   {{- else }}
     {{- printf "server.%s=%s:2888:3888:participant\n" $ordinal $fqdn }}

--- a/addons/zookeeper/scripts-ut-spec/member_join_spec.sh
+++ b/addons/zookeeper/scripts-ut-spec/member_join_spec.sh
@@ -78,4 +78,16 @@ EOF
     The status should be success
     The stdout should include "ZooKeeper member server.3 already exists"
   End
+
+  It "classifies non-contiguous ordinal 4 as an observer"
+    export KB_JOIN_MEMBER_POD_NAME="zookeeper-4"
+    export KB_JOIN_MEMBER_POD_FQDN="zookeeper-4.zookeeper-headless.default.svc.cluster.local"
+    export ZKCLI_GET_OUTPUT="server.0=zookeeper-0.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.2=zookeeper-2.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181"
+    export ZKCLI_GET_OUTPUT_2="server.0=zookeeper-0.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.2=zookeeper-2.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.4=zookeeper-4.zookeeper-headless.default.svc.cluster.local:2888:3888:observer;2181"
+
+    When run command bash ../scripts/member_join.sh
+    The status should be success
+    The stdout should include "Adding ZooKeeper member: server.4=zookeeper-4.zookeeper-headless.default.svc.cluster.local:2888:3888:observer;2181"
+    The stdout should include "ZooKeeper member server.4 added"
+  End
 End

--- a/addons/zookeeper/scripts-ut-spec/member_join_spec.sh
+++ b/addons/zookeeper/scripts-ut-spec/member_join_spec.sh
@@ -1,0 +1,81 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "member_join_spec.sh skip cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "ZooKeeper Member Join Script Tests"
+  setup_mock_zkcli() {
+    mock_bin_dir="$(mktemp -d)"
+    zkcli_call_file="$mock_bin_dir/zkcli.calls"
+    cat > "$mock_bin_dir/zkCli.sh" << 'EOF'
+#!/bin/bash
+set -euo pipefail
+
+call_file="${ZKCLI_CALL_FILE}"
+count=0
+if [ -f "$call_file" ]; then
+  count="$(cat "$call_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$call_file"
+
+input="$(cat)"
+if grep -q "get /zookeeper/config" <<< "$input"; then
+  if [ "$count" -eq 1 ]; then
+    printf '%b\n' "${ZKCLI_GET_OUTPUT:-}"
+  else
+    printf '%b\n' "${ZKCLI_GET_OUTPUT_2:-${ZKCLI_GET_OUTPUT:-}}"
+  fi
+  exit "${ZKCLI_GET_RC:-0}"
+fi
+
+if grep -q "reconfig -add" <<< "$input"; then
+  printf '%b\n' "${ZKCLI_RECONFIG_OUTPUT:-Committed new configuration}"
+  exit "${ZKCLI_RECONFIG_RC:-0}"
+fi
+
+printf '%b\n' "${ZKCLI_OTHER_OUTPUT:-OK}"
+EOF
+    chmod +x "$mock_bin_dir/zkCli.sh"
+    export PATH="$mock_bin_dir:$PATH"
+    export ZKCLI_CALL_FILE="$zkcli_call_file"
+    export ZK_ADMIN_USER="admin"
+    export ZK_ADMIN_PASSWORD="password"
+  }
+
+  cleanup_mock_zkcli() {
+    rm -rf "$mock_bin_dir"
+    unset mock_bin_dir zkcli_call_file ZKCLI_CALL_FILE
+    unset ZKCLI_GET_OUTPUT ZKCLI_GET_OUTPUT_2 ZKCLI_GET_RC
+    unset ZKCLI_RECONFIG_OUTPUT ZKCLI_RECONFIG_RC ZKCLI_OTHER_OUTPUT
+    unset ZK_ADMIN_USER ZK_ADMIN_PASSWORD
+    unset KB_JOIN_MEMBER_POD_NAME KB_JOIN_MEMBER_POD_FQDN
+  }
+
+  BeforeEach "setup_mock_zkcli"
+  AfterEach "cleanup_mock_zkcli"
+
+  It "does not treat same endpoint with wrong member type as already joined"
+    export KB_JOIN_MEMBER_POD_NAME="zookeeper-3"
+    export KB_JOIN_MEMBER_POD_FQDN="zookeeper-3.zookeeper-headless.default.svc.cluster.local"
+    export ZKCLI_GET_OUTPUT="server.0=zookeeper-0.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.3=zookeeper-3.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181"
+
+    When run command bash ../scripts/member_join.sh
+    The status should be failure
+    The stdout should include "Adding ZooKeeper member: server.3="
+    The stderr should include "already exists with a different endpoint or member type"
+  End
+
+  It "accepts an exact target member state as already joined"
+    export KB_JOIN_MEMBER_POD_NAME="zookeeper-3"
+    export KB_JOIN_MEMBER_POD_FQDN="zookeeper-3.zookeeper-headless.default.svc.cluster.local"
+    export ZKCLI_GET_OUTPUT="server.0=zookeeper-0.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.3=zookeeper-3.zookeeper-headless.default.svc.cluster.local:2888:3888:observer;2181"
+
+    When run command bash ../scripts/member_join.sh
+    The status should be success
+    The stdout should include "ZooKeeper member server.3 already exists"
+  End
+End

--- a/addons/zookeeper/scripts-ut-spec/member_join_spec.sh
+++ b/addons/zookeeper/scripts-ut-spec/member_join_spec.sh
@@ -79,6 +79,16 @@ EOF
     The stdout should include "ZooKeeper member server.3 already exists"
   End
 
+  It "accepts ZooKeeper-normalized client address as already joined"
+    export KB_JOIN_MEMBER_POD_NAME="zookeeper-3"
+    export KB_JOIN_MEMBER_POD_FQDN="zookeeper-3.zookeeper-headless.default.svc.cluster.local"
+    export ZKCLI_GET_OUTPUT="server.0=zookeeper-0.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.3=zookeeper-3.zookeeper-headless.default.svc.cluster.local:2888:3888:observer;0.0.0.0:2181"
+
+    When run command bash ../scripts/member_join.sh
+    The status should be success
+    The stdout should include "ZooKeeper member server.3 already exists"
+  End
+
   It "classifies non-contiguous ordinal 4 as an observer"
     export KB_JOIN_MEMBER_POD_NAME="zookeeper-4"
     export KB_JOIN_MEMBER_POD_FQDN="zookeeper-4.zookeeper-headless.default.svc.cluster.local"

--- a/addons/zookeeper/scripts-ut-spec/member_leave_spec.sh
+++ b/addons/zookeeper/scripts-ut-spec/member_leave_spec.sh
@@ -1,0 +1,81 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "member_leave_spec.sh skip cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "ZooKeeper Member Leave Script Tests"
+  setup_mock_zkcli() {
+    mock_bin_dir="$(mktemp -d)"
+    zkcli_call_file="$mock_bin_dir/zkcli.calls"
+    cat > "$mock_bin_dir/zkCli.sh" << 'EOF'
+#!/bin/bash
+set -euo pipefail
+
+call_file="${ZKCLI_CALL_FILE}"
+count=0
+if [ -f "$call_file" ]; then
+  count="$(cat "$call_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$call_file"
+
+input="$(cat)"
+if grep -q "get /zookeeper/config" <<< "$input"; then
+  if [ "$count" -eq 1 ]; then
+    printf '%b\n' "${ZKCLI_GET_OUTPUT:-}"
+  else
+    printf '%b\n' "${ZKCLI_GET_OUTPUT_2:-${ZKCLI_GET_OUTPUT:-}}"
+  fi
+  exit "${ZKCLI_GET_RC:-0}"
+fi
+
+if grep -q "reconfig -remove" <<< "$input"; then
+  printf '%b\n' "${ZKCLI_RECONFIG_OUTPUT:-Committed new configuration}"
+  exit "${ZKCLI_RECONFIG_RC:-0}"
+fi
+
+printf '%b\n' "${ZKCLI_OTHER_OUTPUT:-OK}"
+EOF
+    chmod +x "$mock_bin_dir/zkCli.sh"
+    export PATH="$mock_bin_dir:$PATH"
+    export ZKCLI_CALL_FILE="$zkcli_call_file"
+    export ZK_ADMIN_USER="admin"
+    export ZK_ADMIN_PASSWORD="password"
+  }
+
+  cleanup_mock_zkcli() {
+    rm -rf "$mock_bin_dir"
+    unset mock_bin_dir zkcli_call_file ZKCLI_CALL_FILE
+    unset ZKCLI_GET_OUTPUT ZKCLI_GET_OUTPUT_2 ZKCLI_GET_RC
+    unset ZKCLI_RECONFIG_OUTPUT ZKCLI_RECONFIG_RC ZKCLI_OTHER_OUTPUT
+    unset ZK_ADMIN_USER ZK_ADMIN_PASSWORD
+    unset KB_LEAVE_MEMBER_POD_NAME
+  }
+
+  BeforeEach "setup_mock_zkcli"
+  AfterEach "cleanup_mock_zkcli"
+
+  It "fails closed when ZooKeeper config read returns NoAuth instead of dynamic config"
+    export KB_LEAVE_MEMBER_POD_NAME="zookeeper-3"
+    export ZKCLI_GET_OUTPUT="KeeperErrorCode = NoAuth for /zookeeper/config"
+
+    When run command bash ../scripts/member_leave.sh
+    The status should be failure
+    The stdout should include "Removing ZooKeeper member: server.3"
+    The stderr should include "invalid ZooKeeper dynamic config output"
+    The stderr should include "NoAuth"
+    The stdout should not include "already absent"
+  End
+
+  It "keeps already absent idempotence only after a valid dynamic config read"
+    export KB_LEAVE_MEMBER_POD_NAME="zookeeper-3"
+    export ZKCLI_GET_OUTPUT="server.0=zookeeper-0.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181\nserver.1=zookeeper-1.zookeeper-headless.default.svc.cluster.local:2888:3888:participant;2181"
+
+    When run command bash ../scripts/member_leave.sh
+    The status should be success
+    The stdout should include "ZooKeeper member server.3 is already absent"
+  End
+End

--- a/addons/zookeeper/scripts/member_join.sh
+++ b/addons/zookeeper/scripts/member_join.sh
@@ -12,6 +12,7 @@ member_type="participant"
 if [ "$new_member_index" -ge 3 ]; then
     member_type="observer"
 fi
+server_peer_entry="server.${new_member_index}=${new_member_fqdn}:2888:3888:${member_type}"
 server_entry="server.${new_member_index}=${new_member_fqdn}:2888:3888:${member_type};2181"
 
 echo "Adding ZooKeeper member: $server_entry"
@@ -50,10 +51,11 @@ member_index_exists() {
 }
 
 member_target_exists() {
-    awk -v entry="$server_entry" '
+    awk -v peer_entry="$server_peer_entry" '
       {
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-        if ($0 == entry) {
+        split($0, parts, ";")
+        if (parts[1] == peer_entry) {
           found = 1
         }
       }

--- a/addons/zookeeper/scripts/member_join.sh
+++ b/addons/zookeeper/scripts/member_join.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ -z "${KB_JOIN_MEMBER_POD_NAME:-}" ] || [ -z "${KB_JOIN_MEMBER_POD_FQDN:-}" ]; then
-    echo "ERROR: KB_JOIN_MEMBER_POD_NAME and KB_JOIN_MEMBER_POD_FQDN are required"
+    echo "ERROR: KB_JOIN_MEMBER_POD_NAME and KB_JOIN_MEMBER_POD_FQDN are required" >&2
     exit 1
 fi
 
@@ -16,11 +16,33 @@ server_entry="server.${new_member_index}=${new_member_fqdn}:2888:3888:${member_t
 
 echo "Adding ZooKeeper member: $server_entry"
 
-get_dynamic_config() {
-    zkCli.sh << EOF
+get_dynamic_config_or_die() {
+    local output
+    if ! output="$(zkCli.sh << EOF
 addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
 get /zookeeper/config
 EOF
+)"; then
+        echo "ERROR: failed to read ZooKeeper dynamic config" >&2
+        return 1
+    fi
+
+    if [ -z "$output" ]; then
+        echo "ERROR: invalid ZooKeeper dynamic config output: empty response" >&2
+        return 1
+    fi
+
+    if grep -Eiq "KeeperErrorCode|Exception|NoAuth|AuthFailed|ConnectionLoss|SessionExpired|Connection refused|Unable to connect" <<< "$output"; then
+        echo "ERROR: invalid ZooKeeper dynamic config output: $output" >&2
+        return 1
+    fi
+
+    if ! grep -Eq "^[[:space:]]*server\\.[0-9]+=" <<< "$output"; then
+        echo "ERROR: invalid ZooKeeper dynamic config output: missing server.N entries" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$output"
 }
 
 member_index_exists() {
@@ -28,10 +50,18 @@ member_index_exists() {
 }
 
 member_target_exists() {
-    grep -Fq "server.${new_member_index}=${new_member_fqdn}:"
+    awk -v entry="$server_entry" '
+      {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+        if ($0 == entry) {
+          found = 1
+        }
+      }
+      END { exit found ? 0 : 1 }
+    '
 }
 
-current_config="$(get_dynamic_config)"
+current_config="$(get_dynamic_config_or_die)"
 
 if member_target_exists <<< "$current_config"; then
     echo "ZooKeeper member server.${new_member_index} already exists"
@@ -39,7 +69,7 @@ if member_target_exists <<< "$current_config"; then
 fi
 
 if member_index_exists <<< "$current_config"; then
-    echo "ERROR: ZooKeeper member server.${new_member_index} already exists with a different endpoint"
+    echo "ERROR: ZooKeeper member server.${new_member_index} already exists with a different endpoint or member type" >&2
     exit 1
 fi
 
@@ -48,9 +78,9 @@ addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
 reconfig -add $server_entry
 EOF
 
-updated_config="$(get_dynamic_config)"
+updated_config="$(get_dynamic_config_or_die)"
 if ! member_target_exists <<< "$updated_config"; then
-    echo "ERROR: ZooKeeper member server.${new_member_index} was not observed after reconfig -add"
+    echo "ERROR: ZooKeeper member server.${new_member_index} was not observed after reconfig -add" >&2
     exit 1
 fi
 

--- a/addons/zookeeper/scripts/member_join.sh
+++ b/addons/zookeeper/scripts/member_join.sh
@@ -8,7 +8,11 @@ fi
 
 new_member_index="${KB_JOIN_MEMBER_POD_NAME##*-}"
 new_member_fqdn="$KB_JOIN_MEMBER_POD_FQDN"
-server_entry="server.${new_member_index}=${new_member_fqdn}:2888:3888:participant;2181"
+member_type="participant"
+if [ "$new_member_index" -ge 3 ]; then
+    member_type="observer"
+fi
+server_entry="server.${new_member_index}=${new_member_fqdn}:2888:3888:${member_type};2181"
 
 echo "Adding ZooKeeper member: $server_entry"
 

--- a/addons/zookeeper/scripts/member_join.sh
+++ b/addons/zookeeper/scripts/member_join.sh
@@ -1,22 +1,53 @@
 #!/bin/bash
+set -euo pipefail
 
-# ZOOKEEPER_POD_FQDN_LIST eg:  zk-zookeeper-0.zk-zookeeper-headless.default.svc.cluster.local,zk-zookeeper-1.zk-zookeeper-headless.default.svc.cluster.local
-zk_member_fqdns=${ZOOKEEPER_POD_FQDN_LIST//,/ }
-for member in $zk_member_fqdns; do
-    # if member contains CURRENT_POD_NAME
-    if [[ $member == *"$KB_AGENT_POD_NAME"* ]]; then
-        zk_current_member_fqdn=$member
-    fi
-done
-
-if [ -z "$zk_current_member_fqdn" ]; then
-    echo "ERROR: Could not find current pod FQDN in ZOOKEEPER_POD_FQDN_LIST"
+if [ -z "${KB_JOIN_MEMBER_POD_NAME:-}" ] || [ -z "${KB_JOIN_MEMBER_POD_FQDN:-}" ]; then
+    echo "ERROR: KB_JOIN_MEMBER_POD_NAME and KB_JOIN_MEMBER_POD_FQDN are required"
     exit 1
-else
-    echo "Current pod FQDN: $zk_current_member_fqdn"
-    current_member_index=${KB_AGENT_POD_NAME##*-}
-    zkCli.sh << EOF
-        addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
-        reconfig -add server.${current_member_index}=$zk_current_member_fqdn:2888:3888:participant;2181
-EOF
 fi
+
+new_member_index="${KB_JOIN_MEMBER_POD_NAME##*-}"
+new_member_fqdn="$KB_JOIN_MEMBER_POD_FQDN"
+server_entry="server.${new_member_index}=${new_member_fqdn}:2888:3888:participant;2181"
+
+echo "Adding ZooKeeper member: $server_entry"
+
+get_dynamic_config() {
+    zkCli.sh << EOF
+addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
+get /zookeeper/config
+EOF
+}
+
+member_index_exists() {
+    grep -Eq "^[[:space:]]*server\\.${new_member_index}="
+}
+
+member_target_exists() {
+    grep -Fq "server.${new_member_index}=${new_member_fqdn}:"
+}
+
+current_config="$(get_dynamic_config)"
+
+if member_target_exists <<< "$current_config"; then
+    echo "ZooKeeper member server.${new_member_index} already exists"
+    exit 0
+fi
+
+if member_index_exists <<< "$current_config"; then
+    echo "ERROR: ZooKeeper member server.${new_member_index} already exists with a different endpoint"
+    exit 1
+fi
+
+zkCli.sh << EOF
+addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
+reconfig -add $server_entry
+EOF
+
+updated_config="$(get_dynamic_config)"
+if ! member_target_exists <<< "$updated_config"; then
+    echo "ERROR: ZooKeeper member server.${new_member_index} was not observed after reconfig -add"
+    exit 1
+fi
+
+echo "ZooKeeper member server.${new_member_index} added"

--- a/addons/zookeeper/scripts/member_leave.sh
+++ b/addons/zookeeper/scripts/member_leave.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ -z "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
-    echo "ERROR: KB_LEAVE_MEMBER_POD_NAME is required"
+    echo "ERROR: KB_LEAVE_MEMBER_POD_NAME is required" >&2
     exit 1
 fi
 
@@ -10,18 +10,40 @@ leave_member_index="${KB_LEAVE_MEMBER_POD_NAME##*-}"
 
 echo "Removing ZooKeeper member: server.${leave_member_index}"
 
-get_dynamic_config() {
-    zkCli.sh << EOF
+get_dynamic_config_or_die() {
+    local output
+    if ! output="$(zkCli.sh << EOF
 addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
 get /zookeeper/config
 EOF
+)"; then
+        echo "ERROR: failed to read ZooKeeper dynamic config" >&2
+        return 1
+    fi
+
+    if [ -z "$output" ]; then
+        echo "ERROR: invalid ZooKeeper dynamic config output: empty response" >&2
+        return 1
+    fi
+
+    if grep -Eiq "KeeperErrorCode|Exception|NoAuth|AuthFailed|ConnectionLoss|SessionExpired|Connection refused|Unable to connect" <<< "$output"; then
+        echo "ERROR: invalid ZooKeeper dynamic config output: $output" >&2
+        return 1
+    fi
+
+    if ! grep -Eq "^[[:space:]]*server\\.[0-9]+=" <<< "$output"; then
+        echo "ERROR: invalid ZooKeeper dynamic config output: missing server.N entries" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$output"
 }
 
 member_exists() {
     grep -Eq "^[[:space:]]*server\\.${leave_member_index}="
 }
 
-current_config="$(get_dynamic_config)"
+current_config="$(get_dynamic_config_or_die)"
 
 if ! member_exists <<< "$current_config"; then
     echo "ZooKeeper member server.${leave_member_index} is already absent"
@@ -33,9 +55,9 @@ addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
 reconfig -remove ${leave_member_index}
 EOF
 
-updated_config="$(get_dynamic_config)"
+updated_config="$(get_dynamic_config_or_die)"
 if member_exists <<< "$updated_config"; then
-    echo "ERROR: ZooKeeper member server.${leave_member_index} was still observed after reconfig -remove"
+    echo "ERROR: ZooKeeper member server.${leave_member_index} was still observed after reconfig -remove" >&2
     exit 1
 fi
 

--- a/addons/zookeeper/scripts/member_leave.sh
+++ b/addons/zookeeper/scripts/member_leave.sh
@@ -1,7 +1,42 @@
 #!/bin/bash
+set -euo pipefail
 
-current_member_index=${KB_AGENT_POD_NAME##*-}
-zkCli.sh << EOF
-    addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
-    reconfig -remove ${current_member_index}
+if [ -z "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
+    echo "ERROR: KB_LEAVE_MEMBER_POD_NAME is required"
+    exit 1
+fi
+
+leave_member_index="${KB_LEAVE_MEMBER_POD_NAME##*-}"
+
+echo "Removing ZooKeeper member: server.${leave_member_index}"
+
+get_dynamic_config() {
+    zkCli.sh << EOF
+addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
+get /zookeeper/config
 EOF
+}
+
+member_exists() {
+    grep -Eq "^[[:space:]]*server\\.${leave_member_index}="
+}
+
+current_config="$(get_dynamic_config)"
+
+if ! member_exists <<< "$current_config"; then
+    echo "ZooKeeper member server.${leave_member_index} is already absent"
+    exit 0
+fi
+
+zkCli.sh << EOF
+addauth digest $ZK_ADMIN_USER:$ZK_ADMIN_PASSWORD
+reconfig -remove ${leave_member_index}
+EOF
+
+updated_config="$(get_dynamic_config)"
+if member_exists <<< "$updated_config"; then
+    echo "ERROR: ZooKeeper member server.${leave_member_index} was still observed after reconfig -remove"
+    exit 1
+fi
+
+echo "ZooKeeper member server.${leave_member_index} removed"

--- a/addons/zookeeper/templates/cmpd.yaml
+++ b/addons/zookeeper/templates/cmpd.yaml
@@ -106,7 +106,6 @@ spec:
       namespace: {{ .Release.Namespace }}
       template: {{ include "zookeeper.dynamicConfigTplName" . }}
       volumeName: dynamic-config
-      externalManaged: true
   lifecycleActions:
     roleProbe:
       exec:

--- a/addons/zookeeper/templates/cmpd.yaml
+++ b/addons/zookeeper/templates/cmpd.yaml
@@ -117,9 +117,10 @@ spec:
           - |
             /kubeblocks/scripts/roleprobe.sh
     memberJoin:
-      preCondition: RuntimeReady
       exec:
         container: zookeeper
+        targetPodSelector: Role
+        matchingKey: leader
         command:
           - /bin/bash
           - -c
@@ -129,6 +130,8 @@ spec:
       preCondition: RuntimeReady
       exec:
         container: zookeeper
+        targetPodSelector: Role
+        matchingKey: leader
         command:
           - /bin/bash
           - -c

--- a/addons/zookeeper/templates/cmpd.yaml
+++ b/addons/zookeeper/templates/cmpd.yaml
@@ -127,7 +127,6 @@ spec:
           - |
             /kubeblocks/scripts/member_join.sh
     memberLeave:
-      preCondition: RuntimeReady
       exec:
         container: zookeeper
         targetPodSelector: Role

--- a/addons/zookeeper/templates/cmpd.yaml
+++ b/addons/zookeeper/templates/cmpd.yaml
@@ -10,6 +10,9 @@ spec:
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}
+  replicasLimit:
+    minReplicas: 1
+    maxReplicas: 6
   services:
     - name: default
       spec:


### PR DESCRIPTION
## Summary
- run ZooKeeper memberJoin/memberLeave actions on the current leader instead of the joining/leaving pod
- remove RuntimeReady preCondition from memberJoin/memberLeave so hscale membership work is not blocked by the new pod being unready
- let the dynamic config template be rendered on hscale so the joining pod local `zoo.cfg.dynamic` contains its own server entry
- add observer entries for ordinal >= 3, matching the existing dynamic config template and README scale-out semantics
- use KB_JOIN_MEMBER_* / KB_LEAVE_MEMBER_* action variables and add idempotent readback checks around `/zookeeper/config`

## Evidence
- Original failure tracked in #2726: scale-out pod `zk-hscale-zookeeper-3` crashed with `My id 3 not in the peer list`; dynamic config only had `server.0/1/2` while Component/InstanceSet replicas were 4.
- Intermediate r2 on `bcc6d4c1` proved memberJoin executed on leader and wrote `/zookeeper/config`, but the joining pod local mounted ConfigMap still lacked `server.3`; evidence:
  - `/work/runs/zk-pr152-hscale-r2-patch-bcc6d4c1-20260601T181503Z/live-probe-20260601T182557Z-focused`
  - `/work/runs/zk-pr152-hscale-r2-patch-bcc6d4c1-20260601T181503Z/live-probe-20260601T182822Z-config-cm`, SHA256SUMS sha `6f29672d0c592a8c4f81ee93af3428c0dfd52287c4a5de66db2d8df9aeab95bf`
- Focused r3 on PR head `8de88769` plus kubeblocks-tests head `6458bbc`: hscale PASS 24 / FAIL 0 / SKIP 0; scale-out reached `server.3=...:observer`, role labels matched mntr, data survived scale-out/in, cleanup residual 0. Evidence path `/work/runs/zk-pr152-hscale-r3-patch-8de88769-tests-6458bbc-20260601T183240Z/evidence`, SHA256SUMS sha `fc38e59d44e15f698260bb714d29ae57760aaf9cf3bd16cf5dd5990dfd55dd65`.

## Validation
- `bash -n addons/zookeeper/scripts/member_join.sh addons/zookeeper/scripts/member_leave.sh addons/zookeeper/scripts/roleprobe.sh addons/zookeeper/scripts/startup.sh`
- `helm dependency build addons/zookeeper`
- `helm lint addons/zookeeper`
- `helm template zookeeper addons/zookeeper --namespace kb-system`
- `git diff --check`

Follow-up, not blocking this fix: `>= 3` quorum/observer threshold is duplicated in `config/zookeeper-dynamic.tpl` and `scripts/member_join.sh`; we should later move it to one component variable.

Closes #2726