### PR TITLE
fix(mariadb): hand off replica rejoin on syncer promote

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2153,6 +2153,17 @@ type: application
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
 #
+# alpha.5 (Jack 2026-06-04 — semisync Stop/Start stale primary
+# label fix): replication roleProbe now publishes `secondary` rc=0
+# for a pod that still has `.replication-pending` but is already
+# proven to be a fail-closed secondary by persisted slave config,
+# local syncer role, and local read_only SQL state. Without this,
+# KubeBlocks ignores the failed `initializing` probe and can keep a
+# stale `kubeblocks.io/role=primary` label on the old primary, so the
+# primary Service routes to a read-only replica after Stop/Start.
+# Script ConfigMap content changed, so bump chart version for a fresh
+# mounted script rollout.
+#
 # alpha.4 (Jack 2026-06-04 — semisync role shape publish gate):
 # replication-merged semisync runtime now fail-closed enforces
 # role-specific semisync variables before publishing primary/replica
@@ -2163,7 +2174,7 @@ type: application
 # but it was rendered with the wrong values path (`mariadb.replication.mode`).
 # The chart consumes top-level `replication.mode`, so alpha.3 was not a
 # valid semisync focused verdict.
-version: 1.2.0-alpha.4
+version: 1.2.0-alpha.5
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2161,6 +2161,15 @@ type: application
 # fail-closed path, breaking the Primary Service / roleProbe cycle seen
 # in semisync T7 Stop/Start r16.
 #
+# alpha.8 (Jack 2026-06-04 - semisync replica-rejoin promote handoff):
+# Bumped from 1.2.0-alpha.7 -> 1.2.0-alpha.8 because semisync and
+# merged replication startup scripts now preserve wait_for_replication_
+# healthy rc=2 ("syncer promoted this pod while replica rejoin was in
+# progress") and immediately publish the primary path instead of running
+# the replica defensive fail-closed branch. r19 showed pod-1 promoted by
+# syncer and then pulled back to read_only by the stale replica rejoin
+# continuation.
+#
 # alpha.6 (Jack 2026-06-04 — pending secondary semisync shape gate):
 # alpha.5 allowed pending secondary publication after persisted slave
 # config + syncer secondary + read_only=ON, but in semisync mode that
@@ -2190,7 +2199,7 @@ type: application
 # but it was rendered with the wrong values path (`mariadb.replication.mode`).
 # The chart consumes top-level `replication.mode`, so alpha.3 was not a
 # valid semisync focused verdict.
-version: 1.2.0-alpha.7
+version: 1.2.0-alpha.8
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2153,6 +2153,14 @@ type: application
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
 #
+# alpha.6 (Jack 2026-06-04 — pending secondary semisync shape gate):
+# alpha.5 allowed pending secondary publication after persisted slave
+# config + syncer secondary + read_only=ON, but in semisync mode that
+# could briefly publish a secondary label before the role-specific
+# semisync variables converged. Require master_enabled=OFF and
+# slave_enabled=ON for semisync pending-secondary publication. Script
+# ConfigMap content changed, so bump chart version for a fresh rollout.
+#
 # alpha.5 (Jack 2026-06-04 — semisync Stop/Start stale primary
 # label fix): replication roleProbe now publishes `secondary` rc=0
 # for a pod that still has `.replication-pending` but is already
@@ -2174,7 +2182,7 @@ type: application
 # but it was rendered with the wrong values path (`mariadb.replication.mode`).
 # The chart consumes top-level `replication.mode`, so alpha.3 was not a
 # valid semisync focused verdict.
-version: 1.2.0-alpha.5
+version: 1.2.0-alpha.6
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2153,6 +2153,14 @@ type: application
 # OpsRequest fails with ERROR 1045 (Access denied for
 # kb_internal_root). CmpD spec change requires version bump.
 #
+# alpha.7 (Jack 2026-06-04 - semisync stop/start syncer primary
+# bootstrap gate): Bumped from 1.2.0-alpha.6 -> 1.2.0-alpha.7 because
+# cmpd-replication-merged.yaml changes the existing-slave/no-primary
+# startup branch. The branch now observes local syncer primary promotion
+# and exposes the SQL listener before falling into the no-primary
+# fail-closed path, breaking the Primary Service / roleProbe cycle seen
+# in semisync T7 Stop/Start r16.
+#
 # alpha.6 (Jack 2026-06-04 — pending secondary semisync shape gate):
 # alpha.5 allowed pending secondary publication after persisted slave
 # config + syncer secondary + read_only=ON, but in semisync mode that
@@ -2182,7 +2190,7 @@ type: application
 # but it was rendered with the wrong values path (`mariadb.replication.mode`).
 # The chart consumes top-level `replication.mode`, so alpha.3 was not a
 # valid semisync focused verdict.
-version: 1.2.0-alpha.6
+version: 1.2.0-alpha.7
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -31,6 +31,14 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
+  publish_rejoin_accepts_syncer_primary_before_defensive_fail_closed() {
+    before_line="$(grep -n 'syncer-primary-during-replica-rejoin-before-expose' "$(template_file)" | head -1 | cut -d: -f1)"
+    after_line="$(grep -n 'syncer-primary-during-replica-rejoin-after-expose' "$(template_file)" | head -1 | cut -d: -f1)"
+    fail_closed_line="$(grep -n 'after-expose-not-healthy' "$(template_file)" | head -1 | cut -d: -f1)"
+    [ -n "${before_line}" ] && [ -n "${after_line}" ] && [ -n "${fail_closed_line}" ] || return 1
+    [ "${before_line}" -lt "${fail_closed_line}" ] && [ "${after_line}" -lt "${fail_closed_line}" ]
+  }
+
   It "defines a merged-CmpD local primary publish readiness gate"
     When call function_contains "local_primary_role_published" ".primary-read-write-ready"
     The status should be success
@@ -56,6 +64,17 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     When call template_contains "accepted local syncer primary promotion while Primary Service is empty"
     The status should be success
     The output should include "accepted local syncer primary promotion"
+  End
+
+  It "accepts syncer primary promotion inside replica rejoin before fail-closing as replica"
+    When call publish_rejoin_accepts_syncer_primary_before_defensive_fail_closed
+    The status should be success
+  End
+
+  It "logs replica rejoin handoff to syncer primary publication"
+    When call template_contains "action=accept-primary-promotion"
+    The status should be success
+    The output should include "accept-primary-promotion"
   End
 
   It "keeps pod-0 blocked self-election in a reconcile loop instead of exiting permanently"

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=sh
+# Static gates for semisync recovery behavior in the merged replication CmpD.
+
+Describe "cmpd-replication-merged.yaml semisync startup recovery"
+  template_file() {
+    printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "${SHELLSPEC_CWD:?}"
+  }
+
+  template_contains() {
+    grep -F "$1" "$(template_file)"
+  }
+
+  function_contains() {
+    function_name="$1"
+    expected="$2"
+    awk -v function_name="${function_name}" -v expected="${expected}" '
+      $0 ~ "^[[:space:]]*" function_name "\\(\\) \\{" { inside = 1 }
+      inside && index($0, expected) > 0 { found = 1 }
+      inside && /^[[:space:]]*}/ { exit }
+      END { exit(found ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  no_primary_loop_reconciles_syncer_primary_before_block() {
+    awk '
+      /no_primary_deadline=/ { branch = 1 }
+      branch && /while \[ \$SECONDS -lt \$no_primary_deadline \]/ { loop = 1 }
+      loop && /reconcile_sql_listener_for_syncer_primary_once \|\| true/ { reconcile = NR }
+      branch && /block_existing_datadir_self_election_without_primary/ { block = NR; exit }
+      END { exit(reconcile && block && reconcile < block ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  It "defines a merged-CmpD local primary publish readiness gate"
+    When call function_contains "local_primary_role_published" ".primary-read-write-ready"
+    The status should be success
+  End
+
+  It "requires the SQL listener marker before treating local primary as published"
+    When call function_contains "local_primary_role_published" ".sql-listener-ready"
+    The status should be success
+  End
+
+  It "reconciles local syncer primary during the pod-0 no-primary startup loop before blocking self-election"
+    When call no_primary_loop_reconciles_syncer_primary_before_block
+    The status should be success
+  End
+
+  It "does not enter the no-primary fail-closed path after local syncer primary is published"
+    When call template_contains 'if [ -z "${PRIMARY_SID}" ] && ! local_primary_role_published; then'
+    The status should be success
+    The output should include "local_primary_role_published"
+  End
+
+  It "records the stop/start recovery handoff in startup logs"
+    When call template_contains "accepted local syncer primary promotion while Primary Service is empty"
+    The status should be success
+    The output should include "accepted local syncer primary promotion"
+  End
+
+  It "keeps pod-0 blocked self-election in a reconcile loop instead of exiting permanently"
+    When call template_contains "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service"
+    The status should be success
+    The output should include "blocked self-election"
+  End
+
+  It "lets pod-0 accept syncer primary promotion after blocked self-election"
+    When call template_contains "pod-0 accepted syncer primary promotion after blocked self-election"
+    The status should be success
+    The output should include "accepted syncer primary promotion"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -125,6 +125,102 @@ EOF
       End
     End
 
+    Context "when pending marker exists but local syncer and SQL prove this pod is a peer-reachable semisync primary"
+      setup_pending_primary_fail_closed() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="0"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="OFF"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_pending_primary_fail_closed"
+
+      It "publishes primary so the Primary Service can recover after marker loss"
+        When call check_role
+        The status should be success
+        The output should eq "primary"
+      End
+    End
+
+    Context "when pending primary is still local-listener-only"
+      setup_pending_primary_local_only() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="0"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="OFF"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 1; }
+      }
+      Before "setup_pending_primary_local_only"
+
+      It "does not publish primary before the SQL listener is peer-reachable"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
+    Context "when pending primary is still read-only"
+      setup_pending_primary_read_only() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="OFF"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_pending_primary_read_only"
+
+      It "does not publish primary before read_only is open"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
+    Context "when pending semisync primary has secondary-shaped variables"
+      setup_pending_primary_wrong_semisync_shape() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_READ_ONLY="0"
+        export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_pending_primary_wrong_semisync_shape"
+
+      It "does not publish primary before semisync variables converge"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
     Context "when .replication-pending exists"
       setup_pending() {
         touch "${TEST_DIR}/.replication-ready"

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -131,6 +131,61 @@ EOF
       End
     End
 
+    Context "when pending marker exists but local syncer and SQL prove this pod is a fail-closed secondary"
+      setup_pending_secondary_fail_closed() {
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_READ_ONLY="1"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/.sql-listener-ready"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+      }
+      Before "setup_pending_secondary_fail_closed"
+
+      It "publishes secondary so a stale primary label is removed"
+        When call check_role
+        The status should be success
+        The output should eq "secondary"
+      End
+    End
+
+    Context "when pending secondary is not fail-closed read-only"
+      setup_pending_secondary_writable() {
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_READ_ONLY="0"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+      }
+      Before "setup_pending_secondary_writable"
+
+      It "does not publish a role"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
+    Context "when pending pod has slave config but syncer does not confirm secondary"
+      setup_pending_without_syncer_secondary() {
+        export MOCK_SYNCERCTL_ROLE="primary"
+        export MOCK_MARIADB_READ_ONLY="1"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+      }
+      Before "setup_pending_without_syncer_secondary"
+
+      It "keeps the pod unpublished"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
     Context "when master.info exists (no pending flag)"
       setup_secondary() {
         touch "${TEST_DIR}/.replication-ready"

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -19,11 +19,11 @@ Describe "replication-roleprobe.sh"
   cleanup() {
     rm -rf "$TEST_DIR"
     export PATH="$TEST_ORIG_PATH"
-    unset MARIADB_DATADIR DATA_DIR SYNCERCTL_BIN MOCK_SYNCERCTL_ROLE MARIADB_ROLEPROBE_SKIP_DB_READY MARIADB_ROLEPROBE_REQUIRE_SQL_LISTENER_READY TEST_ORIG_PATH MARIADB_ROOT_HOST MARIADB_INTERNAL_ROOT_USER
+    unset MARIADB_DATADIR DATA_DIR SYNCERCTL_BIN MOCK_SYNCERCTL_ROLE MARIADB_ROLEPROBE_SKIP_DB_READY MARIADB_ROLEPROBE_REQUIRE_SQL_LISTENER_READY TEST_ORIG_PATH MARIADB_ROOT_HOST MARIADB_INTERNAL_ROOT_USER MARIADB_REPLICATION_MODE
     unset MOCK_MARIADB_SELECT1_RC MOCK_MARIADB_SELECT1_STDOUT
     unset MOCK_MARIADB_SHOW_SLAVE_STATUS_RC MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT
     unset MOCK_MARIADB_BIND_ADDRESS MOCK_MARIADB_BIND_ADDRESS_RC
-    unset MOCK_MARIADB_READ_ONLY MOCK_MARIADB_READ_ONLY_RC
+    unset MOCK_MARIADB_READ_ONLY MOCK_MARIADB_READ_ONLY_RC MOCK_MARIADB_SEMISYNC_MASTER MOCK_MARIADB_SEMISYNC_MASTER_RC MOCK_MARIADB_SEMISYNC_SLAVE MOCK_MARIADB_SEMISYNC_SLAVE_RC
     unset MOCK_MARIADB_SQL_RC MOCK_MARIADB_CAPTURE_FILE MOCK_MARIADB_ROOT_SHOW_SLAVE_STATUS_RC MOCK_MARIADB_ROOT_SELECT1_RC
   }
   AfterEach "cleanup"
@@ -75,6 +75,14 @@ case "$*" in
   *"SELECT UPPER(CAST(@@global.read_only AS CHAR));"*)
     printf "%s\n" "${MOCK_MARIADB_READ_ONLY:-0}"
     exit "${MOCK_MARIADB_READ_ONLY_RC:-0}"
+    ;;
+  *"SELECT UPPER(CAST(@@global.rpl_semi_sync_master_enabled AS CHAR));"*)
+    printf "%s\n" "${MOCK_MARIADB_SEMISYNC_MASTER:-0}"
+    exit "${MOCK_MARIADB_SEMISYNC_MASTER_RC:-0}"
+    ;;
+  *"SELECT UPPER(CAST(@@global.rpl_semi_sync_slave_enabled AS CHAR));"*)
+    printf "%s\n" "${MOCK_MARIADB_SEMISYNC_SLAVE:-1}"
+    exit "${MOCK_MARIADB_SEMISYNC_SLAVE_RC:-0}"
     ;;
 esac
 if [ -n "${MOCK_MARIADB_CAPTURE_FILE:-}" ]; then
@@ -165,6 +173,48 @@ EOF
         When call check_role
         The status should be failure
         The output should eq "initializing"
+      End
+    End
+
+    Context "when semisync pending secondary has not reached secondary variable shape"
+      setup_semisync_pending_secondary_master_still_on() {
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="ON"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+      }
+      Before "setup_semisync_pending_secondary_master_still_on"
+
+      It "does not publish secondary before semisync variables converge"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+      End
+    End
+
+    Context "when semisync pending secondary has fail-closed read_only and secondary variable shape"
+      setup_semisync_pending_secondary_ready() {
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+      }
+      Before "setup_semisync_pending_secondary_ready"
+
+      It "publishes secondary after semisync variables converge"
+        When call check_role
+        The status should be success
+        The output should eq "secondary"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.5$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.6$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.5"
+      The output should equal "version: 1.2.0-alpha.6"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.5"
+        The output should equal "version: 1.2.0-alpha.6"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.5"
+        The output should equal "version: 1.2.0-alpha.6"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.7$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.8$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.7"
+      The output should equal "version: 1.2.0-alpha.8"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.7"
+        The output should equal "version: 1.2.0-alpha.8"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.7"
+        The output should equal "version: 1.2.0-alpha.8"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.6$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.7$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.6"
+      The output should equal "version: 1.2.0-alpha.7"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.6"
+        The output should equal "version: 1.2.0-alpha.7"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.6"
+        The output should equal "version: 1.2.0-alpha.7"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.4$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.5$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.4"
+      The output should equal "version: 1.2.0-alpha.5"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.4"
+        The output should equal "version: 1.2.0-alpha.5"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.4"
+        The output should equal "version: 1.2.0-alpha.5"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.7 (alpha.7 bump: semisync stop/start syncer primary bootstrap gate)"
-      When call grep -c '^version: 1.2.0-alpha.7$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.8 (alpha.8 bump: replica rejoin syncer primary handoff)"
+      When call grep -c '^version: 1.2.0-alpha.8$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.4 (alpha.2 bump: semisync pivot — 1.2.0 major for topology merge + semisync fencing)"
-      When call grep -c '^version: 1.2.0-alpha.4$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.5 (alpha.5 bump: semisync Stop/Start stale primary label fix)"
+      When call grep -c '^version: 1.2.0-alpha.5$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.6 (alpha.6 bump: pending secondary semisync shape gate)"
-      When call grep -c '^version: 1.2.0-alpha.6$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.7 (alpha.7 bump: semisync stop/start syncer primary bootstrap gate)"
+      When call grep -c '^version: 1.2.0-alpha.7$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.5 (alpha.5 bump: semisync Stop/Start stale primary label fix)"
-      When call grep -c '^version: 1.2.0-alpha.5$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.6 (alpha.6 bump: pending secondary semisync shape gate)"
+      When call grep -c '^version: 1.2.0-alpha.6$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -269,6 +269,18 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     The output should include "Existing slave config accepted syncer primary promotion"
   End
 
+  It "keeps pod-0 blocked self-election in a reconcile loop instead of exiting permanently"
+    When call template_contains "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service"
+    The status should be success
+    The output should include "blocked self-election"
+  End
+
+  It "lets pod-0 accept syncer primary promotion after blocked self-election"
+    When call template_contains "pod-0 accepted syncer primary promotion after blocked self-election"
+    The status should be success
+    The output should include "accepted syncer primary promotion"
+  End
+
   It "reconciles syncer secondary into fail-closed local SQL state"
     When call function_contains "reconcile_sql_listener_for_syncer_secondary_once" "set_replica_read_only"
     The status should be success

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -36,6 +36,14 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     [ "${begin_line}" -lt "${io_line}" ] && [ "${io_line}" -lt "${cleanup_line}" ]
   }
 
+  publish_rejoin_accepts_syncer_primary_before_defensive_fail_closed() {
+    before_line="$(grep -n 'syncer-primary-during-replica-rejoin-before-expose' "$(template_file)" | head -1 | cut -d: -f1)"
+    after_line="$(grep -n 'syncer-primary-during-replica-rejoin-after-expose' "$(template_file)" | head -1 | cut -d: -f1)"
+    fail_closed_line="$(grep -n 'after-expose-not-healthy' "$(template_file)" | head -1 | cut -d: -f1)"
+    [ -n "${before_line}" ] && [ -n "${after_line}" ] && [ -n "${fail_closed_line}" ] || return 1
+    [ "${before_line}" -lt "${fail_closed_line}" ] && [ "${after_line}" -lt "${fail_closed_line}" ]
+  }
+
   It "declares an internal local admin before fencing user-facing root"
     When call template_contains 'MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"'
     The status should be success
@@ -267,6 +275,17 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     When call template_contains "Existing slave config accepted syncer primary promotion"
     The status should be success
     The output should include "Existing slave config accepted syncer primary promotion"
+  End
+
+  It "accepts syncer primary promotion inside replica rejoin before fail-closing as replica"
+    When call publish_rejoin_accepts_syncer_primary_before_defensive_fail_closed
+    The status should be success
+  End
+
+  It "logs replica rejoin handoff to syncer primary publication"
+    When call template_contains "action=accept-primary-promotion"
+    The status should be success
+    The output should include "accept-primary-promotion"
   End
 
   It "keeps pod-0 blocked self-election in a reconcile loop instead of exiting permanently"

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -436,7 +436,24 @@ pending_secondary_fail_closed_ready() {
   db_ready || return 1
   read_only=$(local_sql -e "SELECT UPPER(CAST(@@global.read_only AS CHAR));" 2>/dev/null || true)
   case "${read_only}" in
-    1|ON|NO_LOCK|NO_LOCK_NO_ADMIN)
+    1|ON|NO_LOCK|NO_LOCK_NO_ADMIN) ;;
+    *) return 1 ;;
+  esac
+  semisync_secondary_shape_ready || return 1
+  return 0
+}
+
+semisync_secondary_shape_ready() {
+  local master_enabled slave_enabled
+  [ "${MARIADB_REPLICATION_MODE:-}" = "semisync" ] || return 0
+  master_enabled=$(local_sql -e "SELECT UPPER(CAST(@@global.rpl_semi_sync_master_enabled AS CHAR));" 2>/dev/null || true)
+  slave_enabled=$(local_sql -e "SELECT UPPER(CAST(@@global.rpl_semi_sync_slave_enabled AS CHAR));" 2>/dev/null || true)
+  case "${master_enabled}" in
+    0|OFF) ;;
+    *) return 1 ;;
+  esac
+  case "${slave_enabled}" in
+    1|ON)
       return 0
       ;;
   esac

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -443,6 +443,39 @@ pending_secondary_fail_closed_ready() {
   return 0
 }
 
+pending_primary_fail_closed_ready() {
+  local role read_only
+  [ ! -f "$(master_info_file)" ] || return 1
+  role=$(syncerctl_getrole) || return 1
+  [ "${role}" = "primary" ] || return 1
+  db_ready || return 1
+  read_only=$(local_sql -e "SELECT UPPER(CAST(@@global.read_only AS CHAR));" 2>/dev/null || true)
+  case "${read_only}" in
+    0|OFF) ;;
+    *) return 1 ;;
+  esac
+  mariadbd_listen_on_all_interfaces || return 1
+  semisync_primary_shape_ready || return 1
+  return 0
+}
+
+semisync_primary_shape_ready() {
+  local master_enabled slave_enabled
+  [ "${MARIADB_REPLICATION_MODE:-}" = "semisync" ] || return 0
+  master_enabled=$(local_sql -e "SELECT UPPER(CAST(@@global.rpl_semi_sync_master_enabled AS CHAR));" 2>/dev/null || true)
+  slave_enabled=$(local_sql -e "SELECT UPPER(CAST(@@global.rpl_semi_sync_slave_enabled AS CHAR));" 2>/dev/null || true)
+  case "${master_enabled}" in
+    1|ON) ;;
+    *) return 1 ;;
+  esac
+  case "${slave_enabled}" in
+    0|OFF)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 semisync_secondary_shape_ready() {
   local master_enabled slave_enabled
   [ "${MARIADB_REPLICATION_MODE:-}" = "semisync" ] || return 0
@@ -603,6 +636,11 @@ check_role() {
     # outputs. Publishing secondary is safe only after local SQL proves the pod
     # is fail-closed read-only; replication may still be pending, but the pod
     # must not remain in the primary Service.
+    if pending_primary_fail_closed_ready; then
+      apply_remote_root_fence "primary" || { not_ready; return $?; }
+      echo -n "primary"
+      return 0
+    fi
     if pending_secondary_fail_closed_ready; then
       apply_remote_root_fence "secondary" || { not_ready; return $?; }
       echo -n "secondary"

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -63,6 +63,19 @@ primary_read_write_ready_file() {
   printf "%s/.primary-read-write-ready" "$(data_dir)"
 }
 
+syncerctl_getrole() {
+  local syncerctl_bin role
+  syncerctl_bin="${SYNCERCTL_BIN:-/tools/syncerctl}"
+  [ -x "${syncerctl_bin}" ] || return 1
+  if command -v timeout >/dev/null 2>&1; then
+    role=$(timeout 3 "${syncerctl_bin}" --host 127.0.0.1 --port "${SYNCERCTL_PORT:-3601}" getrole 2>/dev/null | tr -d '\r\n')
+  else
+    role=$("${syncerctl_bin}" --host 127.0.0.1 --port "${SYNCERCTL_PORT:-3601}" getrole 2>/dev/null | tr -d '\r\n')
+  fi
+  [ -n "${role}" ] || return 1
+  printf "%s" "${role}"
+}
+
 master_info_file() {
   printf "%s/master.info" "$(data_dir)"
 }
@@ -415,6 +428,21 @@ primary_read_write_ready() {
   return 1
 }
 
+pending_secondary_fail_closed_ready() {
+  local role read_only
+  [ -f "$(master_info_file)" ] || return 1
+  role=$(syncerctl_getrole) || return 1
+  [ "${role}" = "secondary" ] || return 1
+  db_ready || return 1
+  read_only=$(local_sql -e "SELECT UPPER(CAST(@@global.read_only AS CHAR));" 2>/dev/null || true)
+  case "${read_only}" in
+    1|ON|NO_LOCK|NO_LOCK_NO_ADMIN)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 attempt_marker_self_heal() {
   # alpha.106 v1 (Jack 2026-05-29): defensive marker reaper for the
   # stuck-pending-after-recovery state surfaced by Round 1c-C async T6
@@ -552,6 +580,17 @@ check_role() {
   # primary -> secondary flips for later pods when syncer prestart is still
   # running.
   if [ -f "$(pending_file)" ] || [ ! -f "$(ready_file)" ]; then
+    # If this pod already has persisted slave config and syncer/DCS reports it
+    # as secondary, continuing to return a failed probe leaves any previous
+    # primary label in place because KubeBlocks ignores failed roleProbe
+    # outputs. Publishing secondary is safe only after local SQL proves the pod
+    # is fail-closed read-only; replication may still be pending, but the pod
+    # must not remain in the primary Service.
+    if pending_secondary_fail_closed_ready; then
+      apply_remote_root_fence "secondary" || { not_ready; return $?; }
+      echo -n "secondary"
+      return 0
+    fi
     not_ready
     return $?
   fi

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1619,8 +1619,18 @@ spec:
               # mark_replication_ready (line below) is the publish point; if any
               # required step fails (set_replica_read_only / expose_sql_listener),
               # the function MUST return 1 BEFORE reaching mark_replication_ready.
-              local label="$1"
-              if ! keep_replica_pending_until_healthy "${label}-before-expose"; then
+              local label="$1" replica_rejoin_rc
+              keep_replica_pending_until_healthy "${label}-before-expose"
+              replica_rejoin_rc=$?
+              if [ "${replica_rejoin_rc}" -eq 2 ]; then
+                prestop_watchdog_log "publish-replica-rejoin label=${label} step=before-expose syncer_role=primary action=accept-primary-promotion"
+                if expose_sql_listener_for_primary_role "syncer-primary-during-replica-rejoin-before-expose-${label}"; then
+                  mark_replication_ready
+                  return 0
+                fi
+                return 2
+              fi
+              if [ "${replica_rejoin_rc}" -ne 0 ]; then
                 return 1
               fi
               if ! set_replica_read_only; then
@@ -1635,7 +1645,17 @@ spec:
                 prestop_watchdog_log "publish-replica-rejoin label=${label} step=after-expose rc=1 tier=required fail_closed=true"
                 return 1
               fi
-              if ! wait_for_replication_healthy "${label}-after-expose" 120 2; then
+              wait_for_replication_healthy "${label}-after-expose" 120 2
+              replica_rejoin_rc=$?
+              if [ "${replica_rejoin_rc}" -eq 2 ]; then
+                prestop_watchdog_log "publish-replica-rejoin label=${label} step=after-expose syncer_role=primary action=accept-primary-promotion"
+                if expose_sql_listener_for_primary_role "syncer-primary-during-replica-rejoin-after-expose-${label}"; then
+                  mark_replication_ready
+                  return 0
+                fi
+                return 2
+              fi
+              if [ "${replica_rejoin_rc}" -ne 0 ]; then
                 # tier=fail-path-defensive: replication is already
                 # known unhealthy; we mark pending and best-effort lock.
                 mark_replication_pending

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1969,6 +1969,11 @@ spec:
               timeout 3 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                 -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || true
             }
+            local_primary_role_published() {
+              [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]
+            }
             local_user_table_count() {
               "${LOCAL[@]}" -e "
                 SELECT COUNT(*)
@@ -2303,19 +2308,44 @@ spec:
                   PRIMARY_SID=$(timeout 10 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                     -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || echo "")
                   [ -n "${PRIMARY_SID}" ] && break
+                  reconcile_sql_listener_for_syncer_primary_once || true
+                  if local_primary_role_published; then
+                    echo "pod-0 startup: accepted local syncer primary promotion while Primary Service is empty"
+                    break
+                  fi
                 done
-                if [ -z "${PRIMARY_SID}" ]; then
+                if [ -z "${PRIMARY_SID}" ] && ! local_primary_role_published; then
+                  blocked_self_election_resolved=false
                   if block_existing_datadir_self_election_without_primary; then
-                    wait ${MARIADB_PID}
-                    exit 1
+                    while true; do
+                      reconcile_sql_listener_for_syncer_primary_once || true
+                      if local_primary_role_published; then
+                        echo "pod-0 accepted syncer primary promotion after blocked self-election"
+                        blocked_self_election_resolved=true
+                        break
+                      fi
+                      if publish_replica_after_rejoin_ready "existing-slave-config"; then
+                        echo "Resumed replication from existing slave config after blocked self-election"
+                        blocked_self_election_resolved=true
+                        break
+                      fi
+                      if fail_closed_for_gtid_divergence; then
+                        wait ${MARIADB_PID}
+                        exit 1
+                      fi
+                      echo "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service, retrying in 5s."
+                      sleep 5
+                    done
                   fi
-                  if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
-                    wait ${MARIADB_PID}
-                    exit 1
+                  if [ "${blocked_self_election_resolved}" != "true" ]; then
+                    if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+                      wait ${MARIADB_PID}
+                      exit 1
+                    fi
+                    mark_replication_ready
+                    echo "Starting as primary (pod-0 with stale slave config, no primary found after ${no_primary_budget}s wait)"
                   fi
-                  mark_replication_ready
-                  echo "Starting as primary (pod-0 with stale slave config, no primary found after ${no_primary_budget}s wait)"
-                  PRIMARY_SID=""  # signal: we self-elected; do not fall through to rejoin
+                  PRIMARY_SID=""  # signal: resolved locally; do not fall through to rejoin
                 fi
               fi
               # alpha.92 fall-through: when PRIMARY_SID is now non-empty
@@ -2326,9 +2356,7 @@ spec:
               if [ -n "${PRIMARY_SID}" ] && [ "${PRIMARY_SID}" != "${SERVICE_ID}" ]; then
                 while true; do
                   reconcile_sql_listener_for_syncer_primary_once || true
-                  if [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                  if local_primary_role_published; then
                     echo "Existing slave config accepted syncer primary promotion"
                     break
                   fi

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1352,8 +1352,18 @@ spec:
               # mark_replication_ready (line below) is the publish point; if any
               # required step fails (set_replica_read_only / expose_sql_listener),
               # the function MUST return 1 BEFORE reaching mark_replication_ready.
-              local label="$1"
-              if ! keep_replica_pending_until_healthy "${label}-before-expose"; then
+              local label="$1" replica_rejoin_rc
+              keep_replica_pending_until_healthy "${label}-before-expose"
+              replica_rejoin_rc=$?
+              if [ "${replica_rejoin_rc}" -eq 2 ]; then
+                prestop_watchdog_log "publish-replica-rejoin label=${label} step=before-expose syncer_role=primary action=accept-primary-promotion"
+                if expose_sql_listener_for_primary_role "syncer-primary-during-replica-rejoin-before-expose-${label}"; then
+                  mark_replication_ready
+                  return 0
+                fi
+                return 2
+              fi
+              if [ "${replica_rejoin_rc}" -ne 0 ]; then
                 return 1
               fi
               if ! set_replica_read_only; then
@@ -1368,7 +1378,17 @@ spec:
                 prestop_watchdog_log "publish-replica-rejoin label=${label} step=after-expose rc=1 tier=required fail_closed=true"
                 return 1
               fi
-              if ! wait_for_replication_healthy "${label}-after-expose" 120 2; then
+              wait_for_replication_healthy "${label}-after-expose" 120 2
+              replica_rejoin_rc=$?
+              if [ "${replica_rejoin_rc}" -eq 2 ]; then
+                prestop_watchdog_log "publish-replica-rejoin label=${label} step=after-expose syncer_role=primary action=accept-primary-promotion"
+                if expose_sql_listener_for_primary_role "syncer-primary-during-replica-rejoin-after-expose-${label}"; then
+                  mark_replication_ready
+                  return 0
+                fi
+                return 2
+              fi
+              if [ "${replica_rejoin_rc}" -ne 0 ]; then
                 # tier=fail-path-defensive: replication is already
                 # known unhealthy; we mark pending and best-effort lock.
                 mark_replication_pending

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1656,6 +1656,11 @@ spec:
               timeout 3 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                 -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || true
             }
+            local_primary_role_published() {
+              [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
+              [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]
+            }
             local_user_table_count() {
               "${LOCAL[@]}" -e "
                 SELECT COUNT(*)
@@ -1914,22 +1919,40 @@ spec:
                 exit 1
               fi
               if [ "${POD_INDEX}" = "0" ] && [ -z "${PRIMARY_SID}" ]; then
+                blocked_self_election_resolved=false
                 if block_existing_datadir_self_election_without_primary; then
-                  wait ${MARIADB_PID}
-                  exit 1
+                  while true; do
+                    reconcile_sql_listener_for_syncer_primary_once || true
+                    if local_primary_role_published; then
+                      echo "pod-0 accepted syncer primary promotion after blocked self-election"
+                      blocked_self_election_resolved=true
+                      break
+                    fi
+                    if publish_replica_after_rejoin_ready "existing-slave-config"; then
+                      echo "Resumed replication from existing slave config after blocked self-election"
+                      blocked_self_election_resolved=true
+                      break
+                    fi
+                    if fail_closed_for_gtid_divergence; then
+                      wait ${MARIADB_PID}
+                      exit 1
+                    fi
+                    echo "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service, retrying in 5s."
+                    sleep 5
+                  done
                 fi
-                if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
-                  wait ${MARIADB_PID}
-                  exit 1
+                if [ "${blocked_self_election_resolved}" != "true" ]; then
+                  if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+                    wait ${MARIADB_PID}
+                    exit 1
+                  fi
+                  mark_replication_ready
+                  echo "Starting as primary (pod-0 with stale slave config, no primary found)"
                 fi
-                mark_replication_ready
-                echo "Starting as primary (pod-0 with stale slave config, no primary found)"
               else
                 while true; do
                   reconcile_sql_listener_for_syncer_primary_once || true
-                  if [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
-                     [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                  if local_primary_role_published; then
                     echo "Existing slave config accepted syncer primary promotion"
                     break
                   fi


### PR DESCRIPTION
## Summary
- preserve `wait_for_replication_healthy` rc=2 in semisync/merged replica rejoin
- when syncer promotes the pod during rejoin, publish the primary SQL-listener path instead of continuing replica fail-closed cleanup
- bump MariaDB chart to `1.2.0-alpha.8`

## Evidence
r19 showed pod-1 was promoted and the first switchover ConfigMap was deleted, then the existing-slave-config rejoin path set read_only again:
- 13:57:33 pod-1 promote success / Take the leader success
- 13:57:49 Delete switchOver configmap succeeded
- 13:57:51 Set fail-closed read_only=ON (existing-slave-config-after-expose-not-healthy)
- 13:57:52-55 writecheck refused because MariaDB is read-only
- 13:57:55 release lease

## Tests
- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh`
- `helm dependency build addons/mariadb`
- `helm lint addons/mariadb`
- `helm template mariadb-test addons/mariadb --set replication.mode=semisync`
- `git diff --check`
