### PR TITLE
mariadb: bump chart to 1.2.0-alpha.2 for semisync pivot

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2152,7 +2152,7 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.2.0-alpha.1
+version: 1.2.0-alpha.2
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add


### PR DESCRIPTION
## Summary
- Bump chart version from 1.2.0-alpha.1 to 1.2.0-alpha.2
- CmpD immutability requires version bump to bake `MARIADB_REPLICATION_MODE=semisync` into CmpD env
- No code changes — mode switch is a values.yaml parameter at helm install/upgrade time

## Context
- async N=2 reached (r23 + r29 both CLEAN PASS)
- Pivoting to semisync full suite testing
- Parent PR: #2633