### PR TITLE
fix(mariadb): reduce galera polling log noise during wait-for-Primary

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1986,6 +1986,14 @@ type: application
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
 #
+# alpha.123 (Helen 2026-06-02 — galera reduce polling log noise):
+# Address Jade's non-blocking review feedback on PR #2734: _any_peer_alive
+# logs per-peer status on every call, producing ~80-120 lines during the
+# _wait_for_primary_peer polling loop (40 iterations × 2 peers). Add a
+# quiet parameter to suppress non-Primary peer status lines during polling.
+# Success lines ("Peer X is alive with Primary") always log. First call
+# and should_bootstrap calls remain verbose for diagnostic value.
+#
 # alpha.122 (Helen 2026-06-02 — galera self-healing non-Primary watcher):
 # Fix TOCTOU race in parallel restart. Alpha.121 added _wait_for_primary_peer
 # so pod-1/pod-2 wait for pod-0 to bootstrap. But the InstanceSet controller
@@ -2141,7 +2149,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.1.1-alpha.122
+version: 1.1.1-alpha.123
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -29,6 +29,7 @@ build_cluster_address() {
 # Instead, query wsrep_cluster_status on each reachable peer. Only
 # "Primary" means the peer belongs to a functioning cluster.
 _any_peer_alive() {
+  local quiet="${1:-}"
   local fqdns="${PEER_FQDNS:-}"
   [ -z "$fqdns" ] && return 1
   local peer
@@ -45,7 +46,7 @@ _any_peer_alive() {
         echo "Peer ${peer} is alive with wsrep_cluster_status=Primary."
         return 0
       fi
-      echo "Peer ${peer} port 3306 open but wsrep_cluster_status=${cluster_status:-unreachable} (not Primary, skipping)."
+      [ -z "${quiet}" ] && echo "Peer ${peer} port 3306 open but wsrep_cluster_status=${cluster_status:-unreachable} (not Primary, skipping)."
     fi
   done
   return 1
@@ -75,7 +76,7 @@ _wait_for_primary_peer() {
   while [ $elapsed -lt $max_wait ]; do
     sleep 3
     elapsed=$((elapsed + 3))
-    if _any_peer_alive; then
+    if _any_peer_alive quiet; then
       echo "Found peer with Primary component after ${elapsed}s."
       return 0
     fi


### PR DESCRIPTION
## Summary
- Add quiet parameter to `_any_peer_alive` to suppress non-Primary peer status lines during polling loop
- Success lines ("Peer X is alive with Primary") always log regardless of quiet mode
- First call in `_wait_for_primary_peer` and all `should_bootstrap` calls remain verbose

## Context
Addresses Jade's non-blocking review feedback on PR #2734: during a full cluster restart, the 120s polling loop calls `_any_peer_alive` up to 40 times, each logging per-peer status. This produces ~80-120 lines of repetitive log noise.

## Test plan
- [ ] Galera full suite still passes (no behavioral change, log-only)
- [ ] During wait-for-Primary, only success/timeout lines appear (no per-peer non-Primary lines)