### PR TITLE
fix(valkey): align backup policy env with DP schema

### DIFF
--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -10,7 +10,10 @@
 #   DP_BACKUP_INFO_FILE  — path to write backup metadata JSON
 #   DP_DATASAFED_BIN_PATH — path to datasafed binary
 #   DATA_DIR             — data mount path (set in ActionSet env)
-#   SENTINEL_POD_FQDN_LIST, SENTINEL_SERVICE_PORT, SENTINEL_PASSWORD — optional
+#
+# Current BackupPolicyTemplate env schema cannot inject cross-component
+# Sentinel FQDN/password values. Sentinel ACL backup is therefore inactive
+# unless those SENTINEL_* variables are supplied by a future explicit contract.
 
 set -o pipefail
 
@@ -47,7 +50,8 @@ else
   connect_url="valkey-cli --no-auth-warning ${tls_args} -h ${DP_DB_HOST} -p ${DP_DB_PORT}"
 fi
 
-# Save Sentinel ACL so it can be restored after a full restore
+# Save Sentinel ACL only when Sentinel connection variables are explicitly
+# supplied. The current chart's BackupPolicyTemplate does not inject them.
 save_sentinel_acl() {
   [ -z "${SENTINEL_POD_FQDN_LIST}" ] && return 0
   local acl_list=""

--- a/addons/valkey/dataprotection/post-restore-sentinel.sh
+++ b/addons/valkey/dataprotection/post-restore-sentinel.sh
@@ -18,8 +18,9 @@
 #   data pod:     <cluster>-<comp>-<n>
 #   sentinel comp: <cluster>-valkey-sentinel  (standard topology name)
 #
-# SENTINEL_SERVICE_PORT and SENTINEL_PASSWORD must be injected via the
-# BackupPolicyTemplate env section if Sentinel auth is enabled.
+# Current BackupPolicyTemplate env schema cannot inject cross-component
+# Sentinel credentials. Re-registration is best-effort and can only authenticate
+# when SENTINEL_PASSWORD is supplied by a future explicit contract.
 
 set -e
 set -o pipefail

--- a/addons/valkey/scripts-ut-spec/backuppolicytemplate_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backuppolicytemplate_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Valkey BackupPolicyTemplate contract"
+  template_file="../templates/backuppolicytemplate.yaml"
+  actionset_file="../templates/backupactionset.yaml"
+
+  It "does not use ComponentDefinition var sources in BackupPolicyTemplate env"
+    When call grep -E "componentVarRef|credentialVarRef" "${template_file}"
+    The status should be failure
+  End
+
+  It "does not declare Sentinel cross-component env in BackupPolicyTemplate"
+    When call grep -E "SENTINEL_POD_FQDN_LIST|SENTINEL_PASSWORD" "${template_file}"
+    The status should be failure
+  End
+
+  It "does not wire the no-op Sentinel ACL restore job into ActionSet"
+    When call grep -F "restore-sentinel-acl.sh" "${actionset_file}"
+    The status should be failure
+  End
+End

--- a/addons/valkey/templates/backupactionset.yaml
+++ b/addons/valkey/templates/backupactionset.yaml
@@ -7,12 +7,12 @@ Backup flow:
 
 Restore flow:
   1. prepareData: pull the archive and extract it into DATA_DIR before the pod starts.
-  2. postReady: once Valkey pods are Running+Ready, restore any Sentinel ACL rules
-     that were saved during backup.
+  2. postReady: best-effort Sentinel monitor re-registration after data restore.
 
 KubeBlocks DataProtection passes standard DP_* variables into all job containers;
-additional variables (DATA_DIR, SENTINEL_*) are injected from the ActionSet env
-and from the BackupPolicyTemplate.
+DATA_DIR is injected from the ActionSet env. Current BackupPolicyTemplate env
+schema only supports versionMapping for this chart path, so cross-component
+Sentinel FQDN/password injection is not available here.
 */}}
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: ActionSet
@@ -51,17 +51,9 @@ spec:
         - |
           {{- .Files.Get "dataprotection/restore.sh" | nindent 10 }}
     postReady:
-      # Step 1: restore Sentinel ACL rules (non-default accounts)
-      - job:
-          image: {{ include "valkey.defaultImage" . }}
-          onError: Fail
-          runOnTargetPodNode: true
-          command:
-            - bash
-            - -c
-            - |
-              {{- .Files.Get "dataprotection/restore-sentinel-acl.sh" | nindent 14 }}
-      # Step 2: re-register the primary with Sentinel (Sentinel's own PVC is not backed up)
+      # Re-register the primary with Sentinel (Sentinel's own PVC is not backed up).
+      # This is best-effort because current DP BackupPolicyTemplate env cannot
+      # inject cross-component Sentinel credentials.
       - job:
           image: {{ include "valkey.defaultImage" . }}
           onError: Continue

--- a/addons/valkey/templates/backuppolicytemplate.yaml
+++ b/addons/valkey/templates/backuppolicytemplate.yaml
@@ -53,23 +53,6 @@ spec:
                 mappedValue: {{ $repo }}:{{ .imageTag }}
               {{- end }}
               {{- end }}
-        # Inject Sentinel connection info so backup.sh can save Sentinel ACL.
-        # These vars come from the data component's vars[] (cross-component refs).
-        - name: SENTINEL_POD_FQDN_LIST
-          valueFrom:
-            componentVarRef:
-              compDef: {{ include "valkeySentinel.cmpdRegexpPattern" . }}
-              optional: true
-              podFQDNs: Required
-        - name: SENTINEL_SERVICE_PORT
-          value: "26379"
-        - name: SENTINEL_PASSWORD
-          valueFrom:
-            credentialVarRef:
-              compDef: {{ include "valkeySentinel.cmpdRegexpPattern" . }}
-              name: default
-              optional: true
-              password: Required
 
     # ── Volume snapshot (CSI-based, StorageClass must support it) ────────────
     - name: volume-snapshot


### PR DESCRIPTION
## Summary
- remove unsupported Sentinel cross-component env refs from Valkey `BackupPolicyTemplate`
- remove the no-op Sentinel ACL restore postReady job from the physical backup ActionSet
- document the current boundary: datafile backup/restore is supported; Sentinel ACL save/restore is not wired until DP has a valid cross-component env contract
- add a ShellSpec guard to prevent reintroducing unsupported BPT var sources

## r34 Evidence Boundary
The r34 vcluster has already been cleaned up, so the live CRD and Helm release object cannot be re-read to prove exactly how the previous chart got installed. Based on the current DP CRD schema, the old `componentVarRef` / `credentialVarRef` fields in `BackupPolicyTemplate` were not a valid contract. Therefore r34 smoke-backup evidence should be read as datafile backup/restore plus restored Sentinel health/topology, not as Sentinel ACL save/restore coverage.

## Validation
- `bash -n addons/valkey/dataprotection/backup.sh addons/valkey/dataprotection/post-restore-sentinel.sh addons/valkey/dataprotection/restore-sentinel-acl.sh`
- `git diff --check`
- `helm dependency build addons/valkey`
- `helm lint addons/valkey`
- `helm template kb-addon-valkey addons/valkey --namespace kb-system > /tmp/valkey-bpt-fix-render.yaml`
- rendered BackupPolicyTemplate grep: no `componentVarRef`, `credentialVarRef`, `SENTINEL_POD_FQDN_LIST`, or `SENTINEL_PASSWORD`
- local ShellSpec 0.28.1: `addons/valkey/scripts-ut-spec/backuppolicytemplate_spec.sh` ran 3 examples / 0 failures; existing bash4 specs skipped on macOS bash 3.2

## Test Handoff
After merge/test pin, rerun addon install and focused smoke-backup for datafile backup + restore. Do not claim Sentinel ACL backup/restore unless a separate test adds an explicit supported contract and assertion.
