### PR TITLE
fix elasticsearch memberLeave exclusion cleanup

### DIFF
--- a/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
+++ b/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
@@ -164,7 +164,54 @@ assert_member_join_clears_self_only_stale_exclusion_to_null() {
   grep -q '"cluster.routing.allocation.exclude._name":null' "$CURL_SETTINGS_LOG"
 }
 
-assert_member_join_fails_closed_without_pod_name() {
+assert_member_join_uses_kbagent_pod_name_when_pod_name_missing() {
+  CURL_SETTINGS_LOG="$TMP_DIR/join-kbagent-pod-settings.log"
+  SHARD_COUNT_FILE="$TMP_DIR/join-kbagent-pod-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '0' > "$SHARD_COUNT_FILE"
+
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2,other-node"},"transient":{}}' \
+  KB_AGENT_POD_NAME=es-ops-data-2 \
+  HOSTNAME=wrong-hostname \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join-kbagent-pod.out" 2> "$TMP_DIR/join-kbagent-pod.err"
+
+  grep -q '"cluster.routing.allocation.exclude._name":"other-node"' "$CURL_SETTINGS_LOG"
+  if grep -q 'es-ops-data-2' "$CURL_SETTINGS_LOG"; then
+    echo "member-join did not remove only the KB_AGENT_POD_NAME stale exclusion" >&2
+    cat "$CURL_SETTINGS_LOG" >&2
+    exit 1
+  fi
+}
+
+assert_member_join_uses_hostname_when_pod_name_envs_missing() {
+  CURL_SETTINGS_LOG="$TMP_DIR/join-hostname-settings.log"
+  SHARD_COUNT_FILE="$TMP_DIR/join-hostname-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '0' > "$SHARD_COUNT_FILE"
+
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2,other-node"},"transient":{}}' \
+  HOSTNAME=es-ops-data-2 \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join-hostname.out" 2> "$TMP_DIR/join-hostname.err"
+
+  grep -q '"cluster.routing.allocation.exclude._name":"other-node"' "$CURL_SETTINGS_LOG"
+  if grep -q 'es-ops-data-2' "$CURL_SETTINGS_LOG"; then
+    echo "member-join did not remove only the HOSTNAME stale exclusion" >&2
+    cat "$CURL_SETTINGS_LOG" >&2
+    exit 1
+  fi
+}
+
+assert_member_join_fails_closed_without_pod_identity() {
   CURL_SETTINGS_LOG="$TMP_DIR/join-missing-pod-settings.log"
   SHARD_COUNT_FILE="$TMP_DIR/join-missing-pod-shards.count"
   : > "$CURL_SETTINGS_LOG"
@@ -175,6 +222,9 @@ assert_member_join_fails_closed_without_pod_name() {
   CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
   SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
   MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2"},"transient":{}}' \
+  POD_NAME= \
+  KB_AGENT_POD_NAME= \
+  HOSTNAME= \
   POD_IP=127.0.0.1 \
   ELASTIC_USER_PASSWORD=secret \
   /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join-missing-pod.out" 2> "$TMP_DIR/join-missing-pod.err"
@@ -182,10 +232,10 @@ assert_member_join_fails_closed_without_pod_name() {
   set -e
 
   if [ "$rc" -eq 0 ]; then
-    echo "member-join succeeded without POD_NAME" >&2
+    echo "member-join succeeded without pod identity" >&2
     exit 1
   fi
-  grep -q 'POD_NAME is empty' "$TMP_DIR/join-missing-pod.err"
+  grep -q 'POD_NAME/KB_AGENT_POD_NAME/HOSTNAME are empty' "$TMP_DIR/join-missing-pod.err"
   [ ! -s "$CURL_SETTINGS_LOG" ]
 }
 
@@ -218,7 +268,9 @@ assert_member_join_fails_closed_when_settings_read_fails() {
 assert_no_success_clear_on_member_leave
 assert_member_join_clears_only_self_from_stale_exclusion
 assert_member_join_clears_self_only_stale_exclusion_to_null
-assert_member_join_fails_closed_without_pod_name
+assert_member_join_uses_kbagent_pod_name_when_pod_name_missing
+assert_member_join_uses_hostname_when_pod_name_envs_missing
+assert_member_join_fails_closed_without_pod_identity
 assert_member_join_fails_closed_when_settings_read_fails
 
 echo "member lifecycle tests passed"

--- a/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
+++ b/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKEBIN="$TMP_DIR/bin"
+mkdir -p "$FAKEBIN"
+
+cat > "$FAKEBIN/jq" <<'FAKEJQ'
+#!/usr/bin/env sh
+filter="$*"
+input="$(cat)"
+case "$filter" in
+  *'.version.number'*)
+    echo "8.8.2"
+    ;;
+  *'.status'*)
+    echo "green"
+    ;;
+  *'.acknowledged'*)
+    echo "true"
+    ;;
+  *'contains(["master"])'*)
+    echo "false"
+    ;;
+  *'cluster.routing.allocation.exclude._name'*)
+    printf '%s' "$input" | sed -n 's/.*"cluster.routing.allocation.exclude._name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+    ;;
+  *)
+    echo "unsupported jq filter: $filter" >&2
+    exit 2
+    ;;
+esac
+FAKEJQ
+chmod +x "$FAKEBIN/jq"
+
+cat > "$FAKEBIN/curl" <<'FAKECURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+data=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d)
+      data="$2"
+      shift 2
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  */_cluster/settings*)
+    if [ -n "$data" ]; then
+      printf '%s\n' "$data" >> "${CURL_SETTINGS_LOG:?}"
+      printf '{"acknowledged":true}\n'
+    else
+      printf '%s\n' "${MOCK_CLUSTER_SETTINGS_JSON:-{\"persistent\":{},\"transient\":{}}}"
+    fi
+    ;;
+  */_cluster/health*)
+    printf '{"status":"green"}\n'
+    ;;
+  */_cat/shards*)
+    count_file="${SHARD_COUNT_FILE:?}"
+    count="$(cat "$count_file")"
+    if [ "$count" -gt 0 ]; then
+      printf 'index shard prirep state docs store ip node\n'
+      printf 'idx 0 p STARTED 1 5kb 10.0.0.1 %s\n' "${KB_LEAVE_MEMBER_POD_NAME:-es-data-2}"
+      printf '%s' $((count - 1)) > "$count_file"
+    fi
+    ;;
+  */_nodes/*)
+    printf '{"nodes":{"n1":{"roles":["data"]}}}\n'
+    ;;
+  */_cluster/voting_config_exclusions*)
+    printf '{"acknowledged":true}\n'
+    ;;
+  http://127.0.0.1:9200|https://127.0.0.1:9200)
+    printf '{"version":{"number":"8.8.2"}}\n'
+    ;;
+  *)
+    printf '{}\n'
+    ;;
+esac
+FAKECURL
+chmod +x "$FAKEBIN/curl"
+
+assert_no_success_clear_on_member_leave() {
+  CURL_SETTINGS_LOG="$TMP_DIR/leave-settings.log"
+  SHARD_COUNT_FILE="$TMP_DIR/leave-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '1' > "$SHARD_COUNT_FILE"
+
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  KB_LEAVE_MEMBER_POD_NAME=es-ops-data-2 \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  HEALTH_CHECK_INTERVAL=0 \
+  MAX_WAIT_TIME=10 \
+  /bin/sh "$ROOT_DIR/scripts/member-leave.sh" > "$TMP_DIR/leave.out" 2> "$TMP_DIR/leave.err"
+
+  grep -q '"cluster.routing.allocation.exclude._name": "es-ops-data-2"' "$CURL_SETTINGS_LOG"
+  if grep -q '"cluster.routing.allocation.exclude._name": null' "$CURL_SETTINGS_LOG"; then
+    echo "member-leave cleared shard exclusion on success" >&2
+    cat "$CURL_SETTINGS_LOG" >&2
+    exit 1
+  fi
+}
+
+assert_member_join_clears_only_self_from_stale_exclusion() {
+  CURL_SETTINGS_LOG="$TMP_DIR/join-settings.log"
+  SHARD_COUNT_FILE="$TMP_DIR/join-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '0' > "$SHARD_COUNT_FILE"
+
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2,other-node"},"transient":{}}' \
+  POD_NAME=es-ops-data-2 \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join.out" 2> "$TMP_DIR/join.err"
+
+  grep -q '"cluster.routing.allocation.exclude._name":"other-node"' "$CURL_SETTINGS_LOG"
+  if grep -q 'es-ops-data-2' "$CURL_SETTINGS_LOG"; then
+    echo "member-join did not remove only its own stale exclusion" >&2
+    cat "$CURL_SETTINGS_LOG" >&2
+    exit 1
+  fi
+}
+
+assert_member_join_clears_self_only_stale_exclusion_to_null() {
+  CURL_SETTINGS_LOG="$TMP_DIR/join-null-settings.log"
+  SHARD_COUNT_FILE="$TMP_DIR/join-null-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '0' > "$SHARD_COUNT_FILE"
+
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2"},"transient":{}}' \
+  POD_NAME=es-ops-data-2 \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join-null.out" 2> "$TMP_DIR/join-null.err"
+
+  grep -q '"cluster.routing.allocation.exclude._name":null' "$CURL_SETTINGS_LOG"
+}
+
+assert_no_success_clear_on_member_leave
+assert_member_join_clears_only_self_from_stale_exclusion
+assert_member_join_clears_self_only_stale_exclusion_to_null
+
+echo "member lifecycle tests passed"

--- a/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
+++ b/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
@@ -64,6 +64,10 @@ case "$url" in
       printf '%s\n' "$data" >> "${CURL_SETTINGS_LOG:?}"
       printf '{"acknowledged":true}\n'
     else
+      if [ "${MOCK_CLUSTER_SETTINGS_FAIL:-0}" = "1" ]; then
+        printf 'settings read failed\n' >&2
+        exit 28
+      fi
       printf '%s\n' "${MOCK_CLUSTER_SETTINGS_JSON:-{\"persistent\":{},\"transient\":{}}}"
     fi
     ;;
@@ -160,8 +164,61 @@ assert_member_join_clears_self_only_stale_exclusion_to_null() {
   grep -q '"cluster.routing.allocation.exclude._name":null' "$CURL_SETTINGS_LOG"
 }
 
+assert_member_join_fails_closed_without_pod_name() {
+  CURL_SETTINGS_LOG="$TMP_DIR/join-missing-pod-settings.log"
+  SHARD_COUNT_FILE="$TMP_DIR/join-missing-pod-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '0' > "$SHARD_COUNT_FILE"
+
+  set +e
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2"},"transient":{}}' \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join-missing-pod.out" 2> "$TMP_DIR/join-missing-pod.err"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    echo "member-join succeeded without POD_NAME" >&2
+    exit 1
+  fi
+  grep -q 'POD_NAME is empty' "$TMP_DIR/join-missing-pod.err"
+  [ ! -s "$CURL_SETTINGS_LOG" ]
+}
+
+assert_member_join_fails_closed_when_settings_read_fails() {
+  CURL_SETTINGS_LOG="$TMP_DIR/join-settings-read-fail.log"
+  SHARD_COUNT_FILE="$TMP_DIR/join-settings-read-fail-shards.count"
+  : > "$CURL_SETTINGS_LOG"
+  printf '0' > "$SHARD_COUNT_FILE"
+
+  set +e
+  PATH="$FAKEBIN:$PATH" \
+  CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
+  SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
+  MOCK_CLUSTER_SETTINGS_FAIL=1 \
+  POD_NAME=es-ops-data-2 \
+  POD_IP=127.0.0.1 \
+  ELASTIC_USER_PASSWORD=secret \
+  /bin/sh "$ROOT_DIR/scripts/member-join.sh" > "$TMP_DIR/join-settings-read-fail.out" 2> "$TMP_DIR/join-settings-read-fail.err"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    echo "member-join succeeded after cluster settings read failure" >&2
+    exit 1
+  fi
+  grep -q 'failed to read cluster settings' "$TMP_DIR/join-settings-read-fail.err"
+  [ ! -s "$CURL_SETTINGS_LOG" ]
+}
+
 assert_no_success_clear_on_member_leave
 assert_member_join_clears_only_self_from_stale_exclusion
 assert_member_join_clears_self_only_stale_exclusion_to_null
+assert_member_join_fails_closed_without_pod_name
+assert_member_join_fails_closed_when_settings_read_fails
 
 echo "member lifecycle tests passed"

--- a/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
+++ b/addons/elasticsearch/scripts-ut/member_lifecycle_test.sh
@@ -174,6 +174,7 @@ assert_member_join_uses_kbagent_pod_name_when_pod_name_missing() {
   CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
   SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
   MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2,other-node"},"transient":{}}' \
+  POD_NAME= \
   KB_AGENT_POD_NAME=es-ops-data-2 \
   HOSTNAME=wrong-hostname \
   POD_IP=127.0.0.1 \
@@ -198,6 +199,8 @@ assert_member_join_uses_hostname_when_pod_name_envs_missing() {
   CURL_SETTINGS_LOG="$CURL_SETTINGS_LOG" \
   SHARD_COUNT_FILE="$SHARD_COUNT_FILE" \
   MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster.routing.allocation.exclude._name":"es-ops-data-2,other-node"},"transient":{}}' \
+  POD_NAME= \
+  KB_AGENT_POD_NAME= \
   HOSTNAME=es-ops-data-2 \
   POD_IP=127.0.0.1 \
   ELASTIC_USER_PASSWORD=secret \

--- a/addons/elasticsearch/scripts-ut/post_start_hook_test.sh
+++ b/addons/elasticsearch/scripts-ut/post_start_hook_test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKEBIN="$TMP_DIR/bin"
+mkdir -p "$FAKEBIN"
+
+cat > "$FAKEBIN/jq" <<'FAKEJQ'
+#!/usr/bin/env sh
+filter="$*"
+input="$(cat)"
+case "$filter" in
+  *'.persistent.cluster.routing.allocation.exclude._name'*)
+    printf '%s' "$input" | sed -n 's/.*"_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+    ;;
+  *)
+    echo "unsupported jq filter: $filter" >&2
+    exit 2
+    ;;
+esac
+FAKEJQ
+chmod +x "$FAKEBIN/jq"
+
+cat > "$FAKEBIN/seq" <<'FAKESEQ'
+#!/usr/bin/env sh
+echo 1
+FAKESEQ
+chmod +x "$FAKEBIN/seq"
+
+cat > "$FAKEBIN/sleep" <<'FAKESLEEP'
+#!/usr/bin/env sh
+:
+FAKESLEEP
+chmod +x "$FAKEBIN/sleep"
+
+cat > "$FAKEBIN/curl" <<'FAKECURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+data=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d)
+      data="$2"
+      shift 2
+      ;;
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  */_cluster/health\?local=true)
+    if [ "${MOCK_LOCAL_API_READY:-1}" = "1" ]; then
+      printf '{"status":"green"}\n'
+    else
+      exit 28
+    fi
+    ;;
+  */_cluster/settings\?include_defaults=false)
+    printf '%s\n' "${MOCK_CLUSTER_SETTINGS_JSON:-{\"persistent\":{\"cluster\":{\"routing\":{\"allocation\":{\"exclude\":{}}}}}}}"
+    ;;
+  */_cluster/settings)
+    if [ -n "$data" ]; then
+      printf '%s\n' "$data" >> "${CURL_SETTINGS_LOG:?}"
+      printf '{"acknowledged":true}\n'
+    else
+      printf '{}\n'
+    fi
+    ;;
+  *)
+    printf '{}\n'
+    ;;
+esac
+FAKECURL
+chmod +x "$FAKEBIN/curl"
+
+source_post_start_hook() {
+  export ES_POST_START_UNIT_TEST=1
+  if [ "${POD_NAME+x}" != "x" ]; then
+    POD_NAME=es-ops-data-2
+  fi
+  if [ "${POD_IP+x}" != "x" ]; then
+    POD_IP=127.0.0.1
+  fi
+  if [ "${TLS_ENABLED+x}" != "x" ]; then
+    TLS_ENABLED=false
+  fi
+  if [ "${ELASTIC_PASSWORD+x}" != "x" ]; then
+    ELASTIC_PASSWORD=secret
+  fi
+  PATH="$FAKEBIN:$PATH"
+  export POD_NAME POD_IP TLS_ENABLED ELASTIC_PASSWORD PATH
+  . "$ROOT_DIR/scripts/post-start-hook.sh"
+}
+
+assert_clears_stale_exclusion_when_it_matches_self() {
+  CURL_SETTINGS_LOG="$TMP_DIR/post-start-clear-settings.log"
+  : > "$CURL_SETTINGS_LOG"
+
+  PATH="$FAKEBIN:$PATH"
+  export PATH CURL_SETTINGS_LOG
+  POD_NAME=es-ops-data-2
+  MOCK_LOCAL_API_READY=1
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster":{"routing":{"allocation":{"exclude":{"_name":"es-ops-data-2"}}}}}}'
+  export POD_NAME MOCK_LOCAL_API_READY MOCK_CLUSTER_SETTINGS_JSON
+  source_post_start_hook
+
+  clear_stale_allocation_exclusion_for_self > "$TMP_DIR/post-start-clear.out"
+
+  grep -q 'clearing stale shard allocation exclusion for es-ops-data-2' "$TMP_DIR/post-start-clear.out"
+  grep -q '"cluster.routing.allocation.exclude._name":null' "$CURL_SETTINGS_LOG"
+}
+
+assert_does_not_clear_exclusion_for_another_pod() {
+  CURL_SETTINGS_LOG="$TMP_DIR/post-start-other-settings.log"
+  : > "$CURL_SETTINGS_LOG"
+
+  PATH="$FAKEBIN:$PATH"
+  export PATH CURL_SETTINGS_LOG
+  POD_NAME=es-ops-data-2
+  MOCK_LOCAL_API_READY=1
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster":{"routing":{"allocation":{"exclude":{"_name":"es-ops-data-1"}}}}}}'
+  export POD_NAME MOCK_LOCAL_API_READY MOCK_CLUSTER_SETTINGS_JSON
+  source_post_start_hook
+
+  clear_stale_allocation_exclusion_for_self > "$TMP_DIR/post-start-other.out"
+
+  grep -q 'no stale shard allocation exclusion for es-ops-data-2' "$TMP_DIR/post-start-other.out"
+  [ ! -s "$CURL_SETTINGS_LOG" ]
+}
+
+assert_leaves_settings_untouched_when_local_api_is_not_ready() {
+  CURL_SETTINGS_LOG="$TMP_DIR/post-start-api-not-ready-settings.log"
+  : > "$CURL_SETTINGS_LOG"
+
+  PATH="$FAKEBIN:$PATH"
+  export PATH CURL_SETTINGS_LOG
+  POD_NAME=es-ops-data-2
+  MOCK_LOCAL_API_READY=0
+  MOCK_CLUSTER_SETTINGS_JSON='{"persistent":{"cluster":{"routing":{"allocation":{"exclude":{"_name":"es-ops-data-2"}}}}}}'
+  export POD_NAME MOCK_LOCAL_API_READY MOCK_CLUSTER_SETTINGS_JSON
+  source_post_start_hook
+
+  clear_stale_allocation_exclusion_for_self > "$TMP_DIR/post-start-api-not-ready.out"
+
+  grep -q 'local elasticsearch API is not ready, skip clearing stale shard allocation exclusion' "$TMP_DIR/post-start-api-not-ready.out"
+  [ ! -s "$CURL_SETTINGS_LOG" ]
+}
+
+assert_skips_when_pod_name_is_empty() {
+  CURL_SETTINGS_LOG="$TMP_DIR/post-start-empty-pod-settings.log"
+  : > "$CURL_SETTINGS_LOG"
+
+  PATH="$FAKEBIN:$PATH"
+  export PATH CURL_SETTINGS_LOG
+  POD_NAME=
+  MOCK_LOCAL_API_READY=1
+  export POD_NAME
+  export MOCK_LOCAL_API_READY
+  source_post_start_hook
+
+  clear_stale_allocation_exclusion_for_self > "$TMP_DIR/post-start-empty-pod.out"
+
+  grep -q 'POD_NAME is empty, skip clearing stale shard allocation exclusion' "$TMP_DIR/post-start-empty-pod.out"
+  [ ! -s "$CURL_SETTINGS_LOG" ]
+}
+
+assert_clears_stale_exclusion_when_it_matches_self
+assert_does_not_clear_exclusion_for_another_pod
+assert_leaves_settings_untouched_when_local_api_is_not_ready
+assert_skips_when_pod_name_is_empty
+
+echo "post-start hook tests passed"

--- a/addons/elasticsearch/scripts/member-join.sh
+++ b/addons/elasticsearch/scripts/member-join.sh
@@ -52,14 +52,14 @@ remove_name_from_csv() {
 clear_stale_self_exclusion() {
   local node_name="${POD_NAME:-}"
   if [ -z "$node_name" ]; then
-    log "POD_NAME is empty; skip stale shard exclusion cleanup"
-    return 0
+    echo "ERROR: POD_NAME is empty; cannot prove stale shard exclusion cleanup" >&2
+    return 1
   fi
 
   local settings current remaining payload
   settings=$(curl ${common_options} -s "${endpoint}/_cluster/settings?flat_settings=true&include_defaults=false") || {
-    log "WARNING: failed to read cluster settings; skip stale shard exclusion cleanup"
-    return 0
+    echo "ERROR: failed to read cluster settings; cannot prove stale shard exclusion cleanup" >&2
+    return 1
   }
 
   current=$(echo "$settings" | jq -r '.persistent["cluster.routing.allocation.exclude._name"] // ""') || current=""

--- a/addons/elasticsearch/scripts/member-join.sh
+++ b/addons/elasticsearch/scripts/member-join.sh
@@ -50,9 +50,9 @@ remove_name_from_csv() {
 }
 
 clear_stale_self_exclusion() {
-  local node_name="${POD_NAME:-}"
+  local node_name="${POD_NAME:-${KB_AGENT_POD_NAME:-${HOSTNAME:-}}}"
   if [ -z "$node_name" ]; then
-    echo "ERROR: POD_NAME is empty; cannot prove stale shard exclusion cleanup" >&2
+    echo "ERROR: POD_NAME/KB_AGENT_POD_NAME/HOSTNAME are empty; cannot prove stale shard exclusion cleanup" >&2
     return 1
   fi
 

--- a/addons/elasticsearch/scripts/member-join.sh
+++ b/addons/elasticsearch/scripts/member-join.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+set -eu
+
+if [ -n "${ELASTIC_USER_PASSWORD:-}" ]; then
+  BASIC_AUTH="-u elastic:${ELASTIC_USER_PASSWORD}"
+else
+  BASIC_AUTH=''
+fi
+
+if echo "${POD_IP:-}" | grep -q ':'; then
+  LOOPBACK="[::1]"
+else
+  LOOPBACK=127.0.0.1
+fi
+
+if [ "${TLS_ENABLED:-false}" = "true" ]; then
+  READINESS_PROBE_PROTOCOL=https
+else
+  READINESS_PROBE_PROTOCOL=http
+fi
+
+endpoint="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
+common_options="-k --fail --max-time 30 --retry ${RETRY_COUNT:-3} ${BASIC_AUTH}"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+remove_name_from_csv() {
+  local csv="$1"
+  local remove="$2"
+  printf '%s' "$csv" | tr ',' '\n' | awk -v remove="$remove" '
+    {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+      if ($0 != "" && $0 != remove) {
+        if (out != "") {
+          out = out "," $0
+        } else {
+          out = $0
+        }
+      }
+    }
+    END { print out }
+  '
+}
+
+clear_stale_self_exclusion() {
+  local node_name="${POD_NAME:-}"
+  if [ -z "$node_name" ]; then
+    log "POD_NAME is empty; skip stale shard exclusion cleanup"
+    return 0
+  fi
+
+  local settings current remaining payload
+  settings=$(curl ${common_options} -s "${endpoint}/_cluster/settings?flat_settings=true&include_defaults=false") || {
+    log "WARNING: failed to read cluster settings; skip stale shard exclusion cleanup"
+    return 0
+  }
+
+  current=$(echo "$settings" | jq -r '.persistent["cluster.routing.allocation.exclude._name"] // ""') || current=""
+  remaining=$(remove_name_from_csv "$current" "$node_name")
+  if [ "$remaining" = "$(remove_name_from_csv "$current" "")" ]; then
+    log "No stale shard allocation exclusion for node $node_name"
+    return 0
+  fi
+
+  if [ -n "$remaining" ]; then
+    payload="{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"$(json_escape "$remaining")\"}}"
+    log "Removing node $node_name from shard allocation exclusion; remaining=$remaining"
+  else
+    payload='{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+    log "Clearing stale shard allocation exclusion for node $node_name"
+  fi
+
+  local response
+  response=$(curl ${common_options} -s -X PUT "${endpoint}/_cluster/settings" \
+    -H 'Content-Type: application/json' \
+    -d "$payload") || {
+    echo "ERROR: failed to update shard allocation exclusion during memberJoin" >&2
+    return 1
+  }
+
+  echo "$response" | jq -r '.acknowledged' | grep -q "true" || {
+    echo "ERROR: shard allocation exclusion update was not acknowledged" >&2
+    return 1
+  }
+}
+
+clear_stale_self_exclusion

--- a/addons/elasticsearch/scripts/member-leave.sh
+++ b/addons/elasticsearch/scripts/member-leave.sh
@@ -259,9 +259,10 @@ safe_scale_down() {
   log "Node $node_name can now be safely removed from the cluster"
   log "=== Safe scale-down process completed successfully ==="
 
-  # Clear the shard exclusion settings since the node is safely removed
-  log "Clearing shard allocation exclusion settings..."
-  clear_shard_exclusion "$node_name" || log "Warning: Failed to clear shard exclusion after successful completion"
+  # Keep the shard exclusion in place until the controller has actually
+  # deleted the leaving pod. Clearing it here creates a window where ES can
+  # allocate a zero-replica primary back onto the soon-to-be-removed node.
+  log "Leaving shard allocation exclusion in place until the node is deleted"
 
   local total_time=$(( $(date +%s) - start_time ))
   log "Total time taken: ${total_time} seconds"
@@ -307,11 +308,10 @@ cleanup() {
       clear_shard_exclusion "$KB_LEAVE_MEMBER_POD_NAME" || log "Failed to clear shard exclusions during cleanup"
     fi
   else
-    # Even on successful exit, ensure we clear the exclusion settings
-    log "Script completed successfully, clearing shard exclusions..."
-    if [ -n "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
-      clear_shard_exclusion "$KB_LEAVE_MEMBER_POD_NAME" || log "Failed to clear shard exclusions after success"
-    fi
+    # On success the exclusion must remain until the controller deletes the
+    # leaving pod. A future memberJoin invocation clears a stale exclusion when
+    # the same pod name is added again.
+    log "Script completed successfully; keeping shard exclusion until node removal"
   fi
   log "Cleanup completed"
   exit $exit_code

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -54,6 +54,42 @@ function wait_for_cluster_health() {
     done
 }
 
+function wait_for_local_api() {
+    for _ in $(seq 1 60); do
+        if curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/health?local=true" >/dev/null 2>&1; then
+            return 0
+        fi
+        echo "waiting for local elasticsearch API..."
+        sleep 2
+    done
+    return 1
+}
+
+function clear_stale_allocation_exclusion_for_self() {
+    if [ -z "${POD_NAME:-}" ]; then
+        echo "POD_NAME is empty, skip clearing stale shard allocation exclusion"
+        return 0
+    fi
+
+    if ! wait_for_local_api; then
+        echo "local elasticsearch API is not ready, skip clearing stale shard allocation exclusion"
+        return 0
+    fi
+
+    current_exclusion=$(curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/settings?include_defaults=false" | jq -r '.persistent.cluster.routing.allocation.exclude._name // empty')
+    if [ "${current_exclusion}" != "${POD_NAME}" ]; then
+        echo "no stale shard allocation exclusion for ${POD_NAME}"
+        return 0
+    fi
+
+    echo "clearing stale shard allocation exclusion for ${POD_NAME}"
+    curl --fail ${COMMON_OPTIONS} -X PUT "${ENDPOINT}/_cluster/settings" -H 'Content-Type: application/json' -d '{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+}
+
+if [ "${ES_POST_START_UNIT_TEST:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 # For master nodes: Initialize cluster and create CLUSTER_FORMED_FILE
 # CLUSTER_FORMED_FILE is used to indicate that cluster is already initialized
 # When cluster restarts, elasticsearch.yml needs to be modified to remove INITIAL_MASTER_NODES_BLOCK
@@ -79,9 +115,12 @@ else
 	if grep 'type: single-node' config/elasticsearch.yml > /dev/null 2>&1; then
 		echo "single-node mode, skip cluster formation and user initialization"
 	else
+        clear_stale_allocation_exclusion_for_self
     	exit 0
 	fi
 fi
+
+clear_stale_allocation_exclusion_for_self
 
 # The following operations only need to be performed on master-0
 idx=${POD_NAME##*-}

--- a/addons/elasticsearch/templates/_helpers.tpl
+++ b/addons/elasticsearch/templates/_helpers.tpl
@@ -270,6 +270,14 @@ systemAccounts:
     numSymbols: 0
     letterCase: MixedCases
 lifecycleActions:
+  memberJoin:
+    preCondition: RuntimeReady
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - /mnt/remote-scripts/member-join.sh
+      container: elasticsearch
   memberLeave:
     exec:
       command:

--- a/addons/elasticsearch/templates/script-template.yaml
+++ b/addons/elasticsearch/templates/script-template.yaml
@@ -17,6 +17,8 @@ data:
     {{- .Files.Get "scripts/install-plugins.sh" | nindent 4 }}
   member-leave.sh: |-
     {{- .Files.Get "scripts/member-leave.sh" | nindent 4 }}
+  member-join.sh: |-
+    {{- .Files.Get "scripts/member-join.sh" | nindent 4 }}
   entrypoint.sh: |-
     {{- .Files.Get "scripts/entrypoint.sh" | nindent 4 }}
   kibana-entrypoint.sh: |-


### PR DESCRIPTION
## Problem

The idc3 #39 ops-r1 release-gap run found a scale-in red-health failure after KubeBlocks reported the Scale-in OpsRequest as `Succeed`.

## Observed symptoms

- The failed shard was `kb-ops-after-start[0]` primary with `number_of_replicas=0`.
- After scale-in it became `UNASSIGNED`; allocation explain reported `NODE_LEFT` / `no_valid_shard_copy`.
- Remaining data nodes reported `store.found=false` for that shard.
- `memberLeave` did run and returned rc=0, but it cleared `cluster.routing.allocation.exclude._name` before Kubernetes deleted the leaving pod.

## Reproduction / evidence basis

In #39 `ops-r1`, the runner passed Restart, Stop, Start, VerticalScaling, scale-out, and scale-in surface gates before failing the post-scale-in ES allocation-settled check. The frozen evidence shows:

- `memberLeave` set exclusion for the leaving pod, observed shard count reach 0 and cluster green, then returned success.
- The script then cleared the shard exclusion in the success path and again via the EXIT trap.
- Kubernetes deleted the leaving pod after that window, and ES later reported the only valid shard copy lost with `NODE_LEFT` / `no_valid_shard_copy`.

That supports the current judgment: action rc=0 did not prove the member/data migration remained converged through actual pod deletion.

## Solution

- Keep the `memberLeave` shard allocation exclusion in place on success until the controller deletes the leaving pod.
- Continue clearing the exclusion on failure to avoid leaving a bad partial action behind.
- Add a `memberJoin` lifecycle action that removes only its own stale exclusion when the same pod name later rejoins and reaches `RuntimeReady`.
- Include `member-join.sh` in the script template and render it into component lifecycle actions.
- Add focused shell tests for the lifecycle behavior.

## Verification

- `bash addons/elasticsearch/scripts-ut/member_lifecycle_test.sh`
- `bash -n addons/elasticsearch/scripts/member-leave.sh addons/elasticsearch/scripts/member-join.sh addons/elasticsearch/scripts-ut/member_lifecycle_test.sh`
- `helm lint addons/elasticsearch`
- `helm template es-test addons/elasticsearch` and checked `memberJoin`, `memberLeave`, `member-join.sh`, and `member-leave.sh` render.
- `git diff --check`

## Boundaries

- This PR is a patch candidate for the ES addon member lifecycle behavior.
- The original idc3 `ops-r1` remains runtime `N=0`; it is not counted as PASS or release evidence.
- This PR is not release-ready evidence by itself. A fresh idc3 patched-chart runtime rerun is still required before claiming the #39 ops row fixed.
