### PR TITLE
chore(redis): move twemproxy startup command to ConfigMap-mounted script

### DIFF
--- a/addons/redis/scripts/redis-twemproxy-start.sh
+++ b/addons/redis/scripts/redis-twemproxy-start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nutcracker -c /etc/proxy/nutcracker.conf -v 4 -m 16384

--- a/addons/redis/templates/cmpd-redis-twemproxy.yaml
+++ b/addons/redis/templates/cmpd-redis-twemproxy.yaml
@@ -90,10 +90,7 @@ spec:
     containers:
     - name: redis-twemproxy
       imagePullPolicy: {{ default .Values.redisTwemproxyImage.pullPolicy "IfNotPresent" }}
-      command:
-        - sh
-        - -c
-        - nutcracker -c /etc/proxy/nutcracker.conf -v 4 -m 16384
+      command: [ "/scripts/redis-twemproxy-start.sh" ]
       env:
         - name: CURRENT_POD_NAME
           valueFrom:


### PR DESCRIPTION
## Summary
- Twemproxy was the only Redis container with an inline startup command (`nutcracker -c ... -v 4 -m 16384`) in the cmpd runtime spec
- Move it to a dedicated ConfigMap-mounted script `redis-twemproxy-start.sh` for consistency with all other Redis containers (standalone, sentinel, cluster)
- This follows the best practice: main container startup scripts should be mounted via ConfigMap, not written directly in runtime commands/args

## Test plan
- [x] `bash -n` syntax check PASS
- [x] `git diff --check` PASS
- [x] helm template renders correctly with new script reference
- [x] Runtime: deploy replication-twemproxy topology, verify twemproxy container starts and proxies correctly
- [x] CI: check-chart, shell-check, shellspec-test all SUCCESS
- [x] Runtime: smoketest #44 PASS (8 pods, proxy roundtrip, pod restart resilience)
- [x] Runtime: parameters #46 PASS 33/0/0 (dynamic + static reconfigure through twemproxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)