### PR TITLE
fix(postgresql): require primary role for availability

### DIFF
--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -50,6 +50,8 @@ spec:
     - name: secondary
       updatePriority: 1
       participatesInQuorum: false
+  available:
+    withRole: primary
   logConfigs:
     {{- range $name,$pattern := $.Values.logConfigs }}
     - name: {{ $name }}


### PR DESCRIPTION
## Background


PostgreSQL pods can stay `Running` while the role probe / InstanceSet status has no `primary` member. The PostgreSQL addon already defines `roleSelector: primary` and a `roleProbe`, but the ComponentDefinition did not bind component availability to the primary role. As a result, the component can still be treated as available from the addon / KubeBlocks perspective when no primary role is present.

## Changes

- Add `spec.available.withRole: primary` to the PostgreSQL ComponentDefinition template.
- Keep the existing `roleProbe`, `roles`, `roleSelector: primary`, scripts, and parameter definitions unchanged.

## Validation

- Before the change, rendered the chart and confirmed all 6 PostgreSQL ComponentDefinitions were missing `available.withRole=primary`.
- After the change, ran `helm template postgresql addons/postgresql` and verified via Ruby/YAML parsing that all 6 ComponentDefinitions render `spec.available.withRole: primary`.
- Ran `helm lint addons/postgresql`.
- Ran `git diff --check`.
- GitHub checks are green: `shell-check`, `shellspec-test`, chart release matrix, generated files, and label checks.