### PR TITLE
fix(mariadb): galera single-owner bootstrap prevents split-brain

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1986,6 +1986,35 @@ type: application
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
 #
+# alpha.119 (Helen 2026-06-02 — galera single-owner bootstrap):
+# Fix split-brain regression in alpha.118. With podManagementPolicy=
+# Parallel, preStop hooks run simultaneously and multiple nodes can
+# end up with safe_to_bootstrap=1 (race in Galera's last-node
+# detection). Alpha.118 added crash recovery for pod-0 (path c) but
+# did not restrict path (b) — any node with safe_to_bootstrap=1
+# could bootstrap independently. Jack's alpha.118 T6 evidence showed
+# pod-0 bootstrapped via path (c) AND pod-2 bootstrapped via path (b),
+# forming a 2+1 split-brain (wsrep_cluster_size=2 instead of 3).
+#
+# Fix: restrict ALL bootstrap decisions to pod-0 only. Galera uses
+# synchronous replication, so all nodes have identical committed data;
+# pod-0 is always a safe bootstrap candidate. Non-pod-0 nodes always
+# join, even if their grastate.dat has safe_to_bootstrap=1 (logged as
+# "Non-pod-0: safe_to_bootstrap=1 ignored (single-owner bootstrap)").
+# Pod-0 also checks _any_peer_alive before bootstrapping — if any
+# peer already has port 3306 open, pod-0 joins instead (handles
+# single-pod restart and rolling restart correctly).
+#
+# Three bootstrap paths, ALL pod-0 only:
+#   (a) Fresh cluster: no data directory → bootstrap.
+#   (b) Clean shutdown: grastate.dat safe_to_bootstrap=1 → bootstrap.
+#   (c) Crash recovery: safe_to_bootstrap=0, no peers alive →
+#       wsrep-recover → set safe_to_bootstrap=1 → bootstrap.
+# Non-pod-0: return 1 (join) unconditionally when grastate.dat exists.
+#
+# No CmpD spec change (script-only fix via ConfigMap), but version
+# bump for traceability.
+#
 # alpha.118 (Helen 2026-06-02 — galera Stop/Start crash recovery):
 # Fix galera-start.sh to handle the case where all nodes have
 # safe_to_bootstrap=0 after a KubeBlocks Stop operation. With
@@ -2028,7 +2057,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.1.1-alpha.118
+version: 1.1.1-alpha.119
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -48,35 +48,43 @@ _wsrep_recover_and_bootstrap() {
 
 # Determine whether this node should bootstrap.
 #
-# Bootstrap if ANY of:
-#   (a) Fresh cluster: this is pod-0 and there is no initialized data directory yet.
-#   (b) Restart after clean shutdown: grastate.dat has safe_to_bootstrap=1,
-#       meaning this is the last node that shut down cleanly.
-#   (c) Full cluster crash recovery: pod-0, grastate.dat has safe_to_bootstrap=0,
-#       AND no peer is alive (distinguishes full-cluster-restart from single-pod-restart).
-#       Runs wsrep-recover to validate InnoDB consistency, then marks safe_to_bootstrap=1.
+# ONLY pod-0 may bootstrap — this prevents split-brain when parallel shutdown
+# (podManagementPolicy=Parallel) causes multiple nodes to have safe_to_bootstrap=1.
+# Galera uses synchronous replication, so all nodes have identical committed data;
+# pod-0 is always a safe bootstrap candidate.
+#
+# Bootstrap if ALL of: this is pod-0, AND no peer is already running, AND one of:
+#   (a) Fresh cluster: no initialized data directory yet.
+#   (b) Restart after clean shutdown: grastate.dat has safe_to_bootstrap=1.
+#   (c) Full cluster crash recovery: grastate.dat has safe_to_bootstrap=0.
+#       Runs wsrep-recover to validate InnoDB consistency before bootstrap.
 should_bootstrap() {
   local pod_index="${POD_NAME##*-}"
 
-  # (b) grastate.dat says we are safe to bootstrap (after full cluster shutdown)
   if [ -f "${DATA_DIR}/grastate.dat" ]; then
-    if grep -q "^safe_to_bootstrap: 1" "${DATA_DIR}/grastate.dat"; then
-      echo "grastate.dat: safe_to_bootstrap=1, this node will bootstrap the cluster."
-      return 0
-    fi
-    # (c) safe_to_bootstrap=0: only pod-0 may attempt crash recovery bootstrap.
-    # This handles the case where podManagementPolicy=Parallel causes all nodes
-    # to shut down simultaneously, leaving every node with safe_to_bootstrap=0.
-    if [ "$pod_index" = "0" ]; then
-      if _any_peer_alive; then
-        echo "Peer node is already running. Pod-0 will join existing cluster."
-        return 1
+    # Non-pod-0 never bootstraps — always join.
+    if [ "$pod_index" != "0" ]; then
+      if grep -q "^safe_to_bootstrap: 1" "${DATA_DIR}/grastate.dat"; then
+        echo "Non-pod-0: safe_to_bootstrap=1 ignored (single-owner bootstrap). Will join."
       fi
-      echo "No peers alive. Pod-0 attempting crash recovery bootstrap..."
-      _wsrep_recover_and_bootstrap
-      return 0
+      return 1
     fi
-    return 1
+
+    # Pod-0: if any peer is already running, join instead of bootstrapping.
+    # This handles single-pod restart and rolling restart correctly.
+    if _any_peer_alive; then
+      echo "Peers alive. Pod-0 will join existing cluster."
+      return 1
+    fi
+
+    # Pod-0, no peers alive: this is a full cluster restart.
+    if grep -q "^safe_to_bootstrap: 1" "${DATA_DIR}/grastate.dat"; then
+      echo "grastate.dat: safe_to_bootstrap=1, pod-0 will bootstrap."
+    else
+      echo "No peers alive. Pod-0 crash recovery bootstrap..."
+      _wsrep_recover_and_bootstrap
+    fi
+    return 0
   fi
 
   # (a) Fresh cluster: no data directory, must be pod-0


### PR DESCRIPTION
## Summary
- Restrict all galera bootstrap decisions to pod-0 only, preventing split-brain when parallel pod shutdown causes multiple nodes to have safe_to_bootstrap=1.
- Pod-0 checks _any_peer_alive before bootstrapping; non-pod-0 nodes always join.
- Three bootstrap paths (fresh/clean-shutdown/crash-recovery) all gated to pod-0.
- Bumps chart to 1.1.1-alpha.119.

## Context
Alpha.118 fixed the all-zero safe_to_bootstrap deadlock but did not restrict path (b) to pod-0. Testing showed pod-0 bootstrapped via path (c) while pod-2 bootstrapped via path (b), forming a 2+1 split-brain (wsrep_cluster_size=2 instead of 3).

## Test plan
- [ ] Galera T6 Stop/Start: all 3 nodes rejoin, wsrep_cluster_size=3
- [ ] Galera T5 Reconfigure: verify no regression