### PR TITLE
fix(redis): revert reconfigure action to env-var iteration

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -206,9 +206,10 @@ reconfigure:
       - -c
       - |
         set -eu
-
-        /scripts/reload-parameter.sh "$1" "$2"
-      - --
+        env | cut -d= -f1 | grep -E '^[a-zA-Z0-9_.-]+$' | sort -u | while IFS= read -r param; do
+          [ -n "${param}" ] || continue
+          /scripts/reload-parameter.sh "${param//_/-}" "$(printenv "${param}")"
+        done
 {{- end -}}
 
 {{- define "apeDts.reshard.image" -}}


### PR DESCRIPTION
## Summary
- PR #2794 (`fcdf51a46`) changed Redis reconfigure exec from env-var iteration to `$1`/`$2` argv pattern with `-- ` separator
- Live kbagent controller (KB main/1.2+) does **not** pass parameter name/value as positional args after `--` — it sets file-level change env vars per addon-api contract (`docs/addon-api/08-parameters-and-config.md`)
- Under `set -eu`, `$1` is unbound → every dynamic reconfigure OpsRequest fails with `$1: unbound variable`
- Reverts to env-var iteration: read param names from env, convert `_` to `-` for Redis hyphenated param names, call `reload-parameter.sh` per param

## Root cause evidence
- Task #46 runner-r2 first-red: A02 `maxmemory-policy` OpsRequest timeout
- Controller stderr: `udf-reconfigure-cmpd-redis-replication-config: -- : line 3: $1: unbound variable`
- runner-r2.log sha256: `f9ae7b81c477b6c3d62b38a673a97aa09790c820730356674f9e1f3b89834192`

## Affects
All Redis topologies using `redis.config.reconfigureAction` template: standalone, replication, repl-twemproxy, cluster.

## Test plan
- [ ] Task #46 rerun (parameters × repl-twemproxy) with this fix patched — target PASS
- [ ] Regression check: existing parameters PASS results (task #37 replication, task #40 cluster) remain valid since env-var approach is the original contract-compliant method
