### PR TITLE
chore(valkey): add switchover failover diagnostics

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -231,6 +231,61 @@ Describe "Valkey Switchover Bash Script Tests"
     End
   End
 
+  Describe "diagnostic logging helpers"
+    Context "when replication info is available"
+      It "summarizes the fields needed to diagnose Sentinel promotion timeout"
+        valkey-cli() {
+          cat <<'VALKEYINFO'
+# Replication
+role:slave
+master_host:valkey-2.headless.default.svc.cluster.local
+master_link_status:up
+master_sync_in_progress:0
+slave_read_repl_offset:150134
+slave_repl_offset:150134
+VALKEYINFO
+        }
+        When call replication_summary_for "valkey-0.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "role=slave"
+        The stdout should include "master_link_status=up"
+        The stdout should include "master_sync_in_progress=0"
+        The stdout should include "slave_repl_offset=150134"
+      End
+    End
+
+    Context "when Sentinel state is requested"
+      setup() {
+        export VALKEY_COMPONENT_NAME="mycluster-valkey"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.headless.default.svc.cluster.local"
+        export SENTINEL_SERVICE_PORT="26379"
+      }
+      Before "setup"
+
+      teardown() {
+        unset VALKEY_COMPONENT_NAME
+        unset SENTINEL_POD_FQDN_LIST
+        unset SENTINEL_SERVICE_PORT
+      }
+      After "teardown"
+
+      It "prints master, replica, and quorum diagnostics"
+        valkey-cli() {
+          case "$*" in
+            *"SENTINEL MASTER"*) echo "name"; echo "mycluster-valkey" ;;
+            *"SENTINEL REPLICAS"*) echo "name"; echo "valkey-0" ;;
+            *"SENTINEL CKQUORUM"*) echo "OK 3 usable Sentinels. Quorum and failover authorization can be reached" ;;
+          esac
+        }
+        When call log_sentinel_state "unit"
+        The status should be success
+        The stderr should include "SENTINEL MASTER mycluster-valkey"
+        The stderr should include "SENTINEL REPLICAS mycluster-valkey"
+        The stderr should include "SENTINEL CKQUORUM mycluster-valkey"
+      End
+    End
+  End
+
   Describe "promote_replica()"
     Context "when REPLICAOF NO ONE succeeds"
       It "returns success"

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -54,6 +54,72 @@ get_role() {
   ${cli} info replication 2>/dev/null | grep "^role:" | tr -d '\r\n' | cut -d: -f2
 }
 
+log_multiline() {
+  local prefix="${1}" text="${2}"
+  if is_empty "${text}"; then
+    echo "${prefix}<empty>" >&2
+    return 0
+  fi
+  while IFS= read -r line; do
+    echo "${prefix}${line}" >&2
+  done <<< "${text}"
+}
+
+replication_summary_for() {
+  local fqdn="${1}"
+  local cli output exit_code=0
+  cli=$(build_cli "${fqdn}")
+  output=$(${cli} info replication 2>&1) || exit_code=$?
+  output="${output//$'\r'/}"
+  if [ "${exit_code}" -ne 0 ]; then
+    echo "unreachable exit=${exit_code} output=${output}"
+    return 0
+  fi
+
+  echo "${output}" | awk -F: '
+    $1 == "role" { role = $2 }
+    $1 == "master_host" { master_host = $2 }
+    $1 == "master_link_status" { master_link_status = $2 }
+    $1 == "master_sync_in_progress" { master_sync = $2 }
+    $1 == "slave_read_repl_offset" { slave_read_offset = $2 }
+    $1 == "slave_repl_offset" { slave_offset = $2 }
+    $1 == "master_repl_offset" { master_offset = $2 }
+    $1 == "connected_slaves" { connected_slaves = $2 }
+    /^slave[0-9]+:/ {
+      if (slaves != "") { slaves = slaves ";" }
+      slaves = slaves $0
+    }
+    END {
+      printf "role=%s", role
+      if (master_host != "") { printf " master_host=%s", master_host }
+      if (master_link_status != "") { printf " master_link_status=%s", master_link_status }
+      if (master_sync != "") { printf " master_sync_in_progress=%s", master_sync }
+      if (slave_read_offset != "") { printf " slave_read_repl_offset=%s", slave_read_offset }
+      if (slave_offset != "") { printf " slave_repl_offset=%s", slave_offset }
+      if (master_offset != "") { printf " master_repl_offset=%s", master_offset }
+      if (connected_slaves != "") { printf " connected_slaves=%s", connected_slaves }
+      if (slaves != "") { printf " slaves=[%s]", slaves }
+      printf "\n"
+    }
+  '
+}
+
+log_replication_summaries() {
+  local label="${1}" expected_fqdn="${2}"
+  local fqdn summary
+  IFS=',' read -ra pod_fqdns <<< "$(pod_fqdns_with_candidate "${expected_fqdn}")"
+  echo "DEBUG: ${label}: replication summaries" >&2
+  for fqdn in "${pod_fqdns[@]}"; do
+    is_empty "${fqdn}" && continue
+    summary=$(replication_summary_for "${fqdn}") || true
+    echo "DEBUG: ${label}: ${fqdn}: ${summary}" >&2
+  done
+}
+
+runtime_diagnostics_enabled() {
+  [ "${ut_mode:-false}" = "false" ]
+}
+
 promote_replica() {
   local target_fqdn="${1}"
   echo "Promoting ${target_fqdn} to primary..."
@@ -162,6 +228,36 @@ sentinel_cli_for() {
   echo "${cmd}"
 }
 
+log_sentinel_command_output() {
+  local label="${1}" s_fqdn="${2}" command_label="${3}" output="${4}" exit_code="${5}"
+  output="${output//$'\r'/}"
+  echo "DEBUG: ${label}: ${s_fqdn}: ${command_label} exit=${exit_code}" >&2
+  log_multiline "DEBUG: ${label}: ${s_fqdn}:   " "${output}"
+}
+
+log_sentinel_state() {
+  local label="${1}"
+  local master_name="${VALKEY_COMPONENT_NAME}"
+  IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
+  for s_fqdn in "${sentinel_fqdns[@]}"; do
+    is_empty "${s_fqdn}" && continue
+    local cli output exit_code
+    cli=$(sentinel_cli_for "${s_fqdn}")
+
+    exit_code=0
+    output=$(${cli} SENTINEL MASTER "${master_name}" 2>&1) || exit_code=$?
+    log_sentinel_command_output "${label}" "${s_fqdn}" "SENTINEL MASTER ${master_name}" "${output}" "${exit_code}"
+
+    exit_code=0
+    output=$(${cli} SENTINEL REPLICAS "${master_name}" 2>&1) || exit_code=$?
+    log_sentinel_command_output "${label}" "${s_fqdn}" "SENTINEL REPLICAS ${master_name}" "${output}" "${exit_code}"
+
+    exit_code=0
+    output=$(${cli} SENTINEL CKQUORUM "${master_name}" 2>&1) || exit_code=$?
+    log_sentinel_command_output "${label}" "${s_fqdn}" "SENTINEL CKQUORUM ${master_name}" "${output}" "${exit_code}"
+  done
+}
+
 _do_set_replica_priority() {
   local fqdn="${1}" prio="${2}"
   local cli output
@@ -197,6 +293,9 @@ execute_sentinel_failover() {
     output="${output//$'\r'/}"
     if [ "${output}" = "OK" ]; then
       echo "Sentinel FAILOVER accepted by ${s_fqdn}"
+      if runtime_diagnostics_enabled; then
+        log_sentinel_state "after-sentinel-failover-accepted"
+      fi
       return 0
     fi
   done
@@ -263,6 +362,9 @@ wait_for_new_master() {
   local max_wait=300 elapsed=0
 
   while [ "${elapsed}" -lt "${max_wait}" ]; do
+    if runtime_diagnostics_enabled && { [ "${elapsed}" -eq 0 ] || [ $((elapsed % 30)) -eq 0 ]; }; then
+      log_replication_summaries "wait_for_new_master elapsed=${elapsed}s expected=${expected_fqdn:-any}" "${expected_fqdn}"
+    fi
     IFS=',' read -ra pod_fqdns <<< "$(pod_fqdns_with_candidate "${expected_fqdn}")"
     for fqdn in "${pod_fqdns[@]}"; do
       local role
@@ -286,6 +388,10 @@ wait_for_new_master() {
     elapsed=$((elapsed + 3))
   done
   echo "WARNING: could not confirm new primary within ${max_wait}s" >&2
+  if runtime_diagnostics_enabled; then
+    log_replication_summaries "wait_for_new_master timeout expected=${expected_fqdn:-any}" "${expected_fqdn}"
+    log_sentinel_state "wait_for_new_master timeout"
+  fi
   return 1
 }
 


### PR DESCRIPTION
## Summary
- add runtime diagnostics around Sentinel-based Valkey switchover
- log Sentinel MASTER/REPLICAS/CKQUORUM state after FAILOVER is accepted and when promotion wait times out
- log compact replication summaries during wait_for_new_master at bounded intervals
- add ShellSpec coverage for the new diagnostic helpers

## Validation
- bash -n addons/valkey/scripts/switchover.sh
- bash -n addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
- git diff --check
- docker run bash:5.2 shellspec for valkey_switchover_spec.sh: 57 examples, 0 failures
- docker run bash:5.2 shellspec for all Valkey script specs: 201 examples, 0 failures

## Notes
This PR only adds diagnostics. It does not change switchover behavior.