### PR TITLE
chore(redis): remove stale TODO in memberLeave script

### DIFF
--- a/addons/redis/redis-cluster-scripts/redis-cluster-replica-member-leave.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-replica-member-leave.sh
@@ -33,7 +33,6 @@ load_redis_cluster_common_utils() {
 }
 
 # remove_replica_from_shard_if_need removes the current pod from the cluster if it is a replica
-# TODO: remove it from preStop hook and it should be implemented in memberLeave lifecycleAction in KubeBlocks
 remove_replica_from_shard_if_need() {
   # get the cluster nodes info
   cluster_nodes_info=$(get_cluster_nodes_info_with_retry "$KB_LEAVE_MEMBER_POD_FQDN" "$service_port")


### PR DESCRIPTION
## Summary
- Remove stale TODO comment in `redis-cluster-replica-member-leave.sh`
- The TODO said to move `remove_replica_from_shard_if_need` from preStop to memberLeave lifecycle action
- This migration is already complete: `memberLeave` (cmpd line 498) calls the function directly, and `preStop` (cmpd line 584) only does ACL save via `redis-cluster-replica-pre-stop.sh`

## Evidence
- `memberLeave` in `cmpd-redis-cluster.yaml:498-506` → calls `redis-cluster-replica-member-leave.sh` → executes `remove_replica_from_shard_if_need()`
- `preStop` in `cmpd-redis-cluster.yaml:584` → calls `redis-cluster-replica-pre-stop.sh` → only `acl_save_before_stop()`
- No behavior change, comment-only removal

## Test plan
- [x] `git diff --check` PASS
- [ ] CI checks (shell-check, shellspec-test, helm check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)