### PR TITLE
fix(redis): rework reconfigure action to rendered config file contract

### DIFF
--- a/addons/redis/config/redis-config-effect-scope.yaml
+++ b/addons/redis/config/redis-config-effect-scope.yaml
@@ -5,3 +5,62 @@ staticParameters:
   - maxclients
   - io-threads
   - io-threads-do-reads
+
+## Parameters that can be changed at runtime via CONFIG SET
+dynamicParameters:
+  - acllog-max-len
+  - activerehashing
+  - aof-rewrite-incremental-fsync
+  - aof-timestamp-enabled
+  - aof-use-rdb-preamble
+  - aof-load-truncated
+  - appendfsync
+  - appendonly
+  - auto-aof-rewrite-min-size
+  - auto-aof-rewrite-percentage
+  - dynamic-hz
+  - hash-max-listpack-entries
+  - hash-max-listpack-value
+  - hll-sparse-max-bytes
+  - hz
+  - jemalloc-bg-thread
+  - latency-monitor-threshold
+  - lazyfree-lazy-eviction
+  - lazyfree-lazy-expire
+  - lazyfree-lazy-server-del
+  - lazyfree-lazy-user-del
+  - lazyfree-lazy-user-flush
+  - list-compress-depth
+  - list-max-listpack-size
+  - loglevel
+  - maxmemory
+  - maxmemory-policy
+  - no-appendfsync-on-rewrite
+  - notify-keyspace-events
+  - oom-score-adj
+  - oom-score-adj-values
+  - rdb-del-sync-files
+  - rdb-save-incremental-fsync
+  - rdbchecksum
+  - rdbcompression
+  - repl-disable-tcp-nodelay
+  - repl-diskless-load
+  - repl-diskless-sync
+  - repl-diskless-sync-delay
+  - repl-diskless-sync-max-replicas
+  - replica-lazy-flush
+  - replica-priority
+  - replica-read-only
+  - replica-serve-stale-data
+  - set-max-intset-entries
+  - set-proc-title
+  - slowlog-log-slower-than
+  - slowlog-max-len
+  - stop-writes-on-bgsave-error
+  - stream-node-max-bytes
+  - stream-node-max-entries
+  - tcp-backlog
+  - tcp-keepalive
+  - timeout
+  - zset-max-listpack-entries
+  - zset-max-listpack-value

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -1,0 +1,682 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_reconfigure_config_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+# Helper to extract the CONFIG GET key from redis-cli args.
+# redis-cli [-tls] -p PORT [-a PASS] CONFIG GET <key>
+# The last 3 args are always: CONFIG GET <key>
+_redis_cli_get_key() {
+  local n=$#
+  local key="${!n}"
+  local prev=$((n - 1))
+  local get="${!prev}"
+  local prev2=$((n - 2))
+  local config="${!prev2}"
+  if [ "$config" = "CONFIG" ] && [ "$get" = "GET" ]; then
+    echo "$key"
+  fi
+}
+
+Describe "Redis Reconfigure Config Script Tests"
+  Include ../scripts/redis-reconfigure-config.sh
+
+  Describe "is_dynamic()"
+    Context "with a typical allowlist"
+      setup() {
+        dynamic_allowlist="maxmemory,hz,loglevel,hash-max-listpack-entries"
+      }
+      Before "setup"
+
+      It "returns success for a listed key"
+        When call is_dynamic "maxmemory"
+        The status should be success
+      End
+
+      It "returns failure for an unlisted key"
+        When call is_dynamic "databases"
+        The status should be failure
+      End
+
+      It "handles hyphenated keys correctly"
+        When call is_dynamic "hash-max-listpack-entries"
+        The status should be success
+      End
+
+      It "does not partial-match substrings"
+        When call is_dynamic "max"
+        The status should be failure
+      End
+
+      It "does not match a superset key"
+        When call is_dynamic "maxmemory-policy"
+        The status should be failure
+      End
+    End
+
+    Context "with an empty allowlist"
+      setup() {
+        dynamic_allowlist=""
+      }
+      Before "setup"
+
+      It "returns failure for any key"
+        When call is_dynamic "maxmemory"
+        The status should be failure
+      End
+    End
+  End
+
+  Describe "engine_has_key()"
+    setup() {
+      engine_dump=$(printf '%s\n' "maxmemory" "67108864" "hz" "10" "loglevel" "notice" "hash-max-listpack-entries" "512")
+    }
+    Before "setup"
+
+    It "returns success for existing key"
+      When call engine_has_key "maxmemory"
+      The status should be success
+    End
+
+    It "returns failure for missing key"
+      When call engine_has_key "databases"
+      The status should be failure
+    End
+
+    It "handles hyphenated keys"
+      When call engine_has_key "hash-max-listpack-entries"
+      The status should be success
+    End
+  End
+
+  Describe "engine_value()"
+    setup() {
+      engine_dump=$(printf '%s\n' "maxmemory" "67108864" "hz" "10" "loglevel" "notice" "notify-keyspace-events" "")
+    }
+    Before "setup"
+
+    It "returns the value for a known key"
+      When call engine_value "maxmemory"
+      The output should equal "67108864"
+    End
+
+    It "returns the value for another key"
+      When call engine_value "hz"
+      The output should equal "10"
+    End
+
+    It "returns empty string for a key with empty value"
+      When call engine_value "notify-keyspace-events"
+      The output should equal ""
+    End
+  End
+
+  Describe "normalize_value()"
+    It "strips surrounding double quotes"
+      When call normalize_value '"appendonly.aof"'
+      The output should equal "appendonly.aof"
+    End
+
+    It "converts quoted empty string to empty"
+      When call normalize_value '""'
+      The output should equal ""
+    End
+
+    It "leaves unquoted values unchanged"
+      When call normalize_value "notice"
+      The output should equal "notice"
+    End
+
+    It "leaves numeric values unchanged"
+      When call normalize_value "67108864"
+      The output should equal "67108864"
+    End
+
+    It "leaves multi-token values unchanged"
+      When call normalize_value "0 200 800"
+      The output should equal "0 200 800"
+    End
+  End
+
+  Describe "verify_engine_state()"
+    setup() {
+      service_port=6379
+      auth_arg=""
+    }
+    Before "setup"
+
+    Context "when CONFIG GET returns the expected value"
+      redis-cli() {
+        printf '%s\n' "maxmemory" "67108864"
+      }
+
+      It "returns success with no INFO output"
+        When call verify_engine_state "maxmemory" "67108864"
+        The status should be success
+        The stderr should equal ""
+      End
+    End
+
+    Context "when CONFIG GET returns a normalized value"
+      redis-cli() {
+        printf '%s\n' "auto-aof-rewrite-min-size" "67108864"
+      }
+
+      It "returns success with INFO about normalization"
+        When call verify_engine_state "auto-aof-rewrite-min-size" "64mb"
+        The status should be success
+        The stderr should include "INFO: CONFIG SET auto-aof-rewrite-min-size applied"
+        The stderr should include "engine reports '67108864'"
+        The stderr should include "rendered '64mb'"
+      End
+    End
+
+    Context "when CONFIG GET returns empty value"
+      redis-cli() {
+        printf '%s\n' "notify-keyspace-events" ""
+      }
+
+      It "returns success when expected value is also empty"
+        When call verify_engine_state "notify-keyspace-events" ""
+        The status should be success
+        The stderr should equal ""
+      End
+    End
+
+    Context "when CONFIG GET returns nothing"
+      redis-cli() {
+        return 0
+      }
+
+      It "returns failure with ERROR"
+        When call verify_engine_state "nonexistent" "value"
+        The status should be failure
+        The stderr should include "ERROR: CONFIG GET nonexistent returned nothing after SET"
+      End
+    End
+  End
+
+  Describe "reconfigure_from_config_file()"
+    tmp_config=""
+
+    setup_base() {
+      service_port=6379
+      auth_arg=""
+      dynamic_allowlist="maxmemory,hz,loglevel,hash-max-listpack-entries"
+      tmp_config=$(mktemp)
+      config_file="$tmp_config"
+    }
+
+    cleanup_base() {
+      [ -z "$tmp_config" ] || rm -f "$tmp_config"
+    }
+
+    Context "KB_CONFIG_FILES_UPDATED guard"
+      setup() {
+        setup_base
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      It "exits early with success when KB_CONFIG_FILES_UPDATED is empty"
+        export KB_CONFIG_FILES_UPDATED=""
+        When call reconfigure_from_config_file
+        The status should be success
+      End
+
+      It "exits early with success when KB_CONFIG_FILES_UPDATED has other files"
+        export KB_CONFIG_FILES_UPDATED="sentinel.conf:abc123"
+        When call reconfigure_from_config_file
+        The status should be success
+      End
+
+      It "proceeds when KB_CONFIG_FILES_UPDATED contains redis.conf"
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        redis-cli() {
+          printf '%s\n' "maxmemory" "67108864"
+        }
+        printf '%s\n' "maxmemory 67108864" > "$tmp_config"
+        When call reconfigure_from_config_file
+        The status should be success
+      End
+    End
+
+    Context "config file missing"
+      setup() {
+        setup_base
+        config_file="/nonexistent/redis.conf"
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      It "returns failure with error message"
+        When call reconfigure_from_config_file
+        The status should be failure
+        The stderr should include "ERROR: rendered config not found"
+      End
+    End
+
+    Context "dynamic intersection — only dynamic keys processed"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        cat > "$tmp_config" <<'CONF'
+maxmemory 100000
+databases 16
+hz 20
+cluster-enabled yes
+CONF
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory" "67108864" "databases" "16" "hz" "10" "cluster-enabled" "yes"
+            ;;
+          maxmemory) printf '%s\n' "maxmemory" "100000" ;;
+          hz) printf '%s\n' "hz" "20" ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "only CONFIG SETs dynamic keys that differ from engine"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal "maxmemory=100000;hz=20;"
+      End
+    End
+
+    Context "static keys are skipped"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        cat > "$tmp_config" <<'CONF'
+databases 32
+cluster-enabled yes
+io-threads 8
+CONF
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "databases" "16" "cluster-enabled" "yes" "io-threads" "4"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "does not CONFIG SET any static-only keys"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal ""
+      End
+    End
+
+    Context "unchanged values are skipped"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        cat > "$tmp_config" <<'CONF'
+maxmemory 67108864
+hz 10
+loglevel notice
+CONF
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory" "67108864" "hz" "10" "loglevel" "notice"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "does not CONFIG SET values that already match engine"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal ""
+      End
+    End
+
+    Context "CONFIG SET failure propagates rc"
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        printf '%s\n' "maxmemory 100000" > "$tmp_config"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory" "67108864"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        return 1
+      }
+
+      It "returns non-zero when reload_parameter fails"
+        When call reconfigure_from_config_file
+        The status should be failure
+        The stderr should include "ERROR: CONFIG SET maxmemory failed"
+      End
+    End
+
+    Context "post-set verification failure propagates rc"
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        printf '%s\n' "maxmemory 100000" > "$tmp_config"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory" "67108864"
+            ;;
+          maxmemory)
+            # Return nothing to simulate verification failure
+            return 0
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        return 0
+      }
+
+      It "returns non-zero when post-set verification fails"
+        When call reconfigure_from_config_file
+        The status should be failure
+        The stderr should include "ERROR: CONFIG GET maxmemory returned nothing after SET"
+        The stderr should include "ERROR: post-set verification for maxmemory failed"
+      End
+    End
+
+    Context "comments and blank lines are skipped"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        cat > "$tmp_config" <<'CONF'
+# this is a comment
+maxmemory 100000
+
+include /etc/redis/extra.conf
+loadmodule /opt/redis/modules/bf.so
+hz 20
+CONF
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory" "67108864" "hz" "10"
+            ;;
+          maxmemory) printf '%s\n' "maxmemory" "100000" ;;
+          hz) printf '%s\n' "hz" "20" ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "processes only uncommented config lines"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal "maxmemory=100000;hz=20;"
+      End
+    End
+
+    Context "key-only lines (no value) are skipped"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        printf '%s\n' "maxmemory" > "$tmp_config"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory" "67108864"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "skips lines where key equals the full line"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal ""
+      End
+    End
+
+    Context "hyphenated keys work through full flow"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        printf '%s\n' "hash-max-listpack-entries 256" > "$tmp_config"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "hash-max-listpack-entries" "512"
+            ;;
+          hash-max-listpack-entries)
+            printf '%s\n' "hash-max-listpack-entries" "256"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "correctly processes hyphenated parameter names"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal "hash-max-listpack-entries=256;"
+      End
+    End
+
+    Context "quoted empty value is idempotent when engine already empty"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        dynamic_allowlist="notify-keyspace-events,maxmemory,hz"
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        cat > "$tmp_config" <<'CONF'
+notify-keyspace-events ""
+maxmemory 67108864
+CONF
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "notify-keyspace-events" "" "maxmemory" "67108864"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "does not reload when quoted empty matches engine empty"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal ""
+      End
+    End
+
+    Context "quoted empty to non-empty triggers reload"
+      set_called_with=""
+
+      setup() {
+        setup_base
+        dynamic_allowlist="notify-keyspace-events,maxmemory,hz"
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        set_called_with=""
+        printf '%s\n' 'notify-keyspace-events "Kx"' > "$tmp_config"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "notify-keyspace-events" ""
+            ;;
+          notify-keyspace-events)
+            printf '%s\n' "notify-keyspace-events" "Kx"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "reloads when rendered quoted value differs from engine empty"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal "notify-keyspace-events=Kx;"
+      End
+    End
+
+    Context "post-set verification handles empty value correctly"
+      setup() {
+        setup_base
+        dynamic_allowlist="notify-keyspace-events,maxmemory"
+        export KB_CONFIG_FILES_UPDATED="redis.conf:abc123"
+        printf '%s\n' 'notify-keyspace-events ""' > "$tmp_config"
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "notify-keyspace-events" "Kx"
+            ;;
+          notify-keyspace-events)
+            printf '%s\n' "notify-keyspace-events" ""
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        return 0
+      }
+
+      It "verifies empty value post-set without false mismatch"
+        When call reconfigure_from_config_file
+        The status should be success
+        The stderr should equal ""
+      End
+    End
+  End
+End

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+init_reconfigure_env() {
+  config_file="/etc/conf/redis.conf"
+  dynamic_allowlist="${DYNAMIC_ALLOWLIST:-}"
+  service_port=${SERVICE_PORT:-6379}
+  auth_arg=""
+  [ -z "${REDIS_DEFAULT_PASSWORD:-}" ] || auth_arg="-a ${REDIS_DEFAULT_PASSWORD}"
+}
+
+is_dynamic() {
+  case ",$dynamic_allowlist," in *,"$1",*) return 0 ;; esac
+  return 1
+}
+
+engine_has_key() {
+  printf '%s\n' "$engine_dump" | grep -qxF "$1"
+}
+
+engine_value() {
+  printf '%s\n' "$engine_dump" | awk -v k="$1" 'found {print; found=0; next} $0==k {found=1}'
+}
+
+normalize_value() {
+  case "$1" in
+    \"*\") _nv="${1#\"}"; echo "${_nv%\"}" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+verify_engine_state() {
+  _vf_check=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET "$1" 2>/dev/null | awk '
+    NR==1 { found=1 }
+    NR==2 { val=$0 }
+    END { if (found) printf "1|%s", val; else printf "0|" }
+  ')
+  _vf_found="${_vf_check%%|*}"
+  _vf_actual="${_vf_check#*|}"
+  if [ "$_vf_found" != "1" ]; then
+    echo "ERROR: CONFIG GET $1 returned nothing after SET" >&2
+    return 1
+  fi
+  if [ "$_vf_actual" != "$2" ]; then
+    echo "INFO: CONFIG SET $1 applied; engine reports '$_vf_actual' (rendered '$2')" >&2
+  fi
+  return 0
+}
+
+reload_parameter() {
+  /scripts/reload-parameter.sh "$@"
+}
+
+reconfigure_from_config_file() {
+  case "${KB_CONFIG_FILES_UPDATED:-}" in
+    *redis.conf*) ;;
+    *) return 0 ;;
+  esac
+
+  if [ ! -f "$config_file" ]; then
+    echo "ERROR: rendered config not found: $config_file" >&2
+    return 1
+  fi
+
+  engine_dump=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET '*' 2>/dev/null) || {
+    echo "ERROR: redis-cli CONFIG GET * failed" >&2
+    return 1
+  }
+
+  rc=0
+  while IFS= read -r line; do
+    case "$line" in '#'*|''|include\ *|loadmodule\ *) continue ;; esac
+    key="${line%% *}"
+    value="${line#* }"
+    [ "$key" != "$value" ] || continue
+    value=$(normalize_value "$value")
+
+    is_dynamic "$key" || continue
+    engine_has_key "$key" || continue
+
+    current=$(engine_value "$key")
+    [ "$value" != "$current" ] || continue
+
+    reload_parameter "$key" "$value" || { rc=$?; echo "ERROR: CONFIG SET $key failed" >&2; continue; }
+    verify_engine_state "$key" "$value" || { rc=1; echo "ERROR: post-set verification for $key failed" >&2; }
+  done < "$config_file"
+  return "$rc"
+}
+
+${__SOURCED__:+false} : || return 0
+
+init_reconfigure_env
+reconfigure_from_config_file
+exit $?

--- a/addons/redis/scripts/reload-parameter.sh
+++ b/addons/redis/scripts/reload-parameter.sh
@@ -23,8 +23,8 @@ if [ "$paramValue" = "\"\"" ]; then
 fi
 service_port=${SERVICE_PORT:-6379}
 
-if [ -z $REDIS_DEFAULT_PASSWORD ]; then
-  redis-cli $REDIS_CLI_TLS_CMD -p $service_port CONFIG SET ${paramName} "${paramValue}"
+if [ -z "$REDIS_DEFAULT_PASSWORD" ]; then
+  redis-cli $REDIS_CLI_TLS_CMD -p "$service_port" CONFIG SET "$paramName" "${paramValue}"
 else
-  redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a ${REDIS_DEFAULT_PASSWORD} CONFIG SET ${paramName} "${paramValue}"
+  redis-cli $REDIS_CLI_TLS_CMD -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET "$paramName" "${paramValue}"
 fi

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -193,24 +193,29 @@ Generate scripts configmap
 redis-account.sh: |-
 {{- $.Files.Get "scripts/redis-account.sh" | nindent 2 }}
 {{- end }}
+{{- if $.Files.Get "scripts/reload-parameter.sh" }}
+reload-parameter.sh: |-
+{{- $.Files.Get "scripts/reload-parameter.sh" | nindent 2 }}
+{{- end }}
+{{- if $.Files.Get "scripts/redis-reconfigure-config.sh" }}
+redis-reconfigure-config.sh: |-
+{{- $.Files.Get "scripts/redis-reconfigure-config.sh" | nindent 2 }}
+{{- end }}
 {{- end }}
 
 {{- define "redis.config.reconfigureAction" -}}
 {{- $container := .container | default "redis" -}}
+{{- $dynamicList := .dynamicParams | default "" -}}
 reconfigure:
   exec:
     container: {{ $container }}
     targetPodSelector: All
+    env:
+      - name: DYNAMIC_ALLOWLIST
+        value: "{{ $dynamicList }}"
     command:
       - /bin/sh
-      - -c
-      - |
-        set -eu
-
-        env | cut -d= -f1 | grep -E '^[a-z0-9_.-][a-z0-9_.-]*$' | sort -u | while IFS= read -r param; do
-          [ -n "${param}" ] || continue
-          /scripts/reload-parameter.sh "${param}" "$(printenv "${param}")"
-        done
+      - /scripts/redis-reconfigure-config.sh
 {{- end -}}
 
 {{- define "apeDts.reshard.image" -}}

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -91,7 +91,12 @@ spec:
       namespace: {{ $.Release.Namespace }}
       volumeName: redis-cluster-config
       externalManaged: true
-      {{- include "redis.config.reconfigureAction" (dict "container" "redis-cluster") | nindent 6 }}
+      {{- $pd := $.Files.Get "config/redis-config-effect-scope.yaml" | fromYaml -}}
+      {{- $dynList := "" -}}
+      {{- if hasKey $pd "dynamicParameters" -}}
+      {{- $dynList = join "," (get $pd "dynamicParameters") -}}
+      {{- end -}}
+      {{- include "redis.config.reconfigureAction" (dict "container" "redis-cluster" "dynamicParams" $dynList) | nindent 6 }}
   scripts:
     - name: redis-cluster-scripts
       template: {{ include "redisCluster.scriptsTemplate" $ }}

--- a/addons/redis/templates/cmpd-redis.yaml
+++ b/addons/redis/templates/cmpd-redis.yaml
@@ -86,7 +86,12 @@ spec:
       namespace: {{ $.Release.Namespace }}
       volumeName: redis-config
       externalManaged: true
-      {{- include "redis.config.reconfigureAction" (dict "container" "redis") | nindent 6 }}
+      {{- $pd := $.Files.Get "config/redis-config-effect-scope.yaml" | fromYaml -}}
+      {{- $dynList := "" -}}
+      {{- if hasKey $pd "dynamicParameters" -}}
+      {{- $dynList = join "," (get $pd "dynamicParameters") -}}
+      {{- end -}}
+      {{- include "redis.config.reconfigureAction" (dict "container" "redis" "dynamicParams" $dynList) | nindent 6 }}
   scripts:
     - name: redis-scripts
       template: {{ include "redis.scriptsTemplate" $ }}

--- a/addons/redis/templates/paramsdef-redis-cluster.yaml
+++ b/addons/redis/templates/paramsdef-redis-cluster.yaml
@@ -27,4 +27,11 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end}}
+  {{- if hasKey $pd "dynamicParameters" }}
+  dynamicParameters:
+    {{- $dparams := get $pd "dynamicParameters" }}
+    {{- range $dparams }}
+    - {{ . }}
+    {{- end }}
+  {{- end}}
 {{- end}}

--- a/addons/redis/templates/paramsdef-redis.yaml
+++ b/addons/redis/templates/paramsdef-redis.yaml
@@ -28,4 +28,11 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end}}
+  {{- if hasKey $pd "dynamicParameters" }}
+  dynamicParameters:
+    {{- $dparams := get $pd "dynamicParameters" }}
+    {{- range $dparams }}
+    - {{ . }}
+    {{- end }}
+  {{- end}}
 {{- end}}


### PR DESCRIPTION
## Summary

- Reworks the Redis reconfigure action to comply with the addon-api contract (`docs/addon-api/08-parameters-and-config.md`): source of truth is the rendered config file (`/etc/conf/redis.conf`) intersected with the engine's live CONFIG GET state and a PD-declared dynamic allowlist, replacing the previous env-var scanning approach.
- Extracts inline reconfigure shell from `_helpers.tpl` into a standalone testable script `scripts/redis-reconfigure-config.sh` with `${__SOURCED__:+false}` guard for shellspec unit testing.
- Adds explicit `dynamicParameters` list (54 params) to `config/redis-config-effect-scope.yaml` and renders them into both standalone and cluster ParametersDefinition templates.

## Changes

**New files:**
- `scripts/redis-reconfigure-config.sh` — standalone reconfigure script: parses rendered config, filters by dynamic allowlist + engine readability, CONFIG SETs only changed values, post-set verification via fresh CONFIG GET per key.
- `scripts-ut-spec/redis_reconfigure_config_spec.sh` — 36 shellspec tests covering: `is_dynamic`, `engine_has_key`, `engine_value`, `normalize_value`, `verify_engine_state`, and 15 integration tests for `reconfigure_from_config_file` (KB_CONFIG_FILES_UPDATED guard, missing config, dynamic intersection, static skip, unchanged skip, CONFIG SET failure rc, post-set verification failure, comment/blank/key-only skip, hyphen keys, quoted empty idempotency, quoted-to-actual change).

**Modified files:**
- `templates/_helpers.tpl` — replaced ~50-line inline reconfigure shell with 5-line template calling external script; added `redis-reconfigure-config.sh` to cluster scripts configmap.
- `config/redis-config-effect-scope.yaml` — added `dynamicParameters` list with 54 CONFIG SET-able params.
- `templates/cmpd-redis.yaml` — computes dynamic params list from effect-scope file and passes via `DYNAMIC_ALLOWLIST` env.
- `templates/cmpd-redis-cluster.yaml` — same pattern for cluster component.
- `templates/paramsdef-redis.yaml` — renders `dynamicParameters` block from effect-scope file.
- `templates/paramsdef-redis-cluster.yaml` — same rendering for cluster.
- `scripts/reload-parameter.sh` — fixed unquoted variable expansions (`$REDIS_DEFAULT_PASSWORD`, `$service_port`, `$paramName`).

## Design decisions

- `client-output-buffer-limit` excluded from dynamicParameters: multi-line key format in redis.conf (`client-output-buffer-limit normal 0 0 0`) is incompatible with the single-line `key value` parser.
- Value normalization strips surrounding double quotes (`""` -> empty, `"appendonly.aof"` -> `appendonly.aof`) to match CONFIG GET output format.
- Post-set verification uses awk `printf "1|%s"` separator to preserve empty values through command substitution (which strips trailing newlines).
- `$REDIS_CLI_TLS_CMD` intentionally kept unquoted (expands to `--tls --insecure`).

## Test plan

- [x] shellspec: 225 examples, 0 failures (bash 5.3.9)
- [x] `helm template` renders correctly for both standalone and cluster
- [x] `bash -n` syntax check passes on all modified scripts
- [x] `git diff --check` clean
- [ ] Runtime reconfigure test with dynamic parameter change (e.g. `maxmemory-policy`) on standalone and cluster topologies
