### PR TITLE
fix(mariadb): gate semisync role shape before ready

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2152,7 +2152,18 @@ type: application
 # reconfigure executor. Without this, any galera Reconfiguring
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
-version: 1.2.0-alpha.2
+#
+# alpha.4 (Jack 2026-06-04 — semisync role shape publish gate):
+# replication-merged semisync runtime now fail-closed enforces
+# role-specific semisync variables before publishing primary/replica
+# readiness: primary master=1/slave=0, replica master=0/slave=1.
+# CmpD template changed, so bump the chart to create a fresh CmpD.
+#
+# alpha.3 was a focused-test candidate with the same role-shape gate,
+# but it was rendered with the wrong values path (`mariadb.replication.mode`).
+# The chart consumes top-level `replication.mode`, so alpha.3 was not a
+# valid semisync focused verdict.
+version: 1.2.0-alpha.4
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add
@@ -2554,7 +2565,7 @@ version: 1.2.0-alpha.2
 #   (Jack design Gate 3 / Blocker 3 — no double-match against
 #   standalone / galera / old async / old semisync PDs).
 # - replication mode source-of-truth is the install/render-time Helm
-#   value `mariadb.replication.mode`, wired to the merged CmpD as
+#   value `replication.mode`, wired to the merged CmpD as
 #   `MARIADB_REPLICATION_MODE`. The current chart deliberately does
 #   not expose any per-Cluster mode parameter named `replicationMode`;
 #   runtime mode flip via OpsRequest reconfigure is deferred.

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -29,7 +29,7 @@ affected.
 {{- define "mariadb.replication.mode.validate" -}}
 {{- $mode := .Values.replication.mode | default "" -}}
 {{- if and $mode (not (has $mode (list "async" "semisync"))) -}}
-{{- fail (printf "invalid mariadb.replication.mode=%q; expected one of \"\", \"async\", \"semisync\" (commit 13 v2 / Jack B2 install-time fail-closed)" $mode) -}}
+{{- fail (printf "invalid replication.mode=%q; expected one of \"\", \"async\", \"semisync\" (commit 13 v2 / Jack B2 install-time fail-closed)" $mode) -}}
 {{- end -}}
 {{- $mode -}}
 {{- end -}}
@@ -131,7 +131,7 @@ clarification) — new CmpD for topology merge (weston 2026-05-19
 14:12 Option B). The merged CmpD consolidates the old
 `mariadb-replication` (async) and `mariadb-semisync` CmpDs into one.
 Current mode selection is install/render-time only: the Helm value
-`mariadb.replication.mode` is validated by
+`replication.mode` is validated by
 `mariadb.replication.mode.validate` and wired to the merged CmpD as
 `MARIADB_REPLICATION_MODE`. The current chart does not expose any
 per-Cluster mode parameter named `replicationMode`.

--- a/addons/mariadb/templates/clusterdefinition.yaml
+++ b/addons/mariadb/templates/clusterdefinition.yaml
@@ -17,7 +17,7 @@ spec:
     # (alpha.89 — topology merge under weston 2026-05-19 Option B
     # msg `d8ecfae7`). The async vs semisync behavior is currently
     # selected at addon install/render time by the Helm value
-    # `mariadb.replication.mode`, which is wired to
+    # `replication.mode`, which is wired to
     # `MARIADB_REPLICATION_MODE` on the merged CmpD. It is NOT a
     # per-Cluster topology selector. The current chart does not expose
     # any user-facing mode parameter named `replicationMode`.

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -267,7 +267,7 @@ spec:
             # msg `696e7b16`) — seed runtime-overrides.d/ from
             # `MARIADB_REPLICATION_MODE` BEFORE the first mariadbd
             # process exec. Without this seeder the Helm value
-            # `mariadb.replication.mode=semisync` set at install
+            # `replication.mode=semisync` set at install
             # time would have no effect until the first
             # reconfigureAction trigger; the seeder closes that gap
             # so the chart-author-selected semisync/async state
@@ -493,6 +493,7 @@ spec:
               lock_remote_root_writes "replica-read-only" || rc=1
               set_fail_closed_read_only "replica-read-only" || rc=1
               lock_local_root_writes "replica-read-only" || rc=1
+              ensure_semisync_replica_role "replica-read-only" || rc=1
               if [ "${rc}" -ne 0 ]; then
                 prestop_watchdog_log "set-replica-read-only label=replica-read-only rc=1 tier=required fail_closed=true"
                 return 1
@@ -1874,6 +1875,30 @@ spec:
             is_semisync_mode_env() {
               [ "${MARIADB_REPLICATION_MODE:-}" = "semisync" ]
             }
+            ensure_semisync_primary_role() {
+              local label="${1:-unknown}"
+              if ! is_semisync_mode_env; then
+                return 0
+              fi
+              if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=1; SET GLOBAL rpl_semi_sync_slave_enabled=0;" >/dev/null 2>&1; then
+                prestop_watchdog_log "semisync-role-shape label=${label} role=primary master=1 slave=0 rc=0"
+                return 0
+              fi
+              prestop_watchdog_log "semisync-role-shape label=${label} role=primary rc=1"
+              return 1
+            }
+            ensure_semisync_replica_role() {
+              local label="${1:-unknown}"
+              if ! is_semisync_mode_env; then
+                return 0
+              fi
+              if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL rpl_semi_sync_master_enabled=0; SET GLOBAL rpl_semi_sync_slave_enabled=1;" >/dev/null 2>&1; then
+                prestop_watchdog_log "semisync-role-shape label=${label} role=secondary master=0 slave=1 rc=0"
+                return 0
+              fi
+              prestop_watchdog_log "semisync-role-shape label=${label} role=secondary rc=1"
+              return 1
+            }
             reset_semisync_master_ack_receiver_if_enabled() {
               local label="${1:-unknown}"
               if ! is_semisync_mode_env; then
@@ -1899,6 +1924,11 @@ spec:
               if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
                 reset_semisync_master_ack_receiver_if_enabled "primary-existing-listener-${label}"
+                if ! ensure_semisync_primary_role "primary-existing-listener-${label}"; then
+                  mark_replication_pending
+                  prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} reason=existing-listener-semisync-role-shape"
+                  return 1
+                fi
                 if set_primary_read_write "${label}"; then
                   touch {{ .Values.dataMountPath }}/.sql-listener-ready
                   prestop_watchdog_log "sql-listener-primary-existing-reconciled label=${label}"
@@ -1918,6 +1948,11 @@ spec:
               fi
               "${LOCAL[@]}" -e "STOP SLAVE; RESET SLAVE ALL;" 2>/dev/null || true
               reset_semisync_master_ack_receiver_if_enabled "primary-fresh-listener-${label}"
+              if ! ensure_semisync_primary_role "primary-fresh-listener-${label}"; then
+                mark_replication_pending
+                prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} reason=fresh-listener-semisync-role-shape"
+                return 1
+              fi
               if ! set_primary_read_write "${label}"; then
                 mark_replication_pending
                 prestop_watchdog_log "sql-listener-primary-expose-failed label=${label}"
@@ -2814,7 +2849,7 @@ spec:
           # (only the env source differs).
           #
           # Empty default = "" means existing clusters whose Helm
-          # values do not set `mariadb.replication.mode` see no
+          # values do not set `replication.mode` see no
           # behavioral change: the mapper short-circuits at the
           # empty-mode early return, the strip-synthetic pass (B2
           # fix in commit 12 v2) still runs unconditionally as
@@ -2822,7 +2857,7 @@ spec:
           # continue to flow through the existing persisted helper.
           # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack B2 fix
           # msg `f9433634`) — value flows through
-          # `mariadb.replication.mode.validate` helper which fails
+          # `replication.mode` validation helper which fails
           # the helm render with a clear error message when the value
           # is not in the accepted set ("" / "async" / "semisync"),
           # so invalid values are caught at install/upgrade time

--- a/addons/mariadb/templates/configmap-scripts-replication.yaml
+++ b/addons/mariadb/templates/configmap-scripts-replication.yaml
@@ -41,11 +41,11 @@ data:
   # alpha.89 v1 commit 13 v2 (Helen 2026-05-20, Jack post-commit-13-v1
   # install-time write-site requirement msg `696e7b16`) — install-time
   # seeder that translates `MARIADB_REPLICATION_MODE` (set by Helm
-  # value mariadb.replication.mode → CmpD container env, commit 13 v1)
+  # value replication.mode → CmpD container env, commit 13 v1)
   # into the four per-parameter override `.cnf` files under
   # runtime-overrides.d/ BEFORE the first mariadbd start. Without this
   # seeder the env wire was dormant: a chart user setting
-  # `mariadb.replication.mode=semisync` at install time would still
+  # `replication.mode=semisync` at install time would still
   # boot async and not flip until the first reconfigureAction trigger.
   # The seeder writes byte-identical content to what
   # reconfigureAction.persisted writes for the same env, so the two

--- a/addons/mariadb/templates/paramsdef.yaml
+++ b/addons/mariadb/templates/paramsdef.yaml
@@ -183,7 +183,7 @@ spec:
   #
   # Class 4 fail-closed for the 4 rpl_semi_sync_* engine vars is
   # still enforced by the three other layers:
-  #   1. Helm template-time validator (`mariadb.replication.mode
+  #   1. Helm template-time validator (`replication.mode
   #      .validate` in _helpers.tpl) rejects invalid `replication
   #      .mode` Helm values at `helm render` time.
   #   2. Startup seeder (`scripts/seed-replication-mode-overrides

--- a/addons/mariadb/values.yaml
+++ b/addons/mariadb/values.yaml
@@ -33,7 +33,7 @@ etcd:
 ## configurable; runtime OpsRequest mode flip is deferred to a future
 ## commit that wires a Cluster annotation OR a non-INI-bound PD).
 ##
-## `mariadb.replication.mode` is the top-level switch consumed by the
+## `replication.mode` is the top-level switch consumed by the
 ## addon-side mapper (`scripts/replication-mode-mapper.sh`) sourced
 ## into the merged CmpD's `reconfigureAction.persisted` helper. The
 ## mapper translates the value into the four real engine variables


### PR DESCRIPTION
## Summary
- bump MariaDB addon chart to `1.2.0-alpha.4`
- enforce role-specific semisync variables before publishing readiness in the merged replication CmpD
  - primary: `rpl_semi_sync_master_enabled=1`, `rpl_semi_sync_slave_enabled=0`
  - secondary: `rpl_semi_sync_master_enabled=0`, `rpl_semi_sync_slave_enabled=1`
- correct replication mode docs/error wording to the actual Helm value path: `replication.mode`

## Validation
- `helm dependency build addons/mariadb`
- `helm template ... --set replication.mode=semisync` renders `mariadb-replication-merged-1.2.0-alpha.4` with `MARIADB_REPLICATION_MODE=semisync`
- extracted rendered merged-CmpD command passes `bash -n`
- `helm lint addons/mariadb --set replication.mode=semisync ...`
- invalid mode fails closed at render time: `invalid replication.mode="bogus"`

## Focused IDC verify
- vcluster: `mariadb-pr187-syncer-idc2-vc`
- namespace: `mariadb-test-semisync-alpha4-cm3`
- cluster: `mdb-ss-a4`
- CmpD: `mariadb-replication-merged-1.2.0-alpha.4`
- syncer image: `docker.io/apecloud/syncer:mariadb-semisync-role-shape-93e694d`
- result: focused CM3 PASS within scope
  - cluster/component Running, 2 pods Running
  - primary: `read_only=0`, master=1, slave=0, timeout=3000, master status ON
  - secondary: `read_only=1`, master=0, slave=1, slave status ON
  - role-shape log lines recorded on both pods
  - cleanup verified namespace absent and no PVC residue

Evidence archive:
`artifacts/task453-alpha4-semisync-cm3-focused-20260604T021928Z.tar.gz`
sha256: `6b4ff64a85b92a23196491e531f022bed9411f83b87b748af7e48f620cb6f8cb`
