### PR TITLE
fix(mariadb): require replication truth for pending secondary role

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.9
+version: 1.2.0-alpha.10
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -295,8 +295,16 @@ EOF
 
     Context "when semisync pending secondary has fail-closed read_only and secondary variable shape"
       setup_semisync_pending_secondary_ready() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
         export MARIADB_REPLICATION_MODE="semisync"
         export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_RC=0
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT="Slave_IO_Running: Yes
+Slave_SQL_Running: Yes
+Last_IO_Errno: 0
+Last_SQL_Errno: 0"
         export MOCK_MARIADB_READ_ONLY="1"
         export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
         export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
@@ -311,6 +319,32 @@ EOF
         When call check_role
         The status should be success
         The output should eq "secondary"
+      End
+    End
+
+    Context "when semisync pending secondary has variable shape but no replication truth"
+      setup_semisync_pending_secondary_empty_slave_status() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_RC=0
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT=""
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+      }
+      Before "setup_semisync_pending_secondary_empty_slave_status"
+
+      It "fails closed instead of publishing a broken secondary"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.9$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.10$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2902,7 +2902,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.9"
+      The output should equal "version: 1.2.0-alpha.10"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2963,7 +2963,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.9"
+        The output should equal "version: 1.2.0-alpha.10"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3140,7 +3140,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.9"
+        The output should equal "version: 1.2.0-alpha.10"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.9 (alpha.9 bump: VersionUpgrade preStop marker lifecycle cleanup)"
-      When call grep -c '^version: 1.2.0-alpha.9$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.10 (alpha.10 bump: pending secondary roleProbe requires replication truth)"
+      When call grep -c '^version: 1.2.0-alpha.10$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -439,6 +439,13 @@ pending_secondary_fail_closed_ready() {
     1|ON|NO_LOCK|NO_LOCK_NO_ADMIN) ;;
     *) return 1 ;;
   esac
+  # alpha.10: r28 semisync VScale showed that read_only + semisync variable
+  # shape is not enough to publish a secondary. A pod can hold
+  # .replication-pending after a transient self-promotion/reset, have
+  # syncerctl role=secondary, and still expose an empty SHOW SLAVE STATUS.
+  # Role labels feed KB service routing and update ordering, so fail closed
+  # until local SQL proves the replica IO/SQL threads are healthy.
+  secondary_replication_ready || return 1
   semisync_secondary_shape_ready || return 1
   return 0
 }


### PR DESCRIPTION
## Summary
- require `pending_secondary_fail_closed_ready()` to verify `secondary_replication_ready()` before publishing the secondary role
- add a regression ShellSpec for the r28 VScale state: pending marker + syncer secondary + semisync variable shape but empty `SHOW SLAVE STATUS`
- bump the MariaDB chart to `1.2.0-alpha.10` because the roleProbe script changes the CmpD payload

## Evidence
- r28 first red: semisync T8 VScale timed out after 180s with primary master status ON and secondary slave status OFF
- frozen live state showed pod-1 had `.replication-pending`, `master.info`, syncer role `secondary`, semisync secondary-shaped variables, but `.replication-ready` was absent and `SHOW SLAVE STATUS` was empty
- KB addon API contract requires roleProbe roles to be reliable because they drive roleSelector services and update/switchover behavior

## Tests
- red/green ShellSpec: `addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh`
- `bash -n addons/mariadb/scripts/replication-roleprobe.sh addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh`
- `git diff --check`
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh --shell bash`
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh --shell bash`
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh --shell bash`
- `helm dependency build addons/mariadb`
- `helm lint addons/mariadb`
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec --shell bash` (583 examples, 0 failures, 9 pendings)

## Next validation
After merge/deploy, keep r28 frozen for comparison and run focused T8 VScale on alpha.10 before starting the next full semisync N=2 round.