### PR TITLE
fix(mariadb): repair stale primary listener markers

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.11
+version: 1.2.0-alpha.12
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -47,6 +47,49 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     [ "${pending_line}" -lt "${fail_line}" ] && [ "${fail_line}" -lt "${runtime_line}" ]
   }
 
+  stale_prestop_cleanup_clears_role_publish_markers() {
+    awk '
+      index($0, "decision=clear-stale-prestop-fence-on-container-start") { block = 1 }
+      block && index($0, "rm -f {{ .Values.dataMountPath }}/.prestop-fence-started") { rmblock = 1 }
+      rmblock && index($0, "{{ .Values.dataMountPath }}/.sql-listener-ready") { sql = 1 }
+      rmblock && index($0, "{{ .Values.dataMountPath }}/.primary-read-write-ready") { primary = 1 }
+      rmblock && index($0, "{{ .Values.dataMountPath }}/.replication-ready") { replica = 1 }
+      block && index($0, "elif [ -f \"{{ .Values.dataMountPath }}/.prestop-fence-started\" ]; then") { exit }
+      END { exit(sql && primary && replica ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  local_primary_role_publish_requires_real_wildcard_listener() {
+    awk '
+      index($0, "local_primary_role_published() {") { fn = 1 }
+      fn && index($0, ".sql-listener-ready") { marker = 1 }
+      fn && index($0, "mariadbd_listen_on_all_interfaces") { listener = 1 }
+      fn && /^            }$/ { exit(marker && listener ? 0 : 1) }
+      END { exit(marker && listener ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  primary_reconcile_fast_path_requires_real_wildcard_listener() {
+    awk '
+      index($0, "reconcile_sql_listener_for_syncer_primary_once() {") { fn = 1 }
+      fn && index($0, ".primary-read-write-ready") && index($0, "mariadbd_listen_on_all_interfaces") { found = 1 }
+      fn && index($0, "runtime-primary-listener-reconcile-repair-begin") { exit(found ? 0 : 1) }
+      END { exit(found ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  no_slave_startup_loop_reconciles_syncer_primary_even_with_stale_listener_marker() {
+    awk '
+      index($0, "elif [ -n \"${PRIMARY_SID}\" ] || [ \"${POD_INDEX}\" -gt 0 ]; then") { branch = 1 }
+      branch && index($0, "while true; do") { loop = 1 }
+      loop && index($0, "if [ -z \"${PRIMARY_SID}\" ] || [ \"${PRIMARY_SID}\" = \"${SERVICE_ID}\" ]; then") { no_primary = 1 }
+      no_primary && index($0, "if [ ! -f \"{{ .Values.dataMountPath }}/.sql-listener-ready\" ]; then") { stale_guard = 1 }
+      no_primary && index($0, "reconcile_sql_listener_for_syncer_primary_once || true") { reconcile = 1 }
+      no_primary && index($0, "_no_primary_iters=") { exit(reconcile && !stale_guard ? 0 : 1) }
+      END { exit(reconcile && !stale_guard ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   It "defines a merged-CmpD local primary publish readiness gate"
     When call function_contains "local_primary_role_published" ".primary-read-write-ready"
     The status should be success
@@ -54,6 +97,11 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
 
   It "requires the SQL listener marker before treating local primary as published"
     When call function_contains "local_primary_role_published" ".sql-listener-ready"
+    The status should be success
+  End
+
+  It "requires a real wildcard listener before treating local primary as published"
+    When call local_primary_role_publish_requires_real_wildcard_listener
     The status should be success
   End
 
@@ -67,6 +115,11 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     When call template_contains "clear-stale-prestop-fence-on-container-start"
     The status should be success
     The output should include "clear-stale-prestop-fence-on-container-start"
+  End
+
+  It "clears stale role and SQL listener markers together with stale PVC preStop markers"
+    When call stale_prestop_cleanup_clears_role_publish_markers
+    The status should be success
   End
 
   It "keeps the preStop fence on later startup attempts in the same container lifecycle"
@@ -83,6 +136,16 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
 
   It "reconciles local syncer primary during the pod-0 no-primary startup loop before blocking self-election"
     When call no_primary_loop_reconciles_syncer_primary_before_block
+    The status should be success
+  End
+
+  It "does not trust .sql-listener-ready without a real wildcard listener in syncer-primary fast path"
+    When call primary_reconcile_fast_path_requires_real_wildcard_listener
+    The status should be success
+  End
+
+  It "runs syncer-primary reconcile even when .sql-listener-ready already exists in the no-slave startup loop"
+    When call no_slave_startup_loop_reconciles_syncer_primary_even_with_stale_listener_marker
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.11$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.12$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2902,7 +2902,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.11"
+      The output should equal "version: 1.2.0-alpha.12"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2963,7 +2963,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.11"
+        The output should equal "version: 1.2.0-alpha.12"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3140,7 +3140,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.11"
+        The output should equal "version: 1.2.0-alpha.12"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.11 (alpha.11 bump: default pod-0 primary write-gate failure enters runtime reconcile)"
-      When call grep -c '^version: 1.2.0-alpha.11$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.12 (alpha.12 bump: stale PVC listener markers cannot bypass primary reconcile)"
+      When call grep -c '^version: 1.2.0-alpha.12$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -440,10 +440,19 @@ spec:
                   printf '\n'
                 } >> {{ .Values.dataMountPath }}/log/startup-fence.log 2>/dev/null || true
               fi
+              # alpha.12 (r35 T15): preStop can kill mariadbd after a primary
+              # reconcile has written .sql-listener-ready, then kbagent starts
+              # a fresh bootstrap-local-only mariadbd on 127.0.0.1. Those
+              # publish markers describe the old process, not the new one.
+              # Clear them together with the stale preStop fence so startup
+              # must re-prove listener exposure and role readiness.
               rm -f {{ .Values.dataMountPath }}/.prestop-fence-started \
                 {{ .Values.dataMountPath }}/.prestop-fence-complete \
                 {{ .Values.dataMountPath }}/.prestop-fence-failed \
-                {{ .Values.dataMountPath }}/.prestop-fence-watchdog-active
+                {{ .Values.dataMountPath }}/.prestop-fence-watchdog-active \
+                {{ .Values.dataMountPath }}/.sql-listener-ready \
+                {{ .Values.dataMountPath }}/.primary-read-write-ready \
+                {{ .Values.dataMountPath }}/.replication-ready
             elif [ -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ]; then
               mkdir -p {{ .Values.dataMountPath }}/log 2>/dev/null || true
               {
@@ -2011,7 +2020,8 @@ spec:
             local_primary_role_published() {
               [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && \
               [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && \
-              [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]
+              [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && \
+              mariadbd_listen_on_all_interfaces
             }
             local_user_table_count() {
               "${LOCAL[@]}" -e "
@@ -2043,7 +2053,7 @@ spec:
               if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
                 role="$(query_local_syncer_role || true)"
                 [ "${role}" = "primary" ] || return 0
-                if [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && [ ! -f "{{ .Values.dataMountPath }}/.remote-root-fence-role" ] && [ ! -f "{{ .Values.dataMountPath }}/master.info" ]; then
+                if [ -f "{{ .Values.dataMountPath }}/.primary-read-write-ready" ] && [ ! -f "{{ .Values.dataMountPath }}/.remote-root-fence-role" ] && [ ! -f "{{ .Values.dataMountPath }}/master.info" ] && mariadbd_listen_on_all_interfaces; then
                   return 0
                 fi
                 prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role}"
@@ -2450,12 +2460,14 @@ spec:
                 PRIMARY_SID=$(timeout 10 mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
                   -P3306 -h"${PRIMARY_HOST}" -N -s -e "SELECT @@server_id;" 2>/dev/null || echo "")
                 if [ -z "${PRIMARY_SID}" ] || [ "${PRIMARY_SID}" = "${SERVICE_ID}" ]; then
-                  if [ ! -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
-                    reconcile_sql_listener_for_syncer_primary_once || true
-                    if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && [ ! -f "{{ .Values.dataMountPath }}/master.info" ]; then
-                      echo "Starting as primary after syncer promoted this pod"
-                      break
-                    fi
+                  # alpha.12 (r35 T15): .sql-listener-ready can be stale after
+                  # preStop kills the exposed mariadbd and kbagent restarts a
+                  # bootstrap-local-only 127.0.0.1 process. Always let the
+                  # syncer-primary reconciler re-check the real listener state.
+                  reconcile_sql_listener_for_syncer_primary_once || true
+                  if local_primary_role_published; then
+                    echo "Starting as primary after syncer promoted this pod"
+                    break
                   fi
                   _no_primary_iters=$((_no_primary_iters + 1))
                   # Observability: log every 30s so external watchers see we are still waiting


### PR DESCRIPTION
## Summary
- bump MariaDB chart to `1.2.0-alpha.12`
- clear stale `.sql-listener-ready`, `.primary-read-write-ready`, and `.replication-ready` markers during fresh container lifecycle startup cleanup
- require a real wildcard SQL listener before trusting local primary publication or syncer-primary existing-listener fast path
- always run syncer-primary listener reconcile in the no-slave startup loop, even when `.sql-listener-ready` already exists

## Why
r35 semisync T15 VersionUpgrade completed the OpsRequest but left the promoted primary listening only on `127.0.0.1:3306`. The secondary then failed to reconnect with `ERROR 2003 connection refused`.

Live evidence showed the upgraded primary had stale PVC markers from the previous process while the new `mariadbd` was started in bootstrap-local-only mode. This matches the in-place container restart contract: VersionUpgrade may restart the container without recreating the Pod, `/tmp` resets, but PVC markers persist.

Contract/doc anchors checked:
- `docs/addon-api/10-day2-operations.md`: upgrade/restart paths require addon startup/readiness support; switchover/roleSelector paths depend on reliable roleProbe.
- `docs/addon-api/05a-lifecycle-roles-and-probe.md`: roleProbe affects services, backup target, update ordering, and switchover.
- `docs/design/addon-inplace-container-restart-pvc-marker-lifecycle-guide.md`: in-place restart preserves PVC markers and requires lifecycle-aware stale marker cleanup.

## Verification
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh --shell bash`
  - 19 examples, 0 failures
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh --shell bash`
  - 25 examples, 0 failures
- `shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh --shell bash`
  - 185 examples, 0 failures, 6 existing pendings
- `helm lint addons/mariadb`
  - 1 chart linted, 0 failed
- `helm template mariadb-alpha12 addons/mariadb >/tmp/mariadb-alpha12-render.yaml`
  - rendered 18195 lines

## Evidence
- r35 failure closeout: `artifacts/task453-alpha11-semisync-r35-full-383f54f-20260605T1008Z/failure-closeout-20260605T1052+0800/evidence.tgz`
- evidence sha256: `8205b72b7d18ba79e85d9714708a638118bd63dde61027a439af167590ceee37`
