### PR TITLE
fix(redis): dynamic reconfigure fails for hyphenated parameters

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -200,14 +200,16 @@ reconfigure:
       - /bin/sh
       - -c
       - |
+        rc=0
         tr '\0' '\n' < /proc/self/environ > /tmp/_reconf_env.txt
         while IFS= read -r line; do
           key="${line%%=*}"
           printf '%s\n' "$key" | grep -qE '^[a-z0-9_.-][a-z0-9_.-]*$' || continue
           value="${line#*=}"
-          /scripts/reload-parameter.sh "$key" "$value"
+          /scripts/reload-parameter.sh "$key" "$value" || rc=$?
         done < /tmp/_reconf_env.txt
         rm -f /tmp/_reconf_env.txt
+        exit "$rc"
 {{- end -}}
 
 {{- define "apeDts.reshard.image" -}}

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -184,10 +184,6 @@ Generate scripts configmap
 redis-account.sh: |-
 {{- $.Files.Get "scripts/redis-account.sh" | nindent 2 }}
 {{- end }}
-{{- if $.Files.Get "scripts/reload-parameter.sh" }}
-reload-parameter.sh: |-
-{{- $.Files.Get "scripts/reload-parameter.sh" | nindent 2 }}
-{{- end }}
 {{- end }}
 
 {{- define "redis.config.reconfigureAction" -}}
@@ -197,19 +193,14 @@ reconfigure:
     container: {{ $container }}
     targetPodSelector: All
     command:
-      - /bin/sh
+      - /bin/bash
       - -c
       - |
-        rc=0
-        tr '\0' '\n' < /proc/self/environ > /tmp/_reconf_env.txt
-        while IFS= read -r line; do
-          key="${line%%=*}"
-          printf '%s\n' "$key" | grep -qE '^[a-z0-9_.-][a-z0-9_.-]*$' || continue
-          value="${line#*=}"
-          /scripts/reload-parameter.sh "$key" "$value" || rc=$?
-        done < /tmp/_reconf_env.txt
-        rm -f /tmp/_reconf_env.txt
-        exit "$rc"
+        set -eu
+        env | cut -d= -f1 | grep -E '^[a-zA-Z0-9_.-]+$' | sort -u | while IFS= read -r param; do
+          [ -n "${param}" ] || continue
+          /scripts/reload-parameter.sh "${param//_/-}" "$(printenv "${param}")"
+        done
 {{- end -}}
 
 {{- define "apeDts.reshard.image" -}}

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -184,6 +184,10 @@ Generate scripts configmap
 redis-account.sh: |-
 {{- $.Files.Get "scripts/redis-account.sh" | nindent 2 }}
 {{- end }}
+{{- if $.Files.Get "scripts/reload-parameter.sh" }}
+reload-parameter.sh: |-
+{{- $.Files.Get "scripts/reload-parameter.sh" | nindent 2 }}
+{{- end }}
 {{- end }}
 
 {{- define "redis.config.reconfigureAction" -}}
@@ -196,12 +200,14 @@ reconfigure:
       - /bin/sh
       - -c
       - |
-        set -eu
-
-        env | cut -d= -f1 | grep -E '^[a-z0-9_.-][a-z0-9_.-]*$' | sort -u | while IFS= read -r param; do
-          [ -n "${param}" ] || continue
-          /scripts/reload-parameter.sh "${param}" "$(printenv "${param}")"
-        done
+        tr '\0' '\n' < /proc/self/environ > /tmp/_reconf_env.txt
+        while IFS= read -r line; do
+          key="${line%%=*}"
+          printf '%s\n' "$key" | grep -qE '^[a-z0-9_.-][a-z0-9_.-]*$' || continue
+          value="${line#*=}"
+          /scripts/reload-parameter.sh "$key" "$value"
+        done < /tmp/_reconf_env.txt
+        rm -f /tmp/_reconf_env.txt
 {{- end -}}
 
 {{- define "apeDts.reshard.image" -}}


### PR DESCRIPTION
## Summary

- Fix dynamic reconfigure (CONFIG SET) failing for Redis parameters with hyphens in their names (e.g. `maxmemory-policy`, `repl-backlog-size`, `slowlog-max-len`)
- Root cause was a three-layer bug stack:
  1. `/bin/sh` strips env vars with invalid POSIX names (hyphens) from its environment, making `env`/`printenv` unable to see them
  2. `set -eu` + pipe `while` loop (`tr | while`) runs in subshell where `set -e` silently exits on first `redis-cli` stderr warning
  3. Redis Cluster scripts ConfigMap was missing `reload-parameter.sh`, breaking reconfigure on cluster topology
- Fix reads from `/proc/self/environ` (preserves original `execve` environment), uses file-redirect loop to avoid subshell, and includes `reload-parameter.sh` in redis-cluster scripts

## Changes

- `_helpers.tpl` `redis.config.reconfigureAction`: Replace `env | cut` + pipe while with `/proc/self/environ` + file-redirect while
- `_helpers.tpl` `redis-cluster.extend.scripts`: Add `reload-parameter.sh` to redis-cluster scripts ConfigMap

## Test plan

- [x] Standalone: 4-param reconfigure (maxmemory-policy, hz, slowlog-max-len, repl-backlog-size) — CONFIG GET all updated, no pod restart
- [x] Replication: Same 4 params — both data pods updated
- [x] Twemproxy: Same 4 params — both backing Redis data pods updated
- [x] Redis Cluster: Same 4 params — all 6 pods (3 shards x 2 replicas) updated
- [ ] Full parameters test suite regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)