### PR TITLE
fix(redis): reclassify maxclients from static to dynamic parameter

### DIFF
--- a/addons/redis/config/redis-config-effect-scope.yaml
+++ b/addons/redis/config/redis-config-effect-scope.yaml
@@ -2,6 +2,5 @@
 staticParameters:
   - cluster-enabled
   - databases
-  - maxclients
   - io-threads
   - io-threads-do-reads


### PR DESCRIPTION
## Summary
- Remove `maxclients` from `staticParameters` in `redis-config-effect-scope.yaml`
- Per CODEOWNER review: when only `staticParameters` is set, all unlisted parameters are treated as dynamic by KB controller — no `dynamicParameters` section needed

## What changed
`maxclients` supports `CONFIG SET` at runtime. Removing it from `staticParameters` prevents unnecessary rolling restarts on reconfigure.

## Test plan
- [x] CI green
- [x] Aria focused review APPROVE
- [x] Max runtime acceptance PASS `8/0/0` (on prior head; re-run needed for narrowed head)

Generated with [Claude Code](https://claude.com/claude-code)