### PR TITLE
fix(clickhouse): check access.tar before adding --rbac during restore

### DIFF
--- a/addons/clickhouse/dataprotection/common.sh
+++ b/addons/clickhouse/dataprotection/common.sh
@@ -602,7 +602,13 @@ function restore_schema_and_sync() {
 		[[ "$mode_info" == "standalone" ]] && unset RESTORE_SCHEMA_ON_CLUSTER
 		local restore_args=(restore_remote "$backup_name" --schema)
 		if [[ -n "${CH_KEEPER_POD_FQDN_LIST:-}" ]]; then
-			restore_args+=(--rbac)
+			export PATH="$PATH:${DP_DATASAFED_BIN_PATH:-}"
+			export DATASAFED_BACKEND_BASE_PATH="${DP_BACKUP_BASE_PATH}/${DP_BACKUP_NAME}"
+			if datasafed list -f / 2>/dev/null | grep -q "access.tar"; then
+				restore_args+=(--rbac)
+			else
+				DP_log "Skip RBAC restore because no access.tar found in backup"
+			fi
 		else
 			DP_log "Skip RBAC restore because ClickHouse keeper is not configured"
 		fi


### PR DESCRIPTION
## Problem

During ClickHouse restore, `clickhouse-backup restore_remote --schema --rbac` fails when the backup doesn't contain RBAC data:

```
FTL cmd/clickhouse-backup/main.go:882 > , error=restoreRBAC: restoreRBACResolveAllConflicts: walk backup access path: walk backup access path: lstat /bitnami/clickh...
```

## Root Cause

The `--rbac` flag was unconditionally added when ClickHouse Keeper is configured, even if the backup doesn't contain `access.tar` (RBAC data). This causes clickhouse-backup to attempt RBAC restore on a backup that has no access data, leading to a fatal filesystem walk error.

## Fix

Before adding `--rbac`, use `datasafed list` to check if `access.tar` exists in the backup. Only add `--rbac` if the file exists.