### PR TITLE
fix(mariadb): galera reconfigure auth — set MARIADB_INTERNAL_ROOT_USER=root

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1985,7 +1985,17 @@ type: application
 # for any Galera reconfigure touching wsrep_slave_threads, which
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
-version: 1.1.1-alpha.116
+#
+# alpha.117 (Helen 2026-06-02 — galera reconfigure auth fix):
+# set MARIADB_INTERNAL_ROOT_USER=root in cmpd-galera.yaml vars.
+# The shared reconfigure helper defaults to kb_internal_root, but
+# galera CmpD does not provision this account (no initdb block like
+# standalone/replication/semisync). Galera root retains full
+# privileges (no alpha.64 SUPER stripping), so root is the correct
+# reconfigure executor. Without this, any galera Reconfiguring
+# OpsRequest fails with ERROR 1045 (Access denied for
+# kb_internal_root). CmpD spec change requires version bump.
+version: 1.1.1-alpha.117
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -79,6 +79,8 @@ spec:
         componentVarRef:
           optional: false
           shortName: Required
+    - name: MARIADB_INTERNAL_ROOT_USER
+      value: root
     - name: PEER_FQDNS
       valueFrom:
         componentVarRef:


### PR DESCRIPTION
## Summary

- Set `MARIADB_INTERNAL_ROOT_USER=root` in galera CmpD vars section
- Bumps alpha.116 → alpha.117

## Root cause

The shared reconfigure helper (`_helpers.tpl:288-291`) defaults `MARIADB_INTERNAL_ROOT_USER` to `kb_internal_root`. Standalone/replication/semisync CmpDs provision this account via initdb, but galera CmpD does not. When a galera Reconfiguring OpsRequest fires (e.g. `slow_query_log=ON`), the helper connects as `kb_internal_root@127.0.0.1` — which does not exist in the DB — and fails with `ERROR 1045 (28000): Access denied`.

## Why root is correct for galera

Galera does not apply the alpha.64 SUPER-stripping security hardening. The user-facing `root@%` retains `ALL PRIVILEGES` including `SUPER`, so `root` can execute `SET GLOBAL` without issue.

## Verification

- `helm dependency build` + `helm template` confirms `MARIADB_INTERNAL_ROOT_USER=root` renders in galera CmpD vars
- `git diff --check` clean
- Reconfigure helper resolution: `INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"` resolves to `root` with the new env var

## Scope

2 files / +13 / -1. Only galera CmpD affected. No script change, no standalone/replication/semisync change.