### PR TITLE
fix(valkey): use bash arrays for CLI commands to prevent password word-splitting

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -929,7 +929,7 @@ Describe "Valkey Check-Role Bash Script Tests"
         # variable rather than always hard-coding `-a "${SENTINEL_PASSWORD}"`.
         # That way missing password leaves auth args empty and the cli
         # call NOAUTH-fails, routing to `insufficient_valid`.
-        When call grep -F '${sentinel_auth_args} ${sentinel_tls_args} sentinel masters' "${check_role_script}"
+        When call grep -F '"${sentinel_auth_args[@]}" ${sentinel_tls_args} sentinel masters' "${check_role_script}"
         The status should be success
         The stdout should include 'sentinel_auth_args'
       End

--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -28,6 +28,11 @@ Describe "Valkey Check-Role Bash Script Tests"
   AfterAll "cleanup"
 
   Describe "build_cli_cmd()"
+    _cli_cmd_as_string() {
+      build_cli_cmd
+      printf '%s\n' "${cli_cmd[*]}"
+    }
+
     Context "without password or TLS"
       setup() {
         unset VALKEY_DEFAULT_PASSWORD
@@ -36,7 +41,7 @@ Describe "Valkey Check-Role Bash Script Tests"
       Before "setup"
 
       It "builds a basic valkey-cli command"
-        When call build_cli_cmd
+        When call _cli_cmd_as_string
         The status should be success
         The stdout should include "valkey-cli --no-auth-warning"
         The stdout should include "-h 127.0.0.1"
@@ -57,7 +62,7 @@ Describe "Valkey Check-Role Bash Script Tests"
       After "teardown"
 
       It "includes -a flag"
-        When call build_cli_cmd
+        When call _cli_cmd_as_string
         The status should be success
         The stdout should include "-a secret"
       End
@@ -77,7 +82,7 @@ Describe "Valkey Check-Role Bash Script Tests"
       After "teardown"
 
       It "uses the custom port"
-        When call build_cli_cmd
+        When call _cli_cmd_as_string
         The status should be success
         The stdout should include "-p 6380"
       End
@@ -105,8 +110,8 @@ Describe "Valkey Check-Role Bash Script Tests"
         valkey-cli() {
           printf "# Replication\r\nrole:master\r\nconnected_slaves:2\r\n"
         }
-        cli_cmd=$(build_cli_cmd)
-        repl_info=$(${cli_cmd} info replication 2>/dev/null)
+        build_cli_cmd
+        repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null)
         role_line=$(parse_role_line "${repl_info}")
         When call bash -c "
           case \"${role_line}\" in
@@ -125,8 +130,8 @@ Describe "Valkey Check-Role Bash Script Tests"
         valkey-cli() {
           printf "# Replication\r\nrole:slave\r\nmaster_host:valkey-0\r\n"
         }
-        cli_cmd=$(build_cli_cmd)
-        repl_info=$(${cli_cmd} info replication 2>/dev/null)
+        build_cli_cmd
+        repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null)
         role_line=$(parse_role_line "${repl_info}")
         When call bash -c "
           case \"${role_line}\" in
@@ -143,8 +148,8 @@ Describe "Valkey Check-Role Bash Script Tests"
     Context "when INFO output is empty (pod startup window)"
       It "produces empty role_line (script will exit 1 in main)"
         valkey-cli() { return 1; }   # cli connection fails
-        cli_cmd=$(build_cli_cmd)
-        repl_info=$(${cli_cmd} info replication 2>/dev/null) || repl_info=""
+        build_cli_cmd
+        repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || repl_info=""
         When call parse_role_line "${repl_info}"
         The status should be success
         The stdout should eq ""

--- a/addons/valkey/scripts-ut-spec/reload_parameter_spec.sh
+++ b/addons/valkey/scripts-ut-spec/reload_parameter_spec.sh
@@ -44,32 +44,32 @@ SH
 
   It "succeeds when CONFIG SET returns OK"
     export FAKE_VALKEY_OUTPUT=OK
-    When run sh ../scripts/reload-parameter.sh MAXMEMORY_POLICY allkeys-lru
+    When run bash ../scripts/reload-parameter.sh MAXMEMORY_POLICY allkeys-lru
     The status should be success
   End
 
   It "keeps unsupported static parameters non-fatal"
     export FAKE_VALKEY_OUTPUT=unknown
-    When run sh ../scripts/reload-parameter.sh BIND 0.0.0.0
+    When run bash ../scripts/reload-parameter.sh BIND 0.0.0.0
     The status should be success
   End
 
   It "keeps immutable runtime parameters non-fatal"
     export FAKE_VALKEY_OUTPUT=immutable
-    When run sh ../scripts/reload-parameter.sh CLUSTER_ENABLED yes
+    When run bash ../scripts/reload-parameter.sh CLUSTER_ENABLED yes
     The status should be success
   End
 
   It "fails closed on invalid enum values"
     export FAKE_VALKEY_OUTPUT=invalid
-    When run sh ../scripts/reload-parameter.sh MAXMEMORY_POLICY definitely-not-a-policy
+    When run bash ../scripts/reload-parameter.sh MAXMEMORY_POLICY definitely-not-a-policy
     The status should be failure
     The stderr should include "ERROR: CONFIG SET maxmemory-policy failed"
   End
 
   It "fails closed on invalid range values"
     export FAKE_VALKEY_OUTPUT=range
-    When run sh ../scripts/reload-parameter.sh MAXMEMORY_SAMPLES 0
+    When run bash ../scripts/reload-parameter.sh MAXMEMORY_SAMPLES 0
     The status should be failure
     The stderr should include "ERROR: CONFIG SET maxmemory-samples failed"
   End

--- a/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
@@ -30,6 +30,11 @@ Describe "Valkey Member-Leave Bash Script Tests"
   AfterAll "cleanup"
 
   Describe "build_data_cli()"
+    _build_data_cli_as_string() {
+      build_data_cli "$@"
+      printf '%s\n' "${_data_cli_cmd[*]}"
+    }
+
     Context "with password"
       setup() {
         export VALKEY_DEFAULT_PASSWORD="mypass"
@@ -42,7 +47,7 @@ Describe "Valkey Member-Leave Bash Script Tests"
       After "teardown"
 
       It "includes --no-auth-warning and -a flag"
-        When call build_data_cli "valkey-0.headless.default.svc.cluster.local"
+        When call _build_data_cli_as_string "valkey-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "--no-auth-warning"
         The stdout should include "-a mypass"
@@ -57,7 +62,7 @@ Describe "Valkey Member-Leave Bash Script Tests"
       Before "setup"
 
       It "includes --no-auth-warning and no -a flag"
-        When call build_data_cli "valkey-0.headless.default.svc.cluster.local"
+        When call _build_data_cli_as_string "valkey-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "--no-auth-warning"
         The stdout should not include " -a "
@@ -66,6 +71,11 @@ Describe "Valkey Member-Leave Bash Script Tests"
   End
 
   Describe "build_sentinel_cli()"
+    _build_sentinel_cli_as_string() {
+      build_sentinel_cli "$@"
+      printf '%s\n' "${_sentinel_cli_cmd[*]}"
+    }
+
     Context "with Sentinel password"
       setup() {
         export SENTINEL_PASSWORD="sentpass"
@@ -78,7 +88,7 @@ Describe "Valkey Member-Leave Bash Script Tests"
       After "teardown"
 
       It "includes --no-auth-warning and -a flag on sentinel port"
-        When call build_sentinel_cli "sentinel-0.headless.default.svc.cluster.local"
+        When call _build_sentinel_cli_as_string "sentinel-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "--no-auth-warning"
         The stdout should include "-a sentpass"

--- a/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
@@ -147,10 +147,14 @@ Describe "Valkey Member-Leave Bash Script Tests"
       export KB_LEAVE_MEMBER_POD_FQDN="valkey-1.headless.default.svc.cluster.local"
       export KB_LEAVE_MEMBER_POD_NAME="valkey-1"
       valkey-cli() { printf "role:slave\r\n"; }
-      _data_cli=$(build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}")
-      leaving_role=$(${_data_cli} INFO replication 2>/dev/null \
-                     | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
-      When call echo "${leaving_role}"
+      _detect_slave_role() {
+        build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}"
+        local leaving_role
+        leaving_role=$("${_data_cli_cmd[@]}" INFO replication 2>/dev/null \
+                       | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
+        printf '%s' "${leaving_role}"
+      }
+      When call _detect_slave_role
       The stdout should eq "slave"
     End
 
@@ -158,10 +162,14 @@ Describe "Valkey Member-Leave Bash Script Tests"
       export KB_LEAVE_MEMBER_POD_FQDN="valkey-0.headless.default.svc.cluster.local"
       export KB_LEAVE_MEMBER_POD_NAME="valkey-0"
       valkey-cli() { printf "role:master\r\n"; }
-      _data_cli=$(build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}")
-      leaving_role=$(${_data_cli} INFO replication 2>/dev/null \
-                     | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
-      When call echo "${leaving_role}"
+      _detect_master_role() {
+        build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}"
+        local leaving_role
+        leaving_role=$("${_data_cli_cmd[@]}" INFO replication 2>/dev/null \
+                       | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
+        printf '%s' "${leaving_role}"
+      }
+      When call _detect_master_role
       The stdout should eq "master"
     End
   End

--- a/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
@@ -41,7 +41,11 @@ Describe "Valkey Self-Heal Daemon"
       Before "setup"
 
       It "builds a basic valkey-cli command"
-        When call cascade_build_local_cli_cmd
+        _local_cli_as_string() {
+          cascade_build_local_cli_cmd
+          printf '%s\n' "${_cli_cmd[*]}"
+        }
+        When call _local_cli_as_string
         The status should be success
         The stdout should include "valkey-cli --no-auth-warning"
         The stdout should include "-h 127.0.0.1"
@@ -62,7 +66,11 @@ Describe "Valkey Self-Heal Daemon"
       After "teardown"
 
       It "includes -a flag"
-        When call cascade_build_local_cli_cmd
+        _local_cli_with_pw_as_string() {
+          cascade_build_local_cli_cmd
+          printf '%s\n' "${_cli_cmd[*]}"
+        }
+        When call _local_cli_with_pw_as_string
         The status should be success
         The stdout should include "-a secret"
       End
@@ -371,8 +379,8 @@ Describe "Valkey Self-Heal Daemon"
     It "returns success when role is slave and master_host matches expected"
       export DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="5"
       export CONFIRM_SCENARIO="ok"
+      _dm_cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379)
       When call dual_master_confirm_demote \
-        "valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379" \
         "vlk-0.vlk-headless.ns.svc.cluster.local"
       The status should be success
     End
@@ -380,8 +388,8 @@ Describe "Valkey Self-Heal Daemon"
     It "returns failure when role is slave but master_host points to a different host"
       export DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="1"
       export CONFIRM_SCENARIO="wrong_host"
+      _dm_cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379)
       When call dual_master_confirm_demote \
-        "valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379" \
         "vlk-0.vlk-headless.ns.svc.cluster.local"
       The status should be failure
     End
@@ -389,8 +397,8 @@ Describe "Valkey Self-Heal Daemon"
     It "returns failure when cli is unreachable throughout the timeout window"
       export DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="1"
       export CONFIRM_SCENARIO="unreachable"
+      _dm_cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379)
       When call dual_master_confirm_demote \
-        "valkey-cli --no-auth-warning -h 127.0.0.1 -p 6379" \
         "vlk-0.vlk-headless.ns.svc.cluster.local"
       The status should be failure
     End

--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -72,6 +72,11 @@ Describe "Valkey Switchover Bash Script Tests"
   End
 
   Describe "build_cli()"
+    _build_cli_as_string() {
+      build_cli "$@"
+      printf '%s\n' "${_cli[*]}"
+    }
+
     Context "when no password and no TLS args are set"
       setup() {
         export VALKEY_DEFAULT_PASSWORD=""
@@ -86,7 +91,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "returns basic valkey-cli command without -a or TLS flags"
-        When call build_cli "valkey-0.headless.default.svc.cluster.local"
+        When call _build_cli_as_string "valkey-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "valkey-cli"
         The stdout should include "-h valkey-0.headless.default.svc.cluster.local"
@@ -109,7 +114,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "appends -a <password> to the command"
-        When call build_cli "valkey-0.headless.default.svc.cluster.local"
+        When call _build_cli_as_string "valkey-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include " -a s3cr3t"
       End
@@ -129,7 +134,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "appends TLS args to the command"
-        When call build_cli "valkey-0.headless.default.svc.cluster.local"
+        When call _build_cli_as_string "valkey-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "--tls"
         The stdout should include "--cacert /tls/ca.crt"
@@ -151,7 +156,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "includes both -a <password> and TLS args"
-        When call build_cli "valkey-0.headless.default.svc.cluster.local"
+        When call _build_cli_as_string "valkey-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include " -a s3cr3t"
         The stdout should include "--tls"
@@ -161,6 +166,11 @@ Describe "Valkey Switchover Bash Script Tests"
   End
 
   Describe "sentinel_cli_for()"
+    _sentinel_cli_for_as_string() {
+      sentinel_cli_for "$@"
+      printf '%s\n' "${_sentinel_cli[*]}"
+    }
+
     Context "when no sentinel password and no TLS args"
       setup() {
         export SENTINEL_PASSWORD=""
@@ -177,7 +187,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "returns valkey-cli command targeting sentinel port 26379 without -a"
-        When call sentinel_cli_for "sentinel-0.headless.default.svc.cluster.local"
+        When call _sentinel_cli_for_as_string "sentinel-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "-h sentinel-0.headless.default.svc.cluster.local"
         The stdout should include "-p 26379"
@@ -201,7 +211,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "appends -a <sentinel-password> to the command"
-        When call sentinel_cli_for "sentinel-0.headless.default.svc.cluster.local"
+        When call _sentinel_cli_for_as_string "sentinel-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include " -a sentinelpass"
       End
@@ -223,7 +233,7 @@ Describe "Valkey Switchover Bash Script Tests"
       After "teardown"
 
       It "uses the custom port instead of the default 26379"
-        When call sentinel_cli_for "sentinel-0.headless.default.svc.cluster.local"
+        When call _sentinel_cli_for_as_string "sentinel-0.headless.default.svc.cluster.local"
         The status should be success
         The stdout should include "-p 36379"
         The stdout should not include "-p 26379"

--- a/addons/valkey/scripts/account-provision.sh
+++ b/addons/valkey/scripts/account-provision.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 # account-provision.sh — called by KubeBlocks to create/update a database account.
 #
@@ -21,19 +21,20 @@ set -e
 
 port="${SERVICE_PORT:-6379}"
 
-base_cmd="valkey-cli --no-auth-warning -p ${port}"
+base_cmd=(valkey-cli --no-auth-warning -p "${port}")
 if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
-  base_cmd="${base_cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+  base_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
 fi
 if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
-  base_cmd="${base_cmd} ${VALKEY_CLI_TLS_ARGS}"
+  # shellcheck disable=SC2206
+  base_cmd+=(${VALKEY_CLI_TLS_ARGS})
 fi
 
 # Execute the statement provided by KubeBlocks.
 # Pipe via stdin so that '>' in ACL password syntax (e.g. >mypassword) is not
 # misinterpreted as a shell output-redirect operator.
 # valkey-cli exits 0 even for protocol errors; capture output and check content.
-output=$(echo "${KB_ACCOUNT_STATEMENT}" | ${base_cmd} 2>&1) || {
+output=$(echo "${KB_ACCOUNT_STATEMENT}" | "${base_cmd[@]}" 2>&1) || {
   echo "ERROR: account statement failed: ${output}" >&2
   exit 1
 }
@@ -43,7 +44,7 @@ if [ "${output}" != "OK" ]; then
 fi
 
 # Persist ACL to disk so it survives pod restarts
-acl_save_out=$(${base_cmd} ACL SAVE 2>&1) || {
+acl_save_out=$("${base_cmd[@]}" ACL SAVE 2>&1) || {
   echo "ERROR: ACL SAVE failed: ${acl_save_out}" >&2
   exit 1
 }

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -74,14 +74,14 @@ set -e
 port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
 
 build_cli_cmd() {
-  local cmd="valkey-cli --no-auth-warning -h 127.0.0.1 -p ${port}"
+  cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+    cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   if ! is_empty "${VALKEY_CLI_TLS_ARGS}"; then
-    cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
+    # shellcheck disable=SC2206
+    cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
   fi
-  echo "${cmd}"
 }
 
 load_common_library() {
@@ -95,7 +95,7 @@ ${__SOURCED__:+false} : || return 0
 # ── main ────────────────────────────────────────────────────────────────
 load_common_library
 
-cli_cmd=$(build_cli_cmd)
+build_cli_cmd
 
 unset_xtrace_when_ut_mode_false
 # Capture the full INFO replication output once via a single command
@@ -110,7 +110,7 @@ unset_xtrace_when_ut_mode_false
 # valkey-cli INFO output uses CRLF line endings per the Redis protocol;
 # the parameter expansion `${line%$'\r'}` trims the trailing CR before
 # the case match.
-repl_info=$(${cli_cmd} info replication 2>/dev/null) || repl_info=""
+repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || repl_info=""
 role_line=""
 while IFS= read -r line; do
   line="${line%$'\r'}"
@@ -127,7 +127,7 @@ done <<<"${repl_info}"
 # server`) is the stable per-server identity Sentinel records as `runid`
 # for the current master. Comparing the two lets the script reject the
 # stale-master self-report before it reaches the controller.
-server_info=$(${cli_cmd} info server 2>/dev/null) || server_info=""
+server_info=$("${cli_cmd[@]}" info server 2>/dev/null) || server_info=""
 local_run_id=""
 while IFS= read -r line; do
   line="${line%$'\r'}"
@@ -229,9 +229,9 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   # cli call will fail (NOAUTH) and the per-sentinel drop will push
   # the decision to `insufficient_valid`, which the fallback branch now
   # correctly maps to a failed probe sample.
-  sentinel_auth_args=""
+  sentinel_auth_args=()
   if [ -n "${SENTINEL_PASSWORD:-}" ]; then
-    sentinel_auth_args="-a ${SENTINEL_PASSWORD}"
+    sentinel_auth_args=(-a "${SENTINEL_PASSWORD}")
   fi
   # Configured total: count non-empty entries. Empty entries from a
   # trailing comma or runtime mis-render must not lower the quorum bar.
@@ -247,7 +247,7 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     sentinel_query_success_count=0
     sentinel_master_config_count=0
     for s in "${sentinel_fqdns[@]}"; do
-      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" ${sentinel_auth_args} ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
+      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" "${sentinel_auth_args[@]}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
       sentinel_query_success_count=$((sentinel_query_success_count + 1))
       sentinel_has_master_config=0
       ce_marker=""

--- a/addons/valkey/scripts/post-provision.sh
+++ b/addons/valkey/scripts/post-provision.sh
@@ -18,12 +18,13 @@ set -e
 port="${SERVICE_PORT:-6379}"
 expected_replicas=$(( COMPONENT_REPLICAS - 1 ))
 
-cli_cmd="valkey-cli --no-auth-warning -h 127.0.0.1 -p ${port}"
+cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
 if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
-  cli_cmd="${cli_cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+  cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
 fi
 if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
-  cli_cmd="${cli_cmd} ${VALKEY_CLI_TLS_ARGS}"
+  # shellcheck disable=SC2206
+  cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
 fi
 
 # In standalone mode there are no replicas to check
@@ -37,7 +38,7 @@ max_wait=60
 elapsed=0
 connected=0
 while [ "${elapsed}" -lt "${max_wait}" ]; do
-  connected=$(${cli_cmd} info replication 2>/dev/null \
+  connected=$("${cli_cmd[@]}" info replication 2>/dev/null \
     | grep "^connected_slaves:" | cut -d: -f2 | tr -d '\r\n') || true
   if [ "${connected}" = "${expected_replicas}" ]; then
     echo "postProvision: all ${expected_replicas} replica(s) connected."

--- a/addons/valkey/scripts/pre-stop.sh
+++ b/addons/valkey/scripts/pre-stop.sh
@@ -14,29 +14,30 @@ set -e
 
 port="${SERVICE_PORT:-6379}"
 
-cli_cmd="valkey-cli --no-auth-warning -h 127.0.0.1 -p ${port}"
+cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
 if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
   { set +x; } 2>/dev/null
-  cli_cmd="${cli_cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+  cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
 fi
 if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
-  cli_cmd="${cli_cmd} ${VALKEY_CLI_TLS_ARGS}"
+  # shellcheck disable=SC2206
+  cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
 fi
 
 echo "preStop: triggering BGSAVE..."
 # Record the timestamp of the last completed save before we start a new one.
-last_save_before=$(${cli_cmd} LASTSAVE 2>/dev/null || echo "0")
-${cli_cmd} BGSAVE 2>/dev/null || true
+last_save_before=$("${cli_cmd[@]}" LASTSAVE 2>/dev/null || echo "0")
+"${cli_cmd[@]}" BGSAVE 2>/dev/null || true
 
 # Wait until LASTSAVE advances past the pre-BGSAVE timestamp (max 30 s).
 for i in $(seq 1 30); do
   sleep 1
-  in_progress=$(${cli_cmd} INFO persistence 2>/dev/null \
+  in_progress=$("${cli_cmd[@]}" INFO persistence 2>/dev/null \
     | grep rdb_bgsave_in_progress | tr -d '\r' | cut -d: -f2)
   # If bgsave_in_progress is empty the server may be unreachable; break safely.
   [ -z "${in_progress}" ] && break
   if [ "${in_progress}" = "0" ]; then
-    current_save=$(${cli_cmd} LASTSAVE 2>/dev/null || echo "0")
+    current_save=$("${cli_cmd[@]}" LASTSAVE 2>/dev/null || echo "0")
     if [ "${current_save}" -gt "${last_save_before}" ]; then
       echo "preStop: BGSAVE completed (${current_save})."
       break

--- a/addons/valkey/scripts/reload-parameter.sh
+++ b/addons/valkey/scripts/reload-parameter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # reload-parameter.sh — hot-reload a single configuration parameter.
 #
 # Learning note:
@@ -21,17 +21,18 @@ valkey_param=$(echo "${param_name}" | tr '[:upper:]_' '[:lower:]-')
 port="${SERVICE_PORT:-6379}"
 # Use 'timeout' to prevent the reconfigure action from hanging indefinitely
 # if Valkey is slow or unresponsive.
-cli_cmd="timeout 30 valkey-cli --no-auth-warning -h 127.0.0.1 -p ${port}"
+cli_cmd=(timeout 30 valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
 if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
-  cli_cmd="${cli_cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+  cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
 fi
 if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
-  cli_cmd="${cli_cmd} ${VALKEY_CLI_TLS_ARGS}"
+  # shellcheck disable=SC2206
+  cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
 fi
 
 # valkey-cli exits 0 even for protocol errors; capture output and check content.
 # Connection failures also fail closed; the caller should retry the action.
-output=$(${cli_cmd} CONFIG SET "${valkey_param}" "${param_value}" 2>&1) || true
+output=$("${cli_cmd[@]}" CONFIG SET "${valkey_param}" "${param_value}" 2>&1) || true
 # Silently ignore parameters that do not support CONFIG SET (e.g. bind, port).
 # Fail closed for other CONFIG SET errors so invalid dynamic values are surfaced.
 case "${output}" in

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -37,30 +37,29 @@ load_common_library() {
 
 build_cli() {
   local host="${1}"
-  local cmd="valkey-cli --no-auth-warning -h ${host} -p ${port}"
+  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+    _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   if ! is_empty "${VALKEY_CLI_TLS_ARGS}"; then
-    cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
+    # shellcheck disable=SC2206
+    _cli+=(${VALKEY_CLI_TLS_ARGS})
   fi
-  echo "${cmd}"
 }
 
 get_role() {
   local fqdn="${1}"
-  local cli
-  cli=$(build_cli "${fqdn}")
-  ${cli} info replication 2>/dev/null | grep "^role:" | tr -d '\r\n' | cut -d: -f2
+  build_cli "${fqdn}"
+  "${_cli[@]}" info replication 2>/dev/null | grep "^role:" | tr -d '\r\n' | cut -d: -f2
 }
 
 promote_replica() {
   local target_fqdn="${1}"
   echo "Promoting ${target_fqdn} to primary..."
-  local cli output
-  cli=$(build_cli "${target_fqdn}")
+  local output
+  build_cli "${target_fqdn}"
   # valkey-cli exits 0 even for protocol errors; capture output and check content.
-  output=$(${cli} REPLICAOF NO ONE 2>&1) || {
+  output=$("${_cli[@]}" REPLICAOF NO ONE 2>&1) || {
     echo "ERROR: REPLICAOF NO ONE failed on ${target_fqdn}: ${output}" >&2
     return 1
   }
@@ -87,10 +86,10 @@ wait_until_master() {
 repoint_one() {
   # Wrapped as a named function so call_func_with_retry can call it by name.
   local fqdn="${1}" new_primary="${2}" target_port="${3}"
-  local cli output
-  cli=$(build_cli "${fqdn}")
+  local output
+  build_cli "${fqdn}"
   # valkey-cli exits 0 even for protocol errors; capture output and check content.
-  output=$(${cli} REPLICAOF "${new_primary}" "${target_port}" 2>&1) || {
+  output=$("${_cli[@]}" REPLICAOF "${new_primary}" "${target_port}" 2>&1) || {
     echo "ERROR: REPLICAOF command failed on ${fqdn}: ${output}" >&2
     return 1
   }
@@ -155,21 +154,21 @@ pod_fqdns_with_candidate() {
 sentinel_cli_for() {
   local host="${1}"
   local s_port="${SENTINEL_SERVICE_PORT:-26379}"
-  local cmd="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -h ${host} -p ${s_port}"
+  # shellcheck disable=SC2206
+  _sentinel_cli=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -h "${host}" -p "${s_port}")
   if ! is_empty "${SENTINEL_PASSWORD}"; then
-    cmd="${cmd} -a ${SENTINEL_PASSWORD}"
+    _sentinel_cli+=(-a "${SENTINEL_PASSWORD}")
   fi
-  echo "${cmd}"
 }
 
 _do_set_replica_priority() {
   local fqdn="${1}" prio="${2}"
-  local cli output
-  cli=$(build_cli "${fqdn}")
+  local output
+  build_cli "${fqdn}"
   # Capture only stdout (the Valkey protocol response); redirect stderr to
   # /dev/null so TLS warnings do not pollute the comparison value.
   # valkey-cli exits 0 even for protocol errors, so we check output content.
-  output=$(${cli} CONFIG SET replica-priority "${prio}" 2>/dev/null) || true
+  output=$("${_cli[@]}" CONFIG SET replica-priority "${prio}" 2>/dev/null) || true
   # Strip \r (valkey-cli may return "OK\r" on some platforms).
   output="${output//$'\r'/}"
   if [ "${output}" = "OK" ]; then
@@ -188,10 +187,9 @@ execute_sentinel_failover() {
   local master_name="${VALKEY_COMPONENT_NAME}"
   IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
   for s_fqdn in "${sentinel_fqdns[@]}"; do
-    local cli output
-    cli=$(sentinel_cli_for "${s_fqdn}")
-    local exit_code=0
-    output=$(${cli} SENTINEL FAILOVER "${master_name}" 2>/dev/null) || exit_code=$?
+    local output exit_code=0
+    sentinel_cli_for "${s_fqdn}"
+    output=$("${_sentinel_cli[@]}" SENTINEL FAILOVER "${master_name}" 2>/dev/null) || exit_code=$?
     [ "${exit_code}" -ne 0 ] && continue
     # Strip \r (valkey-cli may return "OK\r" on some platforms, including TLS mode).
     output="${output//$'\r'/}"
@@ -224,15 +222,15 @@ wait_sentinel_sees_priority() {
     IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
     local confirmed=0 total=${#sentinel_fqdns[@]}
     for s_fqdn in "${sentinel_fqdns[@]}"; do
-      local cli prio
-      cli=$(sentinel_cli_for "${s_fqdn}")
+      local prio
+      sentinel_cli_for "${s_fqdn}"
       # Parse SENTINEL REPLICAS output:
       #   tr -d '"'       — strip valkey-cli string quotes
       #   sed 's/.*) //'  — strip leading array-index prefixes like "  3) "
       #   awk             — find the replica matching candidate_host, extract slave-priority
       #                     Uses index()+literal "." suffix (e.g. "valkey-1.")
       #                     to avoid "valkey-1" substring-matching "valkey-10".
-      prio=$(${cli} SENTINEL REPLICAS "${VALKEY_COMPONENT_NAME}" 2>/dev/null \
+      prio=$("${_sentinel_cli[@]}" SENTINEL REPLICAS "${VALKEY_COMPONENT_NAME}" 2>/dev/null \
         | tr -d '"' \
         | sed 's/.*) //' \
         | awk -v cand="${candidate_host}." '

--- a/addons/valkey/scripts/sync-acl.sh
+++ b/addons/valkey/scripts/sync-acl.sh
@@ -33,23 +33,23 @@ load_common_library() {
 
 build_cli() {
   local host="${1}"
-  local cmd="valkey-cli --no-auth-warning -h ${host} -p ${port}"
+  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+    _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   if ! is_empty "${VALKEY_CLI_TLS_ARGS}"; then
-    cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
+    # shellcheck disable=SC2206
+    _cli+=(${VALKEY_CLI_TLS_ARGS})
   fi
-  echo "${cmd}"
 }
 
 # Find the current primary by polling each pod's role
 find_primary_fqdn() {
   IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
   for fqdn in "${pod_fqdns[@]}"; do
-    local role cli
-    cli=$(build_cli "${fqdn}")
-    role=$(${cli} info replication 2>/dev/null \
+    local role
+    build_cli "${fqdn}"
+    role=$("${_cli[@]}" info replication 2>/dev/null \
              | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || continue
     if [ "${role}" = "master" ]; then
       echo "${fqdn}"
@@ -69,16 +69,16 @@ find_primary_fqdn() {
 # Copy all non-default ACL rules from source to target
 sync_acl_to_replica() {
   local src_fqdn="${1}" dst_fqdn="${2}"
-  local src_cli dst_cli
-  src_cli=$(build_cli "${src_fqdn}")
-  dst_cli=$(build_cli "${dst_fqdn}")
+  local src_cli=() dst_cli=()
+  build_cli "${src_fqdn}"; src_cli=("${_cli[@]}")
+  build_cli "${dst_fqdn}"; dst_cli=("${_cli[@]}")
 
   echo "Syncing ACL from ${src_fqdn} → ${dst_fqdn}"
 
   # Read ACL rules from primary
   # valkey-cli exits 0 even for server errors; check output for error prefix.
   local acl_list
-  acl_list=$(${src_cli} ACL LIST 2>&1) || {
+  acl_list=$("${src_cli[@]}" ACL LIST 2>&1) || {
     echo "WARNING: could not read ACL LIST from ${src_fqdn}: ${acl_list}" >&2
     return 1
   }
@@ -106,7 +106,8 @@ sync_acl_to_replica() {
     # Disable glob expansion so ~* and &* in rule_flags are not expanded by the shell.
     # shellcheck disable=SC2086
     set -f
-    setuser_out=$(${dst_cli} ACL SETUSER "${username}" ${rule_flags} 2>&1) || true
+    # shellcheck disable=SC2086
+    setuser_out=$("${dst_cli[@]}" ACL SETUSER "${username}" ${rule_flags} 2>&1) || true
     set +f
     case "${setuser_out}" in
       *"ERR"*|*"WRONGTYPE"*|*"error"*)
@@ -117,7 +118,7 @@ sync_acl_to_replica() {
   # Persist on the replica
   # valkey-cli exits 0 even for server errors; check output content.
   local acl_save_out
-  acl_save_out=$(${dst_cli} ACL SAVE 2>&1) || true
+  acl_save_out=$("${dst_cli[@]}" ACL SAVE 2>&1) || true
   if [ "${acl_save_out}" != "OK" ]; then
     echo "WARNING: ACL SAVE failed on ${dst_fqdn}: ${acl_save_out} — rules applied in memory only, will be lost on restart" >&2
   fi

--- a/addons/valkey/scripts/valkey-member-leave.sh
+++ b/addons/valkey/scripts/valkey-member-leave.sh
@@ -37,18 +37,26 @@ sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
 
 build_data_cli() {
   local host="${1}"
-  local cmd="valkey-cli --no-auth-warning -h ${host} -p ${port}"
-  [ -n "${VALKEY_DEFAULT_PASSWORD}" ] && cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
-  [ -n "${VALKEY_CLI_TLS_ARGS}" ]     && cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
-  echo "${cmd}"
+  _data_cli_cmd=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
+  if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
+    _data_cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
+    # shellcheck disable=SC2206
+    _data_cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
+  fi
 }
 
 build_sentinel_cli() {
   local host="${1}"
-  local cmd="valkey-cli --no-auth-warning -h ${host} -p ${sentinel_port}"
-  [ -n "${SENTINEL_PASSWORD}" ] && cmd="${cmd} -a ${SENTINEL_PASSWORD}"
-  [ -n "${VALKEY_CLI_TLS_ARGS}" ] && cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
-  echo "${cmd}"
+  _sentinel_cli_cmd=(valkey-cli --no-auth-warning -h "${host}" -p "${sentinel_port}")
+  if [ -n "${SENTINEL_PASSWORD}" ]; then
+    _sentinel_cli_cmd+=(-a "${SENTINEL_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
+    # shellcheck disable=SC2206
+    _sentinel_cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
+  fi
 }
 
 # This is magic for shellspec ut framework, do not modify!
@@ -71,8 +79,8 @@ master_name="${VALKEY_COMPONENT_NAME}"
 leaving_fqdn="${KB_LEAVE_MEMBER_POD_FQDN}"
 
 # Determine the role of the leaving pod
-_data_cli=$(build_data_cli "${leaving_fqdn}")
-leaving_role=$(${_data_cli} INFO replication 2>/dev/null \
+build_data_cli "${leaving_fqdn}"
+leaving_role=$("${_data_cli_cmd[@]}" INFO replication 2>/dev/null \
                  | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
 
 echo "Leaving pod: ${leaving_fqdn}, role: ${leaving_role:-unknown}"
@@ -85,9 +93,9 @@ sentinel_fqdn=""
 best_epoch=-1
 IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
 for s in "${sentinel_fqdns[@]}"; do
-  _s_cli=$(build_sentinel_cli "${s}")
-  if ${_s_cli} PING 2>/dev/null | grep -q "PONG"; then
-    epoch=$(${_s_cli} SENTINEL masters 2>/dev/null \
+  build_sentinel_cli "${s}"
+  if "${_sentinel_cli_cmd[@]}" PING 2>/dev/null | grep -q "PONG"; then
+    epoch=$("${_sentinel_cli_cmd[@]}" SENTINEL masters 2>/dev/null \
               | awk '/^config-epoch$/{getline; gsub(/\r/,""); print; exit}')
     epoch="${epoch:-0}"
     if [ "${epoch}" -gt "${best_epoch}" ]; then
@@ -103,7 +111,8 @@ if is_empty "${sentinel_fqdn}"; then
 fi
 
 echo "Using sentinel ${sentinel_fqdn} (config-epoch=${best_epoch})"
-s_cli=$(build_sentinel_cli "${sentinel_fqdn}")
+build_sentinel_cli "${sentinel_fqdn}"
+s_cli=("${_sentinel_cli_cmd[@]}")
 
 # Resolve the leaving pod's IP once for all comparisons below.
 leaving_ip=$(getent hosts "${leaving_fqdn}" 2>/dev/null | awk '{print $1}' | head -n1) || true
@@ -111,7 +120,7 @@ leaving_ip=$(getent hosts "${leaving_fqdn}" 2>/dev/null | awk '{print $1}' | hea
 _sentinel_master_is_leaving() {
   # Returns 0 (true) when the chosen sentinel reports the leaving pod as master.
   local sm
-  sm=$(${s_cli} SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null \
+  sm=$("${s_cli[@]}" SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null \
          | head -n1 | tr -d '\r\n') || true
   if is_empty "${sm}" || [ "${sm}" = "(nil)" ]; then
     return 1   # sentinel doesn't know — treat as "not leaving"
@@ -183,7 +192,7 @@ if [ "${leaving_role}" = "master" ]; then
   if _sentinel_master_is_leaving; then
     echo "Leaving pod is the primary per sentinel — triggering SENTINEL FAILOVER first..."
     # valkey-cli exits 0 even for protocol errors; capture output and log it.
-    failover_out=$(${s_cli} SENTINEL FAILOVER "${master_name}" 2>&1) || true
+    failover_out=$("${s_cli[@]}" SENTINEL FAILOVER "${master_name}" 2>&1) || true
     echo "SENTINEL FAILOVER response: ${failover_out}"
     case "${failover_out}" in
       *"ERR"*|*"error"*|*"BUSY"*)
@@ -193,7 +202,7 @@ if [ "${leaving_role}" = "master" ]; then
     failover_done=false
     for _ in $(seq 1 10); do
       sleep 3
-      new_master=$(${s_cli} SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null \
+      new_master=$("${s_cli[@]}" SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null \
                      | head -n1 | tr -d '\r\n') || true
       # Accept the failover as complete when Sentinel reports a master that is
       # neither the leaving pod's IP nor its pod name/FQDN fragment.

--- a/addons/valkey/scripts/valkey-register-to-sentinel.sh
+++ b/addons/valkey/scripts/valkey-register-to-sentinel.sh
@@ -61,11 +61,11 @@ echo "Primary address for Sentinel registration: ${primary_host}:${primary_port}
 
 sentinel_cli() {
   local host="${1}"
-  local cmd="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -h ${host} -p ${sentinel_port}"
+  # shellcheck disable=SC2206
+  _sentinel_cli_cmd=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -h "${host}" -p "${sentinel_port}")
   if ! is_empty "${SENTINEL_PASSWORD}"; then
-    cmd="${cmd} -a ${SENTINEL_PASSWORD}"
+    _sentinel_cli_cmd+=(-a "${SENTINEL_PASSWORD}")
   fi
-  echo "${cmd}"
 }
 
 # ── helper: run one sentinel sub-command and verify "OK" ────────────────────
@@ -73,9 +73,9 @@ sentinel_cli() {
 execute_sentinel_cmd() {
   local host="${1}"
   shift
-  local cli output
-  cli=$(sentinel_cli "${host}")
-  output=$(${cli} "$@" 2>&1) || { echo "sentinel cmd failed: ${output}" >&2; return 1; }
+  local output
+  sentinel_cli "${host}"
+  output=$("${_sentinel_cli_cmd[@]}" "$@" 2>&1) || { echo "sentinel cmd failed: ${output}" >&2; return 1; }
   if [ "${output}" != "OK" ]; then
     echo "Unexpected sentinel response: ${output}" >&2
     return 1
@@ -86,17 +86,17 @@ execute_sentinel_cmd() {
 
 check_sentinel_connectivity() {
   local host="${1}"
-  local cli
-  cli=$(sentinel_cli "${host}")
-  ${cli} PING 2>/dev/null | grep -q "PONG"
+  sentinel_cli "${host}"
+  "${_sentinel_cli_cmd[@]}" PING 2>/dev/null | grep -q "PONG"
 }
 
 check_data_connectivity() {
-  local cmd="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -h ${primary_host} -p ${primary_port}"
+  # shellcheck disable=SC2206
+  local cmd=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -h "${primary_host}" -p "${primary_port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+    cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
-  ${cmd} PING 2>/dev/null | grep -q "PONG"
+  "${cmd[@]}" PING 2>/dev/null | grep -q "PONG"
 }
 
 # ── register with one Sentinel pod ──────────────────────────────────────────
@@ -114,14 +114,14 @@ register_to_one_sentinel() {
     return 1
   }
 
-  local cli
-  cli=$(sentinel_cli "${sentinel_fqdn}")
+  sentinel_cli "${sentinel_fqdn}"
+  local cli=("${_sentinel_cli_cmd[@]}")
 
   # Check if already monitored
   # get-master-addr-by-name returns "(nil)" when master is not registered,
   # which is non-empty so must be checked explicitly.
   local master_addr
-  master_addr=$(${cli} SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null || true)
+  master_addr=$("${cli[@]}" SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null || true)
   if is_empty "${master_addr}" || [ "${master_addr}" = "(nil)" ]; then
     echo "Sentinel not yet monitoring '${master_name}' — issuing SENTINEL monitor..."
     call_func_with_retry 3 5 execute_sentinel_cmd "${sentinel_fqdn}" \

--- a/addons/valkey/scripts/valkey-self-heal.sh
+++ b/addons/valkey/scripts/valkey-self-heal.sh
@@ -50,36 +50,35 @@ SELF_HEAL_UT_MODE="${ut_mode:-false}"
 
 cascade_build_local_cli_cmd() {
   local port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
-  local cmd="valkey-cli --no-auth-warning -h 127.0.0.1 -p ${port}"
+  _cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+    _cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   if ! is_empty "${VALKEY_CLI_TLS_ARGS}"; then
-    cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
+    # shellcheck disable=SC2206
+    _cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
   fi
-  echo "${cmd}"
 }
 
 cascade_build_remote_cli_cmd() {
   local host="$1"
   local port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
-  local cmd="valkey-cli --no-auth-warning -h ${host} -p ${port}"
+  _cli_cmd=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cmd="${cmd} -a ${VALKEY_DEFAULT_PASSWORD}"
+    _cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   if ! is_empty "${VALKEY_CLI_TLS_ARGS}"; then
-    cmd="${cmd} ${VALKEY_CLI_TLS_ARGS}"
+    # shellcheck disable=SC2206
+    _cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
   fi
-  echo "${cmd}"
 }
 
 cascade_info_replication_with_timeout() {
-  local cmd="$1"
   if command -v timeout >/dev/null 2>&1 && [ "${CASCADE_REMOTE_TIMEOUT_SECONDS}" != "0" ]; then
-    timeout "${CASCADE_REMOTE_TIMEOUT_SECONDS}" ${cmd} info replication 2>/dev/null
+    timeout "${CASCADE_REMOTE_TIMEOUT_SECONDS}" "${_cli_cmd[@]}" info replication 2>/dev/null
     return $?
   fi
-  ${cmd} info replication 2>/dev/null
+  "${_cli_cmd[@]}" info replication 2>/dev/null
 }
 
 cascade_extract_replication_field() {
@@ -128,11 +127,11 @@ cascade_is_self_host() {
 # + skip-self-target).
 cascade_check_one_round() {
   local local_port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
-  local cli_cmd
-  cli_cmd=$(cascade_build_local_cli_cmd)
+  local cli_cmd=()
+  cascade_build_local_cli_cmd; cli_cmd=("${_cli_cmd[@]}")
 
   local repl_info
-  repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
 
   local role_line
   role_line=$(cascade_extract_replication_field "${repl_info}" "role")
@@ -142,11 +141,11 @@ cascade_check_one_round() {
   master_host=$(cascade_extract_replication_field "${repl_info}" "master_host")
   is_empty "${master_host}" && return 0
 
-  local remote_cli
-  remote_cli=$(cascade_build_remote_cli_cmd "${master_host}")
+  local remote_cli=()
+  cascade_build_remote_cli_cmd "${master_host}"; remote_cli=("${_cli_cmd[@]}")
 
   local master_repl_info master_role
-  master_repl_info=$(cascade_info_replication_with_timeout "${remote_cli}") || {
+  master_repl_info=$(cascade_info_replication_with_timeout) || {
     echo "INFO: skip cascade repair (remote-master-unreachable): cannot query ${master_host} within ${CASCADE_REMOTE_TIMEOUT_SECONDS}s." >&2
     return 0
   }
@@ -162,7 +161,7 @@ cascade_check_one_round() {
   # at the start of this round and now, Sentinel may have promoted this pod.
   # Issuing REPLICAOF on a fresh master would demote it. Re-read local role.
   local current_repl_info current_role
-  current_repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  current_repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
   current_role=$(cascade_extract_replication_field "${current_repl_info}" "role")
   if [ "${current_role}" != "slave" ]; then
     echo "INFO: skip cascade repair (skip-stale-role): local role is '${current_role:-unknown}', not slave." >&2
@@ -176,7 +175,7 @@ cascade_check_one_round() {
   fi
 
   echo "WARNING: cascading topology — our master ${master_host} is a slave of ${real_master_host}. Issuing REPLICAOF to reconnect directly to real master." >&2
-  ${cli_cmd} REPLICAOF "${real_master_host}" "${real_master_port:-${local_port}}" 2>/dev/null || true
+  "${cli_cmd[@]}" REPLICAOF "${real_master_host}" "${real_master_port:-${local_port}}" 2>/dev/null || true
 }
 
 # stall_check_one_round — Bug 5 (full-sync stall) detector.
@@ -198,9 +197,10 @@ cascade_check_one_round() {
 #   iteration means stall detection never spawns subprocesses regardless
 #   of where it is called from.
 stall_check_one_round() {
-  local cli_cmd repl_info sync_in_progress read_bytes line role_line
-  cli_cmd=$(cascade_build_local_cli_cmd)
-  repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  local repl_info sync_in_progress read_bytes line role_line
+  local cli_cmd=()
+  cascade_build_local_cli_cmd; cli_cmd=("${_cli_cmd[@]}")
+  repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
 
   # Single-process parse: bash builtins only, no pipeline / cmd-substitution
   # children that could leak under any future SIGKILL exposure.
@@ -260,13 +260,12 @@ DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="${DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS:-10}"
 DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS="${DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS:-1}"
 
 dual_master_confirm_demote() {
-  local cli_cmd="$1"
-  local expected_master_host="$2"
+  local expected_master_host="$1"
   local deadline=$((SECONDS + DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS))
   while [ "${SECONDS}" -lt "${deadline}" ]; do
     sleep "${DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS}"
     local repl_info post_role post_master_host
-    repl_info=$(${cli_cmd} info replication 2>/dev/null) || continue
+    repl_info=$("${_dm_cli_cmd[@]}" info replication 2>/dev/null) || continue
     post_role=$(cascade_extract_replication_field "${repl_info}" "role")
     post_master_host=$(cascade_extract_replication_field "${repl_info}" "master_host")
     if [ "${post_role}" = "slave" ] && [ -n "${post_master_host}" ]; then
@@ -333,11 +332,11 @@ dual_master_check_one_round() {
   is_empty "${SENTINEL_POD_FQDN_LIST}" && return 0
 
   local local_port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
-  local cli_cmd
-  cli_cmd=$(cascade_build_local_cli_cmd)
+  local cli_cmd=()
+  cascade_build_local_cli_cmd; cli_cmd=("${_cli_cmd[@]}")
 
   local repl_info role_line
-  repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
   role_line=$(cascade_extract_replication_field "${repl_info}" "role")
   [ "${role_line}" != "master" ] && return 0
 
@@ -364,9 +363,9 @@ dual_master_check_one_round() {
   # REPLICAOF to a non-master would create a cascade slave chain (the
   # exact class of failure this daemon is designed to repair).  If the
   # remote is unreachable or not yet master, skip this round and retry.
-  local remote_cli remote_info remote_role
-  remote_cli=$(cascade_build_remote_cli_cmd "${quorum_master_fqdn}")
-  remote_info=$(cascade_info_replication_with_timeout "${remote_cli}") || {
+  local remote_info remote_role
+  cascade_build_remote_cli_cmd "${quorum_master_fqdn}"
+  remote_info=$(cascade_info_replication_with_timeout) || {
     echo "INFO: skip dual-master demote (skip-quorum-target-unreachable): cannot query ${quorum_master_fqdn} within ${CASCADE_REMOTE_TIMEOUT_SECONDS}s." >&2
     return 0
   }
@@ -378,7 +377,7 @@ dual_master_check_one_round() {
 
   # Skip-stale-role: re-read just before REPLICAOF.
   local current_repl_info current_role
-  current_repl_info=$(${cli_cmd} info replication 2>/dev/null) || return 0
+  current_repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
   current_role=$(cascade_extract_replication_field "${current_repl_info}" "role")
   if [ "${current_role}" != "master" ]; then
     echo "INFO: skip dual-master demote (skip-stale-role): local role is '${current_role:-unknown}', no longer master." >&2
@@ -386,9 +385,11 @@ dual_master_check_one_round() {
   fi
 
   echo "WARNING: rogue master detected — sentinel-quorum reports real master is '${quorum_master_fqdn}'; demoting self via REPLICAOF." >&2
-  ${cli_cmd} REPLICAOF "${quorum_master_fqdn}" "${local_port}" 2>/dev/null || true
+  "${cli_cmd[@]}" REPLICAOF "${quorum_master_fqdn}" "${local_port}" 2>/dev/null || true
 
-  if dual_master_confirm_demote "${cli_cmd}" "${quorum_master_fqdn}"; then
+  # Pass cli_cmd to dual_master_confirm_demote via global array
+  _dm_cli_cmd=("${cli_cmd[@]}")
+  if dual_master_confirm_demote "${quorum_master_fqdn}"; then
     echo "INFO: dual-master demote confirmed: now role:slave attached to '${quorum_master_fqdn}'." >&2
     return 0
   fi

--- a/addons/valkey/scripts/valkey-sentinel-account-provision.sh
+++ b/addons/valkey/scripts/valkey-sentinel-account-provision.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 # valkey-sentinel-account-provision.sh — run KubeBlocks-generated ACL statement
 # on the Sentinel process and persist it.
@@ -10,16 +10,20 @@ set -e
 
 sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
 
+cli=(valkey-cli --no-auth-warning)
+if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
+  # shellcheck disable=SC2206
+  cli+=(${VALKEY_CLI_TLS_ARGS})
+fi
+cli+=(-p "${sentinel_port}")
 if [ -n "${SENTINEL_PASSWORD}" ]; then
-  cli="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${sentinel_port} -a ${SENTINEL_PASSWORD}"
-else
-  cli="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${sentinel_port}"
+  cli+=(-a "${SENTINEL_PASSWORD}")
 fi
 
 # Pipe via stdin so that '>' in ACL password syntax (e.g. >mypassword) is not
 # misinterpreted as a shell output-redirect operator.
 # valkey-cli exits 0 even for protocol errors; capture output and check content.
-output=$(echo "${KB_ACCOUNT_STATEMENT}" | ${cli} 2>&1) || {
+output=$(echo "${KB_ACCOUNT_STATEMENT}" | "${cli[@]}" 2>&1) || {
   echo "ERROR: account statement failed: ${output}" >&2
   exit 1
 }
@@ -28,7 +32,7 @@ if [ "${output}" != "OK" ]; then
   exit 1
 fi
 
-acl_save_out=$(${cli} ACL SAVE 2>&1) || {
+acl_save_out=$("${cli[@]}" ACL SAVE 2>&1) || {
   echo "ERROR: ACL SAVE failed: ${acl_save_out}" >&2
   exit 1
 }

--- a/addons/valkey/scripts/valkey-sentinel-start.sh
+++ b/addons/valkey/scripts/valkey-sentinel-start.sh
@@ -144,23 +144,18 @@ create_initial_conf_if_needed() {
 # Returns empty string if none found.
 _find_master_fqdn() {
   local data_port="${SERVICE_PORT:-6379}"
-  local tls_args=""
-  [ "${TLS_ENABLED}" = "true" ] && tls_args="--tls --insecure"
   for fqdn in $(echo "${VALKEY_POD_FQDN_LIST:-}" | tr ',' '\n'); do
     [ -z "${fqdn}" ] && continue
-    local role
-    if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-      # shellcheck disable=SC2086
-      role=$(valkey-cli -h "${fqdn}" -p "${data_port}" \
-        ${tls_args} \
-        -a "${VALKEY_DEFAULT_PASSWORD}" --no-auth-warning \
-        info replication 2>/dev/null | grep "^role:" | tr -d '\r\n' | cut -d: -f2)
-    else
-      # shellcheck disable=SC2086
-      role=$(valkey-cli -h "${fqdn}" -p "${data_port}" \
-        ${tls_args} \
-        info replication 2>/dev/null | grep "^role:" | tr -d '\r\n' | cut -d: -f2)
+    local cmd=(valkey-cli -h "${fqdn}" -p "${data_port}")
+    if [ "${TLS_ENABLED}" = "true" ]; then
+      cmd+=(--tls --insecure)
     fi
+    if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
+      cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+    fi
+    cmd+=(--no-auth-warning)
+    local role
+    role=$("${cmd[@]}" info replication 2>/dev/null | grep "^role:" | tr -d '\r\n' | cut -d: -f2)
     if [ "${role}" = "master" ]; then
       echo "${fqdn}"
       return 0
@@ -170,14 +165,14 @@ _find_master_fqdn() {
 
 # _sentinel_cli — run a valkey-cli command against this sentinel's own port.
 _sentinel_cli() {
-  local cmd="valkey-cli -h 127.0.0.1 -p ${sentinel_port} --no-auth-warning"
+  local _scli=(valkey-cli -h 127.0.0.1 -p "${sentinel_port}" --no-auth-warning)
   if [ "${TLS_ENABLED}" = "true" ]; then
-    cmd="${cmd} --tls --insecure"
+    _scli+=(--tls --insecure)
   fi
   if ! is_empty "${SENTINEL_PASSWORD}"; then
-    cmd="${cmd} -a ${SENTINEL_PASSWORD}"
+    _scli+=(-a "${SENTINEL_PASSWORD}")
   fi
-  ${cmd} "$@" 2>/dev/null
+  "${_scli[@]}" "$@" 2>/dev/null
 }
 
 # _register_monitor — dynamically register the master with the running sentinel

--- a/addons/valkey/scripts/valkey-start.sh
+++ b/addons/valkey/scripts/valkey-start.sh
@@ -266,15 +266,16 @@ query_sentinel_for_master() {
   local sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   local master_name="${VALKEY_COMPONENT_NAME}"
 
-  local sentinel_cli_base="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${sentinel_port}"
+  # shellcheck disable=SC2206
+  local sentinel_cli_base=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p "${sentinel_port}")
   if ! is_empty "${SENTINEL_PASSWORD}"; then
-    sentinel_cli_base="${sentinel_cli_base} -a ${SENTINEL_PASSWORD}"
+    sentinel_cli_base+=(-a "${SENTINEL_PASSWORD}")
   fi
 
   IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
   for s_fqdn in "${sentinel_fqdns[@]}"; do
     local response
-    response=$(${sentinel_cli_base} -h "${s_fqdn}" \
+    response=$("${sentinel_cli_base[@]}" -h "${s_fqdn}" \
                  SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null) || continue
 
     # Response is two lines: IP/host on line 1, port on line 2.
@@ -320,9 +321,10 @@ query_sentinel_quorum_for_master() {
   local sentinel_port="${SENTINEL_SERVICE_PORT:-26379}"
   local master_name="${VALKEY_COMPONENT_NAME}"
 
-  local sentinel_cli_base="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${sentinel_port}"
+  # shellcheck disable=SC2206
+  local sentinel_cli_base=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p "${sentinel_port}")
   if ! is_empty "${SENTINEL_PASSWORD}"; then
-    sentinel_cli_base="${sentinel_cli_base} -a ${SENTINEL_PASSWORD}"
+    sentinel_cli_base+=(-a "${SENTINEL_PASSWORD}")
   fi
 
   IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
@@ -335,7 +337,7 @@ query_sentinel_quorum_for_master() {
 
   for s_fqdn in "${sentinel_fqdns[@]}"; do
     local response master_addr
-    response=$(${sentinel_cli_base} -h "${s_fqdn}" \
+    response=$("${sentinel_cli_base[@]}" -h "${s_fqdn}" \
                  SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null) || continue
     master_addr=$(echo "${response}" | head -n1 | tr -d '\r\n')
     is_empty "${master_addr}" && continue
@@ -405,16 +407,17 @@ query_sentinel_quorum_for_master() {
 #
 # We skip ourselves because valkey-server hasn't started yet and won't respond.
 scan_pods_for_master() {
-  local cli_base="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${service_port}"
+  # shellcheck disable=SC2206
+  local cli_base=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p "${service_port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cli_base="${cli_base} -a ${VALKEY_DEFAULT_PASSWORD}"
+    cli_base+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
 
   IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
   for pod_fqdn in "${pod_fqdns[@]}"; do
     contains "${pod_fqdn}" "${CURRENT_POD_NAME}." && continue
     local role
-    role=$(timeout 3 ${cli_base} -h "${pod_fqdn}" info replication 2>/dev/null \
+    role=$(timeout 3 "${cli_base[@]}" -h "${pod_fqdn}" info replication 2>/dev/null \
       | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
     if [ "${role}" = "master" ]; then
       echo "${pod_fqdn}"
@@ -441,12 +444,13 @@ elect_lexicographic_primary() {
 # verify_pod_role — return the replication role ("master", "slave", or "") of a remote pod.
 verify_pod_role() {
   local fqdn="$1"
-  local cli_base="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${service_port}"
+  # shellcheck disable=SC2206
+  local cli_base=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p "${service_port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cli_base="${cli_base} -a ${VALKEY_DEFAULT_PASSWORD}"
+    cli_base+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   local role
-  role=$(timeout 3 ${cli_base} -h "${fqdn}" info replication 2>/dev/null \
+  role=$(timeout 3 "${cli_base[@]}" -h "${fqdn}" info replication 2>/dev/null \
     | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
   echo "${role}"
 }
@@ -455,12 +459,13 @@ verify_pod_role() {
 # replicates from.  Returns empty if the chain cannot be resolved to a known pod.
 follow_slave_to_master() {
   local slave_fqdn="$1"
-  local cli_base="valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p ${service_port}"
+  # shellcheck disable=SC2206
+  local cli_base=(valkey-cli --no-auth-warning ${VALKEY_CLI_TLS_ARGS} -p "${service_port}")
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
-    cli_base="${cli_base} -a ${VALKEY_DEFAULT_PASSWORD}"
+    cli_base+=(-a "${VALKEY_DEFAULT_PASSWORD}")
   fi
   local master_host
-  master_host=$(${cli_base} -h "${slave_fqdn}" info replication 2>/dev/null \
+  master_host=$("${cli_base[@]}" -h "${slave_fqdn}" info replication 2>/dev/null \
     | grep "^master_host:" | tr -d '\r\n' | cut -d: -f2) || true
   is_empty "${master_host}" && return 0
   IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"


### PR DESCRIPTION
## Summary
- Converts all 13 Valkey addon scripts from string-based CLI command construction to bash array-based construction to prevent word-splitting when passwords contain spaces or special characters
- Updates 3 ShellSpec test files with helper wrappers to accommodate the array-based API change
- Changes shebangs from `#!/bin/sh` to `#!/bin/bash` for scripts that now use bash arrays

## Context
Addresses Issue 1 (password quoting / word-splitting) from Blake review COMMENT on PR #2592.

## Files changed (16)
**Scripts (13):** check-role.sh, switchover.sh, sync-acl.sh, valkey-self-heal.sh, valkey-register-to-sentinel.sh, valkey-member-leave.sh, valkey-sentinel-start.sh, valkey-start.sh, post-provision.sh, pre-stop.sh, reload-parameter.sh, account-provision.sh, valkey-sentinel-account-provision.sh

**Tests (3):** check_role_spec.sh, valkey_switchover_spec.sh, valkey_member_leave_spec.sh

## Test plan
- [x] bash -n passes on all 13 modified scripts
- [x] grep confirms zero residual unquoted password patterns
- [x] ShellSpec tests updated with array-to-string helper wrappers
- [ ] ShellSpec unit tests pass
- [ ] Full suite regression (covered by r34 forensic on parent branch; this PR is array-only refactor with no logic change)