### PR TITLE
fix(redis): add dynamic parameter classifications for timeout/loglevel/maxmemory-policy/appendfsync

### DIFF
--- a/addons/redis/README.md
+++ b/addons/redis/README.md
@@ -563,8 +563,8 @@ kubectl apply -f examples/redis/configure.yaml
 This example will change the `maxclients` to `10001` for the Redis component.
 `maxclients` in Redis specifies the maximum number of simultaneous client connections the server will accept. Once this limit is reached, Redis will start rejecting new connections until existing clients disconnect.
 
-> [!CAUTION]
-> It is defined as a static parameter, which means the Redis component will be restarted after the reconfiguration.
+> [!NOTE]
+> `maxclients` is a dynamic parameter. Redis applies it at runtime via `CONFIG SET` without restarting.
 
 To verify the reconfiguration, you can connect to the Redis pod and check the configuration with the following command:
 

--- a/addons/redis/config/redis-config-effect-scope.yaml
+++ b/addons/redis/config/redis-config-effect-scope.yaml
@@ -8,3 +8,7 @@ staticParameters:
 ## Parameters that can be changed at runtime via CONFIG SET
 dynamicParameters:
   - maxclients
+  - timeout
+  - loglevel
+  - maxmemory-policy
+  - appendfsync

--- a/addons/redis/config/redis-config-effect-scope.yaml
+++ b/addons/redis/config/redis-config-effect-scope.yaml
@@ -1,7 +1,10 @@
-## All parameters need to be restarted
+## Parameters that require restart
 staticParameters:
   - cluster-enabled
   - databases
-  - maxclients
   - io-threads
   - io-threads-do-reads
+
+## Parameters that can be changed at runtime via CONFIG SET
+dynamicParameters:
+  - maxclients

--- a/addons/redis/templates/paramsdef-redis-cluster.yaml
+++ b/addons/redis/templates/paramsdef-redis-cluster.yaml
@@ -27,4 +27,13 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end}}
+
+  ## can be changed at runtime via CONFIG SET
+  {{- if hasKey $pd "dynamicParameters" }}
+  dynamicParameters:
+    {{- $params := get $pd "dynamicParameters" }}
+    {{- range $params }}
+    - {{ . }}
+    {{- end }}
+  {{- end}}
 {{- end}}

--- a/addons/redis/templates/paramsdef-redis.yaml
+++ b/addons/redis/templates/paramsdef-redis.yaml
@@ -28,4 +28,13 @@ spec:
     - {{ . }}
     {{- end }}
   {{- end}}
+
+  ## can be changed at runtime via CONFIG SET
+  {{- if hasKey $pd "dynamicParameters" }}
+  dynamicParameters:
+    {{- $params := get $pd "dynamicParameters" }}
+    {{- range $params }}
+    - {{ . }}
+    {{- end }}
+  {{- end}}
 {{- end}}


### PR DESCRIPTION
## Summary

- Adds `timeout`, `loglevel`, `maxmemory-policy`, and `appendfsync` to `dynamicParameters` in the Redis effect-scope file
- All four parameters support Redis `CONFIG SET` at runtime without restart
- Previously unlisted: when `dynamicParameters` is non-empty, KB controller treats unlisted schema parameters as static (restart path), causing unnecessary rolling restarts for these common runtime-tunable parameters
- Phase 1 of incremental dynamic parameter classification; `maxmemory` excluded due to `@storeResource()` and template-generated default value interactions

**Depends on**: #2798 (adds `dynamicParameters` rendering block to paramsdef templates + maxclients)

## Redis CONFIG SET evidence

| Parameter | CONFIG SET supported | Redis docs reference |
|---|---|---|
| timeout | Yes | `CONFIG SET timeout <seconds>` — client idle timeout |
| loglevel | Yes | `CONFIG SET loglevel <level>` — debug/verbose/notice/warning |
| maxmemory-policy | Yes | `CONFIG SET maxmemory-policy <policy>` — eviction policy. Also proven by task #28 runtime (CONFIG SET to allkeys-lru succeeded) |
| appendfsync | Yes | `CONFIG SET appendfsync <value>` — always/everysec/no |

## Controller behavior evidence

KB main `968cc6e0`: when `dynamicParameters` is non-empty, parameters in the CUE schema but not in either static or dynamic list are treated as static/restart. This is a misclassification, not intentional restriction.

## Verification

```bash
helm template redis addons/redis --show-only templates/paramsdef-redis.yaml | grep -A10 dynamicParameters
# All 4 versions render: maxclients, timeout, loglevel, maxmemory-policy, appendfsync

helm lint addons/redis
# 1 chart(s) linted, 0 chart(s) failed
```

## Test plan

- [ ] CI pass
- [ ] Runtime: for each new parameter, OpsRequest Reconfiguring Succeed + CONFIG GET returns new value + pod UID/restartCount unchanged + cleanup clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)