### PR TITLE
fix(mariadb): wait for backup target connection

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.14
+version: 1.2.0-alpha.15
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/templates/actionset.yaml
+++ b/addons/mariadb/templates/actionset.yaml
@@ -20,7 +20,25 @@ spec:
           set -eo pipefail;
           export PATH="$PATH:$DP_DATASAFED_BIN_PATH";
           export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH";
-          echo "DB_HOST=${DP_DB_HOST} DB_USER=${DP_DB_USER} DB_PASSWORD=${DP_DB_PASSWORD} DATA_DIR=${DATA_DIR} BACKUP_DIR=${DP_BACKUP_DIR} BACKUP_NAME=${DP_BACKUP_NAME}";
+          echo "DB_HOST=${DP_DB_HOST} DB_USER=${DP_DB_USER} DB_PASSWORD=<redacted> DATA_DIR=${DATA_DIR} BACKUP_DIR=${DP_BACKUP_DIR} BACKUP_NAME=${DP_BACKUP_NAME}";
+          wait_for_mariadb_backup_target() {
+            local max_attempts=12
+            local sleep_seconds=5
+            local attempt=1
+            while [ "${attempt}" -le "${max_attempts}" ]; do
+              if mariadb --host="${DP_DB_HOST}" --user="${DP_DB_USER}" --password="${DP_DB_PASSWORD}" \
+                --connect-timeout=2 --skip-ssl -e "SELECT 1;" >/dev/null 2>&1; then
+                echo "MariaDB backup target reachable: host=${DP_DB_HOST} attempt=${attempt}";
+                return 0
+              fi
+              echo "Waiting for MariaDB connection: host=${DP_DB_HOST} attempt=${attempt}/${max_attempts}";
+              sleep "${sleep_seconds}";
+              attempt=$((attempt + 1))
+            done
+            echo "MariaDB backup target ${DP_DB_HOST} did not become reachable after $((max_attempts * sleep_seconds))s" >&2;
+            return 1
+          }
+          wait_for_mariadb_backup_target;
           mariadb-backup --backup --slave-info --stream=mbstream --host=${DP_DB_HOST} \
           --user=${DP_DB_USER} --password=${DP_DB_PASSWORD} --datadir=${DATA_DIR} \
           --skip-ssl | datasafed push - "/${DP_BACKUP_NAME}.mbstream";

--- a/addons/mariadb/templates/backuppolicytemplate.yaml
+++ b/addons/mariadb/templates/backuppolicytemplate.yaml
@@ -8,10 +8,10 @@ spec:
   serviceKind: Mariadb
   compDefs:
     - {{ include "mariadb.cmpdRegexpPattern" . }}
-  # The ActionSet uses `mariadb-backup --safe-slave-backup --slave-info`,
-  # designed to back up a replica without disrupting the writable primary.
-  # The secondary role is the preferred backup target; KubeBlocks falls
-  # back to the primary when no pod with role=secondary exists.
+  # The ActionSet uses `mariadb-backup --slave-info` and waits for the
+  # selected pod's SQL listener before streaming backup data. The
+  # secondary role is the preferred backup target; KubeBlocks falls back
+  # to the primary when no pod with role=secondary exists.
   #
   # Per-topology resolution of target.role under this single BPT:
   #   - replication / replication-merged / semisync: role=secondary
@@ -22,16 +22,13 @@ spec:
   #   - standalone: single pod with role=primary, resolved through
   #     fallbackRole=primary
   #
-  # Method-level override is intentionally NOT used here because
-  # `mariadb-backup --safe-slave-backup` is designed for replica
-  # execution (pauses SQL_thread, takes GTID-consistent snapshot,
-  # resumes). Compare with the MySQL addon, where xtrabackup methods
-  # explicitly override `target.role: primary` because xtrabackup lacks
-  # an equivalent replica-safety flag; the MariaDB tool does not need
-  # that override. If a PITR / binlog-archive method is added later it
-  # must override `target.role: primary` at the method level (binlog
-  # only exists on the primary), matching the MySQL `mysql-pitr`
-  # pattern.
+  # Method-level override is intentionally NOT used here because a
+  # replica full backup avoids primary write latency impact. The backup
+  # remains crash-consistent through InnoDB redo logging; `--slave-info`
+  # records replication metadata without stopping the SQL thread. If a
+  # PITR / binlog-archive method is added later it must override
+  # `target.role: primary` at the method level (binlog only exists on
+  # the primary), matching the MySQL `mysql-pitr` pattern.
   target:
     role: secondary
     fallbackRole: primary


### PR DESCRIPTION
## Problem

MariaDB semisync full suite r41 failed in the backup stage after T15 upgrade. The selected backup target was a secondary pod that was still inside a MariaDB restart window, so the backup container attempted `mariadb-backup` before port 3306 was accepting connections.

## Observed symptoms

- r41 result: 127 PASS / 1 FAIL / 2 SKIP.
- First failure: `semisync backup: Backup failed/timed out`.
- Backup container failed with connection refused against the selected target pod.
- Manager container kept waiting for `backup.info`, so the Backup stayed Running until the test timed out.
- A later focused backup on the same stable cluster completed successfully, which ruled out permanent BackupRepo, DNS, credential, or policy misconfiguration.

## Reproduction / evidence

Test run:

- namespace: `mdb-a14-r41`
- run id: `task453-alpha14-semisync-r41-full-aa0e880-20260605t1035z`
- evidence package sha256: `06a6788d4391375804d7085e3e5cc35c77f9b4f5c6c942746fcc7b8e00c49be5`

Timeline from collected pod/job logs:

- `11:07:05`: target pod MariaDB performed normal shutdown during the upgrade/restart window.
- `11:07:09`: backup container ran `mariadb-backup` and got connection refused.
- `11:07:24`: target pod became ready for connections.

Why this supports the judgment:

- The failure happens exactly inside a bounded MariaDB listener-unavailable window.
- The same BackupPolicy and same target path complete after the cluster is stable.
- The failing ActionSet previously had no DB connection wait before invoking `mariadb-backup`.

## Fix

- Redact `DP_DB_PASSWORD` from the ActionSet diagnostic echo.
- Add a bounded MariaDB connection wait before running `mariadb-backup`:
  - 12 attempts
  - 5s sleep
  - `--connect-timeout=2`
  - fail closed if the target is still unreachable after 60s
- Refresh BackupPolicyTemplate comments so they match the current `--slave-info` behavior and no longer mention the removed `--safe-slave-backup` flag.
- Bump chart version to `1.2.0-alpha.15`.

## Validation

Static validation:

- `helm lint addons/mariadb` PASS
- `helm template mariadb-test addons/mariadb --namespace kb-system --set replication.mode=semisync` PASS
- `git diff --check --cached` PASS
- rendered ActionSet contains password redaction and bounded wait

Runtime validation so far:

- Applied only the rendered alpha.15 ActionSet to the preserved r41 vcluster scene because a full Helm upgrade hit existing managedFields conflicts on ActionSet/CmpV ownership.
- Live ActionSet verified as chart label `mariadb-1.2.0-alpha.15` with the bounded wait and password redaction.
- Focused backup `mdb-ss-1094-backup-alpha15-restart-race` completed with real payload size `59528108` and duration `11s`.

Boundary:

- The focused backup proves the patched ActionSet works on the preserved cluster and does not regress backup behavior.
- It did not directly capture a retry-after-connection-refused log because the successful backup job was garbage-collected quickly and the target was already reachable when the job ran.
- This PR is not release-ready by itself; next step is deploying the chart cleanly and running r42 full suite from T1.
