### PR TITLE
chore(rabbitmq): extract startup script to ConfigMap mount

### DIFF
--- a/addons/rabbitmq/scripts/startup.sh
+++ b/addons/rabbitmq/scripts/startup.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+DATA_DIR="${RABBITMQ_DATA_DIR:-/var/lib/rabbitmq}"
+
+if [ ! -f "$DATA_DIR/enabled_plugins" ]; then
+  cp /etc/rabbitmq/enabled_plugins "$DATA_DIR/enabled_plugins"
+fi
+
+cp /root/erlang.cookie "$DATA_DIR/.erlang.cookie"
+chown rabbitmq:rabbitmq "$DATA_DIR/.erlang.cookie"
+chmod 400 "$DATA_DIR/.erlang.cookie"
+
+cat > /etc/rabbitmq/conf.d/10-kubeblocks-default-user.conf <<EOF
+default_user = ${RABBITMQ_DEFAULT_USER}
+default_pass = ${RABBITMQ_DEFAULT_PASS}
+EOF
+
+exec /opt/rabbitmq/sbin/rabbitmq-server

--- a/addons/rabbitmq/templates/cmpd.yaml
+++ b/addons/rabbitmq/templates/cmpd.yaml
@@ -84,20 +84,10 @@ spec:
       - name: rabbitmq
         command:
           - /bin/sh
-          - -c
-          - |
-            if [ ! -f {{ .Values.dataMountPath }}/enabled_plugins ]; then
-              cp /etc/rabbitmq/enabled_plugins {{ .Values.dataMountPath }}/enabled_plugins
-            fi
-            cp /root/erlang.cookie {{ .Values.dataMountPath }}/.erlang.cookie
-            chown rabbitmq:rabbitmq {{ .Values.dataMountPath }}/.erlang.cookie
-            chmod 400 {{ .Values.dataMountPath }}/.erlang.cookie
-            cat > /etc/rabbitmq/conf.d/10-kubeblocks-default-user.conf <<EOF
-            default_user = ${RABBITMQ_DEFAULT_USER}
-            default_pass = ${RABBITMQ_DEFAULT_PASS}
-            EOF
-            exec /opt/rabbitmq/sbin/rabbitmq-server
+          - /scripts/startup.sh
         env:
+        - name: RABBITMQ_DATA_DIR
+          value: {{ .Values.dataMountPath }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -172,6 +162,9 @@ spec:
           - mountPath: /etc/rabbitmq/enabled_plugins
             name: rabbitmq-config
             subPath: enabled_plugins
+          - mountPath: /scripts/startup.sh
+            name: rabbitmq-config
+            subPath: startup.sh
           - name: timezone
             mountPath: /etc/localtime
             readOnly: true

--- a/addons/rabbitmq/templates/cmpd.yaml
+++ b/addons/rabbitmq/templates/cmpd.yaml
@@ -32,6 +32,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       defaultMode: 0644
       externalManaged: true
+  scripts:
+    - name: script
+      template: {{ include "rabbitmq.cmScriptsName" . }}
+      namespace: {{ .Release.Namespace }}
+      volumeName: scripts
+      defaultMode: 0555
   systemAccounts:
     - name: root
       initAccount: true
@@ -163,7 +169,7 @@ spec:
             name: rabbitmq-config
             subPath: enabled_plugins
           - mountPath: /scripts/startup.sh
-            name: rabbitmq-config
+            name: scripts
             subPath: startup.sh
           - name: timezone
             mountPath: /etc/localtime

--- a/addons/rabbitmq/templates/config-template.yaml
+++ b/addons/rabbitmq/templates/config-template.yaml
@@ -11,8 +11,6 @@ data:
     {{- .Files.Get "config/erlang.cookie.tpl" | nindent 4 }}
   enabled_plugins: |-
     {{- .Files.Get "config/enabled_plugins.tpl" | nindent 4 }}
-  startup.sh: |-
-    {{- .Files.Get "scripts/startup.sh" | nindent 4 }}
 ---
 
 apiVersion: v1

--- a/addons/rabbitmq/templates/config-template.yaml
+++ b/addons/rabbitmq/templates/config-template.yaml
@@ -11,6 +11,8 @@ data:
     {{- .Files.Get "config/erlang.cookie.tpl" | nindent 4 }}
   enabled_plugins: |-
     {{- .Files.Get "config/enabled_plugins.tpl" | nindent 4 }}
+  startup.sh: |-
+    {{- .Files.Get "scripts/startup.sh" | nindent 4 }}
 ---
 
 apiVersion: v1

--- a/addons/rabbitmq/templates/script-template.yaml
+++ b/addons/rabbitmq/templates/script-template.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rabbitmq.cmScriptsName" . }}
+  labels:
+    {{- include "rabbitmq.labels" . | nindent 4 }}
+data:
+  startup.sh: |-
+    {{- .Files.Get "scripts/startup.sh" | nindent 4 }}


### PR DESCRIPTION
## Summary
- Extract inline startup shell from CMPD `runtime.containers[].command` to `scripts/startup.sh`
- Mount via existing config ConfigMap at `/scripts/startup.sh`
- Add `RABBITMQ_DATA_DIR` env var to decouple script from Helm template values
- Complies with addon best practice: main container startup via ConfigMap, not commands/args (Yingshanshan directive 2026-06-10)

## Validation Matrix

| Suite | Scope | N | Replicas | Result |
|---|---|---|---|---|
| smoke | T01-T05 | 1 | 1 | GREEN 10/0/0 |
| smoke | T01-T05 | 1 | 3 | GREEN 10/0/0 |

**Coverage**: 1-rep + 3-rep smoke only. Does not claim full matrix release-ready.

## Review
- Flora: APPROVE (code review)
- CI: 8/8 PASS