### PR TITLE
fix(valkey): derive sentinel monitor quorum dynamically

### DIFF
--- a/addons/valkey/dataprotection/post-restore-sentinel.sh
+++ b/addons/valkey/dataprotection/post-restore-sentinel.sh
@@ -162,7 +162,11 @@ fi
 # bounded scan limit.
 sentinel_fqdn_list=()
 if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
-  IFS=',' read -ra sentinel_fqdn_list <<< "${SENTINEL_POD_FQDN_LIST}"
+  sentinel_fqdn_list_raw=()
+  IFS=',' read -ra sentinel_fqdn_list_raw <<< "${SENTINEL_POD_FQDN_LIST}"
+  for sentinel_fqdn in "${sentinel_fqdn_list_raw[@]}"; do
+    [ -n "${sentinel_fqdn}" ] && sentinel_fqdn_list+=("${sentinel_fqdn}")
+  done
   expected_sentinel_count="${#sentinel_fqdn_list[@]}"
   if [ "${expected_sentinel_count}" -eq 0 ]; then
     echo "ERROR: SENTINEL_POD_FQDN_LIST is set but empty after parsing." >&2
@@ -186,7 +190,7 @@ else
   done
 fi
 
-configured_sentinel_count=0
+reachable_sentinel_fqdn_list=()
 failed_sentinel_count=0
 consecutive_unreachable=0
 for sentinel_fqdn in "${sentinel_fqdn_list[@]}"; do
@@ -199,7 +203,7 @@ for sentinel_fqdn in "${sentinel_fqdn_list[@]}"; do
       continue
     fi
     consecutive_unreachable=$((consecutive_unreachable + 1))
-    [ "${consecutive_unreachable}" -ge 2 ] && [ "${configured_sentinel_count}" -gt 0 ] && break
+    [ "${consecutive_unreachable}" -ge 2 ] && [ "${#reachable_sentinel_fqdn_list[@]}" -gt 0 ] && break
     continue
   }
   response=$(printf '%s' "${response}" | tr -d '\r\n')
@@ -209,6 +213,29 @@ for sentinel_fqdn in "${sentinel_fqdn_list[@]}"; do
     continue
   fi
   consecutive_unreachable=0
+  reachable_sentinel_fqdn_list+=("${sentinel_fqdn}")
+done
+
+if [ "${#reachable_sentinel_fqdn_list[@]}" -eq 0 ]; then
+  echo "ERROR: no Sentinel pod was reachable; postReady cannot report restore success." >&2
+  exit 1
+fi
+
+if [ -n "${expected_sentinel_count}" ] && [ "${#reachable_sentinel_fqdn_list[@]}" -lt "${expected_sentinel_count}" ]; then
+  echo "ERROR: reached ${#reachable_sentinel_fqdn_list[@]}/${expected_sentinel_count} expected Sentinel pods." >&2
+  exit 1
+fi
+
+if [ -n "${expected_sentinel_count}" ]; then
+  sentinel_count="${expected_sentinel_count}"
+else
+  sentinel_count="${#reachable_sentinel_fqdn_list[@]}"
+fi
+sentinel_monitor_quorum=$(( sentinel_count / 2 + 1 ))
+echo "INFO: using Sentinel monitor quorum ${sentinel_monitor_quorum}/${sentinel_count}."
+
+configured_sentinel_count=0
+for sentinel_fqdn in "${reachable_sentinel_fqdn_list[@]}"; do
   sentinel_configured=1
 
   # Check if already monitoring
@@ -220,7 +247,7 @@ for sentinel_fqdn in "${sentinel_fqdn_list[@]}"; do
   if [ -z "${existing}" ] || [ "${existing}" = "(nil)" ]; then
     echo "INFO: Registering master '${master_name}' (${primary_fqdn}:${data_port}) with ${sentinel_fqdn}"
     monitor_out=$("${sentinel_cli_base[@]}" -h "${sentinel_fqdn}" \
-      SENTINEL monitor "${master_name}" "${primary_fqdn}" "${data_port}" 2 2>&1) || {
+      SENTINEL monitor "${master_name}" "${primary_fqdn}" "${data_port}" "${sentinel_monitor_quorum}" 2>&1) || {
       echo "ERROR: SENTINEL monitor command failed on ${sentinel_fqdn}: ${monitor_out}" >&2
       sentinel_configured=0
     }

--- a/addons/valkey/scripts-ut-spec/sentinel_monitor_quorum_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/sentinel_monitor_quorum_contract_spec.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Valkey Sentinel monitor quorum contract"
+  register_script="../scripts/valkey-register-to-sentinel.sh"
+  sentinel_start_script="../scripts/valkey-sentinel-start.sh"
+  post_restore_script="../dataprotection/post-restore-sentinel.sh"
+
+  It "does not pass a fixed quorum 2 to SENTINEL monitor commands"
+    When call bash -c '
+      grep -nE "SENTINEL (MONITOR|monitor).* 2($|[[:space:]])" "$@" || true
+      grep -nE "\"\\$\\{(primary_port|data_port)\\}\" 2($|[[:space:]])" "$@" || true
+    ' -- "${register_script}" "${sentinel_start_script}" "${post_restore_script}"
+    The stdout should eq ""
+  End
+
+  It "computes monitor quorum as strict majority of the Sentinel target count"
+    When call grep -R -nE "sentinel_monitor_quorum=\\$\\(\\( .* / 2 \\+ 1 \\)\\)" \
+      "${register_script}" "${sentinel_start_script}" "${post_restore_script}"
+    The status should be success
+    The stdout should include 'sentinel_monitor_quorum=$(( sentinel_count / 2 + 1 ))'
+  End
+
+  It "keeps empty entries from lowering the computed Sentinel count"
+    When call grep -R -nF '[ -n "${sentinel_fqdn}" ]' \
+      "${register_script}" "${sentinel_start_script}" "${post_restore_script}"
+    The status should be success
+    The stdout should include '[ -n "${sentinel_fqdn}" ]'
+  End
+
+  It "uses the computed quorum in each SENTINEL monitor path"
+    When call grep -R -nF '"${sentinel_monitor_quorum}"' \
+      "${register_script}" "${sentinel_start_script}" "${post_restore_script}"
+    The status should be success
+    The stdout should include "${register_script}"
+    The stdout should include "${sentinel_start_script}"
+    The stdout should include "${post_restore_script}"
+  End
+End

--- a/addons/valkey/scripts/valkey-register-to-sentinel.sh
+++ b/addons/valkey/scripts/valkey-register-to-sentinel.sh
@@ -125,7 +125,7 @@ register_to_one_sentinel() {
   if is_empty "${master_addr}" || [ "${master_addr}" = "(nil)" ]; then
     echo "Sentinel not yet monitoring '${master_name}' — issuing SENTINEL monitor..."
     call_func_with_retry 3 5 execute_sentinel_cmd "${sentinel_fqdn}" \
-      SENTINEL monitor "${master_name}" "${primary_host}" "${primary_port}" 2 || return 1
+      SENTINEL monitor "${master_name}" "${primary_host}" "${primary_port}" "${sentinel_monitor_quorum}" || return 1
   else
     echo "Sentinel already monitoring '${master_name}' at ${master_addr}. Skipping monitor."
   fi
@@ -161,7 +161,18 @@ if is_empty "${SENTINEL_POD_FQDN_LIST}"; then
   exit 1
 fi
 
-IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
+sentinel_fqdns=()
+IFS=',' read -ra sentinel_fqdns_raw <<< "${SENTINEL_POD_FQDN_LIST}"
+for sentinel_fqdn in "${sentinel_fqdns_raw[@]}"; do
+  [ -n "${sentinel_fqdn}" ] && sentinel_fqdns+=("${sentinel_fqdn}")
+done
+sentinel_count="${#sentinel_fqdns[@]}"
+if [ "${sentinel_count}" -eq 0 ]; then
+  echo "ERROR: SENTINEL_POD_FQDN_LIST is set but empty after parsing." >&2
+  exit 1
+fi
+sentinel_monitor_quorum=$(( sentinel_count / 2 + 1 ))
+echo "Sentinel monitor quorum: ${sentinel_monitor_quorum}/${sentinel_count}"
 for fqdn in "${sentinel_fqdns[@]}"; do
   register_to_one_sentinel "${fqdn}" || exit 1
 done

--- a/addons/valkey/scripts/valkey-sentinel-start.sh
+++ b/addons/valkey/scripts/valkey-sentinel-start.sh
@@ -175,18 +175,40 @@ _sentinel_cli() {
   "${_scli[@]}" "$@" 2>/dev/null
 }
 
+calculate_sentinel_monitor_quorum() {
+  local sentinel_fqdns_raw=()
+  local sentinel_count=0
+  local sentinel_fqdn
+  local sentinel_monitor_quorum
+
+  IFS=',' read -ra sentinel_fqdns_raw <<< "${SENTINEL_POD_FQDN_LIST:-}"
+  for sentinel_fqdn in "${sentinel_fqdns_raw[@]}"; do
+    [ -n "${sentinel_fqdn}" ] && sentinel_count=$((sentinel_count + 1))
+  done
+
+  if [ "${sentinel_count}" -eq 0 ]; then
+    echo "ERROR: SENTINEL_POD_FQDN_LIST is empty — cannot compute Sentinel monitor quorum." >&2
+    return 1
+  fi
+
+  sentinel_monitor_quorum=$(( sentinel_count / 2 + 1 ))
+  echo "${sentinel_monitor_quorum}"
+}
+
 # _register_monitor — dynamically register the master with the running sentinel
 # via SENTINEL MONITOR + SENTINEL SET auth-pass.
 _register_monitor() {
   local master_fqdn="${1}"
   local data_port="${SERVICE_PORT:-6379}"
   local monitor_name="${VALKEY_COMPONENT_NAME}"
+  local sentinel_monitor_quorum
   if is_empty "${monitor_name}"; then
     echo "ERROR: VALKEY_COMPONENT_NAME is not set — cannot register sentinel monitor." >&2
     return 1
   fi
+  sentinel_monitor_quorum=$(calculate_sentinel_monitor_quorum) || return 1
   echo "INFO: registering master ${master_fqdn}:${data_port} with sentinel as '${monitor_name}'." >&2
-  _sentinel_cli SENTINEL MONITOR "${monitor_name}" "${master_fqdn}" "${data_port}" 2
+  _sentinel_cli SENTINEL MONITOR "${monitor_name}" "${master_fqdn}" "${data_port}" "${sentinel_monitor_quorum}"
   if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
     _sentinel_cli SENTINEL SET "${monitor_name}" auth-pass "${VALKEY_DEFAULT_PASSWORD}"
   fi


### PR DESCRIPTION
## Problem

Valkey Sentinel registration paths hardcoded `SENTINEL MONITOR ... 2` as the monitor quorum.

The default topology uses 3 Sentinel replicas, so quorum 2 works there. But the addon does not fix Sentinel replicas to 3: users can create a Cluster with more Sentinel pods. With 5 Sentinel replicas, quorum should be 3, not 2.

## Observed symptom

Static review found fixed quorum values in the three monitor-registration paths:

- `scripts/valkey-register-to-sentinel.sh`
- `scripts/valkey-sentinel-start.sh`
- `dataprotection/post-restore-sentinel.sh`

## Reproduction / check

Search for monitor commands that pass a fixed `2` quorum:

```bash
rg -n 'SENTINEL (MONITOR|monitor).* 2|"\$\{(primary_port|data_port)\}" 2' \
  addons/valkey/scripts/valkey-register-to-sentinel.sh \
  addons/valkey/scripts/valkey-sentinel-start.sh \
  addons/valkey/dataprotection/post-restore-sentinel.sh
```

Before this PR, the search finds three monitor paths.

## Solution

- Parse Sentinel target FQDNs and ignore empty entries so a malformed trailing comma cannot lower quorum.
- Compute strict majority as `sentinel_count / 2 + 1`.
- Pass the computed quorum to every `SENTINEL MONITOR` command.
- For post-restore fallback scanning, first collect reachable Sentinel pods, then compute quorum from the authoritative expected count when available, or from the discovered reachable count when no expected count is provided.
- Add a dedicated shellspec contract that rejects fixed quorum `2` in monitor commands and requires the strict-majority computation.

## Validation

Static/local checks:

```bash
bash -n addons/valkey/scripts/valkey-register-to-sentinel.sh \
  addons/valkey/scripts/valkey-sentinel-start.sh \
  addons/valkey/dataprotection/post-restore-sentinel.sh \
  addons/valkey/scripts-ut-spec/sentinel_monitor_quorum_contract_spec.sh

git diff --check

shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash \
  addons/valkey/scripts-ut-spec/sentinel_monitor_quorum_contract_spec.sh
# 4 examples, 0 failures

shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash \
  addons/valkey/scripts-ut-spec/*_spec.sh
# 225 examples, 0 failures
```

GitHub CI: all required checks are green for head `a4065c77154ec5d2e9ce8f6f00fceea7a13f9eef`.

Runtime focused validation on PR head `a4065c77154ec5d2e9ce8f6f00fceea7a13f9eef`:

- Candidate contained only this PR on top of `cfb05a27`.
- 5-Sentinel initial monitor path: all 5 Sentinels reported quorum `3`.
- After Sentinel failover: failover converged to a new master, all 5 Sentinels still reported quorum `3`, and read/write worked.
- Restore monitor path: the restore cluster reached Running/Ready, and all 5 restore Sentinels reported quorum `3`.
- Cleanup: validation namespaces and runner ClusterRoleBindings were removed; the r34 Valkey chart was rolled back from the temporary candidate revision.

Runtime evidence: `artifacts/pr2801-quorum-focused-a4065c77-20260610T0930/closeout.md`, sha `70190ede37df1d7a5d452973d801782bd9a916135feda0531b31e13d0e4aae89`.

A/B restore-readback comparison used to check for side effects:

- A candidate: base `cfb05a27f` + #2797 + this PR. Result: restore readback still failed with source data present, Backup Completed, and restored data empty.
- B baseline: base `cfb05a27f` + #2797 only, without this PR. Result: the same restore readback failure reproduced with the same shape.
- A/B conclusion: the restore readback failure existed without this PR, so the failure is not a direct side effect of the dynamic Sentinel quorum change.

A/B evidence: `artifacts/pr315-restore-rootcause-2797-2801-ed1cf29b-20260610T1055/closeout.md`, sha `739c2dc1fcae189938260bf9db543bd6f10cd414eb7fc760117d0239c57f1a79`.

## Boundary

This PR fixes the monitor quorum contract only. It does not change Sentinel replica defaults, Cluster topology templates, backup archive creation, restore data loading, or the larger `build_replicaof_config` complexity backlog.

The runtime acceptance for this PR is scoped to the Sentinel quorum contract: 5-Sentinel initial registration, failover after registration, and restore-time Sentinel monitor rebuild all used quorum `3` as expected.

A known restore readback failure remains in the restore/DataProtection data path. A/B validation reproduced the same restore readback failure without this PR, so that failure is tracked separately and does not indicate a regression introduced by this quorum change. This PR does not claim restore data correctness, full-suite pass, or release readiness.
