### PR TITLE
fix(mariadb): galera self-healing watcher kills stuck non-Primary nodes

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1986,6 +1986,30 @@ type: application
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
 #
+# alpha.122 (Helen 2026-06-02 — galera self-healing non-Primary watcher):
+# Fix TOCTOU race in parallel restart. Alpha.121 added _wait_for_primary_peer
+# so pod-1/pod-2 wait for pod-0 to bootstrap. But the InstanceSet controller
+# can issue a second restart wave: pod-0 restarts AGAIN after pod-1/pod-2
+# already saw it as Primary and started joining. Pod-1/pod-2 lose pod-0
+# mid-SST, fall to non-Primary, and form a dead 2-node partition. New pod-0
+# bootstraps as a 1-node singleton. The 1+2 split persists because the stuck
+# nodes' MariaDB is alive (not crashing), so Kubernetes never restarts them.
+#
+# Evidence: alpha.121 galera full r1 CM4 — pod-1/pod-2 wait log shows they
+# DID find pod-0 Primary, started join, then pod-0 restarted again.
+# Pod-1/pod-2 stuck at wsrep_cluster_status=non-Primary indefinitely.
+#
+# Fix: add self-healing to the background watcher. The watcher now also
+# queries wsrep_cluster_status each cycle. If the node stays in non-Primary
+# for 90s (30 cycles x 3s) while the socket is available, the watcher
+# kills mariadbd (SIGTERM then SIGKILL after 5s). The container restart
+# triggers galera-start.sh re-evaluation: by then pod-0 is stable Primary,
+# so the restarted pod joins cleanly.
+#
+# The 90s threshold avoids false kills during normal SST/IST (state transfer
+# is typically <60s for small datasets). The counter resets whenever
+# wsrep_local_state reaches 4 (Synced) or cluster_status is not non-Primary.
+#
 # alpha.121 (Helen 2026-06-02 — galera non-pod-0 wait for Primary):
 # Fix 1+2 split after parallel restart. Alpha.120 correctly made pod-0
 # bootstrap when peers are non-Primary, but pod-1/pod-2 start MariaDB
@@ -2117,7 +2141,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.1.1-alpha.121
+version: 1.1.1-alpha.122
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -192,17 +192,31 @@ main() {
   # subshell so a single failed query never kills the loop. Run forever
   # so role flapping (state transitions Synced → Donor/Joining → Synced)
   # is reflected in the file in near real time.
+  #
+  # Self-healing: if wsrep_cluster_status stays non-Primary for 90s after
+  # the socket is available, the node is stuck in a dead partition (e.g.
+  # pod-1/2 formed a 2-node non-Primary group after losing pod-0 mid-SST
+  # during a TOCTOU race in parallel restart). Kill mariadbd to force a
+  # container restart; galera-start.sh will re-evaluate and join the now-
+  # stable Primary cluster.
   (
     set +e
     rm -f "${DATA_DIR}/.galera-synced" "${DATA_DIR}/.galera-role"
     SOCK=/run/mysqld/mysqld.sock
     SYNCED_ONCE=0
+    NON_PRIMARY_COUNT=0
+    NON_PRIMARY_THRESHOLD=30  # 30 × 3s = 90s
     while true; do
       STATE=""
+      CLUSTER_STATUS=""
       if [ -S "${SOCK}" ]; then
         STATE=$(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
           -S "${SOCK}" -N -s \
           -e "SHOW STATUS LIKE 'wsrep_local_state';" 2>/dev/null \
+          | awk '{print $2}')
+        CLUSTER_STATUS=$(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
+          -S "${SOCK}" -N -s \
+          -e "SHOW STATUS LIKE 'wsrep_cluster_status';" 2>/dev/null \
           | awk '{print $2}')
       fi
       if [ "${STATE}" = "4" ]; then
@@ -214,10 +228,23 @@ main() {
           chown mysql:mysql "${DATA_DIR}/.galera-synced" 2>/dev/null || true
           SYNCED_ONCE=1
         fi
+        NON_PRIMARY_COUNT=0
       else
         printf "secondary" > "${DATA_DIR}/.galera-role.tmp" \
           && chown mysql:mysql "${DATA_DIR}/.galera-role.tmp" 2>/dev/null \
           ; mv "${DATA_DIR}/.galera-role.tmp" "${DATA_DIR}/.galera-role"
+        if [ -S "${SOCK}" ] && [ "${CLUSTER_STATUS}" = "non-Primary" ]; then
+          NON_PRIMARY_COUNT=$((NON_PRIMARY_COUNT + 1))
+          if [ ${NON_PRIMARY_COUNT} -ge ${NON_PRIMARY_THRESHOLD} ]; then
+            echo "SELF-HEALING: wsrep_cluster_status=non-Primary for $((NON_PRIMARY_COUNT * 3))s. Killing mariadbd to force restart."
+            pkill -SIGTERM mariadbd 2>/dev/null || true
+            sleep 5
+            pkill -9 mariadbd 2>/dev/null || true
+            NON_PRIMARY_COUNT=0
+          fi
+        else
+          NON_PRIMARY_COUNT=0
+        fi
       fi
       sleep 3
     done


### PR DESCRIPTION
## Summary
- Background watcher now detects `wsrep_cluster_status=non-Primary` persisting for 90s and kills mariadbd to force container restart
- Fixes TOCTOU race where pod-1/2 lose pod-0 mid-SST during second restart wave, forming a dead non-Primary partition that Kubernetes never restarts (MariaDB alive but irrecoverable)
- Counter resets on Synced (state=4) or any non-non-Primary cluster status; 90s threshold avoids false kills during normal SST/IST

## Context
Alpha.121 added `_wait_for_primary_peer` so non-pod-0 waits for pod-0 to bootstrap. But InstanceSet controller can issue a second restart wave: pod-0 restarts again after pod-1/2 started joining. Pod-1/2 fall to non-Primary and stay stuck. This self-healing closes the gap.

## Test plan
- [ ] CM4 static reconfigure (back_log=200): Stop/Start → verify all 3 nodes reach wsrep_cluster_size=3, wsrep_cluster_status=Primary
- [ ] Full galera suite pass (T1-T6, CM1-CM5)