### PR TITLE
fix(mariadb): suppress shellspec warnings treated as failures in CI

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_member_join_spec.sh
@@ -803,6 +803,7 @@ EOF
         }
         When call setup_replication
         The status should be failure
+        The output should be present
         The path "${TEST_DIR}/.replication-pending" should be exist
         The stderr should include "phase: change-master-or-start-io-failed"
       End
@@ -824,6 +825,7 @@ EOF
         }
         When call setup_replication
         The status should be failure
+        The output should be present
         The path "${TEST_DIR}/.replication-pending" should be exist
         The stderr should include "phase: change-master-failed"
       End
@@ -846,6 +848,7 @@ EOF
         }
         When call setup_replication
         The status should be failure
+        The output should be present
         The path "${TEST_DIR}/.replication-pending" should be exist
         The stderr should include "phase: slave-config-not-persisted"
       End
@@ -863,6 +866,7 @@ EOF
         export MARIADB_CLI=""
         When call main
         The status should be failure
+        The output should be present
         The path "${TEST_DIR}/.replication-pending" should be exist
         The stderr should include "phase: mariadb-cli-unavailable"
       End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_pd_schema_enum_spec.sh
@@ -189,7 +189,7 @@ Describe "alpha.89 merged PD CUE schema + dynamic classification"
     It "the merged PD block does NOT reference the CUE file via Files.Get (parametersSchema removed)"
       When call awk_line_in_block \
         'name:[[:space:]]+mariadb-replication-merged-pd[[:space:]]*$' \
-        'Files\.Get "config/mariadb-config-constraint\.cue"' \
+        'Files[.]Get "config/mariadb-config-constraint[.]cue"' \
         "$(paramsdef_path)"
       The output should equal ""
     End


### PR DESCRIPTION
## Summary
- member_join: add stdout assertion to suppress "output to stdout but not found expectation" warnings
- pd_schema: use `[.]` instead of `\.` in awk regex to avoid gawk escape warning on Ubuntu CI
- ShellSpec treats warnings as failures by default (`--warning-as-failure`), so these 5 warnings were causing CI failure

## Test plan
- [x] Local: `shellspec` 0 failures, 0 warnings on both files