### PR TITLE
fix(mariadb): stabilize post-DCS read_only fence against syncer race

### DIFF
--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1468,18 +1468,25 @@ fence_current_primary_local_writes_after_dcs() {
   log_switchover_info "Switchover post-DCS guard: setting current primary ${current_name} read_only=ON before candidate can accept writes"
   local fence_attempt=1
   local fence_max=10
+  local syncer_race_hold=3
   while [ "${fence_attempt}" -le "${fence_max}" ]; do
     set_local_read_only "ON" 2>/dev/null || true
     if local_read_only_is "1"; then
-      log_switchover_info "Switchover post-DCS read_only=ON verified at attempt=${fence_attempt}"
-      break
+      log_switchover_info "Switchover post-DCS read_only=ON set at attempt=${fence_attempt}, holding ${syncer_race_hold}s for syncer race window"
+      sleep "${syncer_race_hold}"
+      if local_read_only_is "1"; then
+        log_switchover_info "Switchover post-DCS read_only=ON stable after ${syncer_race_hold}s hold at attempt=${fence_attempt}"
+        break
+      fi
+      log_switchover_info "Switchover post-DCS read_only reverted during hold (syncer race), re-setting (attempt=${fence_attempt}/${fence_max})"
+    else
+      log_switchover_info "Switchover post-DCS read_only=ON not yet confirmed, retrying (attempt=${fence_attempt}/${fence_max})"
     fi
-    log_switchover_info "Switchover post-DCS read_only=ON not yet stable, retrying (attempt=${fence_attempt}/${fence_max})"
     sleep 1
     fence_attempt=$((fence_attempt + 1))
   done
   if ! local_read_only_is "1"; then
-    log_switchover_error "Switchover failed: current primary read_only=ON was not verified after ${fence_max} attempts"
+    log_switchover_error "Switchover failed: current primary read_only=ON was not stable after ${fence_max} attempts"
     return 1
   fi
   # alpha.60 + alpha.124: synchronously revoke user-facing root admin bypass


### PR DESCRIPTION
## Summary

After DCS switchover, the syncer on the old primary has not yet detected the leadership change. It can set read_only=OFF between the fence loop verify and the post-loop safety check, causing a false switchover failure.

This commit adds a 3-second stabilization hold after the initial read_only=ON verification. The hold covers the syncer DCS poll window (~3s). If the syncer reverts read_only during the hold, the loop re-sets and retries.

## Evidence

- Chain 3 N=12 T10 Switchover FAIL on alpha.25 chart
- OpsRequest: switch pod-1 to pod-0
- kbagent error: current primary read_only=ON was not verified after 10 attempts
- Action duration: 943ms proves the loop broke at attempt 1 and the post-loop re-check raced with the syncer
- Live state after failure: pod-0 correct primary, pod-1 correct secondary, replication healthy -- the switchover succeeded at DB level but the action status report was wrong

## Budget

- Happy path (no syncer race): ~3.5s
- Single syncer race: ~7.5s
- Fence stage budget: 15s

## Test plan

- [ ] Rebuild alpha.25+ chart with this fix
- [ ] Re-run semisync full suite from N=1, targeting 20 clean rounds
- [ ] T10 Switchover must pass consistently