### PR TITLE
fix(mariadb): scope switchover BINLOG ADMIN fence by host

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -1986,6 +1986,22 @@ type: application
 # causes unnecessary Serial pod restarts on a 3-node cluster.
 # Test galera CM3 reconfigures wsrep_slave_threads from 4 to 8.
 #
+# alpha.124 (Jack 2026-06-03 — replication switchover local BINLOG ADMIN):
+# Fix async/semisync post-DCS switchover fence false failure. Alpha.108
+# restored BINLOG ADMIN on local root@localhost/root@127.0.0.1 so chart-
+# internal loopback/socket paths can run SET sql_log_bin=0. r5 async T9
+# evidence showed replication-switchover.sh still classified that local
+# BINLOG ADMIN as a read_only bypass privilege after DCS switchover, failed
+# the post-DCS verifier, and left an unfinished DCS switchover ConfigMap that
+# poisoned the later explicit switchover test.
+#
+# Fix: make the post-DCS revoke/verifier host-scoped. READ_ONLY ADMIN / SUPER
+# are disallowed for every user-facing root host; BINLOG ADMIN is disallowed
+# for non-local root hosts such as @'%', but allowed for local loopback/socket
+# root. BINLOG ADMIN controls binary logging and does not bypass
+# @@global.read_only by itself. Script-only change, version bumped for
+# evidence traceability.
+#
 # alpha.123 (Helen 2026-06-02 — galera reduce polling log noise):
 # Address Jade's non-blocking review feedback on PR #2734: _any_peer_alive
 # logs per-peer status on every call, producing ~80-120 lines during the
@@ -2149,7 +2165,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.1.1-alpha.123
+version: 1.1.1-alpha.124
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=sh
+# shellcheck disable=SC2218
 # Unit tests for replication-switchover.sh
 # Tests role guard, candidate resolution, and syncerctl/DCS handoff.
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -705,25 +705,39 @@ EOF
     End
   End
 
-  # alpha.59 design-contract close-out (Jack 19:45 review blocker 1):
-  # post-DCS local-root write fence must be _verified_ via an actual user-facing
-  # root INSERT being rejected with 1290/read-only, not just by setting
-  # @@global.read_only=ON. Otherwise the contract has a non-empty field that is
-  # never enforced at the write site.
+  # alpha.105+ design-contract close-out:
+  # post-DCS local-root write fence is verified by read-only SHOW GRANTS
+  # inspection, not a destructive INSERT probe. alpha.124 narrows BINLOG ADMIN:
+  # it is allowed for local loopback/socket root because chart-internal
+  # sql_log_bin=0 paths need it, but it remains disallowed for non-local root.
   Describe "verify_post_dcs_local_root_write_fenced()"
     setup_fence_probe() {
       export MARIADB_ROOT_USER="root"
       export MARIADB_ROOT_PASSWORD="pw"
+      export MARIADB_INTERNAL_ROOT_USER="kb_internal_root"
       export MARIADB_CONNECT_TIMEOUT_SECONDS="5"
       export MARIADB_CLIENT_BIN="${TEST_DIR}/mariadb"
     }
     Before "setup_fence_probe"
 
-    It "passes when user-facing root INSERT is rejected with server error 1290"
+    It "alpha.124: passes when local root keeps BINLOG ADMIN but remote root has no bypass privilege"
       cat > "${TEST_DIR}/mariadb" <<'EOF'
 #!/bin/sh
-echo "ERROR 1290 (HY000) at line 4: The MariaDB server is running with the --read-only option so it cannot execute this statement" >&2
-exit 1
+case "$*" in
+  *"SHOW GRANTS FOR 'root'@'%'"*)
+    printf "%s\n" "GRANT SELECT ON *.* TO 'root'@'%'"
+    exit 0
+    ;;
+  *"SHOW GRANTS FOR 'root'@'127.0.0.1'"*)
+    printf "%s\n" "GRANT SELECT, BINLOG ADMIN ON *.* TO 'root'@'127.0.0.1'"
+    exit 0
+    ;;
+  *"SHOW GRANTS FOR 'root'@'localhost'"*)
+    printf "%s\n" "GRANT SELECT, BINLOG ADMIN ON *.* TO 'root'@'localhost'"
+    exit 0
+    ;;
+esac
+exit 0
 EOF
       chmod +x "${TEST_DIR}/mariadb"
       When call verify_post_dcs_local_root_write_fenced
@@ -731,27 +745,49 @@ EOF
       The output should include "Switchover post-DCS local-root write fence verified"
     End
 
-    It "fails closed when user-facing root INSERT unexpectedly succeeds (fence not enforced)"
+    It "alpha.124: fails closed when remote root@% still has BINLOG ADMIN"
       cat > "${TEST_DIR}/mariadb" <<'EOF'
 #!/bin/sh
+case "$*" in
+  *"SHOW GRANTS FOR 'root'@'%'"*)
+    printf "%s\n" "GRANT SELECT, BINLOG ADMIN ON *.* TO 'root'@'%'"
+    exit 0
+    ;;
+  *"SHOW GRANTS FOR 'root'@'127.0.0.1'"*|*"SHOW GRANTS FOR 'root'@'localhost'"*)
+    printf "%s\n" "GRANT SELECT ON *.* TO 'root'@'local'"
+    exit 0
+    ;;
+esac
 exit 0
 EOF
       chmod +x "${TEST_DIR}/mariadb"
       When call verify_post_dcs_local_root_write_fenced
       The status should be failure
       The stderr should include "Switchover failed: post-DCS local-root write fence not enforced"
+      The stderr should include "'root'@'%'"
+      The stderr should include "BINLOG ADMIN"
     End
 
-    It "fails closed when INSERT fails with an unrelated error (no 1290 / no read-only signal)"
+    It "alpha.124: fails closed when local root keeps READ_ONLY ADMIN"
       cat > "${TEST_DIR}/mariadb" <<'EOF'
 #!/bin/sh
-echo "ERROR 1064 (42000) at line 1: You have an error in your SQL syntax" >&2
-exit 1
+case "$*" in
+  *"SHOW GRANTS FOR 'root'@'%'"*|*"SHOW GRANTS FOR 'root'@'127.0.0.1'"*)
+    printf "%s\n" "GRANT SELECT ON *.* TO 'root'@'ok'"
+    exit 0
+    ;;
+  *"SHOW GRANTS FOR 'root'@'localhost'"*)
+    printf "%s\n" "GRANT SELECT, BINLOG ADMIN, READ_ONLY ADMIN ON *.* TO 'root'@'localhost'"
+    exit 0
+    ;;
+esac
+exit 0
 EOF
       chmod +x "${TEST_DIR}/mariadb"
       When call verify_post_dcs_local_root_write_fenced
       The status should be failure
-      The stderr should include "Switchover failed: post-DCS local-root write fence verification got unexpected error"
+      The stderr should include "'root'@'localhost'"
+      The stderr should include "READ_ONLY ADMIN"
     End
 
     It "fails closed when MARIADB_CLIENT_BIN is unavailable"
@@ -784,56 +820,28 @@ EOF
       The output should not include "CREATE TABLE"
     End
 
-    # alpha.75 v1 hard gate 3 — verifier MUST fail closed with distinct
-    # sentinel when probe table is missing (Error 1146). bootstrap-time
-    # ensure_internal_local_admin must own the probe table create.
-    It "alpha.75 v1: fails closed with distinct sentinel on Error 1146 (probe table missing)"
+    It "passes when all user-facing root host variants are absent with Error 1141"
       cat > "${TEST_DIR}/mariadb" <<'EOF'
 #!/bin/sh
-echo "ERROR 1146 (42S02) at line 1: Table 'kubeblocks.kb_post_dcs_fence_probe' doesn't exist" >&2
+echo "ERROR 1141 (42000): There is no such grant defined for user 'root' on host" >&2
 exit 1
 EOF
       chmod +x "${TEST_DIR}/mariadb"
       When call verify_post_dcs_local_root_write_fenced
-      The status should be failure
-      The stderr should include "probe table missing (Error 1146)"
-      The stderr should include "alpha.75 v1 contract"
+      The status should be success
+      The output should include "all hosts 1141"
     End
 
-    # alpha.75 v1 hard gate 4 — verifier MUST FAIL on Error 1227
-    # (BINLOG ADMIN). The alpha.74 v1 RED root cause was 1227 being
-    # reported as failure (correct behaviour), but the verifier body
-    # was generating it. After alpha.75 v1 the verifier body MUST NOT
-    # require BINLOG ADMIN, so a 1227 from any source must NOT be
-    # mistaken for fence closed.
-    It "alpha.75 v1: fails closed with distinct regression-guard sentinel on Error 1227 (BINLOG ADMIN, alpha.74 v1 RED root cause)"
+    It "fails closed when SHOW GRANTS returns an unrelated error"
       cat > "${TEST_DIR}/mariadb" <<'EOF'
 #!/bin/sh
-echo "ERROR 1227 (42000) at line 2: Access denied; you need (at least one of) the BINLOG ADMIN privilege(s) for this operation" >&2
+echo "ERROR 1044 (42000): Access denied for user 'kb_internal_root'@'localhost'" >&2
 exit 1
 EOF
       chmod +x "${TEST_DIR}/mariadb"
       When call verify_post_dcs_local_root_write_fenced
       The status should be failure
-      The stderr should include "implementation error"
-      The stderr should include "Error 1227 BINLOG ADMIN"
-      The stderr should include "alpha.75 v1 regression guard"
-    End
-
-    # alpha.75 v1 hard gate 5 — verifier MUST FAIL on Error 1044
-    # (access denied on the schema). Same class as 1227: the verifier
-    # body must NOT require DDL/database-level grants beyond INSERT.
-    It "alpha.75 v1: fails closed with distinct regression-guard sentinel on Error 1044 (access denied)"
-      cat > "${TEST_DIR}/mariadb" <<'EOF'
-#!/bin/sh
-echo "ERROR 1044 (42000) at line 1: Access denied for user 'root'@'localhost' to database 'kubeblocks'" >&2
-exit 1
-EOF
-      chmod +x "${TEST_DIR}/mariadb"
-      When call verify_post_dcs_local_root_write_fenced
-      The status should be failure
-      The stderr should include "Error 1044 access denied"
-      The stderr should include "alpha.75 v1 regression guard"
+      The stderr should include "SHOW GRANTS FOR 'root'@'%' failed"
     End
   End
 
@@ -1016,9 +1024,10 @@ EOF
     End
   End
 
-  # alpha.60 (Jack 23:28 8-class review): post-DCS read_only=ON does not fence
-  # user-facing root if root holds READ_ONLY ADMIN / SUPER / BINLOG ADMIN.
-  # This describe block exercises the synchronous revoke that closes that gap.
+  # alpha.60 + alpha.124: post-DCS read_only=ON does not fence user-facing
+  # root if it holds READ_ONLY ADMIN / SUPER; non-local root must also not hold
+  # BINLOG ADMIN. Local root may keep BINLOG ADMIN for chart-internal
+  # sql_log_bin=0 paths because it does not bypass read_only by itself.
   Describe "revoke_user_facing_root_admin_privileges_for_secondary()"
     setup_revoke_env() {
       export MARIADB_ROOT_USER="root"
@@ -1048,7 +1057,7 @@ EOF
       The contents of file "${MOCK_REVOKE_CALLS}" should not include "REVOKE READ_ONLY ADMIN"
     End
 
-    It "alpha.60 v2: revokes each bypass priv per-host and verifies post-revoke residual is clean"
+    It "alpha.124: revokes host-disallowed bypass privs and verifies post-revoke residual is clean"
       # Per Jack 23:52 v2 review: REVOKE per-privilege; after all REVOKEs for a
       # host, re-SHOW GRANTS and assert no bypass priv remains. Mock alternates
       # SHOW GRANTS responses (odd-call = initial bypass, even-call = post-
@@ -1087,11 +1096,48 @@ EOF
       The output should include "reason=revoked root@% priv=BINLOG ADMIN"
       The output should include "reason=revoked root@127.0.0.1 priv=READ_ONLY ADMIN"
       The output should include "reason=revoked root@localhost priv=READ_ONLY ADMIN"
-      The output should include "Switchover post-DCS root revoke summary revoked=9"
+      The output should include "Switchover post-DCS root revoke summary revoked=7"
       The contents of file "${MOCK_REVOKE_CALLS}" should include "REVOKE READ_ONLY ADMIN"
       The contents of file "${MOCK_REVOKE_CALLS}" should include "REVOKE SUPER"
       The contents of file "${MOCK_REVOKE_CALLS}" should include "REVOKE BINLOG ADMIN"
+      The contents of file "${MOCK_REVOKE_CALLS}" should not include "REVOKE BINLOG ADMIN ON *.* FROM 'root'@'127.0.0.1'"
+      The contents of file "${MOCK_REVOKE_CALLS}" should not include "REVOKE BINLOG ADMIN ON *.* FROM 'root'@'localhost'"
       The contents of file "${MOCK_REVOKE_CALLS}" should include "FLUSH PRIVILEGES"
+    End
+
+    It "alpha.124: allows local BINLOG ADMIN residual after post-DCS revoke"
+      cat > "${TEST_DIR}/mariadb" <<'EOF'
+#!/bin/sh
+echo "$@" >> "${MOCK_REVOKE_CALLS}"
+case "$*" in
+  *"SELECT Host FROM mysql.user"*)
+    printf "127.0.0.1\nlocalhost\n"
+    exit 0
+    ;;
+  *"SHOW GRANTS FOR 'root'@'127.0.0.1'"*)
+    printf "%s\n" "GRANT SELECT, BINLOG ADMIN ON *.* TO 'root'@'127.0.0.1'"
+    exit 0
+    ;;
+  *"SHOW GRANTS FOR 'root'@'localhost'"*)
+    printf "%s\n" "GRANT SELECT, BINLOG ADMIN ON *.* TO 'root'@'localhost'"
+    exit 0
+    ;;
+  *"REVOKE READ_ONLY ADMIN"*|*"REVOKE SUPER"*)
+    echo "ERROR 1141 (42000): There is no such grant defined for user 'root' on host" >&2
+    exit 1
+    ;;
+  *"FLUSH PRIVILEGES"*|*"SELECT CONCAT"*)
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+      chmod +x "${TEST_DIR}/mariadb"
+      When call revoke_user_facing_root_admin_privileges_for_secondary
+      The status should be success
+      The output should include "failed_hosts=0"
+      The stderr should not include "revoke_residual_bypass"
+      The contents of file "${MOCK_REVOKE_CALLS}" should not include "REVOKE BINLOG ADMIN"
     End
 
     It "fails closed when even one host still has bypass priv that REVOKE refuses (non-1141)"
@@ -1506,8 +1552,8 @@ EOF
 
       It "fails closed (rc=2) when now_epoch fails (NOT silent 0 fallback)"
         export SWITCHOVER_ACTION_DEADLINE_SECONDS=55
-        action_started_epoch=$(date +%s)
-        date() { return 1; }
+        action_started_epoch=100
+        now_epoch() { return 2; }
         When call remaining_action_budget
         The status should equal 2
         The output should equal "0"

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -111,6 +111,39 @@ SWITCHOVER_USER_FACING_WRITE_PATTERN='INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|CRE
 # `GRANT INSERT ... WITH GRANT OPTION` are NOT silently filtered. The
 # verifier counts and dumps ignored lines for audit.
 SWITCHOVER_GRANTS_IGNORED_LINE_PATTERN='^GRANT PROXY ON .* TO .* WITH GRANT OPTION$'
+
+root_read_only_bypass_pattern_for_host() {
+  case "${1}" in
+    "127.0.0.1"|"localhost")
+      printf '%s' 'READ_ONLY ADMIN|READ ONLY ADMIN|(^|[, ])SUPER([, ]|$)|ALL PRIVILEGES'
+      ;;
+    *)
+      printf '%s' 'READ_ONLY ADMIN|READ ONLY ADMIN|BINLOG ADMIN|(^|[, ])SUPER([, ]|$)|ALL PRIVILEGES'
+      ;;
+  esac
+}
+
+root_read_only_bypass_label_for_host() {
+  case "${1}" in
+    "127.0.0.1"|"localhost")
+      printf '%s' 'READ_ONLY ADMIN / SUPER / ALL PRIVILEGES'
+      ;;
+    *)
+      printf '%s' 'READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL PRIVILEGES'
+      ;;
+  esac
+}
+
+root_post_dcs_revoke_privilege_list_for_host() {
+  case "${1}" in
+    "127.0.0.1"|"localhost")
+      printf '%s\n%s\n' "READ_ONLY ADMIN" "SUPER"
+      ;;
+    *)
+      printf '%s\n%s\n%s\n' "READ_ONLY ADMIN" "SUPER" "BINLOG ADMIN"
+      ;;
+  esac
+}
 # Secondary fence GRANT clause body (excludes admin bypass and user-facing
 # writes; aligned with roleProbe secondary fence post-alpha.61).
 SWITCHOVER_SECONDARY_FENCE_GRANT_BODY='SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN'
@@ -1117,9 +1150,10 @@ prepare_current_primary_for_switchover() {
   # NOT modify root@'%' grants during switchover at all. It relies on:
   #   1. read_only=1 set on the demoted primary post-DCS swap
   #   2. semi-sync ACK protocol blocking commits
-  #   3. user-facing root account NOT holding any admin-bypass privileges
-  #      (BINLOG ADMIN / SUPER / READ_ONLY ADMIN), which is the alpha.61
-  #      hard contract that MariaDB has already adopted and we are KEEPING
+  #   3. user-facing root account NOT holding any read_only-bypass privilege
+  #      (SUPER / READ_ONLY ADMIN everywhere, BINLOG ADMIN on non-local hosts),
+  #      which is the alpha.61 hard contract that MariaDB has already adopted
+  #      and we are KEEPING
   #
   # alpha.79 v1 short-circuits this function to a no-op. The post-DCS local-
   # root write fence verifier (verify_post_dcs_local_root_write_fenced)
@@ -1145,15 +1179,18 @@ revoke_user_facing_root_admin_privileges_for_secondary() {
   # on a single privilege only marks THAT privilege already-fenced - never
   # the host as a whole.
   #
-  # post-DCS read_only=ON does not fence user-facing root that holds
-  # READ_ONLY ADMIN / SUPER / BINLOG ADMIN. kb_internal_root is intentionally
-  # OUT of scope (it must keep READ_ONLY ADMIN for secondary-side 1062 repair
-  # in the alpha.59 secondary roleProbe path).
+  # post-DCS read_only=ON does not fence user-facing root that holds READ_ONLY
+  # ADMIN / SUPER. It also does not fence non-local root hosts that hold BINLOG
+  # ADMIN, so remote root@'%' must lose BINLOG ADMIN. Local root@localhost and
+  # root@127.0.0.1 may keep BINLOG ADMIN because chart-internal loopback/socket
+  # paths need SET sql_log_bin=0 and BINLOG ADMIN alone does not bypass
+  # @@global.read_only. kb_internal_root is intentionally OUT of scope (it must
+  # keep READ_ONLY ADMIN for secondary-side 1062 repair in the alpha.59
+  # secondary roleProbe path).
   local root_user="${MARIADB_ROOT_USER:-root}"
   local hosts host grants out rc
   local total_revoked=0 total_already_fenced=0 total_failed_hosts=0
   local snapshot
-  local PRIVS="READ_ONLY ADMIN|SUPER|BINLOG ADMIN"
   if [ -z "${MARIADB_CLIENT_BIN}" ] || [ ! -x "${MARIADB_CLIENT_BIN}" ]; then
     log_switchover_error "Switchover failed: post-DCS root revoke cannot run without MARIADB_CLIENT_BIN"
     return 1
@@ -1197,8 +1234,10 @@ revoke_user_facing_root_admin_privileges_for_secondary() {
       esac
     fi
     # Per-privilege REVOKE. 1141 on one priv is local-skip, NEVER host-wide.
-    local priv
-    for priv in "READ_ONLY ADMIN" "SUPER" "BINLOG ADMIN"; do
+    local priv privs
+    privs=$(root_post_dcs_revoke_privilege_list_for_host "${host}")
+    while IFS= read -r priv; do
+      [ -z "${priv}" ] && continue
       out=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
         --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
         -P3306 -h127.0.0.1 -N -s -e "
@@ -1219,10 +1258,12 @@ revoke_user_facing_root_admin_privileges_for_secondary() {
           *)
             log_switchover_error "Switchover failed: post-DCS root revoke: reason=revoke_failed ${root_user}@${host} priv=${priv} rc=${rc} out=${out}"
             host_failed=$((host_failed + 1))
-            ;;
+          ;;
         esac
       fi
-    done
+    done <<EOF_PRIVS
+${privs}
+EOF_PRIVS
     # Per-host post-revoke residual check. If any bypass priv survived,
     # the host is fail-closed regardless of per-priv counts.
     grants=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
@@ -1240,12 +1281,10 @@ revoke_user_facing_root_admin_privileges_for_secondary() {
           ;;
       esac
     else
-      case "${grants}" in
-        *"READ_ONLY ADMIN"*|*"SUPER"*|*"BINLOG ADMIN"*|*"GRANT ALL PRIVILEGES"*|*"ALL PRIVILEGES ON \\*.\\*"*|*"ALL PRIVILEGES ON *.*"*)
-          log_switchover_error "Switchover failed: post-DCS root revoke: reason=revoke_residual_bypass ${root_user}@${host} grants=${grants}"
-          host_failed=$((host_failed + 1))
-          ;;
-      esac
+      if printf '%s\n' "${grants}" | grep -qE "$(root_read_only_bypass_pattern_for_host "${host}")"; then
+        log_switchover_error "Switchover failed: post-DCS root revoke: reason=revoke_residual_bypass ${root_user}@${host} disallowed_privs=$(root_read_only_bypass_label_for_host "${host}") grants=${grants}"
+        host_failed=$((host_failed + 1))
+      fi
     fi
     if [ "${host_failed}" -gt 0 ]; then
       total_failed_hosts=$((total_failed_hosts + 1))
@@ -1297,7 +1336,7 @@ verify_post_dcs_local_root_write_fenced() {
   # kubeblocks.kb_post_dcs_fence_probe as user-facing root to test whether
   # @@global.read_only=ON actually rejects user-facing writes. Under a real
   # bypass condition (post-DCS root revoke ran but only stripped READ_ONLY
-  # ADMIN / SUPER / BINLOG ADMIN, leaving INSERT/UPDATE/DELETE on
+  # ADMIN / SUPER / remote BINLOG ADMIN, leaving INSERT/UPDATE/DELETE on
   # user-facing root), this INSERT SUCCEEDED, was binlogged on the demoted
   # primary, and the new primary (already promoted in DCS) never replicated
   # it back. That single INSERT became a permanent orphan event and the
@@ -1314,8 +1353,9 @@ verify_post_dcs_local_root_write_fenced() {
   # GRANTS for root@'%' / root@'127.0.0.1' / root@'localhost' (the same
   # host set apply_post_dcs_root_revoke iterates) and scans for any of the
   # read_only-bypass privileges that the revoke step claims to have removed
-  # (READ_ONLY ADMIN / BINLOG ADMIN / SUPER, plus a defensive ALL
-  # PRIVILEGES match). If any bypass-class privilege is still granted, the
+  # (READ_ONLY ADMIN / SUPER everywhere, BINLOG ADMIN only on non-local root
+  # hosts, plus a defensive ALL PRIVILEGES match). If any bypass-class
+  # privilege is still granted, the
   # fence is by definition not enforced; otherwise the contract holds. The
   # query produces zero binlog events and zero observable side effects on
   # data, replication topology, or DCS state, eliminating the self-pollution
@@ -1328,8 +1368,8 @@ verify_post_dcs_local_root_write_fenced() {
   # SHOW GRANTS, not the gate operation itself).
   #
   # Acceptance contract (rewrite):
-  #   - rc=0 + grants contain no READ_ONLY ADMIN / BINLOG ADMIN / SUPER /
-  #     ALL PRIVILEGES on any of the three root hosts                 → PASS
+  #   - rc=0 + grants contain no host-disallowed bypass privilege
+  #     (local BINLOG ADMIN is allowed; remote BINLOG ADMIN is not)    → PASS
   #   - rc=0 + grants contain any bypass-class privilege               → FAIL
   #     (fence not enforced; user-facing root can still bypass read_only)
   #   - rc!=0 with 1141 (no such grant — root@host absent)             → PASS
@@ -1385,8 +1425,8 @@ verify_post_dcs_local_root_write_fenced() {
     # by `[, ]` (privilege list separator) or sitting at start/end of
     # the line. ALL PRIVILEGES is matched as a defensive catch-all in
     # case the chart bootstrap revoke step never ran.
-    if printf '%s\n' "${out}" | grep -qE '(READ_ONLY ADMIN|READ ONLY ADMIN|BINLOG ADMIN|(^|[, ])SUPER([, ]|$)|ALL PRIVILEGES)'; then
-      log_switchover_error "Switchover failed: post-DCS local-root write fence not enforced; 'root'@'${host}' still holds a read_only-bypass privilege (READ_ONLY ADMIN / BINLOG ADMIN / SUPER / ALL PRIVILEGES). grants=${out}"
+    if printf '%s\n' "${out}" | grep -qE "$(root_read_only_bypass_pattern_for_host "${host}")"; then
+      log_switchover_error "Switchover failed: post-DCS local-root write fence not enforced; 'root'@'${host}' still holds a read_only-bypass privilege ($(root_read_only_bypass_label_for_host "${host}")). grants=${out}"
       return 1
     fi
   done
@@ -1410,12 +1450,13 @@ fence_current_primary_local_writes_after_dcs() {
     log_switchover_error "Switchover failed: current primary read_only=ON was not verified after DCS switchover was accepted"
     return 1
   fi
-  # alpha.60: synchronously revoke user-facing root admin bypass privileges
-  # (READ_ONLY ADMIN / SUPER / BINLOG ADMIN) for every root account in
-  # mysql.user. read_only=ON alone does not fence root that holds these
-  # privileges; the alpha.59 verify_post_dcs_local_root_write_fenced caught
-  # this gap. Restoration of secondary follow-time grants stays in roleProbe
-  # secondary path - this action does NOT re-grant admin bypass.
+  # alpha.60 + alpha.124: synchronously revoke user-facing root admin bypass
+  # privileges. READ_ONLY ADMIN / SUPER are disallowed everywhere; BINLOG ADMIN
+  # is disallowed on non-local root hosts but allowed for local loopback/socket
+  # root because chart-internal sql_log_bin=0 paths need it and it does not
+  # bypass read_only by itself. Restoration of secondary follow-time grants
+  # stays in roleProbe secondary path - this action does NOT re-grant read_only
+  # bypass privileges.
   if ! revoke_user_facing_root_admin_privileges_for_secondary; then
     return 1
   fi


### PR DESCRIPTION
## Summary
- bump MariaDB chart to `1.1.1-alpha.124`
- scope post-DCS root privilege checks by host in `replication-switchover.sh`
- allow local `root@localhost` / `root@127.0.0.1` to retain `BINLOG ADMIN` for chart-internal `SET sql_log_bin=0` paths
- keep `BINLOG ADMIN` disallowed for non-local user-facing root hosts, and keep `READ_ONLY ADMIN` / `SUPER` / `ALL PRIVILEGES` disallowed for every root host

## Why
Async validation with patched syncer reached T9, but a prior switchover action failed after creating the DCS switchover record. The post-DCS verifier treated local `BINLOG ADMIN` as a read_only bypass privilege, failed closed, and left an unfinished switchover record that blocked the later explicit T9 switchover.

`BINLOG ADMIN` is needed by local chart-internal SQL paths that run `SET sql_log_bin=0`; it does not bypass `@@global.read_only` by itself. Remote user-facing root must still not hold it.

## Validation
- `bash -n addons/mariadb/scripts/replication-switchover.sh`
- `sh -n addons/mariadb/scripts/replication-switchover.sh`
- targeted ShellSpec lines: 10 examples, 0 failures
- `helm lint addons/mariadb`
- `helm template mariadb-alpha124-test addons/mariadb`
- idc2 vcluster deployed chart `mariadb-1.1.1-alpha.124`, helm revision 8
- `mariadb-replication-merged-1.1.1-alpha.124` is Available
- async r6 is running with CmpD alpha.124 and syncer image `docker.io/apecloud/syncer:mariadb-pr170-e8c2234-lag-fallback`; T1-T5 and CM1-CM4 have passed so far

## Notes
The full historical `replication_switchover_spec.sh` file still has unrelated pre-existing failures from stale mocks and old chart-version assertions. The changed alpha.124 coverage was run by line selection and passed.
