### PR TITLE
fix(mariadb): align shellspec tests with alpha.2 chart + seeder timeout preservation

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -177,21 +177,21 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
     End
   End
 
-  Describe "merged PD parametersSchema wiring"
-    It "the merged PD block declares parametersSchema with the CUE top-level key"
+  Describe "merged PD parametersSchema wiring (removed in alpha.91 — KB validator only reads CUE properties, not additionalProperties)"
+    It "the merged PD block does NOT declare parametersSchema (removed to unblock reconfigure of common dynamic params)"
       When call awk_line_in_block \
         'name:[[:space:]]+mariadb-replication-merged-pd[[:space:]]*$' \
         'topLevelKey:[[:space:]]+MariaDBParameter' \
         "$(paramsdef_path)"
-      The output should equal "ok"
+      The output should equal ""
     End
 
-    It "the merged PD block references the CUE file via Files.Get"
+    It "the merged PD block does NOT reference the CUE file via Files.Get (parametersSchema removed)"
       When call awk_line_in_block \
         'name:[[:space:]]+mariadb-replication-merged-pd[[:space:]]*$' \
         'Files\.Get "config/mariadb-config-constraint\.cue"' \
         "$(paramsdef_path)"
-      The output should equal "ok"
+      The output should equal ""
     End
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -22,6 +22,17 @@ Describe "replication-switchover.sh"
     export SWITCHOVER_POLL_SECONDS="1"
     touch "${MARIADB_CLIENT_BIN}"
     chmod +x "${MARIADB_CLIENT_BIN}"
+    # Provide a timeout stub on macOS where GNU timeout is absent.
+    if ! command -v timeout >/dev/null 2>&1; then
+      mkdir -p "${TEST_DIR}/bin"
+      cat > "${TEST_DIR}/bin/timeout" <<'TIMEOUT_STUB'
+#!/bin/sh
+shift
+exec "$@"
+TIMEOUT_STUB
+      chmod +x "${TEST_DIR}/bin/timeout"
+      export PATH="${TEST_DIR}/bin:${PATH}"
+    fi
   }
   BeforeEach "setup"
 
@@ -258,8 +269,8 @@ EOF
         }
         When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
         The status should be success
-        The output should include "Switchover candidate remote root write probe converged for mdb-mariadb-1"
-        The output should include "Switchover action returned: DCS recorded, current primary fenced, candidate promoted via DCS, candidate writable"
+        The output should include "Switchover candidate remote root primary-readiness probe converged for mdb-mariadb-1"
+        The output should include "candidate root primary-readiness observed without mutating probe"
       End
 
       It "passes pod names to syncerctl instead of candidate FQDN"
@@ -379,7 +390,7 @@ EOF
         When call main
         The status should be success
         The output should include "Switchover using mariadb client: ${MYSQL_CLIENT_DIR}/bin/mariadb"
-        The output should include "Switchover action returned: DCS recorded, current primary fenced, candidate promoted via DCS, candidate writable"
+        The output should include "candidate root primary-readiness observed without mutating probe"
       End
 
       It "alpha.59 contract: never invokes wait_switchover_done / wait_post_switchover_stabilization / wait_primary_service_routes_candidate / current_follows_candidate"
@@ -391,7 +402,7 @@ EOF
         prepare_current_primary_for_switchover() { return 0; }
         fence_local_remote_root_for_secondary() { return 0; }
         local_remote_root_is_fenced_for_secondary() { return 0; }
-        remote_root_write_ready() { return 0; }
+        remote_root_primary_ready() { return 0; }
         verify_post_dcs_local_root_write_fenced() { return 0; }
         revoke_user_facing_root_admin_privileges_for_secondary() { return 0; }
         wait_candidate_promoted_via_syncerctl() { return 0; }
@@ -408,7 +419,7 @@ EOF
         primary_service_routes_candidate() { record_call "BUG_primary_service_routes_candidate_called"; return 0; }
         When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
         The status should be success
-        The output should include "Switchover action returned: DCS recorded, current primary fenced, candidate promoted via DCS, candidate writable"
+        The output should include "candidate root primary-readiness observed without mutating probe"
         The contents of file "${TEST_DIR}/calls" should not include "BUG_wait_switchover_done_called"
         The contents of file "${TEST_DIR}/calls" should not include "BUG_wait_post_switchover_stabilization_called"
         The contents of file "${TEST_DIR}/calls" should not include "BUG_wait_primary_service_routes_candidate_called"
@@ -417,8 +428,8 @@ EOF
         The contents of file "${TEST_DIR}/calls" should not include "BUG_primary_service_routes_candidate_called"
       End
 
-      It "alpha.61 contract: fails closed when candidate remote root write probe does not close in budget"
-        export CANDIDATE_REMOTE_ROOT_WRITE_PROBE_WAIT_SECONDS=0
+      It "alpha.61 contract: fails closed when candidate remote root primary-readiness probe does not close in budget"
+        export CANDIDATE_REMOTE_ROOT_PRIMARY_READY_WAIT_SECONDS=0
         export SWITCHOVER_POLL_SECONDS=1
         make_syncerctl
         prepare_current_primary_for_switchover() { return 0; }
@@ -436,7 +447,7 @@ EOF
         When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
         The status should be failure
         The output should include "Switchover post-DCS guard passed"
-        The stderr should include "reason=candidate_remote_root_write_not_ready_in_budget"
+        The stderr should include "reason=candidate_remote_root_primary_not_ready_in_budget"
         The stderr should include "fail-closed"
       End
     End
@@ -861,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.1.1-alpha.90$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.2$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -1683,7 +1694,7 @@ secondary-other"
   # Each stage entry MUST check remaining_action_budget BEFORE invoking the
   # stage body. Sentinel reasons are distinct so closeout can attribute the
   # exhausted stage. v1 only enforced this on the last 2 stages (promote,
-  # write); v2 enforces on all 5 (prepare, dcs, fence, promote, write).
+  # write); v2 enforces on all 5 (prepare, dcs, fence, promote, ready).
   Describe "run_switchover() alpha.61 v2 per-stage deadline enforcement"
     setup_v2_stage_env() {
       export SWITCHOVER_ACTION_DEADLINE_SECONDS=10
@@ -1778,7 +1789,7 @@ secondary-other"
       The stderr should include "fail-closed"
     End
 
-    It "fails closed at write stage with action_deadline_exhausted_write when promote body exceeds budget"
+    It "fails closed at ready stage with action_deadline_exhausted_ready when promote body exceeds budget"
       prepare_current_primary_for_switchover() { return 0; }
       syncerctl_switchover() { return 0; }
       fence_current_primary_local_writes_after_dcs() { return 0; }
@@ -1789,7 +1800,7 @@ secondary-other"
       When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
       The status should be failure
       The output should include "Switchover stage candidate_promoted"
-      The stderr should include "reason=action_deadline_exhausted_write"
+      The stderr should include "reason=action_deadline_exhausted_ready"
       The stderr should include "fail-closed"
     End
 
@@ -2890,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.1.1-alpha.90"
+      The output should equal "version: 1.2.0-alpha.2"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2951,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.90"
+        The output should equal "version: 1.2.0-alpha.2"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3128,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.1.1-alpha.90"
+        The output should equal "version: 1.2.0-alpha.2"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,14 +79,14 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.1.1-alpha.90 (alpha.90 bump: CmpD immutability — alpha.89 13/14/15/16 mutated merged CmpD spec; KB rejected updates with immutable fields can't be updated; bump produces fresh mariadb-replication-merged-1.1.1-alpha.90 CmpD)"
-      When call grep -c '^version: 1.1.1-alpha.90$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.2 (alpha.2 bump: semisync pivot — 1.2.0 major for topology merge + semisync fencing)"
+      When call grep -c '^version: 1.2.0-alpha.2$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End
 
-    It "does not retain prior alpha.88 version line (no stale literal)"
-      When call grep -c '^version: 1.1.1-alpha.88$' "${CHART_YAML}"
+    It "does not retain prior alpha.90 version line (no stale literal)"
+      When call grep -c '^version: 1.1.1-alpha.90$' "${CHART_YAML}"
       The output should eq "0"
       The status should be failure
     End

--- a/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/seed_replication_mode_overrides_spec.sh
@@ -97,12 +97,30 @@ Describe "alpha.89 commit 13 v2 seed-replication-mode-overrides.sh"
       The status should be success
     End
 
-    It "writes rpl_semi_sync_master_timeout=10000"
+    It "writes rpl_semi_sync_master_timeout=10000 when no timeout override exists"
       MARIADB_REPLICATION_MODE=semisync
       export MARIADB_REPLICATION_MODE
       When call run_seeder
       The status should be success
       The contents of file "${overrides_dir}/rpl_semi_sync_master_timeout.cnf" should include "rpl_semi_sync_master_timeout = 10000"
+    End
+
+    It "preserves an existing valid rpl_semi_sync_master_timeout override across restart seeding"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      printf '[mysqld]\nrpl_semi_sync_master_timeout = 3000\n' > "${overrides_dir}/rpl_semi_sync_master_timeout.cnf"
+      When call run_seeder
+      The status should be success
+      The contents of file "${overrides_dir}/rpl_semi_sync_master_timeout.cnf" should include "rpl_semi_sync_master_timeout = 3000"
+    End
+
+    It "fails closed when an existing rpl_semi_sync_master_timeout override is invalid"
+      MARIADB_REPLICATION_MODE=semisync
+      export MARIADB_REPLICATION_MODE
+      printf '[mysqld]\nrpl_semi_sync_master_timeout = invalid\n' > "${overrides_dir}/rpl_semi_sync_master_timeout.cnf"
+      When call run_seeder
+      The status should equal 5
+      The stderr should include "invalid existing rpl_semi_sync_master_timeout"
     End
   End
 

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -133,7 +133,7 @@ Describe "cmpd-semisync.yaml rejoin fence template"
   End
 
   It "unlocks local root before publishing a primary as writable"
-    When call function_contains "set_primary_read_write" "unlock_local_root_writes \"primary-read-write\""
+    When call function_contains "set_primary_read_write" "unlock_local_root_writes \"\${label}\""
     The status should be success
   End
 
@@ -153,7 +153,7 @@ Describe "cmpd-semisync.yaml rejoin fence template"
   End
 
   It "requires remote root unlock before publishing a primary as writable"
-    When call function_contains "set_primary_read_write" "fail_primary_read_write_gate \"primary-read-write\" \"remote-root-unlock\""
+    When call function_contains "set_primary_read_write" "fail_primary_read_write_gate \"\${label}\" \"remote-root-unlock\""
     The status should be success
   End
 
@@ -168,7 +168,7 @@ Describe "cmpd-semisync.yaml rejoin fence template"
   End
 
   It "fails closed when read_only cannot be opened for a primary"
-    When call function_contains "set_primary_read_write" "fail_primary_read_write_gate \"primary-read-write\" \"read-only-open\""
+    When call function_contains "set_primary_read_write" "fail_primary_read_write_gate \"\${label}\" \"read-only-open\""
     The status should be success
   End
 

--- a/addons/mariadb/scripts/seed-replication-mode-overrides.sh
+++ b/addons/mariadb/scripts/seed-replication-mode-overrides.sh
@@ -34,9 +34,11 @@
 #   2. Empty/unset → no-op (return 0). Existing clusters whose Helm
 #      values do not set the mode see no behavioral change.
 #   3. Conflict not possible at install time (no user-supplied real
-#      vars in the path yet); seeder simply writes the 4 derived
-#      values.
-#   4. Synthetic key never written. Only the four real engine
+#      vars in the path yet); seeder writes the derived mode values.
+#      On later restarts, an existing valid
+#      rpl_semi_sync_master_timeout override is preserved so a dynamic
+#      reconfigure value is not reset to the install-time default.
+#   4. Synthetic key never written. Only the three real engine
 #      variables land in runtime-overrides.d/.
 #   5. Fail-closed on invalid mode: prints sentinel, exits non-zero;
 #      caller (CmpD container command) refuses to proceed with
@@ -137,6 +139,47 @@ seed_replication_mode_validate_target_type() {
     return "${SEED_REPLICATION_MODE_EXIT_OK}"
 }
 
+seed_replication_mode_read_existing_timeout() {
+    target="$1"
+
+    if [ ! -f "${target}" ]; then
+        printf "10000\n"
+        return "${SEED_REPLICATION_MODE_EXIT_OK}"
+    fi
+
+    value="$(awk -F= '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*;/ { next }
+        /^[[:space:]]*$/ { next }
+        /^[[:space:]]*\[/ { next }
+        {
+          key=$1
+          val=$2
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+          if (key == "rpl_semi_sync_master_timeout") {
+            print val
+            exit
+          }
+        }
+    ' "${target}")"
+
+    case "${value}" in
+    ''|*[!0-9]*)
+        echo "seed-replication-mode-overrides: invalid existing rpl_semi_sync_master_timeout override at ${target}: ${value:-<empty>}" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+        ;;
+    esac
+
+    if [ "${value}" -gt 4294967295 ]; then
+        echo "seed-replication-mode-overrides: existing rpl_semi_sync_master_timeout override at ${target} is out of range: ${value}" >&2
+        return "${SEED_REPLICATION_MODE_EXIT_IO}"
+    fi
+
+    printf "%s\n" "${value}"
+    return "${SEED_REPLICATION_MODE_EXIT_OK}"
+}
+
 # Main entry. Reads MARIADB_REPLICATION_MODE from env; returns 0 on
 # success (or no-op when env is empty); returns 2 on invalid mode;
 # returns 5 on IO failure.
@@ -185,6 +228,7 @@ seed_replication_mode_overrides() {
     pair_output="$(seed_replication_mode_derive_master_slave "${mode}")" || return $?
     master_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="master"{print $2; exit}')"
     slave_value="$(printf '%s\n' "${pair_output}" | awk -F= '$1=="slave"{print $2; exit}')"
+    timeout_value="$(seed_replication_mode_read_existing_timeout "${overrides_dir}/rpl_semi_sync_master_timeout.cnf")" || return $?
 
     # --- Phase B: pre-validate target types (B4) ---
     # alpha.89 v1 commit 16 (Helen 2026-05-20, live N=1 third
@@ -211,7 +255,7 @@ seed_replication_mode_overrides() {
         seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi
-    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_timeout 10000; then
+    if ! seed_replication_mode_write_one_tmp "${overrides_dir}" rpl_semi_sync_master_timeout "${timeout_value}"; then
         seed_replication_mode_cleanup_all_tmps "${overrides_dir}"
         return "${SEED_REPLICATION_MODE_EXIT_IO}"
     fi


### PR DESCRIPTION
## Summary
- Align all shellspec test assertions with 1.2.0-alpha.2 chart: version guards, renamed switchover functions, parametersSchema removal, template parameterization
- Add macOS `timeout` stub so tests pass on macOS CI runners
- Seeder preserves existing valid `rpl_semi_sync_master_timeout` override across container restarts, preventing dynamic reconfigure values from being reset to install-time defaults

## Test plan
- [x] `shellspec --load-path ./shellspec --default-path "addons/mariadb/scripts-ut-spec" --shell bash` → 552 examples, 0 failures