### PR TITLE
fix(kafka): backup fail due to word splitting

### DIFF
--- a/addons/kafka/dataprotection/backup.sh
+++ b/addons/kafka/dataprotection/backup.sh
@@ -26,7 +26,7 @@ if [[ -z $topic_list ]]; then
   DP_save_backup_status_info 0
   exit 0
 fi
-echo $topic_list | grep -v __consumer_offsets | datasafed push - topics.txt
+echo "$topic_list" | grep -v __consumer_offsets | datasafed push - topics.txt
 readarray -t topics < <(kafkactl get topics -o compact | grep -v  __consumer_offsets)
 
 for topic in "${topics[@]}"; do


### PR DESCRIPTION
fixes https://github.com/apecloud/kubeblocks/issues/9999

without double quote, topic_list becomes a single line and will be filtered out by grep, consequently result in grep's exit code 1