### PR TITLE
fix(mariadb): recover empty existing slave channel

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.12
+version: 1.2.0-alpha.13
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -90,6 +90,17 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
+  existing_slave_loop_recovers_empty_runtime_slave_status() {
+    awk '
+      index($0, "if [ -n \"${PRIMARY_SID}\" ] && [ \"${PRIMARY_SID}\" != \"${SERVICE_ID}\" ]; then") { branch = 1 }
+      branch && index($0, "while true; do") { loop = 1 }
+      loop && index($0, "publish_replica_after_rejoin_ready \"existing-slave-config\"") { publish = NR }
+      loop && index($0, "recover_empty_existing_slave_config_once \"existing-slave-config\"") { recover = NR }
+      loop && index($0, "Existing slave config is not healthy yet") { retry = NR; exit }
+      END { exit(publish && recover && retry && publish < recover && recover < retry ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   It "defines a merged-CmpD local primary publish readiness gate"
     When call function_contains "local_primary_role_published" ".primary-read-write-ready"
     The status should be success
@@ -146,6 +157,16 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
 
   It "runs syncer-primary reconcile even when .sql-listener-ready already exists in the no-slave startup loop"
     When call no_slave_startup_loop_reconciles_syncer_primary_even_with_stale_listener_marker
+    The status should be success
+  End
+
+  It "defines an existing-slave runtime-status recovery helper"
+    When call function_contains "recover_empty_existing_slave_config_once" "empty-runtime-slave-status"
+    The status should be success
+  End
+
+  It "reconfigures existing slave config when runtime slave status disappears"
+    When call existing_slave_loop_recovers_empty_runtime_slave_status
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -872,7 +872,7 @@ EOF
 
     It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.12$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.13$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2902,7 +2902,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.12"
+      The output should equal "version: 1.2.0-alpha.13"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2963,7 +2963,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.12"
+        The output should equal "version: 1.2.0-alpha.13"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3140,7 +3140,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.12"
+        The output should equal "version: 1.2.0-alpha.13"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.12 (alpha.12 bump: stale PVC listener markers cannot bypass primary reconcile)"
-      When call grep -c '^version: 1.2.0-alpha.12$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.13 (alpha.13 bump: recover empty existing slave runtime channel)"
+      When call grep -c '^version: 1.2.0-alpha.13$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -44,6 +44,13 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     [ "${before_line}" -lt "${fail_closed_line}" ] && [ "${after_line}" -lt "${fail_closed_line}" ]
   }
 
+  existing_slave_loop_recovers_empty_runtime_slave_status() {
+    recover_line="$(grep -n 'recover_empty_existing_slave_config_once "existing-slave-config"' "$(template_file)" | tail -1 | cut -d: -f1)"
+    retry_line="$(grep -n 'Existing slave config is not healthy yet' "$(template_file)" | tail -1 | cut -d: -f1)"
+    [ -n "${recover_line}" ] && [ -n "${retry_line}" ] || return 1
+    [ "${recover_line}" -lt "${retry_line}" ]
+  }
+
   It "declares an internal local admin before fencing user-facing root"
     When call template_contains 'MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"'
     The status should be success
@@ -338,6 +345,16 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     When call template_contains "runtime-secondary-follow-configure-begin"
     The status should be success
     The output should include "runtime-secondary-follow-configure-begin"
+  End
+
+  It "defines an existing-slave runtime-status recovery helper"
+    When call function_contains "recover_empty_existing_slave_config_once" "empty-runtime-slave-status"
+    The status should be success
+  End
+
+  It "reconfigures existing slave config when runtime slave status disappears"
+    When call existing_slave_loop_recovers_empty_runtime_slave_status
+    The status should be success
   End
 
   It "starts runtime secondary IO before local health cleanup"

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -2181,6 +2181,19 @@ spec:
               prestop_watchdog_log "runtime-secondary-follow-configure-not-healthy label=${label}"
               return 1
             }
+            recover_empty_existing_slave_config_once() {
+              local label="${1:-existing-slave-config}"
+              local slave_status
+              slave_status="$(query_slave_status_verbose || true)"
+              [ -z "${slave_status}" ] || return 1
+              prestop_watchdog_log "existing-slave-config-reconfigure-begin label=${label} reason=empty-runtime-slave-status"
+              if configure_replication_from_primary_service_once "${label}-empty-runtime-slave-status"; then
+                prestop_watchdog_log "existing-slave-config-reconfigure-complete label=${label}"
+                return 0
+              fi
+              prestop_watchdog_log "existing-slave-config-reconfigure-defer label=${label}"
+              return 1
+            }
             reconcile_sql_listener_for_syncer_secondary_once() {
               # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
               # mark_replication_ready (line below) is the publish point;
@@ -2382,6 +2395,11 @@ spec:
                         wait ${MARIADB_PID}
                         exit 1
                       fi
+                      if recover_empty_existing_slave_config_once "existing-slave-config-blocked-self-election"; then
+                        echo "Reconfigured replication from Primary Service after existing slave runtime status disappeared"
+                        blocked_self_election_resolved=true
+                        break
+                      fi
                       echo "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service, retrying in 5s."
                       sleep 5
                     done
@@ -2416,6 +2434,10 @@ spec:
                   if fail_closed_for_gtid_divergence; then
                     wait ${MARIADB_PID}
                     exit 1
+                  fi
+                  if recover_empty_existing_slave_config_once "existing-slave-config"; then
+                    echo "Reconfigured replication from Primary Service after existing slave runtime status disappeared"
+                    break
                   fi
                   echo "Existing slave config is not healthy yet; keeping replication pending and read-only, retrying in 5s."
                   sleep 5

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1844,6 +1844,19 @@ spec:
               prestop_watchdog_log "runtime-secondary-follow-configure-not-healthy label=${label}"
               return 1
             }
+            recover_empty_existing_slave_config_once() {
+              local label="${1:-existing-slave-config}"
+              local slave_status
+              slave_status="$(query_slave_status_verbose || true)"
+              [ -z "${slave_status}" ] || return 1
+              prestop_watchdog_log "existing-slave-config-reconfigure-begin label=${label} reason=empty-runtime-slave-status"
+              if configure_replication_from_primary_service_once "${label}-empty-runtime-slave-status"; then
+                prestop_watchdog_log "existing-slave-config-reconfigure-complete label=${label}"
+                return 0
+              fi
+              prestop_watchdog_log "existing-slave-config-reconfigure-defer label=${label}"
+              return 1
+            }
             reconcile_sql_listener_for_syncer_secondary_once() {
               # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
               # mark_replication_ready (line below) is the publish point;
@@ -1976,6 +1989,11 @@ spec:
                       wait ${MARIADB_PID}
                       exit 1
                     fi
+                    if recover_empty_existing_slave_config_once "existing-slave-config-blocked-self-election"; then
+                      echo "Reconfigured replication from Primary Service after existing slave runtime status disappeared"
+                      blocked_self_election_resolved=true
+                      break
+                    fi
                     echo "pod-0 startup: blocked self-election, awaiting syncer promotion or primary Service, retrying in 5s."
                     sleep 5
                   done
@@ -2002,6 +2020,10 @@ spec:
                   if fail_closed_for_gtid_divergence; then
                     wait ${MARIADB_PID}
                     exit 1
+                  fi
+                  if recover_empty_existing_slave_config_once "existing-slave-config"; then
+                    echo "Reconfigured replication from Primary Service after existing slave runtime status disappeared"
+                    break
                   fi
                   echo "Existing slave config is not healthy yet; keeping replication pending and read-only, retrying in 5s."
                   sleep 5


### PR DESCRIPTION
## Summary
- add a startup recovery helper for existing slave config whose runtime SHOW SLAVE STATUS becomes empty
- reuse the existing configure_replication_from_primary_service_once path instead of duplicating CHANGE MASTER logic
- bump MariaDB chart to 1.2.0-alpha.13 and add ShellSpec guards for merged and semisync templates

## Why
CM4 rolling restart can leave master.info on disk while the MariaDB runtime slave channel disappears. The existing-slave-config loop kept retrying START SLAVE through the health path, but there was no channel to start, so replication stayed pending and syncer follow refused to proceed.

## Validation
- shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh --shell bash
- shellspec --load-path ./shellspec --default-path addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh --shell bash
- helm lint addons/mariadb
- helm template mariadb addons/mariadb --set replication.mode=semisync
- helm template mariadb addons/mariadb --set replication.mode=async

## Follow-up
After merge/deploy, run focused CM4 first, then full semisync from T1 per Rule 6.