### PR TITLE
mariadb: alpha.116 — add wsrep_slave_threads to dynamicParameters

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1976,7 +1976,16 @@ type: application
 # cross-checked against the corresponding `+kubebuilder:validation:*`
 # annotation in `apis/apps/v1/`. The "value within shape" check is a
 # separate review dimension from "field shape is correct".
-version: 1.1.1-alpha.115
+#
+# alpha.116 (Helen 2026-06-02 — code-review Pass 4 finding):
+# add wsrep_slave_threads to dynamicParameters in config effect scope.
+# MariaDB documents wsrep_slave_threads as a dynamic system variable
+# (SET GLOBAL applies immediately, no restart required). Without this
+# declaration the KB Configure controller falls back to rolling restart
+# for any Galera reconfigure touching wsrep_slave_threads, which
+# causes unnecessary Serial pod restarts on a 3-node cluster.
+# Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
+version: 1.1.1-alpha.116
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/config/mariadb-config-effect-scope.yaml
+++ b/addons/mariadb/config/mariadb-config-effect-scope.yaml
@@ -212,6 +212,7 @@ dynamicParameters:
   # `mariadbd --verbose --help` to exit rc=7 with "unknown variable",
   # which CrashLoops the engine container on first startup.
   - rpl_semi_sync_master_timeout
+  - wsrep_slave_threads
   - query_cache_limit
   - query_cache_min_res_unit
   - query_cache_size


### PR DESCRIPTION
## Summary

- Add `wsrep_slave_threads` to `dynamicParameters` in `config/mariadb-config-effect-scope.yaml`
- Bump Chart.yaml to `1.1.1-alpha.116`

## Context

Found during code-review Pass 4 (test-phase × chart-code-path paper trace):

- MariaDB documents `wsrep_slave_threads` as a dynamic system variable (`SET GLOBAL` applies immediately)
- The galera test CM3 reconfigures `wsrep_slave_threads` from 4→8 and verifies across all 3 nodes
- Without this entry in `dynamicParameters`, the KB Configure controller falls back to rolling restart instead of the dynamic reconfigure path (`reconfigureAction` + `SET GLOBAL`)
- On a 3-node Galera cluster with Serial `updateStrategy`, an unnecessary rolling restart takes 5-10 minutes vs a few seconds for `SET GLOBAL`

## Scope

- 2 files changed: `Chart.yaml` (version bump + comment) + `config/mariadb-config-effect-scope.yaml` (1 line add)
- No script change. No CmpD spec change. No lifecycle action change.
- The `wsrep_slave_threads` entry appears in all 5 ParametersDefinition objects (shared effect scope file). For non-Galera topologies it is harmless — those topologies do not use wsrep parameters.

## Validation

- `git diff --check` PASS
- `helm dependency build` + `helm template --show-only templates/paramsdef.yaml` — `wsrep_slave_threads` renders in all 5 ParametersDefinition objects under `dynamicParameters`

## Test plan

- [ ] Galera CM3 (`wsrep_slave_threads=8`) should use dynamic reconfigure path (OpsRequest Succeed without pod restarts)
- [ ] Verify OpsRequest type=Reconfiguring, phase=Succeed, no rolling restart events
- [ ] Standalone/replication/semisync tests unaffected (no wsrep usage)