### PR TITLE
fix(mariadb): defer failed pod0 bootstrap to runtime reconcile

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.10
+version: 1.2.0-alpha.11
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -39,6 +39,14 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     [ "${before_line}" -lt "${fail_closed_line}" ] && [ "${after_line}" -lt "${fail_closed_line}" ]
   }
 
+  default_pod0_primary_failure_marks_pending_before_runtime_reconcile() {
+    fail_line="$(grep -n 'Default pod-0 primary publish failed; entering runtime role reconcile loop' "$(template_file)" | head -1 | cut -d: -f1)"
+    pending_line="$(awk -v fail_line="${fail_line}" 'NR < fail_line && index($0, "mark_replication_pending") { line = NR } END { if (line) print line }' "$(template_file)")"
+    runtime_line="$(grep -n 'wait_for_mariadbd_with_role_reconcile' "$(template_file)" | tail -1 | cut -d: -f1)"
+    [ -n "${fail_line}" ] && [ -n "${pending_line}" ] && [ -n "${runtime_line}" ] || return 1
+    [ "${pending_line}" -lt "${fail_line}" ] && [ "${fail_line}" -lt "${runtime_line}" ]
+  }
+
   It "defines a merged-CmpD local primary publish readiness gate"
     When call function_contains "local_primary_role_published" ".primary-read-write-ready"
     The status should be success
@@ -111,5 +119,16 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     When call template_contains "pod-0 accepted syncer primary promotion after blocked self-election"
     The status should be success
     The output should include "accepted syncer primary promotion"
+  End
+
+  It "does not block forever when default pod-0 primary publish fails"
+    When call template_contains "Default pod-0 primary publish failed; entering runtime role reconcile loop"
+    The status should be success
+    The output should include "runtime role reconcile loop"
+  End
+
+  It "keeps default pod-0 primary publish failure pending for runtime reconcile"
+    When call default_pod0_primary_failure_marks_pending_before_runtime_reconcile
+    The status should be success
   End
 End

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.10$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.11$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2902,7 +2902,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.10"
+      The output should equal "version: 1.2.0-alpha.11"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2963,7 +2963,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.10"
+        The output should equal "version: 1.2.0-alpha.11"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3140,7 +3140,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.10"
+        The output should equal "version: 1.2.0-alpha.11"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.10 (alpha.10 bump: pending secondary roleProbe requires replication truth)"
-      When call grep -c '^version: 1.2.0-alpha.10$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.11 (alpha.11 bump: default pod-0 primary write-gate failure enters runtime reconcile)"
+      When call grep -c '^version: 1.2.0-alpha.11$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -2541,12 +2541,18 @@ spec:
               done
             else
               # Pod-0, primary unreachable, no slave config: start as primary by default.
-              if ! expose_sql_listener_for_primary_role "default-pod0-primary"; then
-                wait ${MARIADB_PID}
-                exit 1
+              # If the primary write gate fails, do not block forever inside the
+              # bootstrap branch. Keep the pod fail-closed and let the runtime
+              # reconcile loop observe the syncer/DCS decision: if another pod is
+              # elected primary, this pod can configure replication and publish
+              # secondary only after replica health is real.
+              if expose_sql_listener_for_primary_role "default-pod0-primary"; then
+                mark_replication_ready
+                echo "Starting as primary by default (index=0)"
+              else
+                mark_replication_pending
+                echo "Default pod-0 primary publish failed; entering runtime role reconcile loop"
               fi
-              mark_replication_ready
-              echo "Starting as primary by default (index=0)"
             fi
 
             # Background: clear the semi-sync ACK receiver deadlock when detected.


### PR DESCRIPTION
## Summary
- Fixes the semisync Stop/Start path where pod-0 starts with no primary visible and no slave config, attempts the default primary bootstrap path, but fails the primary write gate.
- Instead of blocking forever on `wait ${MARIADB_PID}`, the startup script now keeps the pod fail-closed/pending and falls through to the runtime role reconcile loop.
- Bumps the MariaDB chart to `1.2.0-alpha.11` so the updated ComponentDefinition can be installed and validated.

## Evidence
Live alpha.10 focused T8 run hit a first red signal during T7 Start:
- both pods were `3/3 Running` on node3;
- Cluster stayed `Updating` with `Role probe timeout`;
- pod-1 had syncer role `primary` and roleProbe returned `primary`;
- pod-0 had syncer role `secondary`, `SHOW SLAVE STATUS` was empty, roleProbe returned `initializing`;
- pod-0 HA loop repeated `follow failed: replication-pending marker exists`.

The local evidence pack for that live scene is:
`artifacts/task453-a10-ss-t8-r32-node3-326daf2-20260605T0850Z/live-roleprobe-timeout-20260605T090217+0800.tgz`
sha256 `926af0f844d56c1955dfb0e0ad0b5e9c9ca6c3c8e1b68ec8a5e8ec74cb060f37`.

## Validation
- `git diff --check`
- `bash -n addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh`
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh --shell bash` => 15 examples, 0 failures
- related ShellSpec (`replication_user_convergence_spec.sh`, `replication_switchover_spec.sh`, `replication_roleprobe_spec.sh`) => 47 examples, 0 failures, 1 pending
- full MariaDB scripts-ut ShellSpec => 585 examples, 0 failures, 9 pending
- `helm dependency build && helm lint .` under `addons/mariadb` => 1 chart linted, 0 failed

## Next
After merge, deploy alpha.11 to the vcluster and rerun focused T7/T8, then restart semisync full-suite acceptance from T1 because the addon chart pin changed.
