### PR TITLE
chore(mongodb): avoid sharded config render helper dependency

### DIFF
--- a/addons/mongodb/config/mongodb-shard-config.tpl
+++ b/addons/mongodb/config/mongodb-shard-config.tpl
@@ -2,16 +2,8 @@
 # for documentation of all options, see:
 #   http://docs.mongodb.org/manual/reference/configuration-options/
 
-{{- $log_root := getVolumePathByName ( index $.podSpec.containers 0 ) "log" }}
-{{- $mongodb_root := getVolumePathByName ( index $.podSpec.containers 0 ) "data" }}
-{{- $mongodb_port_info := getPortByName ( index $.podSpec.containers 0 ) "mongodb" }}
-{{- $phy_memory := getContainerMemory ( index $.podSpec.containers 0 ) }}
-
-# require port
+{{- $mongodb_root := "/data/mongodb" }}
 {{- $mongodb_port := 27017 }}
-{{- if $mongodb_port_info }}
-{{- $mongodb_port = $mongodb_port_info.containerPort }}
-{{- end }}
 
 # where and how to store data.
 storage:

--- a/addons/mongodb/config/mongos-config.tpl
+++ b/addons/mongodb/config/mongos-config.tpl
@@ -2,14 +2,8 @@
 # for documentation of all options, see:
 #   http://docs.mongodb.org/manual/reference/configuration-options/
 
-{{- $mongodb_root := getVolumePathByName ( index $.podSpec.containers 0 ) "data" }}
-{{- $mongodb_port_info := getPortByName ( index $.podSpec.containers 0 ) "mongodb" }}
-
-# require port
+{{- $mongodb_root := "/data/mongodb" }}
 {{- $mongodb_port := 27017 }}
-{{- if $mongodb_port_info }}
-{{- $mongodb_port = $mongodb_port_info.containerPort }}
-{{- end }}
 
 # network interfaces
 net:


### PR DESCRIPTION
## Summary
- remove MongoDB sharded config templates' dependency on KB render helper functions for data path and port
- use the same fixed `/data/mongodb` data root and `27017` port already used by the MongoDB chart/runtime
- child PR for #2742; does not change the #2742 owner branch directly

## Evidence
- Local worktree based on #2742 head `d33c3033b36c28bed22ab8675d7900a40e796524`
- `git diff --check` PASS
- `helm template kb-addon-mongodb addons/mongodb -n kb-system` PASS
- Rendered output has no `getVolumePathByName` / `getPortByName` / `getContainerMemory` tokens and no `volumes: null`
- Target runner focused validation on KB `1.2.0-alpha.1`: sharded Cluster reached Running, mongos marker write/read rc=0

## Boundary
- Runtime validation used a patched addon chart in `mason-idc-mongodb-vc`; cleanup exposed a separate KB finalizer cleanup issue, so cleanup is not claimed as normal CLEAN PASS.
- This PR only addresses the config-render helper dependency.
