### PR TITLE
test(mariadb): align shellspec assertions with alpha.4 chart

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_replication_mode_env_wire_spec.sh
@@ -76,8 +76,8 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
     # per-Cluster ComponentSpec parameter unless the chart actually
     # implements that contract end-to-end.
 
-    It "ClusterDefinition documents mariadb.replication.mode as the current mode source"
-      When call grep -q 'mariadb\.replication\.mode' "$(clusterdefinition_path)"
+    It "ClusterDefinition documents replication.mode as the current mode source"
+      When call grep -q 'replication\.mode' "$(clusterdefinition_path)"
       The status should be success
     End
 
@@ -123,7 +123,7 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
     End
 
     It "validator uses fail to abort helm render on invalid value"
-      When call grep -c 'fail (printf "invalid mariadb\.replication\.mode' "$(helper_path)"
+      When call grep -c 'fail (printf "invalid replication\.mode' "$(helper_path)"
       The status should be success
       The output should equal "1"
     End
@@ -209,8 +209,8 @@ Describe "alpha.89 commit 13 — replication.mode Helm value → MARIADB_REPLICA
         echo "expected non-zero rc but got 0" >&2
         return 1
       fi
-      if ! grep -qF "invalid mariadb.replication.mode" "${file_path}"; then
-        echo "expected stderr to contain 'invalid mariadb.replication.mode'" >&2
+      if ! grep -qF "invalid replication.mode" "${file_path}"; then
+        echo "expected stderr to contain 'invalid replication.mode'" >&2
         return 1
       fi
       if ! grep -qF "${expected_value_in_msg}" "${file_path}"; then

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.2$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.4$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.2"
+      The output should equal "version: 1.2.0-alpha.4"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.2"
+        The output should equal "version: 1.2.0-alpha.4"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.2"
+        The output should equal "version: 1.2.0-alpha.4"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.2 (alpha.2 bump: semisync pivot — 1.2.0 major for topology merge + semisync fencing)"
-      When call grep -c '^version: 1.2.0-alpha.2$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.4 (alpha.2 bump: semisync pivot — 1.2.0 major for topology merge + semisync fencing)"
+      When call grep -c '^version: 1.2.0-alpha.4$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End


### PR DESCRIPTION
## Summary
- Update chart version literals from `1.2.0-alpha.2` to `1.2.0-alpha.4` in 3 spec files
- Update grep patterns to match corrected Helm value path wording (`replication.mode` instead of `mariadb.replication.mode`)
- Follows PR #2762 (alpha.4 role-shape gate)

## Test plan
- [x] Local shellspec: 552 examples, 0 failures
- [ ] CI shellspec passes