### PR TITLE
fix(mariadb): backup ActionSet pipefail + privilege fix

### DIFF
--- a/addons/mariadb/templates/actionset.yaml
+++ b/addons/mariadb/templates/actionset.yaml
@@ -17,11 +17,11 @@ spec:
         - sh
         - -c
         - |
-          set -e;
+          set -eo pipefail;
           export PATH="$PATH:$DP_DATASAFED_BIN_PATH";
           export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH";
           echo "DB_HOST=${DP_DB_HOST} DB_USER=${DP_DB_USER} DB_PASSWORD=${DP_DB_PASSWORD} DATA_DIR=${DATA_DIR} BACKUP_DIR=${DP_BACKUP_DIR} BACKUP_NAME=${DP_BACKUP_NAME}";
-          mariadb-backup --backup --safe-slave-backup --slave-info --stream=mbstream --host=${DP_DB_HOST} \
+          mariadb-backup --backup --slave-info --stream=mbstream --host=${DP_DB_HOST} \
           --user=${DP_DB_USER} --password=${DP_DB_PASSWORD} --datadir=${DATA_DIR} \
           --skip-ssl | datasafed push - "/${DP_BACKUP_NAME}.mbstream";
           TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}');
@@ -33,7 +33,7 @@ spec:
         - sh
         - -c
         - |
-          set -e;
+          set -eo pipefail;
           export PATH="$PATH:$DP_DATASAFED_BIN_PATH";
           export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH";
           echo "BACKUP_DIR=${DP_BACKUP_BASE_PATH} BACKUP_NAME=${DP_BACKUP_NAME} DATA_DIR=${DATA_DIR}";


### PR DESCRIPTION
## Summary

- Add `set -o pipefail` to both backup and restore scripts in the ActionSet
- Remove `--safe-slave-backup` from the backup command

## Root Cause

The backup ActionSet uses `set -e` without `pipefail`. When `mariadb-backup` fails (e.g. missing privilege), the error goes to stderr, stdout is empty, and `datasafed push` succeeds with a 0-byte file. The DataProtection controller sees Job exit 0 and marks Backup as Completed with totalSize=0. The subsequent restore fails with `Can't open backup-my.cnf`.

The `--safe-slave-backup` flag runs `STOP SLAVE SQL_THREAD` which requires `REPLICATION SLAVE ADMIN`. The `root@%` account intentionally lacks this privilege (read-only fence design). Without the flag, `mariadb-backup` still produces a crash-consistent InnoDB backup via its internal redo log mechanism.

## Evidence

- r25 async suite: Backup Completed with totalSize=0, Restore Failed
- Reproduced: `mariadb-backup` stderr shows `FATAL ERROR: failed to execute query STOP SLAVE SQL_THREAD: Access denied; you need REPLICATION SLAVE ADMIN`
- Verified repo PVC: `mdb-async-1547-backup-1547.mbstream` is 0 bytes
- MySQL sibling addon uses `set -o pipefail` (line 3 of `dataprotection/backup.sh`)

## Test Plan

- [ ] Deploy updated ActionSet on vcluster
- [ ] Run backup/restore on async replication cluster
- [ ] Verify backup totalSize > 0 and restore succeeds