### PR TITLE
chore(redis): add bounded retry to cluster restore wait script

### DIFF
--- a/addons/redis/dataprotection/wait-for-cluster-ready.sh
+++ b/addons/redis/dataprotection/wait-for-cluster-ready.sh
@@ -1,24 +1,42 @@
 #!/bin/bash
 
+MAX_RETRIES=${MAX_RETRIES:-120}
+RETRY_INTERVAL=${RETRY_INTERVAL:-5}
+MAX_CONNECT_FAILURES=${MAX_CONNECT_FAILURES:-10}
+
 redis_cmd="redis-cli $REDIS_CLI_TLS_CMD -h ${DP_DB_HOST} -p ${DP_DB_PORT}"
 if [ -n "${REDIS_DEFAULT_PASSWORD}" ]; then
     redis_cmd="${redis_cmd} -a ${REDIS_DEFAULT_PASSWORD}"
 fi
 
-while true; do
+retry_count=0
+connect_failures=0
+
+while [ $retry_count -lt $MAX_RETRIES ]; do
+    retry_count=$((retry_count + 1))
     cluster_info=$(${redis_cmd} CLUSTER INFO 2>/dev/null)
     if [[ $? -ne 0 ]]; then
-        echo "Redis cluster is not reachable yet. Retrying in 5 seconds..."
-        sleep 5
+        connect_failures=$((connect_failures + 1))
+        if [ $connect_failures -ge $MAX_CONNECT_FAILURES ]; then
+            echo "ERROR: Redis cluster is not reachable after $MAX_CONNECT_FAILURES consecutive connection failures. Check host, port, and credentials." >&2
+            exit 1
+        fi
+        echo "Redis cluster is not reachable (attempt $retry_count/$MAX_RETRIES, consecutive failures: $connect_failures/$MAX_CONNECT_FAILURES). Retrying in $RETRY_INTERVAL seconds..."
+        sleep $RETRY_INTERVAL
         continue
     fi
+
+    connect_failures=0
 
     state=$(echo "$cluster_info" | grep 'cluster_state:' | cut -d':' -f2 | tr -d '\r')
     if [[ "$state" == "ok" ]]; then
         echo "Redis cluster is ready."
-        break
+        exit 0
     else
-        echo "Redis cluster state is '$state'. Waiting for it to be 'ok'. Retrying in 5 seconds..."
-        sleep 5
+        echo "Redis cluster state is '$state' (attempt $retry_count/$MAX_RETRIES). Waiting for 'ok'. Retrying in $RETRY_INTERVAL seconds..."
+        sleep $RETRY_INTERVAL
     fi
 done
+
+echo "ERROR: Redis cluster did not become ready after $MAX_RETRIES attempts ($((MAX_RETRIES * RETRY_INTERVAL)) seconds)." >&2
+exit 1


### PR DESCRIPTION
## Summary
- Add bounded retry to `wait-for-cluster-ready.sh` (used in `redis-cluster-br` ActionSet postReady)
- Same class of issue as PR #2766 backup fail-fast: unbounded `while true` loop could hang indefinitely
- Two failure modes now caught:
  - **Connection failures**: fail-fast after 10 consecutive connection failures (wrong host/port/credentials)
  - **Cluster not ready**: bounded at 120 retries × 5s = 10 minutes max wait

## Changes
- `MAX_RETRIES` (default 120): overall wait bound before failing
- `MAX_CONNECT_FAILURES` (default 10): consecutive `redis-cli` connection failures before fail-fast
- Consecutive failure counter resets on successful connection
- Progress logging with attempt counters for diagnostics
- Configurable via env vars if KB/BPT needs to override defaults

## Evidence
- `git diff --check` PASS
- `bash -n` syntax check PASS
- Existing shellspec tests: 37/0/5 (0 failures, 5 pre-existing skips)
- addon-api contract: `bounded eventually` principle from `docs/addon-api/05c-lifecycle-action-contracts.md`

## Test plan
- [ ] CI checks (shell-check, shellspec-test, helm check)
- [ ] Runtime cluster backup/restore acceptance (required before marking ready for review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)