### PR TITLE
fix(redis): fix TLS CLI command typo in pitr-backup.sh

### DIFF
--- a/addons/redis/dataprotection/pitr-backup.sh
+++ b/addons/redis/dataprotection/pitr-backup.sh
@@ -4,7 +4,7 @@ export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 connect_url="redis-cli $REDIS_CLI_TLS_CMD -h ${DP_DB_HOST} -p ${DP_DB_PORT} -a ${DP_DB_PASSWORD}"
 if [ -z ${DP_DB_PASSWORD} ]; then
-  connect_url="redis-cli -$REDIS_CLI_TLS_CMD h ${DP_DB_HOST} -p ${DP_DB_PORT}"
+  connect_url="redis-cli $REDIS_CLI_TLS_CMD -h ${DP_DB_HOST} -p ${DP_DB_PORT}"
 fi
 global_last_purge_time=$(date +%s)
 global_aof_last_modify_time=0


### PR DESCRIPTION
## Summary
- Fix misplaced dash in `pitr-backup.sh` no-password connect_url: `redis-cli -$REDIS_CLI_TLS_CMD h` → `redis-cli $REDIS_CLI_TLS_CMD -h`
- When `DP_DB_PASSWORD` is empty and TLS enabled, the old code produced `redis-cli ---tls --insecure h <host>` (malformed `-h` flag)

## Context
Found during TLS support audit across all Redis addon scripts. The password path (line 5) was correct; only the no-password fallback (line 7) had the typo.

## Test plan
- [x] `bash -n` syntax check PASS
- [ ] Runtime: PITR backup with TLS enabled and no password

🤖 Generated with [Claude Code](https://claude.com/claude-code)