### PR TITLE
fix(mariadb): use bash for ActionSet pipefail

### DIFF
--- a/addons/mariadb/templates/actionset.yaml
+++ b/addons/mariadb/templates/actionset.yaml
@@ -14,7 +14,7 @@ spec:
       image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
       runOnTargetPodNode: true
       command:
-        - sh
+        - bash
         - -c
         - |
           set -eo pipefail;
@@ -30,7 +30,7 @@ spec:
     prepareData:
       image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
       command:
-        - sh
+        - bash
         - -c
         - |
           set -eo pipefail;


### PR DESCRIPTION
## Summary

Follow-up to PR #2753. The mariadb:11.4 Docker image uses `dash` as `/bin/sh`, which does not support `set -o pipefail`. Switch ActionSet command interpreter from `sh` to `bash`.

## Evidence

Live test on vcluster: `sh -c 'set -eo pipefail'` returns `Illegal option -o pipefail`. `bash` is available at `/usr/bin/bash` (GNU bash 5.2.21).

## Test Plan

- [ ] Backup with fixed ActionSet produces non-zero totalSize
- [ ] Restore from that backup succeeds