### PR TITLE
chore(kafka): restore user entries in JAAS config for SASL PLAIN auth

### DIFF
--- a/addons/kafka/scripts/common.sh
+++ b/addons/kafka/scripts/common.sh
@@ -82,7 +82,9 @@ build_server_jaas_config() {
 KafkaServer {
   ${login_module}
   username="$KAFKA_ADMIN_USER"
-  password="$admin_password";
+  password="$admin_password"
+  user_$KAFKA_ADMIN_USER="$admin_password"
+  user_$KAFKA_CLIENT_USER="$client_password";
 };
 KafkaClient {
   ${login_module}


### PR DESCRIPTION
## Summary

- Restore user_XXX entries in the KafkaServer JAAS configuration
- Without these entries, Kafka SASL PLAIN authentication rejects all client connections with "Invalid username or password"
- The username/password fields define inter-broker credentials; the user_XXX fields define the whitelist of users allowed to authenticate to the broker

Fixes #2821

## Root cause

The build_server_jaas_config() function in addons/kafka/scripts/common.sh was missing user_XXX entries in the KafkaServer section. Discovered during SASL+TLS soak testing on idc1:

- helm get manifest kafka --revision 10 (working): KafkaServer has user_XXX entries
- helm get manifest kafka --revision 12 (broken): only username/password, no user_XXX entries
- kafka-topics.sh with admin/client users: "Authentication failed: Invalid username or password"
- After helm rollback kafka 10 (now rev 13): topic create PASS, exporter SASL auth PASS

## Verification

idc1 runner sanity with rev 13 (= rev 10 content, matching this fix):
- SASL+TLS combined_monitor cluster: topic create PASS
- Workload launched with SASL credentials: PASS
- All 3 brokers Running, 0 restarts
- Exporter pod Ready (SASL auth successful)

## Test plan

- [x] Deploy SASL+TLS combined_monitor cluster (verified via idc1 rev 13 rollback)
- [x] Verify kafka-topics.sh with admin credentials succeeds
- [x] Verify exporter SASL authentication succeeds
- [ ] 600s soak sanity with SASL+TLS (in progress via PR #245 sanity5)