### PR TITLE
feat(postgresql): add standby DR promote operation

### DIFF
--- a/addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "promote_standby_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "PostgreSQL promote standby script tests"
+
+  Include ../scripts/promote_standby.sh
+
+  Describe "require_force()"
+    It "rejects missing split-brain acknowledgement"
+      unset force
+      When run require_force
+      The status should be failure
+      The output should include "force=true is required"
+    End
+
+    It "accepts force=true"
+      force="true"
+      When run require_force
+      The status should be success
+    End
+  End
+
+  Describe "require_standby_mode()"
+    It "rejects a non-standby cluster"
+      PG_MODE="primary"
+      When run require_standby_mode
+      The status should be failure
+      The output should include "refusing DR standby promotion"
+    End
+
+    It "accepts standby mode"
+      PG_MODE="standby"
+      When run require_standby_mode
+      The status should be success
+    End
+  End
+
+  Describe "promote_standby()"
+    It "does not patch Patroni from a non-standby-leader pod"
+      force="true"
+      PG_MODE="standby"
+      CURRENT_POD_IP="127.0.0.1"
+      curl() {
+        case "$*" in
+          *"/standby-leader"*) printf '503' ;;
+          *) echo "unexpected curl: $*" ; return 1 ;;
+        esac
+      }
+      When run promote_standby
+      The status should be success
+      The output should include "not Patroni standby leader"
+    End
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
@@ -25,6 +25,22 @@ Describe "PostgreSQL promote standby script tests"
     End
   End
 
+  Describe "warn_if_source_reachable()"
+    It "skips the probe when sourceEndpoint is absent"
+      unset sourceEndpoint
+      When run warn_if_source_reachable
+      The status should be success
+      The output should include "No sourceEndpoint provided"
+    End
+
+    It "warns but succeeds for an invalid sourceEndpoint"
+      sourceEndpoint="invalid"
+      When run warn_if_source_reachable
+      The status should be success
+      The output should include "WARNING: invalid sourceEndpoint"
+    End
+  End
+
   Describe "require_standby_mode()"
     It "rejects a non-standby cluster"
       PG_MODE="primary"
@@ -54,6 +70,14 @@ Describe "PostgreSQL promote standby script tests"
       When run promote_standby
       The status should be success
       The output should include "not Patroni standby leader"
+    End
+  End
+
+  Describe "warn_manual_failback_boundary()"
+    It "documents the manual failback boundary"
+      When run warn_manual_failback_boundary
+      The status should be success
+      The output should include "Automatic failback is not part of pg-promote-standby"
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
@@ -39,6 +39,17 @@ Describe "PostgreSQL promote standby script tests"
       The status should be success
       The output should include "WARNING: invalid sourceEndpoint"
     End
+
+    It "does not interpolate sourceEndpoint into the probe shell"
+      injected_file="${TMPDIR:-/tmp}/pg-promote-standby-injected-$$"
+      rm -f "$injected_file"
+      sourceEndpoint="127.0.0.1;touch ${injected_file}:5432"
+      When run warn_if_source_reachable
+      The status should be success
+      The output should include "sourceEndpoint ${sourceEndpoint} is not TCP-reachable"
+      The file "$injected_file" should not be exist
+      rm -f "$injected_file"
+    End
   End
 
   Describe "require_standby_mode()"

--- a/addons/postgresql/scripts/promote_standby.sh
+++ b/addons/postgresql/scripts/promote_standby.sh
@@ -31,12 +31,12 @@ warn_if_source_reachable() {
   fi
 
   local host="${endpoint%:*}" port="${endpoint##*:}"
-  if [ -z "$host" ] || [ -z "$port" ] || [ "$host" = "$port" ]; then
+  if [ -z "$host" ] || [ -z "$port" ] || [ "$host" = "$port" ] || ! [[ "$port" =~ ^[0-9]+$ ]]; then
     echo "WARNING: invalid sourceEndpoint '$endpoint'; expected host:port. Skipping source reachability probe."
     return 0
   fi
 
-  if timeout 3 bash -c "cat < /dev/null > /dev/tcp/${host}/${port}" 2>/dev/null; then
+  if timeout 3 bash -c 'cat < /dev/null > "/dev/tcp/$1/$2"' _ "$host" "$port" 2>/dev/null; then
     echo "WARNING: sourceEndpoint ${endpoint} is still TCP-reachable while promoting standby. Ensure the source is fenced/stopped to avoid split-brain."
   else
     echo "sourceEndpoint ${endpoint} is not TCP-reachable in best-effort probe."

--- a/addons/postgresql/scripts/promote_standby.sh
+++ b/addons/postgresql/scripts/promote_standby.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Promote a Patroni standby_cluster by removing the dynamic standby_cluster
+# configuration. Patroni documents this as the supported manual promotion path
+# for a remote standby cluster; the caller must first fence/stop the source.
+set -euo pipefail
+
+patroni_url() {
+  printf 'http://%s:8008' "${CURRENT_POD_IP:-localhost}"
+}
+
+is_true() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    true|yes|1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_force() {
+  if ! is_true "${force:-}"; then
+    echo "force=true is required; promote only after the source cluster is fenced/stopped."
+    return 1
+  fi
+}
+
+require_standby_mode() {
+  if ! printf '%s' "${PG_MODE:-}" | tr '[:upper:]' '[:lower:]' | grep -q 'standby'; then
+    echo "PG_MODE=${PG_MODE:-<unset>} is not standby; refusing DR standby promotion."
+    return 1
+  fi
+}
+
+is_standby_leader() {
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$(patroni_url)/standby-leader" || true)"
+  [ "$code" = "200" ]
+}
+
+patch_remove_standby_cluster() {
+  echo "Removing standby_cluster from Patroni dynamic config on $(patroni_url)"
+  curl -fsS -X PATCH -d '{"standby_cluster":null}' "$(patroni_url)/config"
+}
+
+wait_read_write() {
+  local timeout="${PROMOTE_TIMEOUT_SECONDS:-300}"
+  local deadline=$((SECONDS + timeout))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if curl -fsS -o /dev/null "$(patroni_url)/read-write"; then
+      echo "Patroni reports read-write primary after standby promotion."
+      return 0
+    fi
+    sleep 5
+  done
+  echo "Timed out waiting for Patroni read-write primary after standby promotion."
+  return 1
+}
+
+promote_standby() {
+  require_force
+  require_standby_mode
+
+  if ! is_standby_leader; then
+    echo "Current pod is not Patroni standby leader; nothing to promote on this pod."
+    return 0
+  fi
+
+  patch_remove_standby_cluster
+  wait_read_write
+}
+
+${__SOURCED__:+false} : || return 0
+
+promote_standby

--- a/addons/postgresql/scripts/promote_standby.sh
+++ b/addons/postgresql/scripts/promote_standby.sh
@@ -23,6 +23,26 @@ require_force() {
   fi
 }
 
+warn_if_source_reachable() {
+  local endpoint="${sourceEndpoint:-}"
+  if [ -z "$endpoint" ]; then
+    echo "No sourceEndpoint provided; skipping best-effort source reachability probe."
+    return 0
+  fi
+
+  local host="${endpoint%:*}" port="${endpoint##*:}"
+  if [ -z "$host" ] || [ -z "$port" ] || [ "$host" = "$port" ]; then
+    echo "WARNING: invalid sourceEndpoint '$endpoint'; expected host:port. Skipping source reachability probe."
+    return 0
+  fi
+
+  if timeout 3 bash -c "cat < /dev/null > /dev/tcp/${host}/${port}" 2>/dev/null; then
+    echo "WARNING: sourceEndpoint ${endpoint} is still TCP-reachable while promoting standby. Ensure the source is fenced/stopped to avoid split-brain."
+  else
+    echo "sourceEndpoint ${endpoint} is not TCP-reachable in best-effort probe."
+  fi
+}
+
 require_standby_mode() {
   if ! printf '%s' "${PG_MODE:-}" | tr '[:upper:]' '[:lower:]' | grep -q 'standby'; then
     echo "PG_MODE=${PG_MODE:-<unset>} is not standby; refusing DR standby promotion."
@@ -55,8 +75,18 @@ wait_read_write() {
   return 1
 }
 
+warn_manual_failback_boundary() {
+  cat <<'EOF'
+WARNING: DR standby promotion only activates this Patroni cluster.
+WARNING: The KubeBlocks Cluster spec may still contain PG_MODE=standby and serviceRefs to the old source.
+WARNING: Before restarting the old source, update the promoted Cluster spec to remove standby config and either delete or rebuild the old source as a standby.
+WARNING: Automatic failback is not part of pg-promote-standby.
+EOF
+}
+
 promote_standby() {
   require_force
+  warn_if_source_reachable
   require_standby_mode
 
   if ! is_standby_leader; then
@@ -66,6 +96,7 @@ promote_standby() {
 
   patch_remove_standby_cluster
   wait_read_write
+  warn_manual_failback_boundary
 }
 
 ${__SOURCED__:+false} : || return 0

--- a/addons/postgresql/templates/pcr.yaml
+++ b/addons/postgresql/templates/pcr.yaml
@@ -1,0 +1,29 @@
+{{- range .Values.versions }}
+---
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParamConfigRenderer
+metadata:
+  name: {{ include "postgresql.pcr" (dict "major" .major "root" $) }}
+  labels:
+    {{- include "postgresql.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "postgresql.annotations" $ | nindent 4 }}
+spec:
+  componentDef: {{ include "postgresql.componentDefByMajor" (dict "major" .major "root" $) }}
+  serviceVersion: {{ .serviceVersion }}
+  parametersDefs:
+    - {{ include "postgresql.parametersDefinition" (dict "major" .major "root" $) }}
+
+  configs:
+    - name: postgresql.conf
+      fileFormatConfig:
+        format: properties
+      reRenderResourceTypes:
+        - vscale
+        - tls
+    - name: pgbouncer.ini
+      fileFormatConfig:
+        format: ini
+        iniConfig:
+          sectionName: pgbouncer
+{{- end -}}

--- a/addons/postgresql/templates/promote_standby.yaml
+++ b/addons/postgresql/templates/promote_standby.yaml
@@ -24,6 +24,12 @@ spec:
             Must be true to acknowledge that the source cluster has been fenced/stopped.
             Promoting a standby cluster while the source is still running can create split-brain.
           type: string
+        sourceEndpoint:
+          description: |
+            Optional best-effort source endpoint probe in host:port form. If the source endpoint
+            is still reachable during promote, the action emits a warning but does not fail.
+            The source may still be draining and the force=true acknowledgement is authoritative.
+          type: string
       required:
         - force
       type: object
@@ -32,6 +38,7 @@ spec:
       failurePolicy: Fail
       parameters:
         - force
+        - sourceEndpoint
       workload:
         podInfoExtractorName: availablePod
         type: Pod

--- a/addons/postgresql/templates/promote_standby.yaml
+++ b/addons/postgresql/templates/promote_standby.yaml
@@ -1,0 +1,48 @@
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsDefinition
+metadata:
+  name: pg-promote-standby
+spec:
+  podInfoExtractors:
+    - name: availablePod
+      podSelector:
+        multiPodSelectionPolicy: All
+      env:
+        - name: PG_MODE
+          valueFrom:
+            envRef:
+              envName: PG_MODE
+        - name: CURRENT_POD_IP
+          valueFrom:
+            envRef:
+              envName: CURRENT_POD_IP
+  parametersSchema:
+    openAPIV3Schema:
+      properties:
+        force:
+          description: |
+            Must be true to acknowledge that the source cluster has been fenced/stopped.
+            Promoting a standby cluster while the source is still running can create split-brain.
+          type: string
+      required:
+        - force
+      type: object
+  actions:
+    - name: promote-standby
+      failurePolicy: Fail
+      parameters:
+        - force
+      workload:
+        podInfoExtractorName: availablePod
+        type: Pod
+        backoffLimit: 0
+        podSpec:
+          containers:
+            - name: promote-standby
+              image: {{ include "postgresql.initImage" . }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - bash
+                - -c
+                - |
+                  {{- .Files.Get "scripts/promote_standby.sh" | nindent 18 }}


### PR DESCRIPTION
## Summary
- add pg-promote-standby OpsDefinition for PostgreSQL standby-cluster DR cutover
- implement Patroni standby_cluster promotion by requiring force=true, removing standby_cluster from dynamic config, and waiting for read-write status
- add shellspec coverage for force/standby guards and non-standby-leader no-op

## Validation
- bash -n addons/postgresql/scripts/promote_standby.sh
- shellspec --helperdir shellspec --shell /opt/homebrew/bin/bash addons/postgresql/scripts-ut-spec/promote_standby_spec.sh
- helm dependency build addons/postgresql
- helm template pg addons/postgresql >/tmp/pg-dr-cutover-rendered.yaml
- helm lint addons/postgresql
- git diff --check