### PR TITLE
fix(mariadb): galera Stop/Start crash recovery — pod-0 wsrep-recover bootstrap

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1986,6 +1986,39 @@ type: application
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
 #
+# alpha.118 (Helen 2026-06-02 — galera Stop/Start crash recovery):
+# Fix galera-start.sh to handle the case where all nodes have
+# safe_to_bootstrap=0 after a KubeBlocks Stop operation. With
+# podManagementPolicy=Parallel, all pods terminate simultaneously
+# and no node gets designated as safe_to_bootstrap=1 by Galera.
+# On restart, no node bootstraps and the cluster deadlocks in
+# CrashLoop (all nodes try to join but no primary component exists).
+#
+# Fix adds two helpers to galera-start.sh:
+#   _any_peer_alive — TCP probe port 3306 on each peer FQDN to
+#     distinguish full-cluster-restart (no peers → bootstrap) from
+#     single-pod-restart (peers alive → join, prevents split-brain).
+#   _wsrep_recover_and_bootstrap — runs mariadbd --wsrep-recover to
+#     extract last committed position from InnoDB redo log, then
+#     marks safe_to_bootstrap=1 in grastate.dat for pod-0.
+#
+# should_bootstrap() new path (c): if pod-0 AND safe_to_bootstrap=0
+# AND no peer alive → wsrep-recover → set safe_to_bootstrap=1 →
+# bootstrap. Non-pod-0 nodes continue to join; they may CrashLoop
+# briefly until pod-0 finishes bootstrap, then join on next restart.
+#
+# Split-brain safety: _any_peer_alive returns true when ANY peer has
+# port 3306 open (running MariaDB), so pod-0 will join instead of
+# bootstrapping. During full cluster restart, no peer has 3306 open
+# (MariaDB in join mode does not open 3306 until connected to
+# primary), so the check correctly identifies full-cluster-restart.
+#
+# Verified by: alpha.117 galera T6 Stop/Start failure evidence
+# (Jack artifacts sha256 d9c6f97e...), which showed all 3 nodes
+# with safe_to_bootstrap=0 seqno=-1, NON_PRIM, CrashLoop.
+# No CmpD spec change (script-only fix via ConfigMap), but version
+# bump for traceability.
+#
 # alpha.117 (Helen 2026-06-02 — galera reconfigure auth fix):
 # set MARIADB_INTERNAL_ROOT_USER=root in cmpd-galera.yaml vars.
 # The shared reconfigure helper defaults to kb_internal_root, but
@@ -1995,7 +2028,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.1.1-alpha.117
+version: 1.1.1-alpha.118
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -15,12 +15,46 @@ build_cluster_address() {
   echo "gcomm://${addr}"
 }
 
+# Check whether any peer node already has MariaDB listening on port 3306.
+# Used to distinguish "full cluster restart" (no peers alive — pod-0 should
+# bootstrap) from "single pod restart" (peers alive — must join, not bootstrap,
+# to avoid split-brain).
+_any_peer_alive() {
+  local fqdns="${PEER_FQDNS:-}"
+  [ -z "$fqdns" ] && return 1
+  local peer
+  for peer in $(echo "$fqdns" | tr ',' ' '); do
+    echo "$peer" | grep -q "${POD_NAME}" && continue
+    if timeout 3 bash -c "echo > /dev/tcp/${peer}/3306" 2>/dev/null; then
+      echo "Peer ${peer} is alive on port 3306."
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Run wsrep-recover to extract the last committed position from InnoDB,
+# then mark grastate.dat safe_to_bootstrap=1 so MariaDB will accept
+# --wsrep-new-cluster on the next exec.
+_wsrep_recover_and_bootstrap() {
+  local recover_output
+  recover_output=$(mariadbd --wsrep-recover 2>&1) || true
+  local recovered_seqno
+  recovered_seqno=$(echo "$recover_output" | grep 'Recovered position' | sed 's/.*://' | tail -1)
+  echo "wsrep-recover: seqno=${recovered_seqno:-unknown}"
+  sed -i 's/^safe_to_bootstrap: 0/safe_to_bootstrap: 1/' "${DATA_DIR}/grastate.dat"
+  echo "grastate.dat updated: safe_to_bootstrap=1 for crash recovery bootstrap."
+}
+
 # Determine whether this node should bootstrap.
 #
-# Bootstrap if EITHER:
+# Bootstrap if ANY of:
 #   (a) Fresh cluster: this is pod-0 and there is no initialized data directory yet.
-#   (b) Restart after full cluster shutdown: grastate.dat has safe_to_bootstrap=1,
+#   (b) Restart after clean shutdown: grastate.dat has safe_to_bootstrap=1,
 #       meaning this is the last node that shut down cleanly.
+#   (c) Full cluster crash recovery: pod-0, grastate.dat has safe_to_bootstrap=0,
+#       AND no peer is alive (distinguishes full-cluster-restart from single-pod-restart).
+#       Runs wsrep-recover to validate InnoDB consistency, then marks safe_to_bootstrap=1.
 should_bootstrap() {
   local pod_index="${POD_NAME##*-}"
 
@@ -30,7 +64,18 @@ should_bootstrap() {
       echo "grastate.dat: safe_to_bootstrap=1, this node will bootstrap the cluster."
       return 0
     fi
-    # Another node has safe_to_bootstrap=1 — join, don't bootstrap
+    # (c) safe_to_bootstrap=0: only pod-0 may attempt crash recovery bootstrap.
+    # This handles the case where podManagementPolicy=Parallel causes all nodes
+    # to shut down simultaneously, leaving every node with safe_to_bootstrap=0.
+    if [ "$pod_index" = "0" ]; then
+      if _any_peer_alive; then
+        echo "Peer node is already running. Pod-0 will join existing cluster."
+        return 1
+      fi
+      echo "No peers alive. Pod-0 attempting crash recovery bootstrap..."
+      _wsrep_recover_and_bootstrap
+      return 0
+    fi
     return 1
   fi
 


### PR DESCRIPTION
## Summary

Fix Galera cluster deadlock after KubeBlocks Stop/Start operation.

- **Bug**: `podManagementPolicy=Parallel` terminates all Galera nodes simultaneously. No node gets `safe_to_bootstrap=1` in `grastate.dat`, so on restart all nodes try to join but no primary component exists → CrashLoop deadlock.
- **Fix**: Add crash recovery path (c) to `should_bootstrap()` in `galera-start.sh`:
  - `_any_peer_alive()` — TCP probe port 3306 on peer FQDNs to distinguish full-cluster-restart from single-pod-restart (split-brain safety)
  - `_wsrep_recover_and_bootstrap()` — run `mariadbd --wsrep-recover` to validate InnoDB consistency, then mark `safe_to_bootstrap=1`
  - When pod-0 has `safe_to_bootstrap=0` AND no peer alive → recover → bootstrap
- **Split-brain safe**: if any peer has port 3306 open, pod-0 joins instead of bootstrapping
- Chart version bump: alpha.117 → alpha.118 (script-only change via ConfigMap, no CmpD spec mutation)

## Evidence

alpha.117 galera T6 Stop/Start failure: all 3 nodes `safe_to_bootstrap=0 seqno=-1`, `NON_PRIM`, `failed to reach primary view`, cluster Failed/CrashLoop. Evidence sha256 `d9c6f97ed926ba479e6fac681fbefa52b319d939d81c30d704938b9c923dc633`.

## Test plan

- [ ] Helm template render: galera ConfigMap includes new `_any_peer_alive` + `_wsrep_recover_and_bootstrap` functions
- [ ] Standalone / replication topologies render clean (no galera script leakage)
- [ ] Deploy alpha.118 to vcluster, run galera T6 Stop/Start — expect cluster recovery instead of CrashLoop
- [ ] Verify T1-T5 + CM1-CM4 still PASS (no regression)
- [ ] Verify single-pod crash scenario: kill pod-0 while pod-1/pod-2 running → pod-0 should join (not bootstrap)