### PR TITLE
fix(elasticsearch): make memberLeave non-blocking

### DIFF
--- a/addons/elasticsearch/scripts/member-leave.sh
+++ b/addons/elasticsearch/scripts/member-leave.sh
@@ -1,30 +1,26 @@
 #!/bin/sh
-# https://www.elastic.co/guide/en/elasticsearch/reference/7.7/add-elasticsearch-nodes.html
-# Enhanced with safe scale-down process following Elasticsearch best practices
+# Non-blocking memberLeave lifecycle action.
+# Sets shard allocation exclusion and voting config exclusion, then returns
+# immediately. Shard migration happens asynchronously; memberJoin clears
+# stale exclusions when the same pod name rejoins.
 
 set -eu
 
-# Configuration
-MAX_WAIT_TIME=${MAX_WAIT_TIME:-1800}  # 30 minutes max wait time
 RETRY_COUNT=${RETRY_COUNT:-3}
-RETRY_DELAY=${RETRY_DELAY:-5}
-HEALTH_CHECK_INTERVAL=${HEALTH_CHECK_INTERVAL:-10}
 
-# Setup basic auth if credentials are available
 if [ -n "${ELASTIC_USER_PASSWORD:-}" ]; then
   BASIC_AUTH="-u elastic:${ELASTIC_USER_PASSWORD}"
 else
   BASIC_AUTH=''
 fi
 
-# Check if we are using IPv6
 if echo "${POD_IP:-}" | grep -q ':'; then
   LOOPBACK="[::1]"
 else
   LOOPBACK=127.0.0.1
 fi
 
-if [ "${TLS_ENABLED:-false}" == "true" ]; then
+if [ "${TLS_ENABLED:-false}" = "true" ]; then
   READINESS_PROBE_PROTOCOL=https
 else
   READINESS_PROBE_PROTOCOL=http
@@ -33,18 +29,6 @@ fi
 endpoint="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
 common_options="-k --fail --max-time 30 --retry ${RETRY_COUNT} ${BASIC_AUTH}"
 
-echo "Starting safe removal of node $KB_LEAVE_MEMBER_POD_NAME"
-
-# Get Elasticsearch version
-version=$(curl ${common_options} -s ${endpoint} | jq -r .version.number)
-if [ $? != 0 ]; then
-  echo "ERROR: Failed to get Elasticsearch version"
-  exit 1
-fi
-major_version=${version%%.*}
-echo "Detected Elasticsearch version: $version (major: $major_version)"
-
-# Utility functions
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
 }
@@ -54,274 +38,60 @@ error_exit() {
   exit 1
 }
 
-# Check cluster health status
-check_cluster_health() {
-  local status=$(curl ${common_options} -s "${endpoint}/_cluster/health" | jq -r '.status')
-  if [ $? != 0 ]; then
-    error_exit "Failed to get cluster health"
-  fi
-  echo "$status"
-}
+if [ -z "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
+  error_exit "KB_LEAVE_MEMBER_POD_NAME environment variable is not set"
+fi
 
-# Wait for cluster to reach desired status
-wait_for_cluster_status() {
-  local desired_status=$1
-  local timeout=$2
-  local start_time=$(date +%s)
+node_name="$KB_LEAVE_MEMBER_POD_NAME"
+log "=== memberLeave: preparing node $node_name for removal ==="
 
-  log "Waiting for cluster to reach $desired_status status..."
-  while true; do
-    local current_status=$(check_cluster_health)
-    if [ "$current_status" = "$desired_status" ]; then
-      log "Cluster reached $desired_status status"
-      return 0
-    fi
+version=$(curl ${common_options} -s "${endpoint}" | jq -r .version.number)
+if [ $? != 0 ]; then
+  error_exit "Failed to get Elasticsearch version"
+fi
+major_version=${version%%.*}
+log "Elasticsearch version: $version (major: $major_version)"
 
-    local elapsed=$(( $(date +%s) - start_time ))
-    if [ $elapsed -gt $timeout ]; then
-      error_exit "Timeout waiting for cluster to reach $desired_status status (current: $current_status)"
-    fi
+health=$(curl ${common_options} -s "${endpoint}/_cluster/health" | jq -r '.status')
+log "Cluster health: $health"
+if [ "$health" != "green" ] && [ "$health" != "yellow" ]; then
+  error_exit "Cluster is not healthy (status: $health). Resolve before scaling down."
+fi
 
-    log "Current cluster status: $current_status, waiting..."
-    sleep $HEALTH_CHECK_INTERVAL
-  done
-}
-
-# Check if node has any shards
-check_node_shards() {
-  local node_name=$1
-  local shard_count=$(curl ${common_options} -s "${endpoint}/_cat/shards?v" | grep "$node_name" | wc -l)
-  echo "$shard_count"
-}
-
-# Set shard allocation exclusion for the node
-set_shard_exclusion() {
-  local node_name=$1
-
-  log "Setting shard allocation exclusion for node: $node_name"
-  local response=$(curl ${common_options} -s -X PUT "${endpoint}/_cluster/settings" \
-    -H 'Content-Type: application/json' \
-    -d "{\"persistent\": {\"cluster.routing.allocation.exclude._name\": \"${node_name}\"}}")
-
-  if [ $? != 0 ]; then
-    error_exit "Failed to set shard allocation exclusion"
-  fi
-
-  echo "$response" | jq -r '.acknowledged' | grep -q "true" || error_exit "Shard exclusion not acknowledged"
-  log "Successfully set shard allocation exclusion"
-}
-
-# Clear shard allocation exclusion
-clear_shard_exclusion() {
-  local node_name=$1
-
-  log "Clearing shard allocation exclusion for node: $node_name"
-  # Clear all possible exclusion fields to ensure complete cleanup
-  local response=$(curl ${common_options} -s -X PUT "${endpoint}/_cluster/settings" \
-    -H 'Content-Type: application/json' \
-    -d "{\"persistent\": {\"cluster.routing.allocation.exclude._name\": null, \"cluster.routing.allocation.exclude._ip\": null, \"cluster.routing.allocation.exclude._host\": null}}")
-
-  if [ $? != 0 ]; then
-    log "WARNING: Failed to clear shard allocation exclusion"
-  else
-    echo "$response" | jq -r '.acknowledged' | grep -q "true" || log "WARNING: Shard exclusion clearing not acknowledged"
-    log "Successfully cleared shard allocation exclusion"
-  fi
-}
-
-# Check if node is a master-eligible node
-is_master_node() {
-  local node_name=$1
-  local is_master=$(curl ${common_options} -s "${endpoint}/_nodes/${node_name}" | jq -r '.nodes | to_entries[0].value.roles | contains(["master"])')
-  if [ "$is_master" = "true" ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-# Add node to voting config exclusions (ES 7.0+)
-add_voting_exclusion() {
-  local node_name=$1
-
-  if [ "$major_version" -lt 7 ]; then
-    log "Skipping voting config exclusion (not supported in ES $major_version.x)"
-    return 0
-  fi
-
-  local url=""
-  if [ "$major_version" -eq 7 ]; then
-    # Extract minor version for comparison
-    minor_version=$(echo "$version" | cut -d'.' -f2)
-    if [ "$minor_version" -lt 8 ] 2>/dev/null; then
-      url="${endpoint}/_cluster/voting_config_exclusions/${node_name}"
-    else
-      url="${endpoint}/_cluster/voting_config_exclusions?node_names=${node_name}"
-    fi
-  else
-    url="${endpoint}/_cluster/voting_config_exclusions?node_names=${node_name}"
-  fi
-
-  log "Adding node $node_name to voting config exclusions"
-  local response=$(curl ${common_options} -s -X POST "$url")
-
-  if [ $? != 0 ]; then
-    log "WARNING: Failed to add node to voting config exclusions, may be the list is full"
-    # Try to clear exclusions first
-    curl ${common_options} -X DELETE "${endpoint}/_cluster/voting_config_exclusions?pretty&wait_for_removal=false" || true
-    response=$(curl ${common_options} -s -X POST "$url")
-    if [ $? != 0 ]; then
-      error_exit "Failed to add node to voting config exclusions after clearing"
-    fi
-  fi
-
-  log "Successfully added node to voting config exclusions"
-}
-
-# Main safe scale-down process
-safe_scale_down() {
-  local node_name=$KB_LEAVE_MEMBER_POD_NAME
-  local start_time=$(date +%s)
-
-  log "=== Starting safe scale-down process for node: $node_name ==="
-
-  # Step 1: Initial health check
-  log "Step 1: Performing initial cluster health check"
-  local initial_status=$(check_cluster_health)
-  log "Initial cluster status: $initial_status"
-
-  if [ "$initial_status" != "green" ] && [ "$initial_status" != "yellow" ]; then
-    error_exit "Cluster is not in a healthy state (status: $initial_status). Please resolve cluster issues before scaling down."
-  fi
-
-  # Step 2: Check if node is master-eligible
-  if is_master_node "$node_name"; then
-    log "WARNING: Node $node_name is master-eligible. Adding to voting config exclusions."
-    add_voting_exclusion "$node_name"
-  fi
-
-  # Step 3: Check current shards on the node
-  local initial_shard_count=$(check_node_shards "$node_name")
-  log "Node $node_name currently has $initial_shard_count shards"
-
-  # Step 4: Set shard allocation exclusion
-  log "Step 2: Setting shard allocation exclusion to migrate shards away from node"
-  set_shard_exclusion "$node_name"
-
-  # Step 5: Wait for shards to migrate
-  log "Step 3: Waiting for shards to migrate from node $node_name"
-  local migration_start=$(date +%s)
-
-  while true; do
-    local current_shard_count=$(check_node_shards "$node_name")
-    local current_status=$(check_cluster_health)
-
-    log "Current shard count on $node_name: $current_shard_count, cluster status: $current_status"
-
-    # Check if migration is complete
-    if [ "$current_shard_count" -eq 0 ]; then
-      log "All shards have been migrated from node $node_name"
-      break
-    fi
-
-    # Check for timeout
-    local elapsed=$(( $(date +%s) - migration_start ))
-    if [ $elapsed -gt $MAX_WAIT_TIME ]; then
-      error_exit "Timeout waiting for shard migration to complete ($MAX_WAIT_TIME seconds)"
-    fi
-
-    # Check cluster health during migration
-    if [ "$current_status" = "red" ]; then
-      log "WARNING: Cluster became red during migration, but continuing..."
-    fi
-
-    sleep $HEALTH_CHECK_INTERVAL
-  done
-
-  # Step 6: Wait for cluster to return to healthy state
-  log "Step 4: Ensuring cluster returns to healthy state"
-  wait_for_cluster_status "green" 300
-
-  # Step 7: Final verification
-  log "Step 5: Performing final verification"
-  local final_status=$(check_cluster_health)
-  local final_shard_count=$(check_node_shards "$node_name")
-
-  if [ "$final_shard_count" -gt 0 ]; then
-    log "WARNING: Node still has $final_shard_count shards after migration"
-  fi
-
-  if [ "$final_status" != "green" ]; then
-    log "WARNING: Cluster is not green after migration (status: $final_status)"
-  fi
-
-  # Step 8: Node can now be safely removed
-  log "Node $node_name can now be safely removed from the cluster"
-  log "=== Safe scale-down process completed successfully ==="
-
-  # Clear the shard exclusion settings since the node is safely removed
-  log "Clearing shard allocation exclusion settings..."
-  clear_shard_exclusion "$node_name" || log "Warning: Failed to clear shard exclusion after successful completion"
-
-  local total_time=$(( $(date +%s) - start_time ))
-  log "Total time taken: ${total_time} seconds"
-}
-
-# Main execution
-main() {
-  if [ -z "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
-    error_exit "KB_LEAVE_MEMBER_POD_NAME environment variable is not set"
-  fi
-
-  # Run the safe scale-down process
-  safe_scale_down
-
-  # For backward compatibility and to allow the node to be removed naturally
-  # we still perform the original voting exclusion logic if applicable
+is_master=$(curl ${common_options} -s "${endpoint}/_nodes/${node_name}" | jq -r '.nodes | to_entries[0].value.roles | contains(["master"])')
+if [ "$is_master" = "true" ]; then
+  log "Node is master-eligible — adding voting config exclusion"
   if [ "$major_version" -ge 7 ]; then
     if [ "$major_version" -eq 7 ]; then
-      # Extract minor version for comparison
       minor_version=$(echo "$version" | cut -d'.' -f2)
       if [ "$minor_version" -lt 8 ] 2>/dev/null; then
-        url=${endpoint}/_cluster/voting_config_exclusions/$KB_LEAVE_MEMBER_POD_NAME
+        vote_url="${endpoint}/_cluster/voting_config_exclusions/${node_name}"
       else
-        url=${endpoint}/_cluster/voting_config_exclusions?node_names=$KB_LEAVE_MEMBER_POD_NAME
+        vote_url="${endpoint}/_cluster/voting_config_exclusions?node_names=${node_name}"
       fi
     else
-      url=${endpoint}/_cluster/voting_config_exclusions?node_names=$KB_LEAVE_MEMBER_POD_NAME
+      vote_url="${endpoint}/_cluster/voting_config_exclusions?node_names=${node_name}"
     fi
-    curl ${common_options} -v -X POST $url || log "Voting exclusion already set during safe scale-down"
-  else
-    log "ES version $major_version does not support voting_config_exclusions API"
+    if ! curl ${common_options} -s -X POST "$vote_url"; then
+      log "WARNING: voting exclusion failed, clearing stale entries and retrying"
+      curl ${common_options} -X DELETE "${endpoint}/_cluster/voting_config_exclusions?pretty&wait_for_removal=false" || true
+      curl ${common_options} -s -X POST "$vote_url" || error_exit "Failed to add voting config exclusion after clearing"
+    fi
+    log "Voting config exclusion set"
   fi
-}
+fi
 
-# Cleanup function
-cleanup() {
-  local exit_code=$?
-  log "Cleanup function called with exit code: $exit_code"
-  if [ $exit_code -ne 0 ]; then
-    log "Script exited with error code $exit_code, attempting cleanup..."
-    # Try to clear shard exclusions on failure
-    if [ -n "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
-      clear_shard_exclusion "$KB_LEAVE_MEMBER_POD_NAME" || log "Failed to clear shard exclusions during cleanup"
-    fi
-  else
-    # Even on successful exit, ensure we clear the exclusion settings
-    log "Script completed successfully, clearing shard exclusions..."
-    if [ -n "${KB_LEAVE_MEMBER_POD_NAME:-}" ]; then
-      clear_shard_exclusion "$KB_LEAVE_MEMBER_POD_NAME" || log "Failed to clear shard exclusions after success"
-    fi
-  fi
-  log "Cleanup completed"
-  exit $exit_code
-}
+shard_count=$(curl ${common_options} -s "${endpoint}/_cat/shards?v" | grep "$node_name" | wc -l)
+log "Node $node_name currently has $shard_count shards"
 
-# Set trap for cleanup
-trap cleanup EXIT
+log "Setting shard allocation exclusion for node: $node_name"
+response=$(curl ${common_options} -s -X PUT "${endpoint}/_cluster/settings" \
+  -H 'Content-Type: application/json' \
+  -d "{\"persistent\": {\"cluster.routing.allocation.exclude._name\": \"${node_name}\"}}")
+if [ $? != 0 ]; then
+  error_exit "Failed to set shard allocation exclusion"
+fi
+echo "$response" | jq -r '.acknowledged' | grep -q "true" || error_exit "Shard exclusion not acknowledged"
+log "Shard allocation exclusion set — migration will proceed asynchronously"
 
-# Also trap common signals that might cause script termination
-trap cleanup INT TERM
-
-# Run main function
-main
+log "=== memberLeave complete (non-blocking) ==="

--- a/addons/elasticsearch/scripts/member-leave.sh
+++ b/addons/elasticsearch/scripts/member-leave.sh
@@ -6,8 +6,6 @@
 
 set -eu
 
-RETRY_COUNT=${RETRY_COUNT:-3}
-
 if [ -n "${ELASTIC_USER_PASSWORD:-}" ]; then
   BASIC_AUTH="-u elastic:${ELASTIC_USER_PASSWORD}"
 else
@@ -27,7 +25,7 @@ else
 fi
 
 endpoint="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
-common_options="-k --fail --max-time 30 --retry ${RETRY_COUNT} ${BASIC_AUTH}"
+common_options="-k --fail --connect-timeout 5 --max-time 10 --retry 1 ${BASIC_AUTH}"
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
@@ -58,7 +56,14 @@ if [ "$health" != "green" ] && [ "$health" != "yellow" ]; then
   error_exit "Cluster is not healthy (status: $health). Resolve before scaling down."
 fi
 
-is_master=$(curl ${common_options} -s "${endpoint}/_nodes/${node_name}" | jq -r '.nodes | to_entries[0].value.roles | contains(["master"])')
+node_info=$(curl ${common_options} -s "${endpoint}/_nodes/${node_name}")
+node_count=$(echo "$node_info" | jq -r '.nodes | length')
+if [ "$node_count" = "0" ]; then
+  log "Node $node_name not found in cluster — already removed or not yet joined. Skipping voting exclusion."
+  is_master="false"
+else
+  is_master=$(echo "$node_info" | jq -r '.nodes | to_entries[0].value.roles | contains(["master"])')
+fi
 if [ "$is_master" = "true" ]; then
   log "Node is master-eligible — adding voting config exclusion"
   if [ "$major_version" -ge 7 ]; then

--- a/addons/elasticsearch/scripts/member-leave.sh
+++ b/addons/elasticsearch/scripts/member-leave.sh
@@ -84,14 +84,29 @@ fi
 shard_count=$(curl ${common_options} -s "${endpoint}/_cat/shards?v" | grep "$node_name" | wc -l)
 log "Node $node_name currently has $shard_count shards"
 
-log "Setting shard allocation exclusion for node: $node_name"
-response=$(curl ${common_options} -s -X PUT "${endpoint}/_cluster/settings" \
-  -H 'Content-Type: application/json' \
-  -d "{\"persistent\": {\"cluster.routing.allocation.exclude._name\": \"${node_name}\"}}")
-if [ $? != 0 ]; then
-  error_exit "Failed to set shard allocation exclusion"
-fi
-echo "$response" | jq -r '.acknowledged' | grep -q "true" || error_exit "Shard exclusion not acknowledged"
-log "Shard allocation exclusion set — migration will proceed asynchronously"
+current_exclusion=$(curl ${common_options} -s "${endpoint}/_cluster/settings?flat_settings=true&include_defaults=false" \
+  | jq -r '.persistent["cluster.routing.allocation.exclude._name"] // ""')
+
+case ",$current_exclusion," in
+  *",$node_name,"*)
+    log "Node $node_name already in shard allocation exclusion list — skipping"
+    ;;
+  *)
+    if [ -n "$current_exclusion" ]; then
+      new_exclusion="${current_exclusion},${node_name}"
+    else
+      new_exclusion="$node_name"
+    fi
+    log "Setting shard allocation exclusion: $new_exclusion"
+    response=$(curl ${common_options} -s -X PUT "${endpoint}/_cluster/settings" \
+      -H 'Content-Type: application/json' \
+      -d "{\"persistent\": {\"cluster.routing.allocation.exclude._name\": \"${new_exclusion}\"}}")
+    if [ $? != 0 ]; then
+      error_exit "Failed to set shard allocation exclusion"
+    fi
+    echo "$response" | jq -r '.acknowledged' | grep -q "true" || error_exit "Shard exclusion not acknowledged"
+    log "Shard allocation exclusion set — migration will proceed asynchronously"
+    ;;
+esac
 
 log "=== memberLeave complete (non-blocking) ==="

--- a/addons/elasticsearch/scripts/member-leave.sh
+++ b/addons/elasticsearch/scripts/member-leave.sh
@@ -25,7 +25,7 @@ else
 fi
 
 endpoint="${READINESS_PROBE_PROTOCOL}://${LOOPBACK}:9200"
-common_options="-k --fail --connect-timeout 5 --max-time 10 --retry 1 ${BASIC_AUTH}"
+common_options="-k --fail --connect-timeout 2 --max-time 3 ${BASIC_AUTH}"
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
@@ -43,21 +43,20 @@ fi
 node_name="$KB_LEAVE_MEMBER_POD_NAME"
 log "=== memberLeave: preparing node $node_name for removal ==="
 
-version=$(curl ${common_options} -s "${endpoint}" | jq -r .version.number)
-if [ $? != 0 ]; then
-  error_exit "Failed to get Elasticsearch version"
-fi
+version_response=$(curl ${common_options} -s "${endpoint}") || error_exit "Failed to connect to Elasticsearch"
+version=$(echo "$version_response" | jq -r .version.number) || error_exit "Failed to parse Elasticsearch version"
 major_version=${version%%.*}
 log "Elasticsearch version: $version (major: $major_version)"
 
-health=$(curl ${common_options} -s "${endpoint}/_cluster/health" | jq -r '.status')
+health_response=$(curl ${common_options} -s "${endpoint}/_cluster/health") || error_exit "Failed to query cluster health"
+health=$(echo "$health_response" | jq -r '.status') || error_exit "Failed to parse cluster health"
 log "Cluster health: $health"
 if [ "$health" != "green" ] && [ "$health" != "yellow" ]; then
   error_exit "Cluster is not healthy (status: $health). Resolve before scaling down."
 fi
 
-node_info=$(curl ${common_options} -s "${endpoint}/_nodes/${node_name}")
-node_count=$(echo "$node_info" | jq -r '.nodes | length')
+node_info=$(curl ${common_options} -s "${endpoint}/_nodes/${node_name}") || error_exit "Failed to query node info"
+node_count=$(echo "$node_info" | jq -r '.nodes | length') || node_count="0"
 if [ "$node_count" = "0" ]; then
   log "Node $node_name not found in cluster — already removed or not yet joined. Skipping voting exclusion."
   is_master="false"
@@ -86,11 +85,13 @@ if [ "$is_master" = "true" ]; then
   fi
 fi
 
-shard_count=$(curl ${common_options} -s "${endpoint}/_cat/shards?v" | grep "$node_name" | wc -l)
+shards_response=$(curl ${common_options} -s "${endpoint}/_cat/shards?v" 2>/dev/null) || shards_response=""
+shard_count=$(echo "$shards_response" | grep -c "$node_name" || true)
 log "Node $node_name currently has $shard_count shards"
 
-current_exclusion=$(curl ${common_options} -s "${endpoint}/_cluster/settings?flat_settings=true&include_defaults=false" \
-  | jq -r '.persistent["cluster.routing.allocation.exclude._name"] // ""')
+settings_response=$(curl ${common_options} -s "${endpoint}/_cluster/settings?flat_settings=true&include_defaults=false") \
+  || error_exit "Failed to read cluster settings"
+current_exclusion=$(echo "$settings_response" | jq -r '.persistent["cluster.routing.allocation.exclude._name"] // ""')
 
 case ",$current_exclusion," in
   *",$node_name,"*)

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -43,15 +43,57 @@ function reset_password()
 # Function to wait until cluster health becomes green
 # This indicates that all shards are allocated and cluster is fully operational
 function wait_for_cluster_health() {
+    local timeout=${1:-300}
+    local start=$(date +%s)
     while true; do
         result=$(curl ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/health?pretty" | grep 'green')
         if [ $? == 0 ]; then
             echo "cluster is formed"
             break
         fi
-        echo "waiting for cluster to be formed"
+        local elapsed=$(( $(date +%s) - start ))
+        if [ $elapsed -gt $timeout ]; then
+            echo "ERROR: timeout (${timeout}s) waiting for cluster green"
+            exit 1
+        fi
+        echo "waiting for cluster to be formed (${elapsed}s / ${timeout}s)"
         sleep 1
     done
+}
+
+function clear_stale_allocation_exclusion_for_self() {
+    local node_name="${POD_NAME:-${HOSTNAME:-}}"
+    if [ -z "$node_name" ]; then
+        echo "POD_NAME/HOSTNAME empty, skip stale exclusion cleanup"
+        return 0
+    fi
+    local settings
+    settings=$(curl ${COMMON_OPTIONS} -s "${ENDPOINT}/_cluster/settings?flat_settings=true&include_defaults=false") || {
+        echo "failed to read cluster settings, skip stale exclusion cleanup"
+        return 0
+    }
+    local current
+    current=$(echo "$settings" | jq -r '.persistent["cluster.routing.allocation.exclude._name"] // ""') || current=""
+    if [ -z "$current" ]; then
+        return 0
+    fi
+    case ",$current," in
+        *",$node_name,"*)
+            local remaining
+            remaining=$(printf '%s' "$current" | tr ',' '\n' | grep -v "^${node_name}$" | paste -sd ',' -)
+            if [ -n "$remaining" ]; then
+                local payload="{\"persistent\":{\"cluster.routing.allocation.exclude._name\":\"${remaining}\"}}"
+            else
+                local payload='{"persistent":{"cluster.routing.allocation.exclude._name":null}}'
+            fi
+            echo "clearing stale shard allocation exclusion for $node_name"
+            curl ${COMMON_OPTIONS} -s -X PUT "${ENDPOINT}/_cluster/settings" \
+                -H 'Content-Type: application/json' -d "$payload" || echo "WARNING: failed to clear stale exclusion"
+            ;;
+        *)
+            echo "no stale shard allocation exclusion for $node_name"
+            ;;
+    esac
 }
 
 # For master nodes: Initialize cluster and create CLUSTER_FORMED_FILE
@@ -75,10 +117,12 @@ if grep '\- master\|master: true' config/elasticsearch.yml > /dev/null 2>&1; the
         wait_for_cluster_health
         touch ${CLUSTER_FORMED_FILE}
     fi
+    clear_stale_allocation_exclusion_for_self
 else
 	if grep 'type: single-node' config/elasticsearch.yml > /dev/null 2>&1; then
 		echo "single-node mode, skip cluster formation and user initialization"
 	else
+    	clear_stale_allocation_exclusion_for_self
     	exit 0
 	fi
 fi

--- a/addons/elasticsearch/scripts/post-start-hook.sh
+++ b/addons/elasticsearch/scripts/post-start-hook.sh
@@ -61,6 +61,17 @@ function wait_for_cluster_health() {
     done
 }
 
+function wait_for_local_api() {
+    for _ in $(seq 1 60); do
+        if curl --fail ${COMMON_OPTIONS} -X GET "${ENDPOINT}/_cluster/health?local=true" >/dev/null 2>&1; then
+            return 0
+        fi
+        echo "waiting for local elasticsearch API..."
+        sleep 2
+    done
+    return 1
+}
+
 function clear_stale_allocation_exclusion_for_self() {
     local node_name="${POD_NAME:-${HOSTNAME:-}}"
     if [ -z "$node_name" ]; then
@@ -122,7 +133,11 @@ else
 	if grep 'type: single-node' config/elasticsearch.yml > /dev/null 2>&1; then
 		echo "single-node mode, skip cluster formation and user initialization"
 	else
-    	clear_stale_allocation_exclusion_for_self
+    	if wait_for_local_api; then
+    	    clear_stale_allocation_exclusion_for_self
+    	else
+    	    echo "local API not ready, skip stale exclusion cleanup"
+    	fi
     	exit 0
 	fi
 fi


### PR DESCRIPTION
## Summary
- Rewrite member-leave.sh to be non-blocking: sets shard allocation exclusion + voting config exclusion, then returns immediately (< 5s). Previously blocked synchronously for up to 35 minutes (shard migration wait + cluster green wait), violating the KB LFA < 1 minute contract.
- Add clear_stale_allocation_exclusion_for_self() to post-start-hook.sh so that when a pod restarts or scales back, it clears any leftover exclusion for its own name.
- Add 300s timeout to post-start-hook.sh wait_for_cluster_health() which previously had an unbounded while-true loop.

## Motivation
KubeBlocks lifecycle actions (LFA) are called synchronously -- the controller blocks until the action completes. The KB contract requires LFAs to be:
1. Idempotent
2. Re-entrant
3. Non-blocking (< 1 minute)

The old member-leave.sh violated requirement 3 with MAX_WAIT_TIME=1800 (30 min shard migration wait loop) + 300s green wait.

## Design
- **memberLeave**: health check -> voting config exclusion (if master-eligible) -> shard allocation exclusion -> return immediately. ES handles shard migration asynchronously.
- **Stale cleanup**: post-start-hook.sh runs on every pod start. If the pod name appears in cluster.routing.allocation.exclude._name, it removes itself from the exclusion list (handles scale-in -> scale-out and restart cases).
- **Safety**: exclusion prevents new shards from being allocated to the leaving node. When the pod is deleted, ES reassigns orphaned shards to remaining nodes.

## Test plan
- [ ] Static syntax: bash -n passes for all 10 ES scripts
- [ ] Runtime: scale-in triggers memberLeave, returns within seconds
- [ ] Runtime: scale-out after scale-in -- new pod starts, stale exclusion cleared by post-start-hook, shards allocated normally
- [ ] Runtime: restart scenario -- exclusion cleaned on pod restart