### PR TITLE
feat(mysql): chart bump 1.0.3 to 1.0.4

### DIFF
--- a/addons/mysql/Chart.yaml
+++ b/addons/mysql/Chart.yaml
@@ -4,7 +4,7 @@ description: MySQL is a widely used, open-source relational database management 
 
 type: application
 
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the ApeCloud MySQL being deployed,
 # rather than the version number of ApeCloud MySQL-Scale itself.

--- a/addons/mysql/scripts/init-mysql-instance-for-orc.sh
+++ b/addons/mysql/scripts/init-mysql-instance-for-orc.sh
@@ -20,58 +20,6 @@ mysql_error() {
 	exit 1
 }
 
-mysql_uses_legacy_replication_syntax() {
-  [[ "${MYSQL_MAJOR}" == "5.7" ]]
-}
-
-mysql_reset_replica_sql() {
-  if mysql_uses_legacy_replication_syntax; then
-    cat <<'EOF'
-RESET SLAVE;
-RESET SLAVE ALL;
-EOF
-  else
-    cat <<'EOF'
-RESET REPLICA;
-RESET REPLICA ALL;
-EOF
-  fi
-}
-
-mysql_change_replication_source_sql() {
-  local master_host=$1
-  local master_port=$2
-
-  if mysql_uses_legacy_replication_syntax; then
-    cat <<EOF
-STOP SLAVE;
-CHANGE MASTER TO
-MASTER_AUTO_POSITION=1,
-MASTER_CONNECT_RETRY=1,
-MASTER_RETRY_COUNT=86400,
-MASTER_HOST='$master_host',
-MASTER_PORT=$master_port,
-MASTER_USER='$MYSQL_ROOT_USER',
-MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
-START SLAVE;
-EOF
-  else
-    cat <<EOF
-STOP REPLICA;
-CHANGE REPLICATION SOURCE TO
-SOURCE_AUTO_POSITION=1,
-SOURCE_SSL=1,
-SOURCE_CONNECT_RETRY=1,
-SOURCE_RETRY_COUNT=86400,
-SOURCE_HOST='$master_host',
-SOURCE_PORT=$master_port,
-SOURCE_USER='$MYSQL_ROOT_USER',
-SOURCE_PASSWORD='$MYSQL_ROOT_PASSWORD';
-START REPLICA;
-EOF
-  fi
-}
-
 # create orchestrator user in mysql
 create_mysql_user() {
   mysql_note "Create MySQL User and Grant Permissions..."
@@ -94,7 +42,8 @@ EOF
 register_cluster_in_orchestrator() {
   # reset slave info if any
   mysql -P 3306 -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
-$(mysql_reset_replica_sql)
+RESET SLAVE;
+RESET SLAVE ALL;
 EOF
 
   local instance="${POD_NAME}"
@@ -211,12 +160,76 @@ change_master() {
 
   mysql_note "Change master"
 
-  mysql -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
+  if [[ "${MYSQL_MAJOR}" == "5.7" ]]; then
+    mysql -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
 SET GLOBAL READ_ONLY=1;
 SET GLOBAL SUPER_READ_ONLY=1;
-$(mysql_change_replication_source_sql "$master_host" "$master_port")
+STOP SLAVE;
+CHANGE MASTER TO
+MASTER_AUTO_POSITION=1,
+MASTER_CONNECT_RETRY=1,
+MASTER_RETRY_COUNT=86400,
+MASTER_HOST='$master_host',
+MASTER_PORT=$master_port,
+MASTER_USER='$MYSQL_ROOT_USER',
+MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
+START SLAVE;
 EOF
+  else
+    mysql -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
+SET GLOBAL READ_ONLY=1;
+SET GLOBAL SUPER_READ_ONLY=1;
+STOP SLAVE;
+CHANGE MASTER TO
+SOURCE_AUTO_POSITION=1,
+SOURCE_SSL=1,
+MASTER_CONNECT_RETRY=1,
+MASTER_RETRY_COUNT=86400,
+MASTER_HOST='$master_host',
+MASTER_PORT=$master_port,
+MASTER_USER='$MYSQL_ROOT_USER',
+MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
+START SLAVE;
+EOF
+  fi
   mysql_note "CHANGE MASTER successful for $master_host."
+}
+
+repair_cluster_alias() {
+  local anchor_instance="$1"
+  local orchestrator_url="${ORC_ENDPOINTS}"
+  local cluster_name_in_orc
+  cluster_name_in_orc=$(/scripts/orchestrator-client -c which-cluster -i "${anchor_instance}" 2>/dev/null) || true
+  if [ -n "$cluster_name_in_orc" ]; then
+    mysql_note "Repairing stale alias: setting ${CLUSTER_NAME} -> ${cluster_name_in_orc}" >&2
+    curl --silent -X GET "http://${orchestrator_url}/api/set-cluster-alias/${cluster_name_in_orc}?alias=${CLUSTER_NAME}" >/dev/null || true
+  fi
+}
+
+is_valid_master_info() {
+  local val="$1"
+  [ -n "$val" ] && ! echo "$val" | grep -qi "error\|unable\|null"
+}
+
+find_cluster_master() {
+  local result=""
+  result=$(/scripts/orchestrator-client -c which-cluster-master -alias "${CLUSTER_NAME}" 2>/dev/null) || true
+  if is_valid_master_info "$result"; then
+    echo "$result"
+    return 0
+  fi
+
+  local pod0_host="${POD_NAME%-*}-0"
+  mysql_note "Alias lookup failed for '${CLUSTER_NAME}' (got '${result:-}'), trying instance-based fallback via $pod0_host" >&2
+  result=$(/scripts/orchestrator-client -c which-cluster-master -i "${pod0_host}" 2>/dev/null) || true
+  if is_valid_master_info "$result"; then
+    repair_cluster_alias "${pod0_host}"
+    echo "$result"
+    return 0
+  fi
+
+  mysql_note "Both alias and instance-based lookups failed. alias='${CLUSTER_NAME}' pod0='${pod0_host}' orc='${ORC_ENDPOINTS}' last='${result:-}'" >&2
+  return 1
 }
 
 setup_master_slave() {
@@ -228,7 +241,7 @@ setup_master_slave() {
 
   start_time=$(date +%s)
 
-  master_info=$(/scripts/orchestrator-client -c which-cluster-master -alias "${CLUSTER_NAME}")
+  master_info=$(find_cluster_master) || true
 
   while [ -z "$master_info" ]; do
     mysql_note "Waiting for master info..."
@@ -250,13 +263,36 @@ setup_master_slave() {
 
     sleep 5
     mysql_note "Checking topology info."
-    master_info=$(/scripts/orchestrator-client -c which-cluster-master -alias "${CLUSTER_NAME}")
+    master_info=$(find_cluster_master) || true
   done
 
   mysql_note "  Master info: $master_info"
   master_from_orc="${master_info%%:*}"
   if [ "$master_from_orc" == "${POD_NAME}" ]; then
-    mysql_note "This instance is the master"
+    # After VScale/restart, ORC failover may be in-flight: old pod-0 went down,
+    # ORC is promoting another pod, but the new pod-0 queried ORC before the
+    # failover committed.  Poll peer pods for up to 30s to detect split-brain.
+    local base_name="${POD_NAME%-*}"
+    local verify_end=$(( $(date +%s) + 30 ))
+    while [ "$(date +%s)" -lt "$verify_end" ]; do
+      sleep 5
+      for i in 1 2 3 4; do
+        local peer="${base_name}-${i}"
+        local peer_master
+        peer_master=$(/scripts/orchestrator-client -c which-cluster-master -i "${peer}" 2>/dev/null) || true
+        if is_valid_master_info "$peer_master"; then
+          local pm_host="${peer_master%%:*}"
+          if [ "$pm_host" != "${POD_NAME}" ] && [ -n "$pm_host" ]; then
+            mysql_note "Split-brain detected: $peer reports master=$pm_host (not ${POD_NAME}). Re-slaving..."
+            create_mysql_user
+            change_master "$pm_host"
+            /scripts/orchestrator-client -c discover -i "${POD_NAME}" 2>/dev/null || true
+            return 0
+          fi
+        fi
+      done
+    done
+    mysql_note "This instance is the master (verified, no split-brain)"
     return 0
   fi
 
@@ -282,7 +318,7 @@ setup_master_slave() {
     sleep 5
     attempt=$((attempt + 1))
 
-    /scripts/orchestrator-client -c discover -i "${master_from_orc}" 2>/dev/null || true
+    /scripts/orchestrator-client -c discover -i "${POD_NAME}" 2>/dev/null || true
   done
   return 0
 }

--- a/addons/mysql/scripts/init-mysql-instance-for-orc.sh
+++ b/addons/mysql/scripts/init-mysql-instance-for-orc.sh
@@ -20,6 +20,58 @@ mysql_error() {
 	exit 1
 }
 
+mysql_uses_legacy_replication_syntax() {
+  [[ "${MYSQL_MAJOR}" == "5.7" ]]
+}
+
+mysql_reset_replica_sql() {
+  if mysql_uses_legacy_replication_syntax; then
+    cat <<'EOF'
+RESET SLAVE;
+RESET SLAVE ALL;
+EOF
+  else
+    cat <<'EOF'
+RESET REPLICA;
+RESET REPLICA ALL;
+EOF
+  fi
+}
+
+mysql_change_replication_source_sql() {
+  local master_host=$1
+  local master_port=$2
+
+  if mysql_uses_legacy_replication_syntax; then
+    cat <<EOF
+STOP SLAVE;
+CHANGE MASTER TO
+MASTER_AUTO_POSITION=1,
+MASTER_CONNECT_RETRY=1,
+MASTER_RETRY_COUNT=86400,
+MASTER_HOST='$master_host',
+MASTER_PORT=$master_port,
+MASTER_USER='$MYSQL_ROOT_USER',
+MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
+START SLAVE;
+EOF
+  else
+    cat <<EOF
+STOP REPLICA;
+CHANGE REPLICATION SOURCE TO
+SOURCE_AUTO_POSITION=1,
+SOURCE_SSL=1,
+SOURCE_CONNECT_RETRY=1,
+SOURCE_RETRY_COUNT=86400,
+SOURCE_HOST='$master_host',
+SOURCE_PORT=$master_port,
+SOURCE_USER='$MYSQL_ROOT_USER',
+SOURCE_PASSWORD='$MYSQL_ROOT_PASSWORD';
+START REPLICA;
+EOF
+  fi
+}
+
 # create orchestrator user in mysql
 create_mysql_user() {
   mysql_note "Create MySQL User and Grant Permissions..."
@@ -42,8 +94,7 @@ EOF
 register_cluster_in_orchestrator() {
   # reset slave info if any
   mysql -P 3306 -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
-RESET SLAVE;
-RESET SLAVE ALL;
+$(mysql_reset_replica_sql)
 EOF
 
   local instance="${POD_NAME}"
@@ -160,38 +211,11 @@ change_master() {
 
   mysql_note "Change master"
 
-  if [[ "${MYSQL_MAJOR}" == "5.7" ]]; then
-    mysql -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
+  mysql -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
 SET GLOBAL READ_ONLY=1;
 SET GLOBAL SUPER_READ_ONLY=1;
-STOP SLAVE;
-CHANGE MASTER TO
-MASTER_AUTO_POSITION=1,
-MASTER_CONNECT_RETRY=1,
-MASTER_RETRY_COUNT=86400,
-MASTER_HOST='$master_host',
-MASTER_PORT=$master_port,
-MASTER_USER='$MYSQL_ROOT_USER',
-MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
-START SLAVE;
+$(mysql_change_replication_source_sql "$master_host" "$master_port")
 EOF
-  else
-    mysql -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
-SET GLOBAL READ_ONLY=1;
-SET GLOBAL SUPER_READ_ONLY=1;
-STOP SLAVE;
-CHANGE MASTER TO
-SOURCE_AUTO_POSITION=1,
-SOURCE_SSL=1,
-MASTER_CONNECT_RETRY=1,
-MASTER_RETRY_COUNT=86400,
-MASTER_HOST='$master_host',
-MASTER_PORT=$master_port,
-MASTER_USER='$MYSQL_ROOT_USER',
-MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
-START SLAVE;
-EOF
-  fi
   mysql_note "CHANGE MASTER successful for $master_host."
 }
 

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -154,8 +154,12 @@ preTerminate:
       - bash
       - -c
       - |
-        /orc-scripts/preterminate.sh 2>> /tmp/preterminate.log
-        if [ $? -ne 0 ]; then
+        timeout 30 /orc-scripts/preterminate.sh 2>> /tmp/preterminate.log
+        rc=$?
+        if [ $rc -eq 124 ]; then
+          echo "ERROR: preterminate timed out after 30s"
+          exit 1
+        elif [ $rc -ne 0 ]; then
           echo "ERROR: Failed to preterminate"
           exit 1
         fi
@@ -177,9 +181,12 @@ accountProvision:
         # rc-save line on any non-zero result.
         { previous_state=$(set +o); set +ex; } 2>/dev/null
         eval statement=\"${KB_ACCOUNT_STATEMENT}\"
-        mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement};"
+        timeout 10 mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement};"
         mysql_rc=$?
         eval "$previous_state"
+        if [ $mysql_rc -eq 124 ]; then
+          echo "ERROR: accountProvision mysql command timed out after 10s" >&2
+        fi
         exit $mysql_rc
     targetPodSelector: Role
     matchingKey: primary
@@ -220,8 +227,12 @@ memberLeave:
       - /bin/bash
       - -c
       - |
-        /orc-scripts/member-leave.sh 2>> /tmp/member-leave.log
-        if [ $? -ne 0 ]; then
+        timeout 30 /orc-scripts/member-leave.sh 2>> /tmp/member-leave.log
+        rc=$?
+        if [ $rc -eq 124 ]; then
+          echo "ERROR: member-leave timed out after 30s"
+          exit 1
+        elif [ $rc -ne 0 ]; then
           echo "ERROR: Failed to member leave"
           exit 1
         fi
@@ -231,8 +242,12 @@ switchover:
       - /bin/sh
       - -c
       - |
-        /orc-scripts/switchover.sh 2>> /tmp/switchover.log
-        if [ $? -ne 0 ]; then
+        timeout 60 /orc-scripts/switchover.sh 2>> /tmp/switchover.log
+        rc=$?
+        if [ $rc -eq 124 ]; then
+          echo "ERROR: switchover timed out after 60s"
+          exit 1
+        elif [ $rc -ne 0 ]; then
           echo "ERROR: Failed to switchover"
           exit 1
         fi

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -71,8 +71,6 @@ spec:
             value: mysql
           - name: KB_WORKLOAD_TYPE
             value: mgr
-          - name: MYSQL_INITDB_SKIP_TZINFO
-            value: "1"
           - name: MYSQL_ROOT_HOST
             value: {{ .Values.auth.rootHost | default "%" | quote }}
           - name: SERVICE_PORT

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -81,8 +81,6 @@ spec:
           {{- include "mysql.spec.runtime.ldPreloadEnv" . | nindent 10 }}
           - name: KB_SERVICE_CHARACTER_TYPE
             value: mysql
-          - name: MYSQL_INITDB_SKIP_TZINFO
-            value: "1"
           - name: MYSQL_ROOT_HOST
             value: {{ .Values.auth.rootHost | default "%" | quote }}
           - name: SERVICE_PORT

--- a/addons/mysql/templates/cmpd-proxysql.yaml
+++ b/addons/mysql/templates/cmpd-proxysql.yaml
@@ -133,7 +133,7 @@ spec:
           podFQDNs: Required
 
   runtime:
-    volumes:
+    volumes: []
     containers:
       - name: proxysql
         imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}


### PR DESCRIPTION
## Summary
- Chart.yaml version 1.0.3 to 1.0.4
- ORC LFA timeout wrappers (preterminate 30s, accountProvision 10s, memberLeave 30s, switchover 60s)
- Remove MYSQL_INITDB_SKIP_TZINFO from mysql-8.4 CMPDs (timezone tables populated on init)
- SLAVE to REPLICA syntax in init-mysql-instance-for-orc.sh (5.7 keeps legacy via version conditional)
- ProxySQL volumes: null to volumes: [] (API validation fix for fresh install)
- VScale split-brain prevention: 30s polling verification after ORC reports "you are master" to detect in-flight failover
- ORC alias fallback: instance-based master lookup when alias stale after HScale
- Discover fix: register self (not master) after change_master

## Missing
- Item 6: PR #2816 startup script extraction (pending merge to release-1.0, then cherry-pick)

## Runtime validation matrix

Environment: idc2 vcluster, KB 1.0.3-beta.8, addon chart mysql-1.0.4

| Topology | Engine | Target N | Current N | Status | Notes |
|---|---|---|---|---|---|
| semisync | 8.0.33 | 10 | 46 | DONE | Self-contained harness |
| semisync | 8.4.2 | 10 | 46 | DONE | Self-contained harness |
| mgr | 8.0.33 | 10 | 10 | Candidate | Patch syncer `0.6.8-pr206-01e5127`, needs official image recount |
| mgr | 8.4.2 | 10 | 0 | Blocked | Known syncer MGR join settling issue |
| orc | 8.0.33 | 10 | 10 | DONE | memberLeave `c21aa31c`, init-mysql `3813cdf1` |
| semisync-proxysql | 8.0.33 | 10 | 10 | Candidate | Patch syncer, needs official image recount |
| mgr-proxysql | 8.0.33 | 10 | 10 | Candidate | Patch syncer, needs official image recount |
| orc-proxysql | 8.0.33 | 10 | 10 | DONE (scoped) | VScale split-brain fix `f5b3546a`, live CM validated, now in PR head |

Init script candidate SHA: `f5b3546a647acdcc` (commit `547cde08`)

## CI status
- chart/check-addons: 6/6 PASS
- shell-check: PASS
- shellspec-test: FAIL (Redis test `redis_start_spec.sh:94` — pre-existing on release-1.0 baseline, run 27534902802)
- pr-label-check: FAIL (expected for DRAFT)

## Boundary
- DRAFT until: item 6 merged + mgr 8.4 resolved + candidate rows recounted on official syncer
- orc-proxysql = live ConfigMap scoped closeout, needs final chart package recount
- mgr/mgr-proxysql/semisync-proxysql = patch syncer candidate, needs PR #206 official image recount
- shellspec red = release-1.0 Redis baseline issue, not MySQL
- **Not release-ready** — scoped row-level evidence only

### Item 6 cherry-pick recount rule
PR #2816 (startup script extraction) changes all MySQL startup entry points (57/80/80-mgr/84/84-mgr + scripts.yaml). After cherry-pick into this branch:
1. PR head changes → historical N=10 rows become "historical/supporting evidence, expected behavior-equivalent", **not** final-package acceptance
2. Post cherry-pick gate: `helm render` / static diff to verify scripts mount correctly + env deletion preserved
3. Affected CMPDs (all topologies including semisync + ORC) require final-package minimum regression + key runtime recount
4. mgr 8.4 remains separately blocked