### PR TITLE
fix(redis): remove trailing space in repl-diskless-sync cue key name

### DIFF
--- a/addons/redis/config/redis-cluster5-config-constraint.cue
+++ b/addons/redis/config/redis-cluster5-config-constraint.cue
@@ -255,7 +255,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis-cluster6-config-constraint.cue
+++ b/addons/redis/config/redis-cluster6-config-constraint.cue
@@ -382,7 +382,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis-cluster7-config-constraint.cue
+++ b/addons/redis/config/redis-cluster7-config-constraint.cue
@@ -401,7 +401,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis-cluster8-config-constraint.cue
+++ b/addons/redis/config/redis-cluster8-config-constraint.cue
@@ -709,7 +709,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis5-config-constraint.cue
+++ b/addons/redis/config/redis5-config-constraint.cue
@@ -255,7 +255,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis6-config-constraint.cue
+++ b/addons/redis/config/redis6-config-constraint.cue
@@ -388,7 +388,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis7-config-constraint.cue
+++ b/addons/redis/config/redis7-config-constraint.cue
@@ -418,7 +418,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 

--- a/addons/redis/config/redis8-config-constraint.cue
+++ b/addons/redis/config/redis8-config-constraint.cue
@@ -699,7 +699,7 @@
 
     "replica-read-only": string & "yes" | "no" | *"yes"
 
-    "repl-diskless-sync ":string & "yes" | "no" | *"yes"
+    "repl-diskless-sync":string & "yes" | "no" | *"yes"
 
     "repl-diskless-sync-delay": int | *5
 


### PR DESCRIPTION
## Problem
Reconfiguring parameter `repl-diskless-sync` fails with:
`Failed: reconfigure parameter failed: parameter repl-diskless-sync not found in parameters schema`

## Root Cause
In all 8 cue constraint files, the key name has a trailing space inside the quotes:
`"repl-diskless-sync "` instead of `"repl-diskless-sync"`, so the parameter name does not match.

## Fix
Removed the trailing space from the key name in all 8 redis cue constraint files.
