### PR TITLE
chore(mysql): move standard startup commands to scripts

### DIFF
--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -274,6 +274,75 @@ chown -R mysql:root {{ .Values.dataMountPath }}
 SERVICE_ID=$((${POD_NAME##*-} + 1))
 {{ end }}
 
+{{- define "mysql.startup.archLdPreloadGuard" -}}
+ARCH=$(uname -m)
+if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
+  echo "ARM system detected. Skipping jemalloc configuration."
+  export LD_PRELOAD=""
+fi
+{{- end }}
+
+{{- define "mysql.startup.common" -}}
+{{- include "mysql.startup.archLdPreloadGuard" . }}
+{{ include "mysql.spec.runtime.entrypoint" . }}
+{{- end }}
+
+{{- define "mysql.startup.script57" -}}
+#!/bin/bash
+{{ include "mysql.startup.common" . }}
+docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+  --ignore-db-dir=lost+found \
+  --plugin-load-add=rpl_semi_sync_master=semisync_master.so \
+  --plugin-load-add=rpl_semi_sync_slave=semisync_slave.so \
+  --plugin-load-add=audit_log=audit_log.so \
+  --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
+  --skip-slave-start=ON
+{{- end }}
+
+{{- define "mysql.startup.script80" -}}
+#!/bin/bash
+{{ include "mysql.startup.common" . }}
+docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+   --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
+   --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
+   --plugin-load-add=audit_log=audit_log.so \
+   --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
+   --skip-slave-start=ON
+{{- end }}
+
+{{- define "mysql.startup.script84" -}}
+#!/bin/bash
+{{ include "mysql.startup.common" . }}
+docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+   --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
+   --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
+   --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
+   --skip-slave-start=ON
+{{- end }}
+
+{{- define "mysql.startup.script80Mgr" -}}
+#!/bin/bash
+{{ include "mysql.startup.common" . }}
+docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+   --report-host ${POD_NAME}.${CLUSTER_COMPONENT_NAME}-headless \
+   --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
+   --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
+   --plugin-load-add=audit_log=audit_log.so \
+   --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
+   --skip-slave-start=ON
+{{- end }}
+
+{{- define "mysql.startup.script84Mgr" -}}
+#!/bin/bash
+{{ include "mysql.startup.common" . }}
+docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+   --report-host ${POD_NAME}.${CLUSTER_COMPONENT_NAME}-headless \
+   --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
+   --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
+   --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
+   --skip-slave-start=ON
+{{- end }}
+
 {{- define "mysql.spec.runtime.common" -}}
 - command:
     - cp

--- a/addons/mysql/templates/cmpd-mysql57.yaml
+++ b/addons/mysql/templates/cmpd-mysql57.yaml
@@ -58,22 +58,7 @@ spec:
           - --port
           - "3601"
           - --
-          - bash
-          - -c
-          - |
-            ARCH=$(uname -m)
-            if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
-              echo "ARM system detected. Skipping jemalloc configuration."
-              export LD_PRELOAD=""
-            fi
-            {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
-              --ignore-db-dir=lost+found \
-              --plugin-load-add=rpl_semi_sync_master=semisync_master.so \
-              --plugin-load-add=rpl_semi_sync_slave=semisync_slave.so \
-              --plugin-load-add=audit_log=audit_log.so \
-              --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
-              --skip-slave-start=ON
+          - /scripts/mysql-startup-57.sh
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -122,4 +107,3 @@ spec:
                 fieldPath: status.podIP
       - name: mysql-exporter
         {{- include "mysql.spec.runtime.exporter" . | nindent 8 }}
-

--- a/addons/mysql/templates/cmpd-mysql80-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-mgr.yaml
@@ -48,17 +48,7 @@ spec:
           - --port
           - "3601"
           - --
-          - bash
-          - -c
-          - |
-            {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
-               --report-host ${POD_NAME}.${CLUSTER_COMPONENT_NAME}-headless \
-               --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
-               --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
-               --plugin-load-add=audit_log=audit_log.so \
-               --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
-               --skip-slave-start=ON
+          - /scripts/mysql-startup-80-mgr.sh
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql80.yaml
+++ b/addons/mysql/templates/cmpd-mysql80.yaml
@@ -58,21 +58,7 @@ spec:
           - --port
           - "3601"
           - --
-          - bash
-          - -c
-          - |
-            ARCH=$(uname -m)
-            if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
-              echo "ARM system detected. Skipping jemalloc configuration."
-              export LD_PRELOAD=""
-            fi
-            {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
-               --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
-               --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
-               --plugin-load-add=audit_log=audit_log.so \
-               --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
-               --skip-slave-start=ON
+          - /scripts/mysql-startup-80.sh
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -37,16 +37,7 @@ spec:
           - --port
           - "3601"
           - --
-          - bash
-          - -c
-          - |
-            {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
-               --report-host ${POD_NAME}.${CLUSTER_COMPONENT_NAME}-headless \
-               --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
-               --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
-               --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
-               --skip-slave-start=ON
+          - /scripts/mysql-startup-84-mgr.sh
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -47,20 +47,7 @@ spec:
           - --port
           - "3601"
           - --
-          - bash
-          - -c
-          - |
-            ARCH=$(uname -m)
-            if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
-              echo "ARM system detected. Skipping jemalloc configuration."
-              export LD_PRELOAD=""
-            fi
-            {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
-               --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
-               --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
-               --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
-               --skip-slave-start=ON
+          - /scripts/mysql-startup-84.sh
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/scripts.yaml
+++ b/addons/mysql/templates/scripts.yaml
@@ -17,6 +17,16 @@ data:
     {{- .Files.Get "scripts/cluster-info.sql" | nindent 4 }}
   mysql-entrypoint.sh: |-
     {{- .Files.Get "scripts/mysql-entrypoint.sh" | nindent 4 }}
+  mysql-startup-57.sh: |-
+    {{- include "mysql.startup.script57" . | nindent 4 }}
+  mysql-startup-80.sh: |-
+    {{- include "mysql.startup.script80" . | nindent 4 }}
+  mysql-startup-84.sh: |-
+    {{- include "mysql.startup.script84" . | nindent 4 }}
+  mysql-startup-80-mgr.sh: |-
+    {{- include "mysql.startup.script80Mgr" . | nindent 4 }}
+  mysql-startup-84-mgr.sh: |-
+    {{- include "mysql.startup.script84Mgr" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Summary
- Move the standard MySQL CMPD main-container startup command bodies from inline `bash -c` YAML blocks into scripts rendered in the existing `mysql-scripts` ConfigMap.
- Keep the kbagent/syncer invocation shape unchanged: `syncer --port 3601 -- /scripts/<startup-script>.sh`.

## Scripts Added
- `mysql-startup-57.sh`
- `mysql-startup-80.sh`
- `mysql-startup-84.sh`
- `mysql-startup-80-mgr.sh`
- `mysql-startup-84-mgr.sh`

## Scope
- Changed: MySQL 5.7 / 8.0 / 8.4 standard and MGR ComponentDefinition startup entries plus `scripts.yaml`.
- Not changed: ORC startup wrapper, ORC lifecycle timeout behavior, ProxySQL startup, image tags, chart version.

## Contract / Best-practice Check
- Checked release-1.0 contract docs: `docs/addon-api-1.0/02-component-definition.md`, `05-lifecycle.md`, `13-cross-cutting-practice.md`.
- No literal release-1.0 contract forbids inline startup commands.
- This PR is a best-practice remediation: startup scripts become reviewable/rendered script artifacts instead of large inline YAML command strings.

## Verification
- `helm dependency build addons/mysql`
- `helm lint addons/mysql`
- `helm template mysql addons/mysql ...` for affected startup entries
- Rendered script syntax checked with `bash -n`.
- Diff review confirmed the command tail still enters the same MySQL startup command through the same `syncer --port 3601 --` boundary.

## CI / Review Boundary
- MySQL chart checks and shell-check are green.
- `shellspec-test` is red from an unrelated release-1.0 Redis baseline warning: `addons/redis/scripts-ut-spec/redis_start_spec.sh:94-101` reports `/data/.kb_redis_start_initialized: No such file or directory` while ShellSpec records `462 examples, 0 failures, 1 warning` and exits red because warnings are treated as suite failure.
- This PR does not touch Redis, so I am not mixing a Redis/baseline fix into this MySQL PR.
- PR is ready for review on the scoped startup-script extraction diff.

## Runtime / Merge Boundary
- This PR changes all standard MySQL startup entry points, so merge/release acceptance needs final chart-package runtime validation after it is included in the release-1.0 chart bump path.
- PR #2826 currently records this as missing item 6 and defines the post-cherry-pick recount rule: after this diff enters #2826, historical runtime rows become supporting evidence only, and the final package needs minimum regression/key runtime recount.
- Not claiming release-ready from static checks alone.

## XP Design Contract Self-check
- Class 1 silent fallback: no fallback added; startup command path remains explicit through `/scripts/mysql-startup-*.sh`.
- Class 2 non-empty contract field: script path is explicit in each affected CMPD; no optional empty value introduced.
- Class 3 commit-state continuity: no runtime state read/write sequence changed; this is command relocation.
- Class 4 sentinel value: no new sentinel value introduced.
- Class 5 conditional cleanup: no cleanup path changed.
- Class 6 NotFound short-circuit: no read/create branch changed.
- Class 7 terminating vs absent: no cleanup/release path changed.
- Class 8 precedence: moved shell bodies preserve existing simple conditionals; no complex boolean chain added.
