### PR TITLE
chore(rabbitmq): make member_leave.sh re-entrant with timeout guards

### DIFF
--- a/addons/rabbitmq/scripts/member_leave.sh
+++ b/addons/rabbitmq/scripts/member_leave.sh
@@ -42,6 +42,9 @@ get_target_node() {
     echo "$TARGET_NODE"
 }
 
+LOCK_FILE="/tmp/member_leave.lock"
+LOCK_MAX_AGE=55
+
 # if test by shellspec include, just return 0
 if [ "${__SOURCED__:+x}" ]; then
   return 0
@@ -52,11 +55,8 @@ if [[ -z "$KB_LEAVE_MEMBER_POD_NAME" ]]; then
     echo "no leave member name provided"
     exit 1
 fi
-
-LOCK_FILE="/tmp/member_leave.lock"
-LOCK_MAX_AGE=55
 if [[ -f "$LOCK_FILE" ]]; then
-    lock_mtime=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo 0)
+    lock_mtime=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || stat -f %m "$LOCK_FILE" 2>/dev/null || echo 0)
     now=$(date +%s)
     lock_age=$(( now - lock_mtime ))
     if (( lock_age > LOCK_MAX_AGE )); then

--- a/addons/rabbitmq/scripts/member_leave.sh
+++ b/addons/rabbitmq/scripts/member_leave.sh
@@ -13,7 +13,7 @@ is_node_deleted() {
 
 cleanup() {
     echo "Cleaning up..."
-    rm -f /tmp/member_leave.lock
+    rm -f "$LOCK_FILE"
 }
 
 get_target_node() {
@@ -53,9 +53,19 @@ if [[ -z "$KB_LEAVE_MEMBER_POD_NAME" ]]; then
     exit 1
 fi
 
-if [[ -f /tmp/member_leave.lock ]]; then
-    echo "member_leave.sh is already running"
-    exit 1
+LOCK_FILE="/tmp/member_leave.lock"
+LOCK_MAX_AGE=55
+if [[ -f "$LOCK_FILE" ]]; then
+    lock_mtime=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    lock_age=$(( now - lock_mtime ))
+    if (( lock_age > LOCK_MAX_AGE )); then
+        echo "stale lock detected (${lock_age}s old), removing"
+        rm -f "$LOCK_FILE"
+    else
+        echo "member_leave.sh is already running (lock age: ${lock_age}s)"
+        exit 1
+    fi
 fi
 
 CURRENT_POD_NAME=$(echo "${RABBITMQ_NODENAME}"|grep -oP '(?<=rabbit@).*?(?=\.)')
@@ -70,17 +80,14 @@ if [[ -f /tmp/${KB_LEAVE_MEMBER_POD_NAME}_leave.success ]]; then
 fi
 
 
-touch /tmp/member_leave.lock
-# Define the cleanup function
-
-# Set the trap to call the cleanup function on script exit
+touch "$LOCK_FILE"
 trap cleanup EXIT
 
 # the node to leave the cluster
 LEAVE_NODE="${RABBITMQ_NODENAME/$CURRENT_POD_NAME/$KB_LEAVE_MEMBER_POD_NAME}"
 
 # the output of rabbitmqctl cluster_status
-CLUSTER_STATUS=$(rabbitmqctl cluster_status --formatter table)
+CLUSTER_STATUS=$(timeout 10 rabbitmqctl cluster_status --formatter table)
 
 if is_node_deleted "$CLUSTER_STATUS"; then
     echo "Node $KB_LEAVE_MEMBER_POD_NAME has been deleted."
@@ -95,9 +102,8 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-# execute forget_cluster_node on the target node
-rabbitmqctl -n $LEAVE_NODE stop_app
-rabbitmqctl -n $TARGET_NODE forget_cluster_node $LEAVE_NODE
+timeout 20 rabbitmqctl -n $LEAVE_NODE stop_app || echo "stop_app failed or timed out, proceeding with forget_cluster_node"
+timeout 20 rabbitmqctl -n $TARGET_NODE forget_cluster_node $LEAVE_NODE
 
 touch /tmp/${KB_LEAVE_MEMBER_POD_NAME}_leave.success
 


### PR DESCRIPTION
## Summary
- Fix `member_leave.sh` re-entrancy for addon best practice Rule 2 (lifecycle action idempotent/re-entrant/non-blocking)
- Stale lock detection (55s max age) replaces simple lock check
- Timeout wrapping: `cluster_status` 10s, `stop_app` 20s (non-fatal), `forget_cluster_node` 20s
- Total timeout budget 10+20+20=50s < LOCK_MAX_AGE=55s

## Validation Matrix

| Suite | Scope | N | Replicas | Result |
|---|---|---|---|---|
| smoke | T01-T05 | 1 | 1 | GREEN 10/0/0 |
| smoke | T01-T05 | 1 | 3 | GREEN 10/0/0 |
| day2 | D01-D07 (incl. D03 scale-in 5→3) | 1 | 3→5→3 | GREEN 13/0/0 |

**Coverage**: smoke + day2 (D03 scale-in exercises member_leave.sh). Does not claim full matrix release-ready.

## Review
- Flora: APPROVE (code review + `stat -c %Y` safety, timeout budget, stop_app non-fatal under `set -e`)
- CI: 9/9 PASS