### PR TITLE
docs(redis): update maxclients from static to dynamic in README

### DIFF
--- a/addons/redis/README.md
+++ b/addons/redis/README.md
@@ -563,8 +563,8 @@ kubectl apply -f examples/redis/configure.yaml
 This example will change the `maxclients` to `10001` for the Redis component.
 `maxclients` in Redis specifies the maximum number of simultaneous client connections the server will accept. Once this limit is reached, Redis will start rejecting new connections until existing clients disconnect.
 
-> [!CAUTION]
-> It is defined as a static parameter, which means the Redis component will be restarted after the reconfiguration.
+> [!NOTE]
+> `maxclients` is a dynamic parameter. Redis applies it at runtime via `CONFIG SET` without restarting.
 
 To verify the reconfiguration, you can connect to the Redis pod and check the configuration with the following command:
 


### PR DESCRIPTION
## Summary
- Update README CAUTION about `maxclients` being static to NOTE about it being dynamic
- After PR #2798 removed `maxclients` from `staticParameters`, the old CAUTION ("will be restarted") is inaccurate

## Test plan
- [x] Doc-only change, no runtime impact

Generated with [Claude Code](https://claude.com/claude-code)