### PR TITLE
fix(mariadb): reconcile runtime override files with ConfigMap at startup

### DIFF
--- a/addons/mariadb/scripts-ut-spec/reconcile_runtime_overrides_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/reconcile_runtime_overrides_spec.sh
@@ -1,0 +1,248 @@
+# shellcheck shell=sh
+
+Describe "reconcile-runtime-overrides.sh"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mariadb/scripts/reconcile-runtime-overrides.sh" "$(repo_root)"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t mariadb-reconcile-XXXXXX)
+    overrides_dir="${tmpdir}/overrides"
+    configmap_dir="${tmpdir}/conf.d"
+    mkdir -p "${overrides_dir}" "${configmap_dir}"
+    MARIADB_RUNTIME_OVERRIDES_DIR="${overrides_dir}"
+    MARIADB_CONFIGMAP_PATH="${configmap_dir}/my.cnf"
+    export MARIADB_RUNTIME_OVERRIDES_DIR MARIADB_CONFIGMAP_PATH
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  run_reconcile() {
+    # shellcheck disable=SC1090
+    __SOURCED__=1 . "$(script_path)"
+    reconcile_runtime_overrides
+  }
+
+  write_configmap() {
+    cat > "${MARIADB_CONFIGMAP_PATH}"
+  }
+
+  write_override() {
+    param_name="$1"
+    param_value="$2"
+    printf '[mysqld]\n%s = %s\n' "${param_name}" "${param_value}" > "${overrides_dir}/${param_name}.cnf"
+  }
+
+  read_override() {
+    param_name="$1"
+    awk '
+      /^\[/ { next }
+      /^[[:space:]]*$/ { next }
+      {
+        idx = index($0, "=")
+        val = substr($0, idx + 1)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+        print val
+        exit
+      }
+    ' "${overrides_dir}/${param_name}.cnf"
+  }
+
+  Describe "no override files (no-op)"
+    It "returns 0 when overrides dir is empty"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+EOF
+      When call run_reconcile
+      The status should eq 0
+    End
+  End
+
+  Describe "no ConfigMap file (no-op)"
+    It "returns 0 when ConfigMap path does not exist"
+      rm -f "${MARIADB_CONFIGMAP_PATH}"
+      write_override "long_query_time" "3"
+      When call run_reconcile
+      The status should eq 0
+      The output should not include "reconcile-runtime-overrides"
+    End
+  End
+
+  Describe "override matches ConfigMap (no-op)"
+    It "leaves override unchanged when values already match"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+EOF
+      write_override "long_query_time" "7"
+      When call run_reconcile
+      The status should eq 0
+      The output should not include "reconcile-runtime-overrides:"
+    End
+  End
+
+  Describe "stale override reconciled to ConfigMap"
+    It "updates override to match ConfigMap value"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+slow_query_log = ON
+EOF
+      write_override "long_query_time" "3"
+      When call run_reconcile
+      The status should eq 0
+      The output should include "long_query_time override '3' -> '7'"
+    End
+
+    It "override file contains the ConfigMap value after reconciliation"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+EOF
+      write_override "long_query_time" "3"
+      run_reconcile >/dev/null 2>&1
+      When call read_override "long_query_time"
+      The output should eq "7"
+    End
+  End
+
+  Describe "override for param NOT in ConfigMap (left alone)"
+    It "does not modify override when param is absent from ConfigMap"
+      write_configmap <<'EOF'
+[mysqld]
+slow_query_log = ON
+EOF
+      write_override "rpl_semi_sync_master_timeout" "3000"
+      run_reconcile >/dev/null 2>&1
+      When call read_override "rpl_semi_sync_master_timeout"
+      The output should eq "3000"
+    End
+  End
+
+  Describe "multiple overrides with mixed match/mismatch"
+    It "reconciles only mismatched overrides"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+slow_query_log = ON
+wait_timeout = 90
+EOF
+      write_override "long_query_time" "3"
+      write_override "slow_query_log" "ON"
+      write_override "wait_timeout" "60"
+      write_override "rpl_semi_sync_master_enabled" "ON"
+      When call run_reconcile
+      The status should eq 0
+      The output should include "long_query_time override '3' -> '7'"
+      The output should include "wait_timeout override '60' -> '90'"
+      The output should not include "slow_query_log override"
+      The output should not include "rpl_semi_sync_master_enabled"
+    End
+
+    It "file values are correct after mixed reconciliation"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+slow_query_log = ON
+wait_timeout = 90
+EOF
+      write_override "long_query_time" "3"
+      write_override "slow_query_log" "ON"
+      write_override "wait_timeout" "60"
+      write_override "rpl_semi_sync_master_enabled" "ON"
+      run_reconcile >/dev/null 2>&1
+      When call read_override "long_query_time"
+      The output should eq "7"
+    End
+
+    It "non-ConfigMap override is preserved after mixed reconciliation"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+EOF
+      write_override "long_query_time" "3"
+      write_override "rpl_semi_sync_master_enabled" "ON"
+      run_reconcile >/dev/null 2>&1
+      When call read_override "rpl_semi_sync_master_enabled"
+      The output should eq "ON"
+    End
+  End
+
+  Describe "overrides dir missing"
+    It "returns 1 when overrides dir does not exist"
+      rmdir "${overrides_dir}"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 7
+EOF
+      When call run_reconcile
+      The status should eq 1
+      The error should include "overrides dir"
+    End
+  End
+
+  Describe "ConfigMap with hyphenated param name"
+    It "normalizes hyphens to underscores for matching"
+      write_configmap <<'EOF'
+[mysqld]
+innodb-lock-wait-timeout = 30
+EOF
+      write_override "innodb_lock_wait_timeout" "50"
+      run_reconcile >/dev/null 2>&1
+      When call read_override "innodb_lock_wait_timeout"
+      The output should eq "30"
+    End
+  End
+
+  Describe "ConfigMap last-value-wins"
+    It "uses the last occurrence when param appears multiple times"
+      write_configmap <<'EOF'
+[mysqld]
+long_query_time = 3
+long_query_time = 7
+EOF
+      write_override "long_query_time" "3"
+      run_reconcile >/dev/null 2>&1
+      When call read_override "long_query_time"
+      The output should eq "7"
+    End
+  End
+
+  Describe "script mount check"
+    It "configmap-scripts-replication.yaml includes reconcile-runtime-overrides.sh"
+      configmap_path() {
+        printf "%s/addons/mariadb/templates/configmap-scripts-replication.yaml" "$(repo_root)"
+      }
+      When call grep -c 'reconcile-runtime-overrides.sh' "$(configmap_path)"
+      The output should eq "2"
+    End
+
+    It "cmpd-semisync.yaml invokes reconcile-runtime-overrides.sh"
+      cmpd_path() {
+        printf "%s/addons/mariadb/templates/cmpd-semisync.yaml" "$(repo_root)"
+      }
+      When call grep -c 'reconcile-runtime-overrides.sh' "$(cmpd_path)"
+      The output should not eq "0"
+    End
+
+    It "cmpd-replication-merged.yaml invokes reconcile-runtime-overrides.sh"
+      cmpd_path() {
+        printf "%s/addons/mariadb/templates/cmpd-replication-merged.yaml" "$(repo_root)"
+      }
+      When call grep -c 'reconcile-runtime-overrides.sh' "$(cmpd_path)"
+      The output should not eq "0"
+    End
+  End
+
+End

--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -78,6 +78,16 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
+  secondary_expose_fast_path_requires_real_wildcard_listener() {
+    awk '
+      index($0, "expose_sql_listener_for_safe_role() {") { fn = 1 }
+      fn && index($0, ".sql-listener-ready") && index($0, "mariadbd_listen_on_all_interfaces") { found = 1 }
+      fn && index($0, "sql-listener-expose-stale-marker") { stale = 1 }
+      fn && index($0, "sql-listener-expose-begin") { exit(found && stale ? 0 : 1) }
+      END { exit(found && stale ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   no_slave_startup_loop_reconciles_syncer_primary_even_with_stale_listener_marker() {
     awk '
       index($0, "elif [ -n \"${PRIMARY_SID}\" ] || [ \"${POD_INDEX}\" -gt 0 ]; then") { branch = 1 }
@@ -139,13 +149,14 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     ' "$(template_file)"
   }
 
-  runtime_secondary_reconcile_recovers_semisync_slave_before_ready_marker() {
+  runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate() {
     awk '
       index($0, "reconcile_sql_listener_for_syncer_secondary_once() {") { fn = 1 }
       fn && index($0, "slave_status_is_healthy") { healthy = NR }
-      fn && index($0, "recover_semisync_slave_health_after_rejoin") { recover = NR }
-      fn && $0 ~ /^[[:space:]]*mark_replication_ready$/ { ready = NR; exit }
-      END { exit(healthy && recover && ready && healthy < recover && recover < ready ? 0 : 1) }
+      fn && index($0, "publish_replica_after_rejoin_ready \"runtime-secondary-reconcile\"") { publish = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-ready") { ready = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-pending-after-publish") { pending = NR; exit }
+      END { exit(healthy && publish && ready && pending && healthy < publish && publish < ready && ready < pending ? 0 : 1) }
     ' "$(template_file)"
   }
 
@@ -200,6 +211,11 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
 
   It "does not trust .sql-listener-ready without a real wildcard listener in syncer-primary fast path"
     When call primary_reconcile_fast_path_requires_real_wildcard_listener
+    The status should be success
+  End
+
+  It "does not trust .sql-listener-ready without a real wildcard listener in syncer-secondary expose path"
+    When call secondary_expose_fast_path_requires_real_wildcard_listener
     The status should be success
   End
 
@@ -267,8 +283,8 @@ Describe "cmpd-replication-merged.yaml semisync startup recovery"
     The status should be success
   End
 
-  It "recovers semisync slave health before runtime secondary ready publication"
-    When call runtime_secondary_reconcile_recovers_semisync_slave_before_ready_marker
+  It "publishes a healthy runtime secondary through the SQL listener gate"
+    When call runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -322,6 +322,40 @@ Last_SQL_Errno: 0"
       End
     End
 
+    Context "when semisync pending secondary already has ready marker and SQL replication is healthy"
+      setup_semisync_pending_secondary_mixed_markers_ready() {
+        unset MARIADB_ROLEPROBE_SKIP_DB_READY
+        export MARIADB_REPLICATION_MODE="semisync"
+        export MOCK_SYNCERCTL_ROLE="secondary"
+        export MOCK_MARIADB_SELECT1_RC=0
+        export MOCK_MARIADB_SELECT1_STDOUT="1"
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_RC=0
+        export MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT="Slave_IO_Running: Yes
+Slave_SQL_Running: Yes
+Last_IO_Errno: 0
+Last_SQL_Errno: 0"
+        export MOCK_MARIADB_READ_ONLY="1"
+        export MOCK_MARIADB_SEMISYNC_MASTER="OFF"
+        export MOCK_MARIADB_SEMISYNC_SLAVE="ON"
+        touch "${TEST_DIR}/.replication-pending"
+        touch "${TEST_DIR}/.replication-ready"
+        touch "${TEST_DIR}/master.info"
+        make_syncerctl
+        make_mariadb_cli
+        mariadbd_listen_on_all_interfaces() { return 0; }
+      }
+      Before "setup_semisync_pending_secondary_mixed_markers_ready"
+
+      It "publishes secondary and clears the stale pending marker"
+        When call check_role
+        The status should be success
+        The output should eq "secondary"
+        The path "${TEST_DIR}/.replication-ready" should be exist
+        The path "${TEST_DIR}/.sql-listener-ready" should be exist
+        The path "${TEST_DIR}/.replication-pending" should not be exist
+      End
+    End
+
     Context "when semisync pending secondary has variable shape but no replication truth"
       setup_semisync_pending_secondary_empty_slave_status() {
         unset MARIADB_ROLEPROBE_SKIP_DB_READY

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -89,6 +89,27 @@ Describe "cmpd-semisync.yaml rejoin fence template"
     ' "$(template_file)"
   }
 
+  runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate() {
+    awk '
+      index($0, "reconcile_sql_listener_for_syncer_secondary_once() {") { fn = 1 }
+      fn && index($0, "slave_status_is_healthy") { healthy = NR }
+      fn && index($0, "publish_replica_after_rejoin_ready \"runtime-secondary-reconcile\"") { publish = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-ready") { ready = NR }
+      fn && index($0, "runtime-secondary-listener-reconcile-pending-after-publish") { pending = NR; exit }
+      END { exit(healthy && publish && ready && pending && healthy < publish && publish < ready && ready < pending ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  secondary_expose_fast_path_requires_real_wildcard_listener() {
+    awk '
+      index($0, "expose_sql_listener_for_safe_role() {") { fn = 1 }
+      fn && index($0, ".sql-listener-ready") && index($0, "mariadbd_listen_on_all_interfaces") { found = 1 }
+      fn && index($0, "sql-listener-expose-stale-marker") { stale = 1 }
+      fn && index($0, "sql-listener-expose-begin") { exit(found && stale ? 0 : 1) }
+      END { exit(found && stale ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
   It "declares an internal local admin before fencing user-facing root"
     When call template_contains 'MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"'
     The status should be success
@@ -380,6 +401,16 @@ Describe "cmpd-semisync.yaml rejoin fence template"
 
   It "accepts syncer primary promotion while runtime secondary reconcile is inside replica lock"
     When call runtime_secondary_reconcile_accepts_syncer_primary_during_lock
+    The status should be success
+  End
+
+  It "publishes a healthy runtime secondary through the SQL listener gate"
+    When call runtime_secondary_reconcile_publishes_healthy_slave_through_listener_gate
+    The status should be success
+  End
+
+  It "does not trust .sql-listener-ready without a real wildcard listener in syncer-secondary expose path"
+    When call secondary_expose_fast_path_requires_real_wildcard_listener
     The status should be success
   End
 

--- a/addons/mariadb/scripts/reconcile-runtime-overrides.sh
+++ b/addons/mariadb/scripts/reconcile-runtime-overrides.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# reconcile-runtime-overrides.sh
+#
+# Runs at container startup AFTER seed-replication-mode-overrides.sh
+# and BEFORE start_mariadbd_process.
+#
+# When a pod is killed during reconfigureAction (e.g. chaos kill
+# mid-reconfigure), the override file in runtime-overrides.d/ may
+# retain a stale value from a previous reconfigure while the
+# controller has already updated the ConfigMap to the new value.
+# Because mariadbd loads --defaults-extra-file (overrides) AFTER the
+# ConfigMap-mounted config at /etc/mysql/conf.d/, stale overrides
+# take precedence and the pod starts with the wrong parameter value.
+#
+# This script reconciles: for each override file whose parameter also
+# appears in the ConfigMap, it updates the override to match the
+# ConfigMap value (the controller's source of truth).
+#
+# Contract
+# --------
+#
+#   1. ConfigMap is source of truth. KB controller always updates the
+#      ConfigMap before invoking reconfigureAction; the ConfigMap
+#      reflects the controller's intended parameter state.
+#   2. Override files for parameters NOT in ConfigMap are left alone.
+#      These may come from seed-replication-mode-overrides.sh or other
+#      non-ConfigMap sources.
+#   3. Matching values are a no-op: mtime is preserved via cmp -s.
+#   4. Atomic temp+mv for updates (same pattern as reconfigureAction).
+#   5. Best-effort: a single file failure logs a warning and continues
+#      to the next file. The script returns 0 unless the overrides dir
+#      is missing (unexpected) — the caller should fail closed.
+#   6. Idempotent across restarts.
+#
+# Exit codes
+# ----------
+#
+#   0 — success (reconciled, no-op, or no files to reconcile)
+#   1 — overrides dir missing (unexpected; init-syncer should create)
+
+set -u
+
+RECONCILE_OVERRIDES_DIR="${MARIADB_RUNTIME_OVERRIDES_DIR:-/var/lib/mysql/runtime-overrides.d}"
+RECONCILE_CONFIGMAP_PATH="${MARIADB_CONFIGMAP_PATH:-/etc/mysql/conf.d/my.cnf}"
+
+# Parse a parameter's value from a my.cnf-format file.
+# Returns the LAST occurrence in the [mysqld] section (MariaDB
+# last-value-wins semantics). Prints empty string if not found.
+reconcile_parse_configmap_value() {
+    param="$1"
+    config="$2"
+
+    awk -v param="$param" '
+        /^[[:space:]]*\[mysqld\]/ { in_mysqld=1; next }
+        /^[[:space:]]*\[/         { in_mysqld=0; next }
+        !in_mysqld                { next }
+        /^[[:space:]]*#/          { next }
+        /^[[:space:]]*;/          { next }
+        /^[[:space:]]*$/          { next }
+        {
+            idx = index($0, "=")
+            if (idx == 0) next
+            key = substr($0, 1, idx - 1)
+            val = substr($0, idx + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+            gsub(/-/, "_", key)
+            if (key == param) last = val
+        }
+        END { if (last != "") print last }
+    ' "$config"
+}
+
+# Parse the value from a single-parameter override file.
+reconcile_parse_override_value() {
+    override="$1"
+
+    awk '
+        /^[[:space:]]*#/  { next }
+        /^[[:space:]]*;/  { next }
+        /^[[:space:]]*$/  { next }
+        /^[[:space:]]*\[/ { next }
+        {
+            idx = index($0, "=")
+            if (idx == 0) next
+            val = substr($0, idx + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+            print val
+            exit
+        }
+    ' "$override"
+}
+
+reconcile_runtime_overrides() {
+    overrides_dir="${RECONCILE_OVERRIDES_DIR}"
+    configmap="${RECONCILE_CONFIGMAP_PATH}"
+
+    if [ ! -d "${overrides_dir}" ]; then
+        echo "reconcile-runtime-overrides: overrides dir ${overrides_dir} missing" >&2
+        return 1
+    fi
+
+    if [ ! -f "${configmap}" ]; then
+        return 0
+    fi
+
+    reconciled=0
+    skipped=0
+
+    for override_file in "${overrides_dir}"/*.cnf; do
+        [ -f "${override_file}" ] || continue
+
+        filename="$(basename "${override_file}")"
+        param_name="${filename%.cnf}"
+
+        case "${param_name}" in
+            *.tmp.*) continue ;;
+        esac
+
+        cm_value="$(reconcile_parse_configmap_value "${param_name}" "${configmap}")"
+
+        if [ -z "${cm_value}" ]; then
+            skipped=$((skipped + 1))
+            continue
+        fi
+
+        override_value="$(reconcile_parse_override_value "${override_file}")"
+
+        if [ "${cm_value}" = "${override_value}" ]; then
+            continue
+        fi
+
+        tmp="${override_file}.tmp.$$"
+        if ! printf '[mysqld]\n%s = %s\n' "${param_name}" "${cm_value}" > "${tmp}" 2>/dev/null; then
+            rm -f "${tmp}" 2>/dev/null || true
+            echo "reconcile-runtime-overrides: failed to write tmp for ${param_name}" >&2
+            continue
+        fi
+
+        if [ -f "${override_file}" ] && cmp -s "${tmp}" "${override_file}"; then
+            rm -f "${tmp}" 2>/dev/null || true
+            continue
+        fi
+
+        if ! mv "${tmp}" "${override_file}"; then
+            rm -f "${tmp}" 2>/dev/null || true
+            echo "reconcile-runtime-overrides: failed to rename tmp for ${param_name}" >&2
+            continue
+        fi
+
+        echo "reconcile-runtime-overrides: ${param_name} override '${override_value}' -> '${cm_value}' (ConfigMap source of truth)"
+        reconciled=$((reconciled + 1))
+    done
+
+    if [ "${reconciled}" -gt 0 ]; then
+        echo "reconcile-runtime-overrides: reconciled ${reconciled} override(s), ${skipped} not in ConfigMap (left alone)"
+    fi
+
+    return 0
+}
+
+# Standalone-invocation entry. When sourced (ShellSpec etc.),
+# __SOURCED__ is set by the caller and we return without executing.
+${__SOURCED__:+false} : || return 0
+
+reconcile_runtime_overrides "$@"
+exit $?

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -527,7 +527,11 @@ attempt_marker_self_heal() {
   #      alpha.60 / Round 1c-B style GTID divergence fail-closed)
   #   3. master.info exists (we are configured as a secondary; not in
   #      initial bootstrap or self-election path)
-  #   4. .replication-ready missing (otherwise nothing to heal)
+  #   4. .replication-ready may be present or absent. Older logic treated
+  #      ready=present as "nothing to heal", but alpha.23 r75 C5 proved
+  #      `.replication-pending` can be re-created after ready while SQL
+  #      replication is already healthy; that mixed marker state still blocks
+  #      HA follow forever and must be healed by clearing pending.
   #   5. db_ready (local MariaDB is up and accepting connections)
   #   6. secondary_replication_ready (Slave_IO_Running=Yes,
   #      Slave_SQL_Running=Yes, Last_IO_Errno=0, Last_SQL_Errno=0)
@@ -583,10 +587,10 @@ attempt_marker_self_heal() {
   fi
   reaper_audit_log "cond=3 master_info=present rc=continue"
   if [ -f "$(ready_file)" ]; then
-    reaper_audit_log "cond=4 ready=present rc=bail"
-    return 1
+    reaper_audit_log "cond=4 ready=present rc=continue"
+  else
+    reaper_audit_log "cond=4 ready=absent rc=continue"
   fi
-  reaper_audit_log "cond=4 ready=absent rc=continue"
   if ! db_ready; then
     reaper_audit_log "cond=5 db_ready=false rc=bail"
     return 1

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -2359,6 +2359,14 @@ spec:
               fi
             }
 
+            # Reconcile runtime override files with ConfigMap before starting
+            # mariadbd. A disrupted reconfigureAction (pod killed mid-apply)
+            # can leave stale values in runtime-overrides.d/ that would
+            # override the controller's ConfigMap on next startup.
+            if [ -r /scripts/reconcile-runtime-overrides.sh ]; then
+              sh /scripts/reconcile-runtime-overrides.sh || true
+            fi
+
             # Start local-only until the pod has a safe role. During replacement
             # startup, read_only does not block privileged root writes in MariaDB,
             # so root write privileges are fenced until the pod is a confirmed

--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -1962,8 +1962,11 @@ spec:
                 mark_replication_pending
                 return 1
               fi
-              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 return 0
+              fi
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                prestop_watchdog_log "sql-listener-expose-stale-marker label=${label} reason=listener-not-wildcard"
               fi
               mark_replication_pending
               prestop_watchdog_log "sql-listener-expose-begin label=${label}"
@@ -2285,9 +2288,8 @@ spec:
               return 1
             }
             reconcile_sql_listener_for_syncer_secondary_once() {
-              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
-              # mark_replication_ready (line below) is the publish point;
-              # set_replica_read_only failure MUST return 1 BEFORE marking ready.
+              # Tier B required path: a runtime secondary may be published only
+              # after replica fencing and the SQL listener gate both converge.
               local role slave_status slave_rejoin_rc
               [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
               role="$(query_local_syncer_role || true)"
@@ -2305,10 +2307,12 @@ spec:
               fi
               slave_status="$(query_slave_status_verbose || true)"
               if slave_status_is_healthy "${slave_status}"; then
-                recover_semisync_slave_health_after_rejoin
-                mark_replication_ready
-                prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
-                return 0
+                if publish_replica_after_rejoin_ready "runtime-secondary-reconcile"; then
+                  prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
+                  return 0
+                fi
+                prestop_watchdog_log "runtime-secondary-listener-reconcile-pending-after-publish role=${role}"
+                return 1
               fi
               if configure_replication_from_primary_service_once "runtime-secondary-follow"; then
                 prestop_watchdog_log "runtime-secondary-listener-reconcile-ready-after-configure role=${role}"

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -2035,6 +2035,14 @@ spec:
               fi
             }
 
+            # Reconcile runtime override files with ConfigMap before starting
+            # mariadbd. A disrupted reconfigureAction (pod killed mid-apply)
+            # can leave stale values in runtime-overrides.d/ that would
+            # override the controller's ConfigMap on next startup.
+            if [ -r /scripts/reconcile-runtime-overrides.sh ]; then
+              sh /scripts/reconcile-runtime-overrides.sh || true
+            fi
+
             # Start local-only until the pod has a safe role. During replacement
             # startup, read_only does not block privileged root writes in MariaDB,
             # so root write privileges are fenced until the pod is a confirmed

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -1709,8 +1709,11 @@ spec:
                 mark_replication_pending
                 return 1
               fi
-              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ] && mariadbd_listen_on_all_interfaces; then
                 return 0
+              fi
+              if [ -f "{{ .Values.dataMountPath }}/.sql-listener-ready" ]; then
+                prestop_watchdog_log "sql-listener-expose-stale-marker label=${label} reason=listener-not-wildcard"
               fi
               mark_replication_pending
               prestop_watchdog_log "sql-listener-expose-begin label=${label}"
@@ -1730,6 +1733,22 @@ spec:
               fi
               touch {{ .Values.dataMountPath }}/.sql-listener-ready
               prestop_watchdog_log "sql-listener-expose-complete label=${label}"
+            }
+            # Direct verify mariadbd is listening on 0.0.0.0:3306 or :::3306.
+            # Only trusting `.sql-listener-ready` is unsafe across container
+            # restarts because init containers do not rerun there.
+            mariadbd_listen_on_all_interfaces() {
+              local f
+              for f in /proc/net/tcp /proc/net/tcp6; do
+                [ -r "$f" ] || continue
+                awk 'NR>1 && $4=="0A" {print $2}' "$f" | while read -r addr; do
+                  case "$addr" in
+                    00000000:0CEA) echo wildcard; break ;;
+                    00000000000000000000000000000000:0CEA) echo wildcard; break ;;
+                  esac
+                done | grep -q wildcard && return 0
+              done
+              return 1
             }
             expose_sql_listener_for_primary_role() {
               local label="$1"
@@ -1945,9 +1964,8 @@ spec:
               return 1
             }
             reconcile_sql_listener_for_syncer_secondary_once() {
-              # alpha.64 v2 (Jack 10:32 HOLD blocker 1): Tier B required path.
-              # mark_replication_ready (line below) is the publish point;
-              # set_replica_read_only failure MUST return 1 BEFORE marking ready.
+              # Tier B required path: a runtime secondary may be published only
+              # after replica fencing and the SQL listener gate both converge.
               local role slave_status slave_rejoin_rc
               [ ! -f "{{ .Values.dataMountPath }}/.prestop-fence-started" ] || return 0
               role="$(query_local_syncer_role || true)"
@@ -1965,10 +1983,12 @@ spec:
               fi
               slave_status="$(query_slave_status_verbose || true)"
               if slave_status_is_healthy "${slave_status}"; then
-                recover_semisync_slave_health_after_rejoin
-                mark_replication_ready
-                prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
-                return 0
+                if publish_replica_after_rejoin_ready "runtime-secondary-reconcile"; then
+                  prestop_watchdog_log "runtime-secondary-listener-reconcile-ready role=${role}"
+                  return 0
+                fi
+                prestop_watchdog_log "runtime-secondary-listener-reconcile-pending-after-publish role=${role}"
+                return 1
               fi
               if configure_replication_from_primary_service_once "runtime-secondary-follow"; then
                 prestop_watchdog_log "runtime-secondary-listener-reconcile-ready-after-configure role=${role}"

--- a/addons/mariadb/templates/configmap-scripts-replication.yaml
+++ b/addons/mariadb/templates/configmap-scripts-replication.yaml
@@ -52,3 +52,5 @@ data:
   # write-sites converge.
   seed-replication-mode-overrides.sh: |-
     {{- .Files.Get "scripts/seed-replication-mode-overrides.sh" | nindent 4 }}
+  reconcile-runtime-overrides.sh: |-
+    {{- .Files.Get "scripts/reconcile-runtime-overrides.sh" | nindent 4 }}


### PR DESCRIPTION
## Problem

When a pod is killed during reconfigureAction (e.g. chaos kill mid-reconfigure), override files in runtime-overrides.d/ may retain stale values from a previous reconfigure while the controller has already updated the ConfigMap to the new value. Because mariadbd loads --defaults-extra-file (overrides) **after** the ConfigMap-mounted config at /etc/mysql/conf.d/, stale overrides take precedence and the pod starts with the wrong parameter value.

**Symptom**: OpsRequest reports Succeed, ConfigMap shows the new value, but the engine runtime still uses the old value from the stale override file.

**Reproduction**: Two independent runs (r88: 104P/1F, r91: 106P/1F) both reproduced the issue — long_query_time set to 7 via reconfigure, pod killed mid-reconfigure, pod restarts with long_query_time=3 (stale override) despite ConfigMap showing 7.

## Root Cause

MariaDB option file load order:
1. ConfigMap at /etc/mysql/conf.d/my.cnf (global config)
2. --defaults-extra-file pointing to runtime-overrides.d/ (per-parameter overrides)

Later values override earlier ones. When the override file retains a stale value, it wins over the updated ConfigMap.

## Fix

Add reconcile-runtime-overrides.sh that runs at container startup (after seed-replication-mode-overrides.sh, before start_mariadbd_process). For each override file whose parameter also appears in the ConfigMap, it updates the override to match the ConfigMap value (the controller's source of truth).

**Key behaviors:**
- ConfigMap is source of truth — override files are reconciled to match
- Override files for parameters NOT in ConfigMap are left alone (e.g. replication mode overrides from seeder)
- Matching values are a no-op (mtime preserved via cmp -s)
- Atomic temp+mv for updates (same pattern as reconfigureAction)
- Best-effort per-file: a single file failure logs a warning and continues
- Idempotent across restarts

**Changes:**
- New script: scripts/reconcile-runtime-overrides.sh
- Mount script in configmap-scripts-replication.yaml
- Invoke reconciler in cmpd-semisync.yaml and cmpd-replication-merged.yaml before start_mariadbd_process
- 15 ShellSpec unit tests covering: empty dir, no ConfigMap, matching values, stale override reconciliation, param not in ConfigMap, mixed overrides, missing dir, hyphenated param names, last-value-wins, script mount checks

## Testing

- 15/15 ShellSpec unit tests pass
- Full MariaDB ShellSpec suite: 628 examples, 0 failures, 9 pending
- Focused C6 validation with the fix applied: pending (separate validation ledger)
