### PR TITLE
fix(valkey): keep primary label on invalid sentinel quorum

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -769,12 +769,16 @@ Describe "Valkey Check-Role Bash Script Tests"
     #
     # check-role.sh defence: when Sentinel is configured (any of
     # `insufficient_valid`, `split_view`, etc.) but quorum is invalid,
-    # do NOT emit legacy `primary` from `local INFO=master`. Emit
-    # `secondary` instead, so the primary Service may briefly have no
-    # endpoint while Sentinel converges but no engine-versioned peer
-    # can be cleaned. `no_sentinel_env` / `no_sentinel_configured`
-    # paths keep the original local-INFO mapping because they are the
-    # only authority for standalone topologies.
+    # do NOT emit legacy `primary` from `local INFO=master`. Fail the
+    # current probe sample instead. KB controller skips non-zero
+    # roleProbe events, so the last trusted primary label is preserved
+    # while Sentinel converges, and a new pod with no trusted label is
+    # not promoted from a stale local INFO result. But local
+    # `role:slave` is safe and should emit `secondary` so a demoted pod
+    # does not keep a stale primary label. `no_sentinel_env` /
+    # `no_sentinel_configured` paths keep the original local-INFO
+    # mapping because they are the only authority for standalone
+    # topologies.
     Context "Sentinel configured + quorum invalid + INFO=master"
       check_role_script="../scripts/check-role.sh"
 
@@ -784,17 +788,26 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should include 'no_sentinel_env|no_sentinel_configured'
       End
 
-      It "documents the cross-mode safety rationale next to the fallback case"
-        When call grep -c -F 'no engine-versioned peer can be exclusive-cleaned' "${check_role_script}"
+      It "documents the controller skip contract next to the fallback case"
+        When call grep -c -F 'KB controller treats a non-zero roleProbe event as' "${check_role_script}"
         The status should be success
         The stdout should not equal "0"
       End
 
-      It "ensures the quorum-invalid branch maps role:master to secondary (not primary)"
-        # In the *quorum-invalid* fallback, role:master and role:slave
-        # both collapse to `secondary`. Production line shape:
-        # `"role:master"|"role:slave") printf %s "secondary" ;;`
-        When call grep -F '"role:master"|"role:slave") printf %s "secondary"' "${check_role_script}"
+      It "ensures the quorum-invalid role:master branch fails the probe instead of emitting a role"
+        When call grep -F 'sentinel quorum invalid (${__quorum_decision_reason}); skipping master role update' "${check_role_script}"
+        The status should be success
+        The stdout should include 'skipping master role update'
+      End
+
+      It "does not map quorum-invalid role:master to secondary"
+        When call bash -c 'grep -c -F "\"role:master\"|\"role:slave\") printf %s \"secondary\"" ../scripts/check-role.sh || true'
+        The status should be success
+        The stdout should equal "0"
+      End
+
+      It "keeps quorum-invalid role:slave mapped to secondary"
+        When call grep -F '"role:slave") printf %s "secondary" ;;' "${check_role_script}"
         The status should be success
         The stdout should include 'secondary'
       End
@@ -812,32 +825,30 @@ Describe "Valkey Check-Role Bash Script Tests"
       End
 
       It "documents that the no-sentinel branch preserves original local-INFO mapping"
-        When call grep -c -F 'only authority for standalone' "${check_role_script}"
+        When call grep -c -F 'original local-INFO mapping' "${check_role_script}"
         The status should be success
         The stdout should not equal "0"
       End
     End
 
-    Context "role:slave under any quorum decision"
+    Context "role:slave fallback"
       check_role_script="../scripts/check-role.sh"
 
-      It "maps to secondary in the no_sentinel fallback"
+      It "maps to secondary in fallback paths"
         When call grep -c -F '"role:slave")  printf %s "secondary"' "${check_role_script}"
         The status should be success
         The stdout should not equal "0"
       End
     End
 
-    Context "unknown role under any quorum decision"
+    Context "unknown role under fallback paths"
       check_role_script="../scripts/check-role.sh"
 
-      It "exits non-zero so KubeBlocks clears the stale role label via failureThreshold"
-        # The unknown-role branch must remain `echo + exit 1` in both
-        # the no-sentinel and the quorum-invalid path.
+      It "exits non-zero so KubeBlocks skips the invalid sample"
+        # Unknown-role branches must remain `echo + exit 1` in both the
+        # no-sentinel and quorum-invalid paths.
         When call grep -c -F "unknown role: '" "${check_role_script}"
         The status should be success
-        # Two occurrences: one for no_sentinel branch, one for
-        # quorum-invalid branch.
         The stdout should equal "2"
       End
     End

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -29,8 +29,12 @@
 #     - When Sentinel is configured but quorum is transiently invalid
 #       (insufficient valid sentinels / split view / missing password
 #       causing NOAUTH / non-numeric epoch / empty or malformed runid):
-#       emit `secondary` regardless of local INFO to prevent a legacy
-#       `primary` event from stripping an engine-versioned peer label.
+#       only trust a local `role:slave` demotion. Local `role:master`
+#       cannot prove primary without Sentinel majority, so fail the
+#       current probe without emitting a role token. KubeBlocks consumes
+#       a non-zero roleProbe event as "skip this sample", keeping the last
+#       trusted role label instead of accepting a possibly stale master
+#       self-report.
 #
 #   Using valkey-cli (not redis-cli) because Valkey ships its own CLI.
 #   The -h 127.0.0.1 ensures we hit this pod's own server.
@@ -154,10 +158,11 @@ done <<<"${server_info}"
 #       - `flags` contains any transient/failure marker
 #         (`failover_in_progress`, `force_failover`, `s_down`, `o_down`).
 #   - If fewer than `min_valid` valid entries remain, OR the valid entries
-#     fall into more than one `(epoch, runid)` group, fall back to legacy
-#     single-token output. The controller then uses its existing EventTime
-#     gate and the Pod annotation is NOT advanced to `engine:N`, so once
-#     sentinels converge the next emission can take effect.
+#     fall into more than one `(epoch, runid)` group, local `role:master`
+#     fails the current probe sample without emitting a role token, while
+#     local `role:slave` emits `secondary`. The controller skips failed
+#     roleProbe samples and keeps the previous Pod role label, so once
+#     sentinels converge the next successful emission can take effect.
 #   - When all valid entries agree on a single `(epoch, runid)` group AND
 #     there are at least `min_valid` of them, that group is the quorum
 #     authority. The version token is the group's epoch; the role token
@@ -211,8 +216,8 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   # Auth flag is conditional: only add -a when the password is set.
   # When password is missing on a sentinel-configured topology, the
   # cli call will fail (NOAUTH) and the per-sentinel drop will push
-  # the decision to `insufficient_valid`, which the fallback branch
-  # now correctly maps to `secondary`.
+  # the decision to `insufficient_valid`, which the fallback branch now
+  # correctly maps to a failed probe sample.
   sentinel_auth_args=""
   if [ -n "${SENTINEL_PASSWORD:-}" ]; then
     sentinel_auth_args="-a ${SENTINEL_PASSWORD}"
@@ -391,13 +396,16 @@ else
   # rejected as staleRoleEventVersion).
   #
   # Safe degrade: when Sentinel is configured but quorum is transiently
-  # invalid, emit `secondary` regardless of local INFO. The primary
-  # Service may have no endpoint briefly while Sentinel converges, but
-  # no engine-versioned peer can be exclusive-cleaned. When Sentinel is
-  # not configured / not envvar-provided (`no_sentinel_env` /
-  # `no_sentinel_configured`), keep the original local-INFO mapping
-  # because that is the only authority for standalone / no-sentinel
-  # topologies.
+  # invalid, local `role:master` fails this probe sample instead of
+  # emitting any role. KB controller treats a non-zero roleProbe event as
+  # "skip this sample", so an existing trusted primary label is preserved
+  # while Sentinel recovers, and a new pod with no trusted label is not
+  # promoted from a possibly stale local INFO result. Local `role:slave`
+  # still emits `secondary`: a demotion is safe and must not leave a stale
+  # primary label behind. When Sentinel is not configured / not
+  # envvar-provided (`no_sentinel_env` / `no_sentinel_configured`), keep
+  # the original local-INFO mapping because that is the only authority for
+  # standalone / no-sentinel topologies.
   case "${__quorum_decision_reason}" in
     no_sentinel_env|no_sentinel_configured)
       case "${role_line}" in
@@ -410,9 +418,16 @@ else
       esac
       ;;
     *)
-      # insufficient_valid / split_view / future quorum-invalid reasons
+      # insufficient_valid / split_view / future quorum-invalid reasons.
       case "${role_line}" in
-        "role:master"|"role:slave") printf %s "secondary" ;;
+        "role:master")
+          # Do not emit a role token here; stdout must stay empty so the
+          # controller cannot accept a stale local master self-report as
+          # primary.
+          echo "sentinel quorum invalid (${__quorum_decision_reason}); skipping master role update" >&2
+          exit 1
+          ;;
+        "role:slave") printf %s "secondary" ;;
         *)
           echo "unknown role: '${role_line}'" >&2
           exit 1


### PR DESCRIPTION
## Summary
- change Valkey check-role fallback for sentinel-configured quorum-invalid windows
- local `role:master` now exits non-zero without stdout so the controller skips this sample and keeps the previous trusted label
- local `role:slave` still emits `secondary` so demoted pods do not keep a stale primary label
- update shellspec guards/comments for the new fallback contract

## Validation
- `bash -n addons/valkey/scripts/check-role.sh`
- `bash -n addons/valkey/scripts-ut-spec/check_role_spec.sh`
- `git diff --check HEAD~1..HEAD`
- local stub: `role:master` + invalid sentinel quorum -> `rc=1`, stdout empty
- local stub: `role:slave` + invalid sentinel quorum -> `rc=0`, stdout `secondary`

## Boundary
This PR does not provide final release evidence. After merge, kubeblocks-tests T10 needs to be updated to this contract and the Valkey full suite rerun on the new addon head.