### PR TITLE
fix(valkey): guard self-heal during fresh promotion

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh
@@ -412,12 +412,15 @@ Describe "Valkey Self-Heal Daemon"
       export POD_FQDN="vlk-2.vlk-headless.ns.svc.cluster.local"
       replicaof_calls_file="$(mktemp)"
       dm_info_call_index_file="$(mktemp)"
+      dm_local_info_call_index_file="$(mktemp)"
       printf "0" > "${dm_info_call_index_file}"
+      printf "0" > "${dm_local_info_call_index_file}"
 
       # Stub valkey-cli: differentiates local (127.0.0.1) and remote (quorum
       # target FQDN) calls so the data-plane verification guard can be tested.
       #   - REPLICAOF calls: recorded to replicaof_calls_file.
-      #   - Local INFO calls  (host=127.0.0.1): always return role:master.
+      #   - Local INFO calls  (host=127.0.0.1): return role driven by
+      #       DM_LOCAL_ROLES (comma sequence), default "master".
       #   - Remote INFO calls (host=other):     return role driven by
       #       DM_REMOTE_ROLE (default "master"); "unreachable" → exit 1.
       valkey-cli() {
@@ -435,7 +438,12 @@ Describe "Valkey Self-Heal Daemon"
         idx=$(( $(cat "${dm_info_call_index_file}") + 1 ))
         printf "%s" "${idx}" > "${dm_info_call_index_file}"
         if [ "${target_host}" = "127.0.0.1" ]; then
-          printf "# Replication\r\nrole:master\r\n"
+          local local_idx local_role
+          local_idx=$(( $(cat "${dm_local_info_call_index_file}") + 1 ))
+          printf "%s" "${local_idx}" > "${dm_local_info_call_index_file}"
+          local_role=$(echo "${DM_LOCAL_ROLES:-master}" | cut -d, -f"${local_idx}")
+          is_empty "${local_role}" && local_role="master"
+          printf "# Replication\r\nrole:%s\r\n" "${local_role}"
         else
           local remote_role="${DM_REMOTE_ROLE:-master}"
           [ "${remote_role}" = "unreachable" ] && return 1
@@ -457,10 +465,13 @@ Describe "Valkey Self-Heal Daemon"
     Before "setup"
 
     teardown() {
-      rm -f "${replicaof_calls_file}" "${dm_info_call_index_file}"
+      rm -f "${replicaof_calls_file}" "${dm_info_call_index_file}" "${dm_local_info_call_index_file}"
       unset SENTINEL_COMPONENT_NAME SENTINEL_POD_FQDN_LIST
       unset CURRENT_POD_NAME POD_FQDN
-      unset DM_QUORUM_RESULT DM_REMOTE_ROLE DM_CONFIRM_RESULT
+      unset DM_QUORUM_RESULT DM_REMOTE_ROLE DM_CONFIRM_RESULT DM_LOCAL_ROLES
+      unset DUAL_MASTER_EPOCH_NOW DUAL_MASTER_PROMOTION_GRACE_SECONDS
+      _dual_master_last_role=""
+      _dual_master_last_master_since=""
       unset -f query_sentinel_quorum_for_master
     }
     After "teardown"
@@ -487,6 +498,43 @@ Describe "Valkey Self-Heal Daemon"
       The status should be success
       The stderr should include "skip-quorum-target-not-master"
       The contents of file "${replicaof_calls_file}" should eq ""
+    End
+
+    It "skips demote while a local slave-to-master promotion is inside the grace window"
+      export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_REMOTE_ROLE="master"
+      export DM_LOCAL_ROLES="slave,master,master"
+      export DUAL_MASTER_PROMOTION_GRACE_SECONDS="120"
+      exercise_fresh_promotion_in_grace() {
+        export DUAL_MASTER_EPOCH_NOW="1000"
+        dual_master_check_one_round
+        export DUAL_MASTER_EPOCH_NOW="1001"
+        dual_master_check_one_round
+      }
+      When call exercise_fresh_promotion_in_grace
+      The status should be success
+      The stderr should include "skip-fresh-promotion"
+      The contents of file "${replicaof_calls_file}" should eq ""
+    End
+
+    It "allows demote after the promotion grace window expires"
+      export DM_QUORUM_RESULT="vlk-0.vlk-headless.ns.svc.cluster.local"
+      export DM_REMOTE_ROLE="master"
+      export DM_CONFIRM_RESULT="0"
+      export DM_LOCAL_ROLES="slave,master,master,master,master"
+      export DUAL_MASTER_PROMOTION_GRACE_SECONDS="120"
+      exercise_fresh_promotion_after_grace() {
+        export DUAL_MASTER_EPOCH_NOW="1000"
+        dual_master_check_one_round
+        export DUAL_MASTER_EPOCH_NOW="1001"
+        dual_master_check_one_round
+        export DUAL_MASTER_EPOCH_NOW="1122"
+        dual_master_check_one_round
+      }
+      When call exercise_fresh_promotion_after_grace
+      The status should be success
+      The stderr should include "rogue master detected"
+      The contents of file "${replicaof_calls_file}" should include "vlk-0.vlk-headless.ns.svc.cluster.local"
     End
 
     It "issues REPLICAOF and confirms demote when quorum identifies a verified foreign master"

--- a/addons/valkey/scripts/valkey-self-heal.sh
+++ b/addons/valkey/scripts/valkey-self-heal.sh
@@ -258,6 +258,9 @@ stall_restart_server_for_recovery() {
 # state for the next round to retry.
 DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS="${DUAL_MASTER_CONFIRM_TIMEOUT_SECONDS:-10}"
 DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS="${DUAL_MASTER_CONFIRM_POLL_INTERVAL_SECONDS:-1}"
+DUAL_MASTER_PROMOTION_GRACE_SECONDS="${DUAL_MASTER_PROMOTION_GRACE_SECONDS:-120}"
+_dual_master_last_role=""
+_dual_master_last_master_since=""
 
 dual_master_confirm_demote() {
   local expected_master_host="$1"
@@ -298,6 +301,14 @@ _dm_hosts_resolve_same() {
   return 1
 }
 
+dual_master_epoch_now() {
+  if ! is_empty "${DUAL_MASTER_EPOCH_NOW:-}"; then
+    echo "${DUAL_MASTER_EPOCH_NOW}"
+    return 0
+  fi
+  date +%s
+}
+
 # dual_master_check_one_round — detect rogue-master state and demote.
 #
 # Evidence anchor: KB-10196 — when KB controller's isExclusive enforcement
@@ -326,6 +337,9 @@ _dm_hosts_resolve_same() {
 #     we are the legitimate master → nothing to do.
 #   - skip-stale-role: re-read local role just before issuing REPLICAOF
 #     (between initial read and decision, sentinel may have re-elected us).
+#   - skip-fresh-promotion: if this daemon just observed a slave -> master
+#     transition, give Sentinel a bounded window to publish +switch-master
+#     before treating the new local master as rogue.
 #   - bounded confirmation: see dual_master_confirm_demote above.
 dual_master_check_one_round() {
   is_empty "${SENTINEL_COMPONENT_NAME}" && return 0
@@ -338,7 +352,16 @@ dual_master_check_one_round() {
   local repl_info role_line
   repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
   role_line=$(cascade_extract_replication_field "${repl_info}" "role")
-  [ "${role_line}" != "master" ] && return 0
+  local previous_role="${_dual_master_last_role:-}"
+  if [ "${role_line}" != "master" ]; then
+    _dual_master_last_role="${role_line:-unknown}"
+    _dual_master_last_master_since=""
+    return 0
+  fi
+  if [ "${previous_role}" = "slave" ] && is_empty "${_dual_master_last_master_since}" ; then
+    _dual_master_last_master_since="$(dual_master_epoch_now)"
+  fi
+  _dual_master_last_role="master"
 
   if ! declare -F query_sentinel_quorum_for_master >/dev/null 2>&1; then
     # Helper not sourced (e.g. shellspec single-file mode).  Stay passive.
@@ -380,8 +403,20 @@ dual_master_check_one_round() {
   current_repl_info=$("${cli_cmd[@]}" info replication 2>/dev/null) || return 0
   current_role=$(cascade_extract_replication_field "${current_repl_info}" "role")
   if [ "${current_role}" != "master" ]; then
+    _dual_master_last_role="${current_role:-unknown}"
+    _dual_master_last_master_since=""
     echo "INFO: skip dual-master demote (skip-stale-role): local role is '${current_role:-unknown}', no longer master." >&2
     return 0
+  fi
+
+  if ! is_empty "${_dual_master_last_master_since}"; then
+    local now age
+    now="$(dual_master_epoch_now)"
+    age=$(( now - _dual_master_last_master_since ))
+    if [ "${age}" -lt "${DUAL_MASTER_PROMOTION_GRACE_SECONDS}" ]; then
+      echo "INFO: skip dual-master demote (skip-fresh-promotion): local role changed from slave to master ${age}s ago; waiting ${DUAL_MASTER_PROMOTION_GRACE_SECONDS}s before demotion decisions." >&2
+      return 0
+    fi
   fi
 
   echo "WARNING: rogue master detected — sentinel-quorum reports real master is '${quorum_master_fqdn}'; demoting self via REPLICAOF." >&2


### PR DESCRIPTION
## Summary

- Add a fresh-promotion grace window in `dual_master_check_one_round`.
- When the self-heal daemon observes a local `slave -> master` transition, it skips rogue-master demotion for `DUAL_MASTER_PROMOTION_GRACE_SECONDS` (default 120s).
- Keep the existing dual-master repair path after the grace window, so real stale rogue masters can still be demoted.
- Add shellspec coverage for both behaviors: grace-window skip and post-grace demote.

## Evidence

The 9.0.4 T14 stress run stopped at round 9 after 8 PASS / 1 FAIL. Frozen evidence showed:

- Sentinel accepted failover and promoted the candidate.
- The candidate entered PRIMARY.
- Less than 1s later, the self-heal daemon classified it as a rogue master because Sentinel still reported the old master, then issued `REPLICAOF` back to the old primary.
- Sentinel later aborted wait-promotion and the switchover action failed.

This patch prevents self-heal from racing Sentinel during that promotion propagation window.

## Validation

- `bash -n addons/valkey/scripts/valkey-self-heal.sh`
- `git diff --check`
- `shellspec -I shellspec --shell /opt/homebrew/bin/bash addons/valkey/scripts-ut-spec/valkey_self_heal_spec.sh`
  - `31 examples, 0 failures`

## Follow-up Validation

After merge into `feat/valkey-addon`, testing should rerun Valkey 9.0.4 T14 focused stress N=30 on the patched addon head. Any FAIL should stop and preserve the live scene.
