### PR TITLE
fix(mariadb): recover semisync primary after stop start

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2153,6 +2153,14 @@ type: application
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
 #
+# alpha.7 (Jack 2026-06-04 - semisync stop/start syncer primary
+# bootstrap gate): Bumped from 1.2.0-alpha.6 -> 1.2.0-alpha.7 because
+# cmpd-replication-merged.yaml changes the existing-slave/no-primary
+# startup branch. The branch now observes local syncer primary promotion
+# and exposes the SQL listener before falling into the no-primary
+# fail-closed path, breaking the Primary Service / roleProbe cycle seen
+# in semisync T7 Stop/Start r16.
+#
 # alpha.6 (Jack 2026-06-04 — pending secondary semisync shape gate):
 # alpha.5 allowed pending secondary publication after persisted slave
 # config + syncer secondary + read_only=ON, but in semisync mode that
@@ -2182,7 +2190,7 @@ type: application
 # but it was rendered with the wrong values path (`mariadb.replication.mode`).
 # The chart consumes top-level `replication.mode`, so alpha.3 was not a
 # valid semisync focused verdict.
-version: 1.2.0-alpha.6
+version: 1.2.0-alpha.7
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=sh
+# Static gates for semisync recovery behavior in the merged replication CmpD.
+
+Describe "cmpd-replication-merged.yaml semisync startup recovery"
+  template_file() {
+    printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "${SHELLSPEC_CWD:?}"
+  }
+
+  template_contains() {
+    grep -F "$1" "$(template_file)"
+  }
+
+  function_contains() {
+    function_name="$1"
+    expected="$2"
+    awk -v function_name="${function_name}" -v expected="${expected}" '
+      $0 ~ "^[[:space:]]*" function_name "\\(\\) \\{" { inside = 1 }
+      inside && index($0, expected) > 0 { found = 1 }
+      inside && /^[[:space:]]*}/ { exit }
+      END { exit(found ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  no_primary_loop_reconciles_syncer_primary_before_block() {
+    awk '
+      /no_primary_deadline=/ { branch = 1 }
+      branch && /while \[ \$SECONDS -lt \$no_primary_deadline \]/ { loop = 1 }
+      loop && /reconcile_sql_listener_for_syncer_primary_once \|\| true/ { reconcile = NR }
+      branch && /block_existing_datadir_self_election_without_primary/ { block = NR; exit }
+      END { exit(reconcile && block && reconcile < block ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  It "defines a merged-CmpD local primary publish readiness gate"
+    When call function_contains "local_primary_role_published" ".primary-read-write-ready"
+    The status should be success
+  End
+
+  It "requires the SQL listener marker before treating local primary as published"
+    When call function_contains "local_primary_role_published" ".sql-listener-ready"
+    The status should be success
+  End
+
+  It "reconciles local syncer primary during the pod-0 no-primary startup loop before blocking self-election"
+    When call no_primary_loop_reconciles_syncer_primary_before_block
+    The status should be success
+  End
+
+  It "does not enter the no-primary fail-closed path after local syncer primary is published"
+    When call template_contains 'if [ -z "${PRIMARY_SID}" ] && ! local_primary_role_published; then'
+    The status should be success
+    The output should include "local_primary_role_published"
+  End
+
+  It "records the stop/start recovery handoff in startup logs"
+    When call template_contains "accepted local syncer primary promotion while Primary Service is empty"
+    The status should be success
+    The output should include "accepted local syncer primary promotion"
+  End
+
+  It "keeps pod-0 blocked self-election in a reconcile loop instead of exiting permanently"
+    When call template_contains "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service"
+    The status should be success
+    The output should include "blocked self-election"
+  End
+
+  It "lets pod-0 accept syncer primary promotion after blocked self-election"
+    When call template_contains "pod-0 accepted syncer primary promotion after blocked self-election"
+    The status should be success
+    The output should include "accepted syncer primary promotion"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -125,6 +125,102 @@ EOF
       End
     End
 
+    Context "when pending marker exists but local syncer and SQL prove this pod is a peer-reachable semisync primary"
+      setup_pending_primary_fail_closed() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="0"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="OFF"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_pending_primary_fail_closed"
+
+      It "publishes primary so the Primary Service can recover after marker loss"
+        When call check_role
+        The status should be success
+        The output should eq "primary"
+      End
+    End
+
+    Context "when pending primary is still local-listener-only"
+      setup_pending_primary_local_only() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="0"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="OFF"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 1; }
+      }
+      Before "setup_pending_primary_local_only"
+
+      It "does not publish primary before the SQL listener is peer-reachable"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
+    Context "when pending primary is still read-only"
+      setup_pending_primary_read_only() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="OFF"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_pending_primary_read_only"
+
+      It "does not publish primary before read_only is open"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
+    Context "when pending semisync primary has secondary-shaped variables"
+      setup_pending_primary_wrong_semisync_shape() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="0"
+        export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_pending_primary_wrong_semisync_shape"
+
+      It "does not publish primary before semisync variables converge"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
     Context "when .replication-pending exists"
       setup_pending() {
         touch "${TEST_DIR}/.replication-ready"

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.6$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.7$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.6"
+      The output should equal "version: 1.2.0-alpha.7"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.6"
+        The output should equal "version: 1.2.0-alpha.7"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.6"
+        The output should equal "version: 1.2.0-alpha.7"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.6 (alpha.6 bump: pending secondary semisync shape gate)"
-      When call grep -c '^version: 1.2.0-alpha.6$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.7 (alpha.7 bump: semisync stop/start syncer primary bootstrap gate)"
+      When call grep -c '^version: 1.2.0-alpha.7$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -269,6 +269,18 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     The output should include "Existing slave config accepted syncer primary promotion"
   End
 
+  It "keeps pod-0 blocked self-election in a reconcile loop instead of exiting permanently"
+    When call template_contains "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service"
+    The status should be success
+    The output should include "blocked self-election"
+  End
+
+  It "lets pod-0 accept syncer primary promotion after blocked self-election"
+    When call template_contains "pod-0 accepted syncer primary promotion after blocked self-election"
+    The status should be success
+    The output should include "accepted syncer primary promotion"
+  End
+
   It "reconciles syncer secondary into fail-closed local SQL state"
     When call function_contains "reconcile_sql_listener_for_syncer_secondary_once" "set_replica_read_only"
     The status should be success

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -443,6 +443,39 @@ pending_secondary_fail_closed_ready() {
   return 0
 }
 
+pending_primary_fail_closed_ready() {
+  local role read_only
+  [ ! -f "$(master_info_file)" ] || return 1
+  role=$(syncerctl_getrole) || return 1
+  [ "${role}" = "primary" ] || return 1
+  db_ready || return 1
+  read_only=$(local_sql -e "SELECT UPPER(CAST(@@global.read_only AS CHAR));" 2>/dev/null || true)
+  case "${read_only}" in
+    0|OFF) ;;
+    *) return 1 ;;
+  esac
+  mariadbd_listen_on_all_interfaces || return 1
+  semisync_primary_shape_ready || return 1
+  return 0
+}
+
+semisync_primary_shape_ready() {
+  local master_enabled slave_enabled
+  [ "${MARIADB_REPLICATION_MODE:-}" = "semisync" ] || return 0
+  master_enabled=$(local_sql -e "SELECT UPPER(CAST(@@global.rpl_semi_sync_master_enabled AS CHAR));" 2>/dev/null || true)
+  slave_enabled=$(local_sql -e "SELECT UPPER(CAST(@@global.rpl_semi_sync_slave_enabled AS CHAR));" 2>/dev/null || true)
+  case "${master_enabled}" in
+    1|ON) ;;
+    *) return 1 ;;
+  esac
+  case "${slave_enabled}" in
+    0|OFF)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 semisync_secondary_shape_ready() {
   local master_enabled slave_enabled
   [ "${MARIADB_REPLICATION_MODE:-}" = "semisync" ] || return 0
@@ -603,6 +636,11 @@ check_role() {
     # outputs. Publishing secondary is safe only after local SQL proves the pod
     # is fail-closed read-only; replication may still be pending, but the pod
     # must not remain in the primary Service.
+    if pending_primary_fail_closed_ready; then
+      apply_remote_root_fence "primary" || { not_ready; return $?; }
+      echo -n "primary"
+      return 0
+    fi
     if pending_secondary_fail_closed_ready; then
       apply_remote_root_fence "secondary" || { not_ready; return $?; }
       echo -n "secondary"

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1969,6 +1969,11 @@ spec:
               timeout 3 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                 -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || true
             }
+            local_primary_role_published() {
+              [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]
+            }
             local_user_table_count() {
               "${LOCAL[@]}" -e "
                 SELECT COUNT(*)
@@ -2303,19 +2308,44 @@ spec:
                   PRIMARY_SID=$(timeout 10 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                     -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || echo "")
                   [ -n "${PRIMARY_SID}" ] && break
+                  reconcile_sql_listener_for_syncer_primary_once || true
+                  if local_primary_role_published; then
+                    echo "pod-0 startup: accepted local syncer primary promotion while Primary Service is empty"
+                    break
+                  fi
                 done
-                if [ -z "${PRIMARY_SID}" ]; then
+                if [ -z "${PRIMARY_SID}" ] && ! local_primary_role_published; then
+                  blocked_self_election_resolved=false
                   if block_existing_datadir_self_election_without_primary; then
-                    wait ${MARIADB_PID}
-                    exit 1
+                    while true; do
+                      reconcile_sql_listener_for_syncer_primary_once || true
+                      if local_primary_role_published; then
+                        echo "pod-0 accepted syncer primary promotion after blocked self-election"
+                        blocked_self_election_resolved=true
+                        break
+                      fi
+                      if publish_replica_after_rejoin_ready "existing-slave-config"; then
+                        echo "Resumed replication from existing slave config after blocked self-election"
+                        blocked_self_election_resolved=true
+                        break
+                      fi
+                      if fail_closed_for_gtid_divergence; then
+                        wait ${MARIADB_PID}
+                        exit 1
+                      fi
+                      echo "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service, retrying in 5s."
+                      sleep 5
+                    done
                   fi
-                  if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
-                    wait ${MARIADB_PID}
-                    exit 1
+                  if [ "${blocked_self_election_resolved}" != "true" ]; then
+                    if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+                      wait ${MARIADB_PID}
+                      exit 1
+                    fi
+                    mark_replication_ready
+                    echo "Starting as primary (pod-0 with stale slave config, no primary found after ${no_primary_budget}s wait)"
                   fi
-                  mark_replication_ready
-                  echo "Starting as primary (pod-0 with stale slave config, no primary found after ${no_primary_budget}s wait)"
-                  PRIMARY_SID=""  # signal: we self-elected; do not fall through to rejoin
+                  PRIMARY_SID=""  # signal: resolved locally; do not fall through to rejoin
                 fi
               fi
               # alpha.92 fall-through: when PRIMARY_SID is now non-empty
@@ -2326,9 +2356,7 @@ spec:
               if [ -n "${PRIMARY_SID}" ] && [ "${PRIMARY_SID}" != "${SERVICE_ID}" ]; then
                 while true; do
                   reconcile_sql_listener_for_syncer_primary_once || true
-                  if [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                  if local_primary_role_published; then
                     echo "Existing slave config accepted syncer primary promotion"
                     break
                   fi

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1656,6 +1656,11 @@ spec:
               timeout 3 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                 -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || true
             }
+            local_primary_role_published() {
+              [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]
+            }
             local_user_table_count() {
               "${LOCAL[@]}" -e "
                 SELECT COUNT(*)
@@ -1914,22 +1919,40 @@ spec:
                 exit 1
               fi
               if [ "${POD_INDEX}" = "0" ] && [ -z "${PRIMARY_SID}" ]; then
+                blocked_self_election_resolved=false
                 if block_existing_datadir_self_election_without_primary; then
-                  wait ${MARIADB_PID}
-                  exit 1
+                  while true; do
+                    reconcile_sql_listener_for_syncer_primary_once || true
+                    if local_primary_role_published; then
+                      echo "pod-0 accepted syncer primary promotion after blocked self-election"
+                      blocked_self_election_resolved=true
+                      break
+                    fi
+                    if publish_replica_after_rejoin_ready "existing-slave-config"; then
+                      echo "Resumed replication from existing slave config after blocked self-election"
+                      blocked_self_election_resolved=true
+                      break
+                    fi
+                    if fail_closed_for_gtid_divergence; then
+                      wait ${MARIADB_PID}
+                      exit 1
+                    fi
+                    echo "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service, retrying in 5s."
+                    sleep 5
+                  done
                 fi
-                if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
-                  wait ${MARIADB_PID}
-                  exit 1
+                if [ "${blocked_self_election_resolved}" != "true" ]; then
+                  if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+                    wait ${MARIADB_PID}
+                    exit 1
+                  fi
+                  mark_replication_ready
+                  echo "Starting as primary (pod-0 with stale slave config, no primary found)"
                 fi
-                mark_replication_ready
-                echo "Starting as primary (pod-0 with stale slave config, no primary found)"
               else
                 while true; do
                   reconcile_sql_listener_for_syncer_primary_once || true
-                  if [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                  if local_primary_role_published; then
                     echo "Existing slave config accepted syncer primary promotion"
                     break
                   fi


### PR DESCRIPTION
## Summary
- keep the semisync existing-slave/no-primary startup path in a reconcile loop instead of exiting permanently
- let the merged replication startup loop observe local syncer primary promotion before the Primary Service publishes a role
- add a pending-primary roleProbe gate for marker-loss recovery, requiring syncer primary, read_only=OFF, peer-reachable listener, and semisync primary variable shape
- bump chart version to 1.2.0-alpha.7

## Tests
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
- sh -n addons/mariadb/scripts/replication-roleprobe.sh
- helm template mariadb-test addons/mariadb --set replication.mode=semisync >/tmp/mariadb-alpha7-render.yaml