### PR TITLE
fix(mariadb): recover semisync slave status in merged rejoin

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.13
+version: 1.2.0-alpha.14
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -101,6 +101,23 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
+  replica_publish_recovers_semisync_slave_before_ready_marker() {
+    recover_line="$(grep -n 'recover_semisync_slave_health_after_rejoin' "$(template_file)" | tail -2 | head -1 | cut -d: -f1)"
+    ready_line="$(awk -v recover="${recover_line}" 'NR > recover && index($0, "mark_replication_ready") { print NR; exit }' "$(template_file)")"
+    [ -n "${recover_line}" ] && [ -n "${ready_line}" ] || return 1
+    [ "${recover_line}" -lt "${ready_line}" ]
+  }
+
+  runtime_secondary_reconcile_recovers_semisync_slave_before_ready_marker() {
+    awk '
+      index($0, "reconcile_sql_listener_for_syncer_secondary_once() {") { fn = 1 }
+      fn && index($0, "slave_status_is_healthy") { healthy = NR }
+      fn && index($0, "recover_semisync_slave_health_after_rejoin") { recover = NR }
+      fn && $0 ~ /^[[:space:]]*mark_replication_ready$/ { ready = NR; exit }
+      END { exit(healthy && recover && ready && healthy < recover && recover < ready ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   It "defines a merged-CmpD local primary publish readiness gate"
     When call function_contains "local_primary_role_published" ".primary-read-write-ready"
     The status should be success
@@ -184,6 +201,28 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
 
   It "accepts syncer primary promotion inside replica rejoin before fail-closing as replica"
     When call publish_rejoin_accepts_syncer_primary_before_defensive_fail_closed
+    The status should be success
+  End
+
+  It "defines semisync slave health recovery after replication rejoin"
+    When call template_contains "recover_semisync_slave_health_after_rejoin()"
+    The status should be success
+    The output should include "recover_semisync_slave_health_after_rejoin"
+  End
+
+  It "restarts the slave IO thread when semisync slave status stays OFF"
+    When call template_contains "STOP SLAVE IO_THREAD; START SLAVE IO_THREAD;"
+    The status should be success
+    The output should include "START SLAVE IO_THREAD"
+  End
+
+  It "recovers semisync slave health before publishing replica rejoin readiness"
+    When call replica_publish_recovers_semisync_slave_before_ready_marker
+    The status should be success
+  End
+
+  It "recovers semisync slave health before runtime secondary ready publication"
+    When call runtime_secondary_reconcile_recovers_semisync_slave_before_ready_marker
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -870,9 +870,9 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is current (alpha.89 — topology merge scaffolding + PD CUE schema with INI section binding + validate-replication-mode.sh helper mount)"
+    It "Chart.yaml literal version is current (alpha.14 — semisync slave health recovery after rejoin)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.13$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.14$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -2902,7 +2902,7 @@ EOF
       # chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.13"
+      The output should equal "version: 1.2.0-alpha.14"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -2963,7 +2963,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.13"
+        The output should equal "version: 1.2.0-alpha.14"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3140,7 +3140,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.13"
+        The output should equal "version: 1.2.0-alpha.14"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -79,8 +79,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.13 (alpha.13 bump: recover empty existing slave runtime channel)"
-      When call grep -c '^version: 1.2.0-alpha.13$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.14 (alpha.14 bump: recover semisync slave health after rejoin)"
+      When call grep -c '^version: 1.2.0-alpha.14$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -51,6 +51,13 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     [ "${recover_line}" -lt "${retry_line}" ]
   }
 
+  replica_publish_recovers_semisync_slave_before_ready_marker() {
+    recover_line="$(grep -n 'recover_semisync_slave_health_after_rejoin' "$(template_file)" | tail -2 | head -1 | cut -d: -f1)"
+    ready_line="$(awk -v recover="${recover_line}" 'NR > recover && index($0, "mark_replication_ready") { print NR; exit }' "$(template_file)")"
+    [ -n "${recover_line}" ] && [ -n "${ready_line}" ] || return 1
+    [ "${recover_line}" -lt "${ready_line}" ]
+  }
+
   It "declares an internal local admin before fencing user-facing root"
     When call template_contains 'MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"'
     The status should be success
@@ -310,6 +317,23 @@ Describe "cmpd-semisync.yaml rejoin fence template"
 
   It "accepts syncer primary promotion inside replica rejoin before fail-closing as replica"
     When call publish_rejoin_accepts_syncer_primary_before_defensive_fail_closed
+    The status should be success
+  End
+
+  It "defines semisync slave health recovery after replication rejoin"
+    When call template_contains "recover_semisync_slave_health_after_rejoin()"
+    The status should be success
+    The output should include "recover_semisync_slave_health_after_rejoin"
+  End
+
+  It "restarts the slave IO thread when semisync slave status stays OFF"
+    When call template_contains "STOP SLAVE IO_THREAD; START SLAVE IO_THREAD;"
+    The status should be success
+    The output should include "START SLAVE IO_THREAD"
+  End
+
+  It "recovers semisync slave health before publishing replica rejoin readiness"
+    When call replica_publish_recovers_semisync_slave_before_ready_marker
     The status should be success
   End
 

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1548,6 +1548,37 @@ spec:
                 *) return 1 ;;
               esac
             }
+            recover_semisync_slave_health_after_rejoin() {
+              local semisync_enabled
+              semisync_enabled=$("${LOCAL[@]}" -N -s -e \
+                "SELECT @@global.rpl_semi_sync_slave_enabled;" 2>/dev/null || echo "0")
+              [ "${semisync_enabled}" = "1" ] || return 0
+
+              local status deadline
+              deadline=$((SECONDS + 10))
+              while [ $SECONDS -lt $deadline ]; do
+                status=$("${LOCAL[@]}" -N -s -e \
+                  "SHOW STATUS LIKE 'Rpl_semi_sync_slave_status';" 2>/dev/null | awk '{print $2}')
+                [ "${status}" = "ON" ] && return 0
+                sleep 2
+              done
+
+              echo "Rpl_semi_sync_slave_status=OFF after replication rejoin; restarting IO thread"
+              "${LOCAL[@]}" -e "STOP SLAVE IO_THREAD; START SLAVE IO_THREAD;" 2>/dev/null || true
+
+              deadline=$((SECONDS + 15))
+              while [ $SECONDS -lt $deadline ]; do
+                status=$("${LOCAL[@]}" -N -s -e \
+                  "SHOW STATUS LIKE 'Rpl_semi_sync_slave_status';" 2>/dev/null | awk '{print $2}')
+                if [ "${status}" = "ON" ]; then
+                  echo "Rpl_semi_sync_slave_status recovered to ON after IO thread restart"
+                  return 0
+                fi
+                sleep 2
+              done
+
+              echo "WARNING: Rpl_semi_sync_slave_status still OFF after IO thread restart"
+            }
             # alpha.99 (Helen 2026-05-25): removed
             # slave_status_has_kb_health_check_repairable_error +
             # repair_kb_health_check_replication_error functions.
@@ -1692,6 +1723,7 @@ spec:
                 lock_local_root_writes "${label}-after-expose-not-healthy" || true # tier=fail-path-defensive
                 return 1
               fi
+              recover_semisync_slave_health_after_rejoin
               mark_replication_ready
               return 0
             }
@@ -2209,6 +2241,7 @@ spec:
               fi
               slave_status="$(query_slave_status_verbose || true)"
               if slave_status_is_healthy "${slave_status}"; then
+                recover_semisync_slave_health_after_rejoin
                 mark_replication_ready
                 prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
                 return 0

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1268,6 +1268,37 @@ spec:
                 *) return 1 ;;
               esac
             }
+            recover_semisync_slave_health_after_rejoin() {
+              local semisync_enabled
+              semisync_enabled=$("${LOCAL[@]}" -N -s -e \
+                "SELECT @@global.rpl_semi_sync_slave_enabled;" 2>/dev/null || echo "0")
+              [ "${semisync_enabled}" = "1" ] || return 0
+
+              local status deadline
+              deadline=$((SECONDS + 10))
+              while [ $SECONDS -lt $deadline ]; do
+                status=$("${LOCAL[@]}" -N -s -e \
+                  "SHOW STATUS LIKE 'Rpl_semi_sync_slave_status';" 2>/dev/null | awk '{print $2}')
+                [ "${status}" = "ON" ] && return 0
+                sleep 2
+              done
+
+              echo "Rpl_semi_sync_slave_status=OFF after replication rejoin; restarting IO thread"
+              "${LOCAL[@]}" -e "STOP SLAVE IO_THREAD; START SLAVE IO_THREAD;" 2>/dev/null || true
+
+              deadline=$((SECONDS + 15))
+              while [ $SECONDS -lt $deadline ]; do
+                status=$("${LOCAL[@]}" -N -s -e \
+                  "SHOW STATUS LIKE 'Rpl_semi_sync_slave_status';" 2>/dev/null | awk '{print $2}')
+                if [ "${status}" = "ON" ]; then
+                  echo "Rpl_semi_sync_slave_status recovered to ON after IO thread restart"
+                  return 0
+                fi
+                sleep 2
+              done
+
+              echo "WARNING: Rpl_semi_sync_slave_status still OFF after IO thread restart"
+            }
             slave_status_has_kb_health_check_repairable_error() {
               local slave_status="$1"
               [ -n "${slave_status}" ] || return 1
@@ -1416,6 +1447,7 @@ spec:
                 lock_local_root_writes "${label}-after-expose-not-healthy" || true # tier=fail-path-defensive
                 return 1
               fi
+              recover_semisync_slave_health_after_rejoin
               mark_replication_ready
               return 0
             }
@@ -1872,6 +1904,7 @@ spec:
               fi
               slave_status="$(query_slave_status_verbose || true)"
               if slave_status_is_healthy "${slave_status}"; then
+                recover_semisync_slave_health_after_rejoin
                 mark_replication_ready
                 prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
                 return 0


### PR DESCRIPTION
## Problem

The alpha.13 semisync full run stopped at CM4 after a static `back_log` reconfigure rolling restart. Replication IO/SQL threads were healthy, but the semisync slave side stayed OFF long enough for the test to fail.

## Observed symptom

`semisync CM4: semi-sync healthy after back_log restart` failed with primary `Rpl_semi_sync_master_status=ON` and secondary `Rpl_semi_sync_slave_status=OFF` after the bounded wait. The business pods stayed Running, so this is not a pod crash or runner-start failure.

## Reproduce

1. Deploy the semisync merged replication chart at alpha.13.
2. Run the semisync full suite from PR #173 commit `c1542af`.
3. Let CM4 perform static `back_log` reconfigure and rolling restart.
4. Observe the secondary after rejoin: `SHOW SLAVE STATUS` is healthy, but `SHOW STATUS LIKE 'Rpl_semi_sync_slave_status'` can remain `OFF`.

## Why this evidence supports the fix

The runner entered the real test body and stopped on the first CM4 assertion. The frozen scene showed the database pods were Running and replication itself was healthy, while the semisync slave status had not recovered. That narrows the first blocker to the addon rejoin readiness path: it was publishing replica readiness after IO/SQL health, without repairing or waiting for the semisync slave negotiation.

## Solution

This PR ports the semisync slave rejoin recovery into the merged replication CmpD used by the current semisync tests:

- add `recover_semisync_slave_health_after_rejoin()` to `cmpd-replication-merged.yaml`
- call it before replica readiness publication in the rejoin path and runtime secondary reconcile path
- keep the same helper in the legacy semisync CmpD for parity
- bump the chart to `1.2.0-alpha.14`
- update ShellSpec gates so the merged CmpD must recover semisync slave status before publishing readiness

## Verification

- `helm lint addons/mariadb` PASS
- `helm template mariadb-alpha14 addons/mariadb --set replication.mode=semisync` confirms the alpha.14 merged CmpD renders the recovery helper and IO-thread restart path
- ShellSpec full suite: 600 examples, 0 failures, 9 existing pending

## Runtime boundary

Runtime focused CM4 validation on alpha.14 is the next step. This PR is not claiming release-ready until focused CM4 passes and a fresh semisync full round passes from T1.
