### PR TITLE
chore(postgresql): reclone replica when patroni rewind cannot recover

### DIFF
--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ description: A PostgreSQL (with Patroni HA) cluster definition Helm chart for Ku
 
 type: application
 
-version: 1.1.0-alpha.1
+version: 1.1.0-alpha.2
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # appVersion should be consistent with the highest PostgreSQL (with Patroni HA) kernel version.

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -374,6 +374,9 @@ spec:
                 initdb:
                   - auth-host: md5
                   - auth-local: trust
+              postgresql:
+                remove_data_directory_on_rewind_failure: true
+                remove_data_directory_on_diverged_timelines: true
           - name: ALLOW_NOSSL
             value: "true"
           - name: PGROOT


### PR DESCRIPTION
## What

Create a new PostgreSQL chart/CmpD revision and add Patroni recovery settings:

- chart version: `postgresql-1.1.0-alpha.1` -> `postgresql-1.1.0-alpha.2`
- new ComponentDefinitions: `postgresql-{12,14,15,16,17,18}-1.1.0-alpha.2`
- Patroni settings in `SPILO_CONFIGURATION`:
  - `remove_data_directory_on_rewind_failure: true`
  - `remove_data_directory_on_diverged_timelines: true`

The chart version bump is intentional. KubeBlocks marks an existing same-name ComponentDefinition unavailable if its immutable spec fields are changed in place, so this PR uses the addon’s versioned CmpD naming model instead of mutating the old `1.1.0-alpha.1` CmpDs.

## Why

KB1.1 PG18.4 Phase A r1v7 hit a product recovery failure during restart. The secondary stayed in startup after `pg_rewind` failed because the required WAL segment was missing, and Patroni did not remove/re-clone the data directory.

Evidence captured in Slock/runner artifacts:

- failed run: `20260603-1930-kb11-pg184-phaseA-r1v7`
- failure: `[replication] T08: Restart failed`
- root log: `pg_rewind: error: could not open file ... pg_wal/000000010000000000000004`
- root log: `ERROR: Failed to rewind from healthy primary`

## Validation

Local static validation:

- `helm dependency build` under `addons/postgresql`
- `helm template postgresql .`
- rendered all 6 new alpha.2 ComponentDefinitions
- all 6 new ComponentDefinitions include both Patroni settings
- `ComponentVersion` compatibility remains major-prefix based, so both old alpha.1 and new alpha.2 CmpDs are compatible definitions

Targeted live validation on the frozen failed scene:

- patched PG18 ComponentDefinition + failed InstanceSet with this setting to validate the DB recovery behavior
- recreated only the stuck secondary pod
- secondary recovered to Replica/streaming TL3 with lag 0
- primary and replica LSN matched at `0/611B920`
- both pods became `6/6 Running`, InstanceSet `READY=2 AVAILABLE=2`

That targeted validation proves the DB recovery path. The old live-patched r1v7 scene is not counted as release gate because the pre-existing OpsRequest remained `Running 2/2`.

Install/upgrade validation for the corrected versioned-CmpD shape:

- direct same-name CmpD mutation was rejected by KubeBlocks as `Unavailable: immutable fields can't be updated`; the aborted run `r1v8-b811` is not counted
- corrected chart upgrade with alpha.2 CmpDs succeeded using Helm server-side apply with conflict takeover in the test environment
- PG18 alpha.2 CmpD is `Available` and contains both Patroni settings
- new clean run `20260603-2039-kb11-pg184-phaseA-r1v9-alpha2` is running; short check confirms the cluster selected `postgresql-18-1.1.0-alpha.2`

## Notes

- PR owner: @Violet
- Focused review: @Easton via Slock DM/thread per current review rule
- No GitHub review comments should be used for code review discussion
