### PR TITLE
chore: adapt addon restore examples to cluster restore api

### DIFF
--- a/addons/apecloud-mysql/README.md
+++ b/addons/apecloud-mysql/README.md
@@ -697,9 +697,15 @@ kind: Cluster
 metadata:
   name: acmysql-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"mysql":{"name":"acmysql-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: acmysql-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: apecloud-mysql
   topology: apecloud-mysql

--- a/addons/clickhouse/README.md
+++ b/addons/clickhouse/README.md
@@ -1426,10 +1426,15 @@ kind: Cluster
 metadata:
   name: clickhouse-cluster-restore
   namespace: demo
-  annotations:
-    # clickhouse-cluster-backup is the Backup CR name.
-    kubeblocks.io/restore-from-backup: '{"clickhouse":{"name":"clickhouse-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: clickhouse-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   clusterDef: clickhouse
   topology: cluster
   terminationPolicy: Delete
@@ -1511,10 +1516,15 @@ kind: Cluster
 metadata:
   name: clickhouse-cluster-restore
   namespace: demo
-  annotations:
-    # clickhouse-cluster-backup is the Backup CR name.
-    kubeblocks.io/restore-from-backup: '{"clickhouse":{"name":"clickhouse-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: clickhouse-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   clusterDef: clickhouse
   topology: cluster
   terminationPolicy: Delete

--- a/addons/etcd/README.md
+++ b/addons/etcd/README.md
@@ -713,10 +713,15 @@ kind: Cluster
 metadata:
   name: etcd-cluster-restore
   namespace: demo
-  annotations:
-    # etcd-cluster-backup is the backup name.
-    kubeblocks.io/restore-from-backup: '{"etcd":{"name":"etcd-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: etcd-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:
     - name: etcd

--- a/addons/falkordb/README.md
+++ b/addons/falkordb/README.md
@@ -753,9 +753,15 @@ kind: Cluster
 metadata:
   name: falkordb-replication-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"falkordb":{"name":"falkordb-backup-datafile","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: falkordb-backup-datafile
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: falkordb
   topology: replication

--- a/addons/mongodb/README.md
+++ b/addons/mongodb/README.md
@@ -670,9 +670,15 @@ kind: Cluster
 metadata:
   name: mongo-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"mongodb":{"name":"mongo-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: mongo-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: mongodb
   topology: replicaset

--- a/addons/mongodb/scripts/mongodb-common.sh
+++ b/addons/mongodb/scripts/mongodb-common.sh
@@ -21,10 +21,19 @@ function wait_restore_completion_by_cluster_cr() {
             continue
         fi
 
-        restore_from_backup=$(echo "$cluster_json" | jq -r '.metadata.annotations["kubeblocks.io/restore-from-backup"] // empty')
-        if [ -z "$restore_from_backup" ]; then
-            # echo "INFO: No restore-from-backup annotation, do not need to restore."
+        if ! is_restore_cluster "$cluster_json"; then
+            # echo "INFO: No restore spec, do not need to restore."
             return 0
+        fi
+
+        restore_status=$(echo "$cluster_json" | jq -r '.status.conditions[]? | select(.type=="Restore") | .status' | head -n 1)
+        if [ "$restore_status" = "True" ]; then
+            echo "INFO: Restore completed."
+            return 0
+        elif [ "$restore_status" = "False" ]; then
+            restore_message=$(echo "$cluster_json" | jq -r '.status.conditions[]? | select(.type=="Restore") | .message // empty' | head -n 1)
+            echo "ERROR: Restore failed. $restore_message"
+            exit 1
         else
             if [[ "$state" != "1" ]]; then
                 echo "INFO: Waiting for restore completion..."
@@ -51,6 +60,13 @@ function kill_process() {
         kill -9 $process_pid
         echo "INFO: kill $process_name with pid $process_pid"
     fi
+}
+
+function is_restore_cluster() {
+    local cluster_json="$1"
+    local restore_source_name
+    restore_source_name=$(echo "$cluster_json" | jq -r '.spec.restore.source.name // empty')
+    [ -n "$restore_source_name" ]
 }
 
 function process_restore_signal() {
@@ -121,9 +137,8 @@ function boot_or_enter_restore() {
             continue
         fi
 
-        restore_from_backup=$(echo "$cluster_json" | jq -r '.metadata.annotations["kubeblocks.io/restore-from-backup"] // empty')
-        if [ -z "$restore_from_backup" ]; then
-            # echo "INFO: No restore-from-backup annotation, do not need to restore."
+        if ! is_restore_cluster "$cluster_json"; then
+            # echo "INFO: No restore spec, do not need to restore."
             exec $process
             exit 0
         else

--- a/addons/mysql/README.md
+++ b/addons/mysql/README.md
@@ -579,9 +579,15 @@ kind: Cluster
 metadata:
   name: mysql-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"mysql":{"name":"mysql-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: mysql-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:
     - name: mysql

--- a/addons/oceanbase-ce/README.md
+++ b/addons/oceanbase-ce/README.md
@@ -538,9 +538,15 @@ kind: Cluster
 metadata:
   name: oceanbase-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"oceanbase":{"name":"ob-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: ob-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: oceanbase-ce
   topology: distribution

--- a/addons/postgresql/README.md
+++ b/addons/postgresql/README.md
@@ -777,9 +777,15 @@ kind: Cluster
 metadata:
   name: pg-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"postgresql":{"name":"pg-cluster-pg-basebackup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: pg-cluster-pg-basebackup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: postgresql
   topology: replication

--- a/addons/qdrant/README.md
+++ b/addons/qdrant/README.md
@@ -439,10 +439,15 @@ kind: Cluster
 metadata:
   name: qdrant-cluster-restore
   namespace: demo
-  annotations:
-    # qdrant-cluster-backup is the backup name
-    kubeblocks.io/restore-from-backup: '{"qdrant":{"name":"qdrant-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: qdrant-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: qdrant
   topology: cluster

--- a/addons/redis/README.md
+++ b/addons/redis/README.md
@@ -754,9 +754,15 @@ kind: Cluster
 metadata:
   name: redis-replication-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"redis":{"name":"redis-replication-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: redis-replication-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: redis
   topology: replication

--- a/addons/vanilla-postgresql/README.md
+++ b/addons/vanilla-postgresql/README.md
@@ -573,9 +573,15 @@ kind: Cluster
 metadata:
   name: vanpg-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"postgresql":{"name":"vanpg-cluster-pg-basebackup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: vanpg-cluster-pg-basebackup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: vanilla-postgresql
   topology: vanilla-postgresql

--- a/addons/zookeeper/README.md
+++ b/addons/zookeeper/README.md
@@ -545,10 +545,15 @@ kind: Cluster
 metadata:
   name: zk-cluster-restore
   namespace: demo
-  annotations:
-    # zk-cluster-backup is the backup name.
-    kubeblocks.io/restore-from-backup: '{"zookeeper":{"name":"zk-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: zk-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:
     - name: zookeeper

--- a/examples/apecloud-mysql/restore.yaml
+++ b/examples/apecloud-mysql/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: acmysql-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"mysql":{"name":"acmysql-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: acmysql-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: apecloud-mysql
   topology: apecloud-mysql

--- a/examples/clickhouse/restore.yaml
+++ b/examples/clickhouse/restore.yaml
@@ -3,10 +3,15 @@ kind: Cluster
 metadata:
   name: clickhouse-cluster-restore
   namespace: demo
-  annotations:
-    # clickhouse-cluster-backup is the Backup CR name.
-    kubeblocks.io/restore-from-backup: '{"clickhouse":{"name":"clickhouse-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: clickhouse-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   clusterDef: clickhouse
   topology: cluster
   terminationPolicy: Delete

--- a/examples/etcd/restore.yaml
+++ b/examples/etcd/restore.yaml
@@ -3,10 +3,15 @@ kind: Cluster
 metadata:
   name: etcd-cluster-restore
   namespace: demo
-  annotations:
-    # etcd-cluster-backup is the backup name.
-    kubeblocks.io/restore-from-backup: '{"etcd":{"name":"etcd-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: etcd-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:
     - name: etcd

--- a/examples/falkordb/restore.yaml
+++ b/examples/falkordb/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: falkordb-replication-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"falkordb":{"name":"falkordb-backup-datafile","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: falkordb-backup-datafile
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: falkordb
   topology: replication

--- a/examples/mongodb/restore.yaml
+++ b/examples/mongodb/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: mongo-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"mongodb":{"name":"mongo-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: mongo-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: mongodb
   topology: replicaset

--- a/examples/mysql/restore.yaml
+++ b/examples/mysql/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: mysql-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"mysql":{"name":"mysql-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: mysql-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:
     - name: mysql

--- a/examples/oceanbase-ce/restore.yaml
+++ b/examples/oceanbase-ce/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: oceanbase-cluster-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"oceanbase":{"name":"ob-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: ob-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: oceanbase-ce
   topology: distribution

--- a/examples/postgresql/restore.yaml
+++ b/examples/postgresql/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: pg-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"postgresql":{"name":"pg-cluster-pg-basebackup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: pg-cluster-pg-basebackup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: postgresql
   topology: replication

--- a/examples/qdrant/restore.yaml
+++ b/examples/qdrant/restore.yaml
@@ -3,10 +3,15 @@ kind: Cluster
 metadata:
   name: qdrant-cluster-restore
   namespace: demo
-  annotations:
-    # qdrant-cluster-backup is the backup name
-    kubeblocks.io/restore-from-backup: '{"qdrant":{"name":"qdrant-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: qdrant-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: qdrant
   topology: cluster

--- a/examples/redis/restore.yaml
+++ b/examples/redis/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: redis-replication-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"redis":{"name":"redis-replication-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: redis-replication-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: redis
   topology: replication

--- a/examples/vanilla-postgresql/restore.yaml
+++ b/examples/vanilla-postgresql/restore.yaml
@@ -3,9 +3,15 @@ kind: Cluster
 metadata:
   name: vanpg-restore
   namespace: demo
-  annotations:
-    kubeblocks.io/restore-from-backup: '{"postgresql":{"name":"vanpg-cluster-pg-basebackup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: vanpg-cluster-pg-basebackup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: vanilla-postgresql
   topology: vanilla-postgresql

--- a/examples/zookeeper/restore.yaml
+++ b/examples/zookeeper/restore.yaml
@@ -3,10 +3,15 @@ kind: Cluster
 metadata:
   name: zk-cluster-restore
   namespace: demo
-  annotations:
-    # zk-cluster-backup is the backup name.
-    kubeblocks.io/restore-from-backup: '{"zookeeper":{"name":"zk-cluster-backup","namespace":"demo","volumeRestorePolicy":"Parallel"}}'
 spec:
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: zk-cluster-backup
+      namespace: demo
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:
     - name: zookeeper


### PR DESCRIPTION
## Summary

- update addon restore examples to use Cluster spec.restore instead of the legacy restore-from-backup annotation
- sync addon README restore snippets with the new API shape
- update MongoDB restore startup logic to read spec.restore and the Cluster Restore condition

## Validation

- bash -n addons/mongodb/scripts/mongodb-common.sh addons/mongodb/scripts/backup-agent-setup.sh addons/mongodb/scripts/mongodb-shard-setup.sh addons/mongodb/scripts/mongodb-mongos-setup.sh
- ruby YAML restore example validation
- rg legacy restore annotation scan
- shellspec --load-path ./shellspec --default-path addons/mongodb/scripts-ut-spec --shell bash
- git diff --check