### PR TITLE
fix(mariadb): clear stale prestop fence on container restart

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -2170,6 +2170,17 @@ type: application
 # syncer and then pulled back to read_only by the stale replica rejoin
 # continuation.
 #
+# alpha.9 (Jack 2026-06-04 - VersionUpgrade preStop marker cleanup):
+# Bumped from 1.2.0-alpha.8 -> 1.2.0-alpha.9 because semisync and
+# merged replication startup scripts now clear stale PVC preStop fence
+# markers on the first startup attempt of a new container lifecycle. r20
+# T15 showed VersionUpgrade can restart only the mariadb container
+# in-place: init-syncer does not re-run, so init-time marker cleanup is
+# insufficient. The fix uses a container-local /tmp lifecycle marker:
+# first startup in a restarted container clears stale PVC fence markers;
+# later startup attempts in the same container keep the fence and refuse
+# mariadbd restart during a real preStop.
+#
 # alpha.6 (Jack 2026-06-04 — pending secondary semisync shape gate):
 # alpha.5 allowed pending secondary publication after persisted slave
 # config + syncer secondary + read_only=ON, but in semisync mode that
@@ -2199,7 +2210,7 @@ type: application
 # but it was rendered with the wrong values path (`mariadb.replication.mode`).
 # The chart consumes top-level `replication.mode`, so alpha.3 was not a
 # valid semisync focused verdict.
-version: 1.2.0-alpha.8
+version: 1.2.0-alpha.9
 
 # alpha.101 v1 (Helen 2026-05-25 — Phase 1 mitigation for orphan
 # event / GTID divergence cascade surfaced after alpha.100): add

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -49,6 +49,30 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     The status should be success
   End
 
+  It "clears stale preStop fence markers only on the first startup attempt in a container lifecycle"
+    When call template_contains 'LIFECYCLE_MARKER="/tmp/.mariadb-startup-lifecycle"'
+    The status should be success
+    The output should include "/tmp/.mariadb-startup-lifecycle"
+  End
+
+  It "logs startup-time cleanup of stale PVC preStop markers"
+    When call template_contains "clear-stale-prestop-fence-on-container-start"
+    The status should be success
+    The output should include "clear-stale-prestop-fence-on-container-start"
+  End
+
+  It "keeps the preStop fence on later startup attempts in the same container lifecycle"
+    When call template_contains 'elif [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then'
+    The status should be success
+    The output should include ".prestop-fence-started"
+  End
+
+  It "logs refusal when preStop fence appears after the lifecycle marker exists"
+    When call template_contains "decision=refuse-restart-after-prestop"
+    The status should be success
+    The output should include "refuse-restart-after-prestop"
+  End
+
   It "reconciles local syncer primary during the pod-0 no-primary startup loop before blocking self-election"
     When call no_primary_loop_reconciles_syncer_primary_before_block
     The status should be success

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.8$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.9$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2901,7 +2901,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.8"
+      The output should equal "version: 1.2.0-alpha.9"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2962,7 +2962,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.8"
+        The output should equal "version: 1.2.0-alpha.9"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3139,7 +3139,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.8"
+        The output should equal "version: 1.2.0-alpha.9"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.8 (alpha.8 bump: replica rejoin syncer primary handoff)"
-      When call grep -c '^version: 1.2.0-alpha.8$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.9 (alpha.9 bump: VersionUpgrade preStop marker lifecycle cleanup)"
+      When call grep -c '^version: 1.2.0-alpha.9$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -76,6 +76,30 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     The status should be success
   End
 
+  It "clears stale preStop fence markers only on the first startup attempt in a container lifecycle"
+    When call template_contains 'LIFECYCLE_MARKER="/tmp/.mariadb-startup-lifecycle"'
+    The status should be success
+    The output should include "/tmp/.mariadb-startup-lifecycle"
+  End
+
+  It "logs startup-time cleanup of stale PVC preStop markers"
+    When call template_contains "clear-stale-prestop-fence-on-container-start"
+    The status should be success
+    The output should include "clear-stale-prestop-fence-on-container-start"
+  End
+
+  It "keeps the preStop fence on later startup attempts in the same container lifecycle"
+    When call template_contains 'elif [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then'
+    The status should be success
+    The output should include ".prestop-fence-started"
+  End
+
+  It "logs refusal when preStop fence appears after the lifecycle marker exists"
+    When call template_contains "decision=refuse-restart-after-prestop"
+    The status should be success
+    The output should include "refuse-restart-after-prestop"
+  End
+
   It "requires internal admin primary semisync dynamic privilege before role publishing"
     When call function_contains "internal_local_admin_has_required_privileges" "REPLICATION_MASTER_ADMIN"
     The status should be success

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -425,7 +425,26 @@ spec:
             ROOT_LOCAL=(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
             INTERNAL_LOCAL=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
             LOCAL=("${ROOT_LOCAL[@]}")
-            if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+            LIFECYCLE_MARKER="/tmp/.mariadb-startup-lifecycle"
+            if [ ! -f "${LIFECYCLE_MARKER}" ]; then
+              touch "${LIFECYCLE_MARKER}" 2>/dev/null || true
+              if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || \
+                 [ -f "{{ .Values.dataMountPath }}/.prestop-fence-complete" ] || \
+                 [ -f "{{ .Values.dataMountPath }}/.prestop-fence-failed" ]; then
+                mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+                {
+                  printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                  printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
+                  printf 'decision=clear-stale-prestop-fence-on-container-start\n'
+                  printf 'reason=tmp lifecycle marker absent; this is the first startup attempt in this container\n'
+                  printf '\n'
+                } >> {{ .Values.dataMountPath }}/log/startup-fence.log 2>/dev/null || true
+              fi
+              rm -f {{ .Values.dataMountPath }}/.prestop-fence-started \
+                {{ .Values.dataMountPath }}/.prestop-fence-complete \
+                {{ .Values.dataMountPath }}/.prestop-fence-failed \
+                {{ .Values.dataMountPath }}/.prestop-fence-watchdog-active
+            elif [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
               mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
               {
                 printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -275,7 +275,26 @@ spec:
             ROOT_LOCAL=(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
             INTERNAL_LOCAL=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
             LOCAL=("${ROOT_LOCAL[@]}")
-            if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
+            LIFECYCLE_MARKER="/tmp/.mariadb-startup-lifecycle"
+            if [ ! -f "${LIFECYCLE_MARKER}" ]; then
+              touch "${LIFECYCLE_MARKER}" 2>/dev/null || true
+              if [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || \
+                 [ -f "{{ .Values.dataMountPath }}/.prestop-fence-complete" ] || \
+                 [ -f "{{ .Values.dataMountPath }}/.prestop-fence-failed" ]; then
+                mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
+                {
+                  printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                  printf 'pod_name=%s\n' "${POD_NAME:-unknown}"
+                  printf 'decision=clear-stale-prestop-fence-on-container-start\n'
+                  printf 'reason=tmp lifecycle marker absent; this is the first startup attempt in this container\n'
+                  printf '\n'
+                } >> {{ .Values.dataMountPath }}/log/startup-fence.log 2>/dev/null || true
+              fi
+              rm -f {{ .Values.dataMountPath }}/.prestop-fence-started \
+                {{ .Values.dataMountPath }}/.prestop-fence-complete \
+                {{ .Values.dataMountPath }}/.prestop-fence-failed \
+                {{ .Values.dataMountPath }}/.prestop-fence-watchdog-active
+            elif [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
               mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
               {
                 printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"


### PR DESCRIPTION
## Summary
- Clear stale PVC preStop fence markers on the first startup attempt of a new mariadb container lifecycle.
- Keep the existing refuse-restart guard for later startup attempts in the same container lifecycle, so a real terminating pod still cannot restart mariadbd after preStop starts.
- Bump the MariaDB chart to `1.2.0-alpha.9` and add ShellSpec guards for semisync and merged replication templates.

## Root Cause
Semisync r20 failed at T15 after VersionUpgrade. The DB pods remained Running with role labels, but mariadbd was not running and port 3306 was closed. The startup-fence log showed `refuse-restart-after-prestop` because `.prestop-fence-started` persisted on the PVC.

VersionUpgrade restarted the mariadb container in-place. The pod was not recreated, so init containers did not run again and the existing init-time cleanup for preStop markers did not execute.

## Fix
Use a container-local `/tmp/.mariadb-startup-lifecycle` marker in both semisync and merged replication startup scripts:

- if the marker is absent, this is the first startup attempt in this container lifecycle, so stale PVC preStop markers are cleared;
- if the marker is present and `.prestop-fence-started` exists, the script keeps the existing refuse-restart behavior for the same container lifecycle.

## Validation
- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh`
  - 106 examples, 0 failures
- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh`
  - 185 examples, 0 failures, 6 existing pendings
- `helm dependency build addons/mariadb`
- `helm lint addons/mariadb`
- `helm template mariadb-alpha9 addons/mariadb --set replication.mode=semisync --show-only templates/cmpd-replication-merged.yaml`
- `helm template mariadb-alpha9 addons/mariadb --set replication.mode=semisync --show-only templates/cmpd-semisync.yaml`
- `git diff --check`

## Follow-up Test Plan
Deploy alpha.9 to the approved vcluster, then run focused semisync T15 VersionUpgrade verification first. If focused T15 passes, restart semisync full suite from T1.
