### PR TITLE
ci: install helm in shellspec CI workflows

### DIFF
--- a/.github/workflows/shellspec-pr-review.yml
+++ b/.github/workflows/shellspec-pr-review.yml
@@ -13,6 +13,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install helm
         uses: azure/setup-helm@v4
+      - name: Build helm chart dependencies
+        run: |
+          for chart in addons/*/Chart.yaml; do
+            dir=$(dirname "$chart")
+            if grep -q 'dependencies:' "$chart" 2>/dev/null; then
+              helm dependency build "$dir" 2>/dev/null || true
+            fi
+          done
       - name: shellspec test
         run: |
           make scripts-test

--- a/.github/workflows/shellspec-pr-review.yml
+++ b/.github/workflows/shellspec-pr-review.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install helm
+        uses: azure/setup-helm@v4
       - name: shellspec test
         run: |
           make scripts-test

--- a/.github/workflows/shellspec-push.yml
+++ b/.github/workflows/shellspec-push.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Install helm
         uses: azure/setup-helm@v4
 
+      - name: Build helm chart dependencies
+        run: |
+          for chart in addons/*/Chart.yaml; do
+            dir=$(dirname "$chart")
+            if grep -q 'dependencies:' "$chart" 2>/dev/null; then
+              helm dependency build "$dir" 2>/dev/null || true
+            fi
+          done
+
       - name: shellspec test
         run: |
           make scripts-test-kcov

--- a/.github/workflows/shellspec-push.yml
+++ b/.github/workflows/shellspec-push.yml
@@ -30,6 +30,9 @@ jobs:
           make -j$(nproc)
           sudo make install
 
+      - name: Install helm
+        uses: azure/setup-helm@v4
+
       - name: shellspec test
         run: |
           make scripts-test-kcov


### PR DESCRIPTION
## Summary
- Install helm via `azure/setup-helm@v4` in both shellspec CI workflows (`shellspec-push.yml` and `shellspec-pr-review.yml`)
- Fixes 12 shellspec failures from helm-dependent tests that validate chart template rendering (ComponentVersion compatibility rules and MARIADB_REPLICATION_MODE env wiring)
- These tests use `helm template` to render the mariadb chart and verify the output — they require helm to be installed

## Test plan
- [ ] CI shellspec test passes with 0 failures
- [ ] The 12 previously-failing helm-dependent tests now execute and pass