### PR TITLE
fix(redis): fail fast on backup redis-cli errors

### DIFF
--- a/addons/redis/dataprotection/backup.sh
+++ b/addons/redis/dataprotection/backup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o pipefail
+set -eo pipefail
 
 # if the script exits with a non-zero exit code, touch a file to indicate that the backup failed,
 # the sync progress container will check this file and exit if it exists


### PR DESCRIPTION
## Summary

- fail fast when Redis backup action `redis-cli LASTSAVE`, `BGSAVE`, or `INFO persistence` cannot connect or returns non-zero
- include the target host/port and original `redis-cli` stderr in the action log
- fail when `INFO persistence` omits the expected `rdb_bgsave_in_progress` / `rdb_last_bgsave_status` fields instead of looping forever
- add shellspec coverage for LASTSAVE/BGSAVE/INFO connection failure and the success path

## Why

During Redis PR #182 B05 candidate rerun `redis-pr182-b05-pr10328-head-r3`, the first blocker was B02 backup stuck in `Running` for >600s because `backupdata` repeatedly hit headless DNS failure and the backup script did not fail fast. Mason/Clara later classified that specific DNS failure as a vcluster CoreDNS image-source environment blocker, not a Redis product failure. This PR only hardens Redis backup action behavior so the same class of `redis-cli` DNS/connection failure becomes a clear failed job with readable logs.

This does not claim to fix the vcluster/CoreDNS root cause and does not validate B05 restore/PVC/readback.

## Validation

- `/opt/homebrew/bin/shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_backup_spec.sh` -> `4 examples, 0 failures`
- `/opt/homebrew/bin/shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec` -> `202 examples, 0 failures`
- `bash -n addons/redis/dataprotection/backup.sh`
- `bash -n addons/redis/scripts-ut-spec/redis_backup_spec.sh`
- `git diff origin/main...HEAD --check`

## Evidence Context

- Redis thread Mason DNS review attachment: `23af24f4-1068-4420-b48e-f580fd560ade`
- sha256: `8d03733aa9a4ea517dbb0814a4c088aee807d2b1b6157af97a8339817f148843`
- Classification: r3 B02 first blocker is environment-layer vcluster DNS/CoreDNS image-source blocker; this PR is independent action-script hardening.
