### PR TITLE
chore(mongodb): initialize oplog_005 directory before wal-g oplog-push

### DIFF
--- a/addons/mongodb/dataprotection/mongo-pitr-backup.sh
+++ b/addons/mongodb/dataprotection/mongo-pitr-backup.sh
@@ -12,6 +12,9 @@ export WALG_DATASAFED_CONFIG=""
 export WALG_COMPRESSION_METHOD=zstd
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
+# wal-g oplog-push expects /oplog_005 to exist in the storage backend;
+# on first run no prior backup has created it yet.
+datasafed mkdir /oplog_005 2>/dev/null || true
 # retention time
 export OPLOG_PITR_DISCOVERY_INTERVAL=168h
 retryTimes=0


### PR DESCRIPTION
## Summary
- wal-g oplog-push expects /oplog_005 storage directory to exist on first run
- With a fresh BackupRepo, no prior backup creates this directory, causing oplog-push to crash with directory not found
- Add datasafed mkdir /oplog_005 before starting the archiving process

## Root Cause
The MongoDB addon datafile backup uses tar+datasafed (not wal-g backup-push), so the /oplog_005 directory that wal-g expects is never created.

## Evidence
Verified on KB 1.1 (v1.1.0-beta.6) with MongoDB 8.0.17:
1. Without fix: wal-g oplog-push crashes in <1s with /oplog_005: directory not found
2. After manually creating the directory: wal-g oplog-push starts successfully
3. First oplog archive file produced: oplog_1780382182.4_1780382313.3.zst

## Test plan
- [ ] Verify bash -n clean on modified script
- [ ] Deploy modified addon and confirm archive-oplog Backup transitions to Running without manual mkdir
- [ ] Confirm existing archive-oplog functionality is not affected (idempotent mkdir)