### PR TITLE
fix(kafka): inject TLS_ENABLED into kafka-exporter for SASL+TLS support

### DIFF
--- a/addons-cluster/kafka/templates/cluster.yaml
+++ b/addons-cluster/kafka/templates/cluster.yaml
@@ -112,5 +112,7 @@ spec:
       replicas: {{ .Values.monitor.replicas }}
       env:
         {{- include "kafka-cluster.basicEnv" . | nindent 8 }}
+        - name: TLS_ENABLED
+          value: "{{ .Values.tlsEnable }}"
       {{- include "kafka-exporter.resources" . | nindent 6 }}
     {{- end }}

--- a/addons-cluster/kafka/values.yaml
+++ b/addons-cluster/kafka/values.yaml
@@ -11,7 +11,6 @@ exporterVersion: 1.6.0
 mode: combined
 
 # Enable TLS
-# Todo: Monitoring is not supported when tls is enabled
 tlsEnable: false
 
 


### PR DESCRIPTION
## Summary

Fixes #2821 -- kafka-exporter does not support SASL authentication

- Inject TLS_ENABLED env var into kafka-exporter component from tlsEnable value
- Remove outdated TODO comment about monitoring not supporting TLS

### Analysis

The SASL env vars (KB_KAFKA_ENABLE_SASL, KB_KAFKA_SASL_ENABLE, KB_CLUSTER_WITH_ZK, KB_KAFKA_SASL_MECHANISMS) are already injected via kafka-cluster.basicEnv helper in the cluster chart. The credential vars (KAFKA_ADMIN_USER_COMBINE/BROKER, KAFKA_ADMIN_PASSWORD_COMBINE/BROKER) are already in the exporter CMPD vars section via credentialVarRef.

The only clearly missing env var is TLS_ENABLED, which broker/controller get from tlsVarRef in their CMPDs. Since the exporter does not have its own TLS configuration (it connects TO brokers, not serves TLS), it cannot use tlsVarRef. This PR adds it explicitly from the cluster chart tlsEnable value.

## Test plan

- [ ] Deploy SASL+TLS cluster with combined_monitor topology (exporter present)
- [ ] Verify exporter starts with --sasl.enabled parameter
- [ ] Verify exporter /metrics endpoint scrapes offset data
- [ ] Soak sanity 600s with combined_monitor + SASL+TLS (exporter crosscheck)