### PR TITLE
chore(mongodb): avoid rendering null volumes in CmpD templates

### DIFF
--- a/addons/mongodb/templates/cmpd-config-server.yaml
+++ b/addons/mongodb/templates/cmpd-config-server.yaml
@@ -242,13 +242,13 @@ spec:
         env:
           - name: MONGODB_URI
             value: mongodb://127.0.0.1:$(KB_SERVICE_PORT)
+    {{- if .Values.logCollector.enabled }}
     volumes:
-      {{- if .Values.logCollector.enabled }}
       - name: log-data
         hostPath:
           path: /var/log/kubeblocks
           type: DirectoryOrCreate
-      {{- end }}
+    {{- end }}
   services:
     - name: default
       spec:

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -289,13 +289,13 @@ spec:
         env:
           - name: MONGODB_URI
             value: mongodb://127.0.0.1:$(KB_SERVICE_PORT)
+    {{- if .Values.logCollector.enabled }}
     volumes:
-      {{- if .Values.logCollector.enabled }}
       - name: log-data
         hostPath:
           path: /var/log/kubeblocks
           type: DirectoryOrCreate
-      {{- end }}
+    {{- end }}
   vars:
     - name: CLUSTER_NAME
       valueFrom:

--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -262,13 +262,13 @@ spec:
         env:
           - name: MONGODB_URI
             value: mongodb://127.0.0.1:$(KB_SERVICE_PORT)
+    {{- if .Values.logCollector.enabled }}
     volumes:
-      {{- if .Values.logCollector.enabled }}
       - name: log-data
         hostPath:
           path: /var/log/kubeblocks
           type: DirectoryOrCreate
-      {{- end }}
+    {{- end }}
   vars:
     - name: CLUSTER_NAME
       valueFrom:


### PR DESCRIPTION
## Summary
- When `logCollector.enabled=false` (default), the `volumes:` key in MongoDB CmpD templates was rendered with no items, producing a null value
- KB 1.2 strict CRD validation rejects null arrays for `spec.runtime.volumes`
- Fix: move the `volumes:` key inside the `{{- if .Values.logCollector.enabled }}` block so it is only emitted when logCollector is enabled

## Affected templates
- `cmpd.yaml` (mongodb)
- `cmpd-config-server.yaml` (mongo-config-server)
- `cmpd-mongodb-shard.yaml` (mongo-shard)
- `cmpd-mongos.yaml` is not affected (has unconditional volume entries)

## Test plan
- [x] `helm lint addons/mongodb` passes
- [x] `helm template` renders without `volumes: null`
- [x] Verified on KB 1.2.0-alpha.1: CmpDs install and reach Available status
- [x] MongoDB 8.0.17 cluster creates and reaches Running with 1P/2S

🤖 Generated with [Claude Code](https://claude.com/claude-code)