### PR TITLE
fix(mariadb): DCS primary overrides service routing during rolling update

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2152,7 +2152,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1991,13 +1991,12 @@ spec:
                   return 0
                 fi
               fi
-              primary_sid="$(query_primary_service_server_id || true)"
-              if [ -n "${primary_sid}" ] && [ "${primary_sid}" != "${SERVICE_ID}" ]; then
-                prestop_watchdog_log "runtime-primary-listener-reconcile-defer reason=primary-service-routes-to-peer primary_sid=${primary_sid} service_id=${SERVICE_ID}"
-                return 0
-              fi
               role="$(query_local_syncer_role || true)"
               [ "${role}" = "primary" ] || return 0
+              primary_sid="$(query_primary_service_server_id || true)"
+              if [ -n "${primary_sid}" ] && [ "${primary_sid}" != "${SERVICE_ID}" ]; then
+                prestop_watchdog_log "runtime-primary-listener-reconcile-override reason=dcs-primary-overrides-service-routing primary_sid=${primary_sid} service_id=${SERVICE_ID} syncer_role=${role}"
+              fi
               prestop_watchdog_log "runtime-primary-listener-reconcile-begin role=${role}"
               expose_sql_listener_for_primary_role "syncer-promoted-primary" || return 1
               mark_replication_ready


### PR DESCRIPTION
## Summary
- During static parameter reconfigure (e.g. back_log), rolling update triggers switchover. After switchover, the new DCS primary was blocked by the primary-service-routes-to-peer check because K8s service still pointed to the old primary, creating a deadlock.
- Fix: check DCS/syncer role first (authority source). If this pod is DCS primary, proceed with listener reconciliation regardless of K8s service routing state. Log service mismatch as override instead of blocking.
- Bump chart version 1.2.0-alpha.0 to 1.2.0-alpha.1 (CmpD immutability).

## Evidence
- r28 CM4 back_log Reconfiguring FAIL: OpsRequest stuck Running 420s, InstanceSet updatedReplicas=1/2
- Root cause: watchdog log shows endless loop of rejoin-replication-exit-on-dcs-primary + primary-service-routes-to-peer defer
- Both pods stuck in read_only=ON, no role label published, InstanceSet cannot converge

## Test plan
- [ ] Focused CM4 back_log reconfigure verify on fresh cluster
- [ ] Full suite r29 from T1 after focused verify passes