### PR TITLE
chore(mysql): render proxysql empty volumes as array

### DIFF
--- a/addons/mysql/templates/cmpd-proxysql.yaml
+++ b/addons/mysql/templates/cmpd-proxysql.yaml
@@ -133,7 +133,7 @@ spec:
           podFQDNs: Required
 
   runtime:
-    volumes:
+    volumes: []
     containers:
       - name: proxysql
         imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}


### PR DESCRIPTION
## Summary
- Render ProxySQL `runtime.volumes` as an explicit empty array (`volumes: []`) instead of a null value.
- Keep the change scoped to the MySQL ProxySQL ComponentDefinition template.

## Why
Fresh release-1.0 MySQL ProxySQL install can trip API validation when the chart renders `runtime.volumes:` without an array value. The API expects an array shape; an empty list is the intended no-volume contract.

## Scope
- Changed: `addons/mysql/templates/cmpd-proxysql.yaml`
- Not changed: image tags, lifecycle scripts, syncer, ORC, semisync/MGR behavior, chart version.

## Verification
- `helm dependency build addons/mysql`
- `helm lint addons/mysql`
- `helm template mysql addons/mysql --set version=8.0.33 --set topology=semisync-proxysql`
- Rendered ProxySQL ComponentDefinition now has `runtime.volumes: []`.
- Diff scope is one YAML shape fix.

## Runtime Evidence
- Evidence path: `/Users/wei/.slock/agents/beeaf92e-9737-4a15-a301-72d3aaca3991/evidence/proxysql-volumes-runtime-20260611T180741CST/`
- Candidate chart: `mysql-1.0.3.tgz`, sha256 `53262de610f1be8e7647d9d930d2e0065ff44b67e334c740de8ff57625a65b53`
- Single-object server-side dry-run/apply passed for the rendered ProxySQL ComponentDefinition.
- Live recheck on 2026-06-14: `proxysql-mysql-1.0.3` available with `.spec.runtime.volumes=[]`.

## CI / Review Boundary
- MySQL chart checks and shell-check are green.
- `shellspec-test` is red from an unrelated release-1.0 Redis baseline warning: `addons/redis/scripts-ut-spec/redis_start_spec.sh:94-101` reports `/data/.kb_redis_start_initialized: No such file or directory` while ShellSpec records `462 examples, 0 failures, 1 warning` and exits red because warnings are treated as suite failure.
- This PR does not touch Redis, so I am not mixing a Redis/baseline fix into this MySQL PR.
- PR is ready for review on the scoped ProxySQL YAML contract fix.
- Merge/release acceptance still depends on the clean-environment chart-bump validation path in PR #2826 if reviewers require full chart-package runtime recount.

## XP Design Contract Self-check
- Class 1 silent fallback: no fallback added; the template now emits the explicit empty-array contract.
- Class 2 non-empty contract field: not applicable; this fixes array shape, not a required string.
- Class 3 commit-state continuity: no runtime state read/write path changed.
- Class 4 sentinel value: removes ambiguous null/empty rendering by using `[]`.
- Class 5 conditional cleanup: no cleanup path changed.
- Class 6 NotFound short-circuit: no read/create branch changed.
- Class 7 terminating vs absent: no cleanup/release path changed.
- Class 8 precedence: no boolean logic changed.
