### PR TITLE
fix(valkey): allow role probe bootstrap before sentinel master registration

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -496,9 +496,9 @@ Describe "Valkey Check-Role Bash Script Tests"
       # each sentinel's response by (uint64 epoch, hex runid, no
       # transient/failure flags), then requires a strict majority of the
       # CONFIGURED sentinel count to fall in a single (epoch, runid)
-      # group. Otherwise fall back to legacy single-token output so the
-      # controller stays on its EventTime path and the Pod annotation is
-      # not advanced to `engine:N` prematurely.
+      # group. Otherwise it either takes the bootstrap local-INFO path
+      # (successful sentinel query but no master record yet) or the
+      # quorum-invalid unsafe path.
 
       # Compute strict majority of total configured sentinel count, NOT
       # of reachable/valid count.
@@ -508,19 +508,28 @@ Describe "Valkey Check-Role Bash Script Tests"
       }
 
       # Encode a list of (epoch, runid, flags) triples (one per sentinel
-      # entry, "skip" for unreachable) and decide quorum: emit either
-      # `EMIT <epoch>:<runid>` or `LEGACY` plus a diagnostic suffix.
+      # entry, "skip" for unreachable/NOAUTH and "empty" for a
+      # successful bootstrap query with no master record) and decide
+      # quorum: emit either `EMIT <epoch>:<runid>`, `BOOTSTRAP`, or
+      # `LEGACY` plus a diagnostic suffix.
       quorum_decide() {
         local total="$1"; shift
         local min_valid
         min_valid=$(min_valid_for "${total}")
         local entry epoch runid flags
         local -a keys=()
+        local query_success_count=0
+        local master_config_count=0
         for entry in "$@"; do
-          # skip = unreachable sentinel
+          # skip = unreachable sentinel / NOAUTH / client failure
           if [ "${entry}" = "skip" ]; then
             continue
           fi
+          query_success_count=$((query_success_count + 1))
+          if [ "${entry}" = "empty" ]; then
+            continue
+          fi
+          master_config_count=$((master_config_count + 1))
           IFS='|' read -r epoch runid flags <<< "${entry}"
           case "${epoch}" in
             ''|*[!0-9]*) continue ;;
@@ -535,6 +544,10 @@ Describe "Valkey Check-Role Bash Script Tests"
         done
         local valid_count=${#keys[@]}
         if [ "${valid_count}" -lt "${min_valid}" ]; then
+          if [ "${query_success_count}" -gt 0 ] && [ "${master_config_count}" -eq 0 ]; then
+            printf "BOOTSTRAP"
+            return 0
+          fi
           printf "LEGACY"
           return 0
         fi
@@ -606,6 +619,24 @@ Describe "Valkey Check-Role Bash Script Tests"
         The stdout should eq "LEGACY"
       End
 
+      It "successful sentinel queries with no master records → bootstrap local-INFO fallback"
+        When call quorum_decide 3 "empty" "empty" "empty"
+        The status should be success
+        The stdout should eq "BOOTSTRAP"
+      End
+
+      It "all 3 sentinels unreachable or NOAUTH-failed → legacy unsafe path, not bootstrap"
+        When call quorum_decide 3 "skip" "skip" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
+      It "sentinels with master config but invalid records → legacy unsafe path, not bootstrap"
+        When call quorum_decide 3 "17||master" "17||master" "skip"
+        The status should be success
+        The stdout should eq "LEGACY"
+      End
+
       It "2 valid at SAME epoch but DIFFERENT runid → legacy (master identity split)"
         When call quorum_decide 3 "17|00d5beef|master" "17|deadbeef|master" "17||master"
         The status should be success
@@ -614,12 +645,6 @@ Describe "Valkey Check-Role Bash Script Tests"
 
       It "2 valid at DIFFERENT epochs → legacy (epoch split)"
         When call quorum_decide 3 "17|00d5beef|master" "16|3119abcd|master" "skip"
-        The status should be success
-        The stdout should eq "LEGACY"
-      End
-
-      It "all 3 sentinels unreachable → legacy"
-        When call quorum_decide 3 "skip" "skip" "skip"
         The status should be success
         The stdout should eq "LEGACY"
       End
@@ -772,20 +797,21 @@ Describe "Valkey Check-Role Bash Script Tests"
     # do NOT emit legacy `primary` from `local INFO=master`. Fail the
     # current probe sample instead. KB controller skips non-zero
     # roleProbe events, so the last trusted primary label is preserved
-    # while Sentinel converges, and a new pod with no trusted label is
-    # not promoted from a stale local INFO result. But local
-    # `role:slave` is safe and should emit `secondary` so a demoted pod
-    # does not keep a stale primary label. `no_sentinel_env` /
-    # `no_sentinel_configured` paths keep the original local-INFO
-    # mapping because they are the only authority for standalone
-    # topologies.
+    # while Sentinel converges. But local `role:slave` is safe and should
+    # emit `secondary` so a demoted pod does not keep a stale primary
+    # label. `no_sentinel_env` / `no_sentinel_configured` paths keep the
+    # original local-INFO mapping because they are the only authority for
+    # standalone topologies. Bootstrap gets one extra safe local-INFO path:
+    # if configured Sentinel queries succeed but return no master records,
+    # there is no old primary label to preserve yet and postProvision
+    # needs a primary execution pod to register the first master.
     Context "Sentinel configured + quorum invalid + INFO=master"
       check_role_script="../scripts/check-role.sh"
 
-      It "branches on quorum decision reason via a no_sentinel_env|no_sentinel_configured case"
-        When call grep -F 'no_sentinel_env|no_sentinel_configured' "${check_role_script}"
+      It "branches on quorum decision reason via a local-INFO fallback allowlist"
+        When call grep -F 'no_sentinel_env|no_sentinel_configured|bootstrap_no_sentinel_master' "${check_role_script}"
         The status should be success
-        The stdout should include 'no_sentinel_env|no_sentinel_configured'
+        The stdout should include 'bootstrap_no_sentinel_master'
       End
 
       It "documents the controller skip contract next to the fallback case"
@@ -810,6 +836,18 @@ Describe "Valkey Check-Role Bash Script Tests"
         When call grep -F '"role:slave") printf %s "secondary" ;;' "${check_role_script}"
         The status should be success
         The stdout should include 'secondary'
+      End
+
+      It "detects bootstrap only after at least one successful sentinel query"
+        When call grep -F '[ "${sentinel_query_success_count}" -gt 0 ] && [ "${sentinel_master_config_count}" -eq 0 ]' "${check_role_script}"
+        The status should be success
+        The stdout should include 'sentinel_query_success_count'
+      End
+
+      It "classifies successful no-master sentinel responses as bootstrap_no_sentinel_master"
+        When call grep -F '__quorum_decision_reason="bootstrap_no_sentinel_master"' "${check_role_script}"
+        The status should be success
+        The stdout should include 'bootstrap_no_sentinel_master'
       End
     End
 

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -35,6 +35,11 @@
 #       a non-zero roleProbe event as "skip this sample", keeping the last
 #       trusted role label instead of accepting a possibly stale master
 #       self-report.
+#     - Bootstrap exception: before postProvision registers the initial
+#       master, reachable Sentinels can legitimately return no master
+#       records. That is not a steady-state quorum failure. In that
+#       specific case, fall back to local INFO so the first local master
+#       can receive `primary` and postProvision can run.
 #
 #   Using valkey-cli (not redis-cli) because Valkey ships its own CLI.
 #   The -h 127.0.0.1 ensures we hit this pod's own server.
@@ -163,6 +168,12 @@ done <<<"${server_info}"
 #     local `role:slave` emits `secondary`. The controller skips failed
 #     roleProbe samples and keeps the previous Pod role label, so once
 #     sentinels converge the next successful emission can take effect.
+#   - Bootstrap-only exception: if at least one configured Sentinel
+#     answers successfully but NONE of the successful answers contains a
+#     master record yet, treat this as `bootstrap_no_sentinel_master` and
+#     use local INFO. This only covers first-start registration. Failed
+#     Sentinel queries, NOAUTH, malformed master records, and split views
+#     do not enter this exception.
 #   - When all valid entries agree on a single `(epoch, runid)` group AND
 #     there are at least `min_valid` of them, that group is the quorum
 #     authority. The version token is the group's epoch; the role token
@@ -233,8 +244,12 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   if [ "${configured_count}" -ge 1 ]; then
     min_valid=$((configured_count / 2 + 1))
     quorum_keys=()
+    sentinel_query_success_count=0
+    sentinel_master_config_count=0
     for s in "${sentinel_fqdns[@]}"; do
       sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" ${sentinel_auth_args} ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
+      sentinel_query_success_count=$((sentinel_query_success_count + 1))
+      sentinel_has_master_config=0
       ce_marker=""
       runid_marker=""
       flags_marker=""
@@ -254,13 +269,17 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
           flags_marker=""
         else
           case "${sline}" in
-            "config-epoch") ce_marker="1" ;;
-            "runid")        runid_marker="1" ;;
-            "flags")        flags_marker="1" ;;
+            "name")         sentinel_has_master_config=1 ;;
+            "config-epoch") sentinel_has_master_config=1; ce_marker="1" ;;
+            "runid")        sentinel_has_master_config=1; runid_marker="1" ;;
+            "flags")        sentinel_has_master_config=1; flags_marker="1" ;;
           esac
         fi
         [ -n "${epoch}" ] && [ -n "${runid}" ] && [ -n "${flags}" ] && break
       done <<<"${sentinel_out}"
+      if [ "${sentinel_has_master_config}" -eq 1 ] || [ -n "${epoch}" ] || [ -n "${runid}" ] || [ -n "${flags}" ]; then
+        sentinel_master_config_count=$((sentinel_master_config_count + 1))
+      fi
       __drop_reason=""
       # Validate: epoch must be uint64.
       case "${epoch}" in
@@ -293,7 +312,11 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     done
     valid_count=${#quorum_keys[@]}
     if [ "${valid_count}" -lt "${min_valid}" ]; then
-      __quorum_decision_reason="insufficient_valid"
+      if [ "${sentinel_query_success_count}" -gt 0 ] && [ "${sentinel_master_config_count}" -eq 0 ]; then
+        __quorum_decision_reason="bootstrap_no_sentinel_master"
+      else
+        __quorum_decision_reason="insufficient_valid"
+      fi
     else
       first_key="${quorum_keys[0]}"
       all_agree=1
@@ -383,14 +406,16 @@ if [ -n "${authoritative_role}" ]; then
 else
   # Legacy single-token fallback. The mode of fallback matters: when
   # Sentinel is *not configured at all* the local INFO is the only
-  # authority and `role:master` legitimately means `primary`. But when
-  # Sentinel *is* configured and the quorum is merely transiently
-  # invalid (split-view, insufficient_valid, flags transient, missing
-  # auth), a sibling pod may already hold an engine-versioned `primary`
-  # annotation on the controller. Emitting plain legacy `primary` from
-  # this Pod's `role:master` in that window lets the controller's
-  # cross-mode `removeExclusiveRoleLabels` strip the sibling's
-  # engine-versioned label, after which the controller's strict
+  # authority and `role:master` legitimately means `primary`. The same is
+  # true during bootstrap when configured Sentinels answer but none has a
+  # master record yet: postProvision cannot run until one pod is labelled
+  # primary. But when Sentinel *is* configured and the quorum is merely
+  # transiently invalid (split-view, insufficient_valid, flags transient,
+  # missing auth), a sibling pod may already hold an engine-versioned
+  # `primary` annotation on the controller. Emitting plain legacy
+  # `primary` from this Pod's `role:master` in that window lets the
+  # controller's cross-mode `removeExclusiveRoleLabels` strip the
+  # sibling's engine-versioned label, after which the controller's strict
   # `engine:>` gate refuses to repair the missing label even when this
   # Pod resumes emitting versioned output (the same-version events are
   # rejected as staleRoleEventVersion).
@@ -399,15 +424,15 @@ else
   # invalid, local `role:master` fails this probe sample instead of
   # emitting any role. KB controller treats a non-zero roleProbe event as
   # "skip this sample", so an existing trusted primary label is preserved
-  # while Sentinel recovers, and a new pod with no trusted label is not
-  # promoted from a possibly stale local INFO result. Local `role:slave`
-  # still emits `secondary`: a demotion is safe and must not leave a stale
-  # primary label behind. When Sentinel is not configured / not
-  # envvar-provided (`no_sentinel_env` / `no_sentinel_configured`), keep
-  # the original local-INFO mapping because that is the only authority for
-  # standalone / no-sentinel topologies.
+  # while Sentinel recovers. Local `role:slave` still emits `secondary`:
+  # a demotion is safe and must not leave a stale primary label behind.
+  # When Sentinel is not configured / not envvar-provided
+  # (`no_sentinel_env` / `no_sentinel_configured`), or configured
+  # Sentinels have not registered their first master yet
+  # (`bootstrap_no_sentinel_master`), keep the original local-INFO mapping
+  # because that is the only available authority for the startup path.
   case "${__quorum_decision_reason}" in
-    no_sentinel_env|no_sentinel_configured)
+    no_sentinel_env|no_sentinel_configured|bootstrap_no_sentinel_master)
       case "${role_line}" in
         "role:master") printf %s "primary"   ;;
         "role:slave")  printf %s "secondary" ;;


### PR DESCRIPTION
### What
- Distinguish Valkey Sentinel bootstrap from steady-state quorum loss in `check-role.sh`.
- If configured Sentinels answer successfully but none has a master record yet, use the local INFO fallback so the initial local master can emit `primary` and postProvision can run.
- Keep the #2733 steady-state safety behavior: unreachable/NOAUTH Sentinels, malformed master records, split views, and insufficient valid quorum do not let local `role:master` emit `primary`; local `role:slave` still emits `secondary`.

### Why
A new Sentinel cluster can start with no registered master before postProvision. The previous #2733 behavior failed `role:master` whenever Sentinel quorum was invalid, which preserved old labels correctly in steady state but left a new cluster with no `primary` pod for postProvision.

### Validation
- `bash -n addons/valkey/scripts/check-role.sh`
- `bash -n addons/valkey/scripts-ut-spec/check_role_spec.sh`
- `git diff --check`
- Docker bash 5.2 ShellSpec: `199 examples, 0 failures`

### Follow-up validation after merge
- New cluster bootstrap: local master can become `primary` before Sentinel master registration and Cluster reaches Running.
- Steady-state invalid quorum: local master exits non-zero, existing primary label is preserved, local slave emits `secondary`.
