### PR TITLE
fix(mariadb): galera peer check queries wsrep_cluster_status

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1986,6 +1986,36 @@ type: application
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
 #
+# alpha.120 (Helen 2026-06-02 — galera _any_peer_alive wsrep query):
+# Fix non-Primary deadlock after static parameter reconfigure (CM4
+# back_log=200). With podManagementPolicy=Parallel, static reconfigure
+# triggers simultaneous pod restart. Pod-1/pod-2 start MariaDB in join
+# mode: port 3306 opens but wsrep_cluster_status=non-Primary (waiting
+# for primary). Alpha.119's TCP-only _any_peer_alive sees port 3306
+# open → returns true → pod-0 also joins → all three deadlocked in
+# non-Primary/Initialized, no quorum, no recovery.
+#
+# Fix: _any_peer_alive now queries wsrep_cluster_status on each
+# reachable peer via mariadb client. Only "Primary" counts as a
+# functioning cluster member. Peers in non-Primary/Initialized state
+# are skipped. If no peer has Primary, pod-0 bootstraps.
+#
+# Edge cases verified by design:
+#   - Single pod restart (other pods healthy/Primary): peer query
+#     returns Primary → pod-0 joins → correct.
+#   - Full cluster restart (Stop/Start): no peer has 3306 open →
+#     TCP check fails → pod-0 bootstraps → correct (same as alpha.119).
+#   - Parallel restart (reconfigure): peers have 3306 open but
+#     non-Primary → skipped → pod-0 bootstraps → pod-1/pod-2 join
+#     pod-0's new Primary → correct.
+#
+# Evidence: Jack alpha.119 galera full r2 CM4 failure —
+# wsrep_cluster_status=non-Primary on all 3 nodes, grastate.dat
+# seqno=-1 safe_to_bootstrap=0, .galera-role=secondary.
+# Evidence sha256: 7a0b3cd2...
+# No CmpD spec change (script-only fix via ConfigMap), but version
+# bump for traceability.
+#
 # alpha.119 (Helen 2026-06-02 — galera single-owner bootstrap):
 # Fix split-brain regression in alpha.118. With podManagementPolicy=
 # Parallel, preStop hooks run simultaneously and multiple nodes can
@@ -2057,7 +2087,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.1.1-alpha.119
+version: 1.1.1-alpha.120
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -15,10 +15,19 @@ build_cluster_address() {
   echo "gcomm://${addr}"
 }
 
-# Check whether any peer node already has MariaDB listening on port 3306.
-# Used to distinguish "full cluster restart" (no peers alive — pod-0 should
-# bootstrap) from "single pod restart" (peers alive — must join, not bootstrap,
-# to avoid split-brain).
+# Check whether any peer node has a functioning Galera Primary component.
+# Used to distinguish "full cluster restart" (no peers with Primary — pod-0
+# should bootstrap) from "single pod restart" (peers with Primary — must
+# join, not bootstrap, to avoid split-brain).
+#
+# A simple TCP probe on port 3306 is insufficient: MariaDB in join mode
+# opens port 3306 while stuck in non-Primary/Initialized state. If all
+# pods restart simultaneously (podManagementPolicy=Parallel), pod-1/pod-2
+# start in join mode with 3306 open, and a TCP-only check would make
+# pod-0 also join → all three deadlocked in non-Primary.
+#
+# Instead, query wsrep_cluster_status on each reachable peer. Only
+# "Primary" means the peer belongs to a functioning cluster.
 _any_peer_alive() {
   local fqdns="${PEER_FQDNS:-}"
   [ -z "$fqdns" ] && return 1
@@ -26,8 +35,17 @@ _any_peer_alive() {
   for peer in $(echo "$fqdns" | tr ',' ' '); do
     echo "$peer" | grep -q "${POD_NAME}" && continue
     if timeout 3 bash -c "echo > /dev/tcp/${peer}/3306" 2>/dev/null; then
-      echo "Peer ${peer} is alive on port 3306."
-      return 0
+      local cluster_status
+      cluster_status=$(timeout 5 mariadb \
+        -u"${MARIADB_ROOT_USER}" -p"${MARIADB_ROOT_PASSWORD}" \
+        -h "${peer}" -N -s \
+        -e "SHOW STATUS LIKE 'wsrep_cluster_status';" 2>/dev/null \
+        | awk '{print $2}')
+      if [ "${cluster_status}" = "Primary" ]; then
+        echo "Peer ${peer} is alive with wsrep_cluster_status=Primary."
+        return 0
+      fi
+      echo "Peer ${peer} port 3306 open but wsrep_cluster_status=${cluster_status:-unreachable} (not Primary, skipping)."
     fi
   done
   return 1


### PR DESCRIPTION
## Summary
- Enhance _any_peer_alive to query wsrep_cluster_status via mariadb client instead of TCP-only port 3306 probe.
- Peers in non-Primary/Initialized state are skipped; only Primary counts as a live cluster.
- Fixes deadlock after static parameter reconfigure with podManagementPolicy=Parallel.
- Bumps chart to 1.1.1-alpha.120.

## Context
Alpha.119 galera full suite r2 failed at CM4 (back_log=200 static reconfigure). All 3 pods restarted simultaneously, pod-1/pod-2 opened port 3306 in non-Primary/Initialized state, pod-0 saw open ports and joined instead of bootstrapping, all three deadlocked.

## Test plan
- [ ] Galera CM4 static reconfigure (back_log=200): cluster recovers to wsrep_cluster_size=3
- [ ] Galera T6 Stop/Start: no regression (still PASS)
- [ ] Full galera suite pass