### PR TITLE
fix(mariadb): gate runtime secondary publish on listener readiness

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -78,6 +78,16 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
+  secondary_expose_fast_path_requires_real_wildcard_listener() {
+    awk '
+      index($0, "expose_sql_listener_for_safe_role() {") { fn = 1 }
+      fn && index($0, ".sql-listener-ready") && index($0, "mariadbd_listen_on_all_interfaces") { found = 1 }
+      fn && index($0, "sql-listener-expose-stale-marker") { stale = 1 }
+      fn && index($0, "sql-listener-expose-begin") { exit(found && stale ? 0 : 1) }
+      END { exit(found && stale ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   no_slave_startup_loop_reconciles_syncer_primary_even_with_stale_listener_marker() {
     awk '
       index($0, "elif [ -n \"${PRIMARY_SID}\" ] || [ \"${POD_INDEX}\" -gt 0 ]; then") { branch = 1 }
@@ -139,13 +149,14 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
-  runtime_secondary_reconcile_recovers_semisync_slave_before_ready_marker() {
+  runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate() {
     awk '
       index($0, "reconcile_sql_listener_for_syncer_secondary_once() {") { fn = 1 }
       fn && index($0, "slave_status_is_healthy") { healthy = NR }
-      fn && index($0, "recover_semisync_slave_health_after_rejoin") { recover = NR }
-      fn && $0 ~ /^[[:space:]]*mark_replication_ready$/ { ready = NR; exit }
-      END { exit(healthy && recover && ready && healthy < recover && recover < ready ? 0 : 1) }
+      fn && index($0, "publish_replica_after_rejoin_ready \"runtime-secondary-reconcile\"") { publish = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-ready") { ready = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-pending-after-publish") { pending = NR; exit }
+      END { exit(healthy && publish && ready && pending && healthy < publish && publish < ready && ready < pending ? 0 : 1) }
     ' "$(template_file)"
   }
 
@@ -200,6 +211,11 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
 
   It "does not trust .sql-listener-ready without a real wildcard listener in syncer-primary fast path"
     When call primary_reconcile_fast_path_requires_real_wildcard_listener
+    The status should be success
+  End
+
+  It "does not trust .sql-listener-ready without a real wildcard listener in syncer-secondary expose path"
+    When call secondary_expose_fast_path_requires_real_wildcard_listener
     The status should be success
   End
 
@@ -267,8 +283,8 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     The status should be success
   End
 
-  It "recovers semisync slave health before runtime secondary ready publication"
-    When call runtime_secondary_reconcile_recovers_semisync_slave_before_ready_marker
+  It "publishes a healthy runtime secondary through the SQL listener gate"
+    When call runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -322,6 +322,40 @@ Last_SQL_Errno: 0"
       End
     End
 
+    Context "when semisync pending secondary already has ready marker and SQL replication is healthy"
+      setup_semisync_pending_secondary_mixed_markers_ready() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_RC=0
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT="Slave_IO_Running: Yes
+Slave_SQL_Running: Yes
+Last_IO_Errno: 0
+Last_SQL_Errno: 0"
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/.replication-ready"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_semisync_pending_secondary_mixed_markers_ready"
+
+      It "publishes secondary and clears the stale pending marker"
+        When call check_role
+        The status should be success
+        The output should eq "secondary"
+        The path "${TEST_DIR}/.replication-ready" should be exist
+        The path "${TEST_DIR}/.sql-listener-ready" should be exist
+        The path "${TEST_DIR}/.replication-pending" should not be exist
+      End
+    End
+
     Context "when semisync pending secondary has variable shape but no replication truth"
       setup_semisync_pending_secondary_empty_slave_status() {
         unset MARIADB_ROLEPROBE_SKIP_DB_READY

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -89,6 +89,27 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     ' "$(template_file)"
   }
 
+  runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate() {
+    awk '
+      index($0, "reconcile_sql_listener_for_syncer_secondary_once() {") { fn = 1 }
+      fn && index($0, "slave_status_is_healthy") { healthy = NR }
+      fn && index($0, "publish_replica_after_rejoin_ready \"runtime-secondary-reconcile\"") { publish = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-ready") { ready = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-pending-after-publish") { pending = NR; exit }
+      END { exit(healthy && publish && ready && pending && healthy < publish && publish < ready && ready < pending ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  secondary_expose_fast_path_requires_real_wildcard_listener() {
+    awk '
+      index($0, "expose_sql_listener_for_safe_role() {") { fn = 1 }
+      fn && index($0, ".sql-listener-ready") && index($0, "mariadbd_listen_on_all_interfaces") { found = 1 }
+      fn && index($0, "sql-listener-expose-stale-marker") { stale = 1 }
+      fn && index($0, "sql-listener-expose-begin") { exit(found && stale ? 0 : 1) }
+      END { exit(found && stale ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   It "declares an internal local admin before fencing user-facing root"
     When call template_contains 'MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"'
     The status should be success
@@ -380,6 +401,16 @@ Describe "cmpd-semisync.yaml rejoin fence template"
 
   It "accepts syncer primary promotion while runtime secondary reconcile is inside replica lock"
     When call runtime_secondary_reconcile_accepts_syncer_primary_during_lock
+    The status should be success
+  End
+
+  It "publishes a healthy runtime secondary through the SQL listener gate"
+    When call runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate
+    The status should be success
+  End
+
+  It "does not trust .sql-listener-ready without a real wildcard listener in syncer-secondary expose path"
+    When call secondary_expose_fast_path_requires_real_wildcard_listener
     The status should be success
   End
 

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -527,7 +527,11 @@ attempt_marker_self_heal() {
   #      alpha.60 / Round 1c-B style GTID divergence fail-closed)
   #   3. master.info exists (we are configured as a secondary; not in
   #      initial bootstrap or self-election path)
-  #   4. .replication-ready missing (otherwise nothing to heal)
+  #   4. .replication-ready may be present or absent. Older logic treated
+  #      ready=present as "nothing to heal", but alpha.23 r75 C5 proved
+  #      `.replication-pending` can be re-created after ready while SQL
+  #      replication is already healthy; that mixed marker state still blocks
+  #      HA follow forever and must be healed by clearing pending.
   #   5. db_ready (local MariaDB is up and accepting connections)
   #   6. secondary_replication_ready (Slave_IO_Running=Yes,
   #      Slave_SQL_Running=Yes, Last_IO_Errno=0, Last_SQL_Errno=0)
@@ -583,10 +587,10 @@ attempt_marker_self_heal() {
   fi
   reaper_audit_log "cond=3 master_info=present rc=continue"
   if [ -f "$(ready_file)" ]; then
-    reaper_audit_log "cond=4 ready=present rc=bail"
-    return 1
+    reaper_audit_log "cond=4 ready=present rc=continue"
+  else
+    reaper_audit_log "cond=4 ready=absent rc=continue"
   fi
-  reaper_audit_log "cond=4 ready=absent rc=continue"
   if ! db_ready; then
     reaper_audit_log "cond=5 db_ready=false rc=bail"
     return 1

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1962,8 +1962,11 @@ spec:
                 mark_replication_pending
                 return 1
               fi
-              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 return 0
+              fi
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                prestop_watchdog_log "sql-listener-expose-stale-marker label=${label} reason=listener-not-wildcard"
               fi
               mark_replication_pending
               prestop_watchdog_log "sql-listener-expose-begin label=${label}"
@@ -2285,9 +2288,8 @@ spec:
               return 1
             }
             reconcile_sql_listener_for_syncer_secondary_once() {
-              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
-              # mark_replication_ready (line below) is the publish point;
-              # set_replica_read_only failure MUST return 1 BEFORE marking ready.
+              # Tier B required path: a runtime secondary may be published only
+              # after replica fencing and the SQL listener gate both converge.
               local role slave_status slave_rejoin_rc
               [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
               role="$(query_local_syncer_role || true)"
@@ -2305,10 +2307,12 @@ spec:
               fi
               slave_status="$(query_slave_status_verbose || true)"
               if slave_status_is_healthy "${slave_status}"; then
-                recover_semisync_slave_health_after_rejoin
-                mark_replication_ready
-                prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
-                return 0
+                if publish_replica_after_rejoin_ready "runtime-secondary-reconcile"; then
+                  prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
+                  return 0
+                fi
+                prestop_watchdog_log "runtime-secondary-listener-reconcile-pending-after-publish role=${role}"
+                return 1
               fi
               if configure_replication_from_primary_service_once "runtime-secondary-follow"; then
                 prestop_watchdog_log "runtime-secondary-listener-reconcile-ready-after-configure role=${role}"

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1709,8 +1709,11 @@ spec:
                 mark_replication_pending
                 return 1
               fi
-              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 return 0
+              fi
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                prestop_watchdog_log "sql-listener-expose-stale-marker label=${label} reason=listener-not-wildcard"
               fi
               mark_replication_pending
               prestop_watchdog_log "sql-listener-expose-begin label=${label}"
@@ -1730,6 +1733,22 @@ spec:
               fi
               touch {{ .Values.dataMountPath }}/.sql-listener-ready
               prestop_watchdog_log "sql-listener-expose-complete label=${label}"
+            }
+            # Direct verify mariadbd is listening on 0.0.0.0:3306 or :::3306.
+            # Only trusting `.sql-listener-ready` is unsafe across container
+            # restarts because init containers do not rerun there.
+            mariadbd_listen_on_all_interfaces() {
+              local f
+              for f in /proc/net/tcp /proc/net/tcp6; do
+                [ -r "$f" ] || continue
+                awk 'NR>1 && $4=="0A" {print $2}' "$f" | while read -r addr; do
+                  case "$addr" in
+                    00000000:0CEA) echo wildcard; break ;;
+                    00000000000000000000000000000000:0CEA) echo wildcard; break ;;
+                  esac
+                done | grep -q wildcard && return 0
+              done
+              return 1
             }
             expose_sql_listener_for_primary_role() {
               local label="$1"
@@ -1945,9 +1964,8 @@ spec:
               return 1
             }
             reconcile_sql_listener_for_syncer_secondary_once() {
-              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
-              # mark_replication_ready (line below) is the publish point;
-              # set_replica_read_only failure MUST return 1 BEFORE marking ready.
+              # Tier B required path: a runtime secondary may be published only
+              # after replica fencing and the SQL listener gate both converge.
               local role slave_status slave_rejoin_rc
               [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
               role="$(query_local_syncer_role || true)"
@@ -1965,10 +1983,12 @@ spec:
               fi
               slave_status="$(query_slave_status_verbose || true)"
               if slave_status_is_healthy "${slave_status}"; then
-                recover_semisync_slave_health_after_rejoin
-                mark_replication_ready
-                prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
-                return 0
+                if publish_replica_after_rejoin_ready "runtime-secondary-reconcile"; then
+                  prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
+                  return 0
+                fi
+                prestop_watchdog_log "runtime-secondary-listener-reconcile-pending-after-publish role=${role}"
+                return 1
               fi
               if configure_replication_from_primary_service_once "runtime-secondary-follow"; then
                 prestop_watchdog_log "runtime-secondary-listener-reconcile-ready-after-configure role=${role}"


### PR DESCRIPTION
## Summary

Fixes a MariaDB semisync runtime-secondary publish gap found in the alpha.20 r63 full-suite run.

Observed failure:
- `mdb-a20-r63` finished `PASS=133 / FAIL=1 / SKIP=2`.
- Failed case: semisync backup target `mdb-ss-1039-mariadb-1` was role-published as secondary, but the live SQL listener stayed on `127.0.0.1:3306`, so the DataProtection backup pod could not connect through the pod/service DNS path.

Evidence:
- r63 addendum: `work/artifacts/task453-alpha20-semisync-full-r63-pr2633-8a9d3cf48-pr173-f8e2b50-20260606T224521Z/helen-addendum-20260606T232746Z/`
- init/restart addendum: `work/artifacts/task453-alpha20-semisync-full-r63-pr2633-8a9d3cf48-pr173-f8e2b50-20260606T224521Z/helen-init-restart-addendum-20260607T0736Z/`
- Key observation: init containers completed at `2026-06-06T23:08:37Z..23:08:39Z`, but the `mariadb` container restarted at `2026-06-06T23:14:12Z` with `restartCount=1`; init containers did not rerun for that restart.
- Live pod state later showed `.sql-listener-ready` present while `mariadbd` and SQL variable `bind_address` were still `127.0.0.1`.

## Fix

- Route the healthy-slave branch in `reconcile_sql_listener_for_syncer_secondary_once` through `publish_replica_after_rejoin_ready "runtime-secondary-reconcile"` instead of directly marking replication/listener ready.
- Make `expose_sql_listener_for_safe_role` trust `.sql-listener-ready` only when `/proc/net/tcp*` proves `mariadbd` is actually listening on `0.0.0.0:3306` or `:::3306`.
- Apply the same invariant to both merged replication and semisync templates.
- Add ShellSpec gates for:
  - healthy runtime secondary publication must pass through the SQL listener gate;
  - stale `.sql-listener-ready` cannot bypass the actual bind-address check.

## Validation

Local/static only, no local Kubernetes execution:

- `bash -n addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh`
- `bash -n addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh`
- `git diff --check -- addons/mariadb/templates/cmpd-replication-merged.yaml addons/mariadb/templates/cmpd-semisync.yaml addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh`
- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh` -> 29 examples, 0 failures
- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh` -> 78 examples, 0 failures
- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh` -> 188 examples, 0 failures, 6 pending
- `helm template mariadb addons/mariadb --namespace kb-system >/tmp/mariadb-render-runtime-secondary-listener-gate-v2.yaml`

Runtime validation against r63 replacement is not yet done; this PR is the candidate fix for the first blocker.
