### PR TITLE
fix: start redis cluster pods in parallel

### DIFF
--- a/addons/redis/scripts/redis-start.sh
+++ b/addons/redis/scripts/redis-start.sh
@@ -351,8 +351,11 @@ is_redis_start_initialized() {
 }
 
 mark_redis_start_initialized() {
-  mkdir -p "$(dirname "$redis_start_initialized_file")" 2>/dev/null || true
-  date +%s > "$redis_start_initialized_file" 2>/dev/null || true
+  local redis_start_initialized_dir
+  redis_start_initialized_dir="$(dirname "$redis_start_initialized_file")"
+  if mkdir -p "$redis_start_initialized_dir" 2>/dev/null; then
+    date +%s > "$redis_start_initialized_file" 2>/dev/null || true
+  fi
 }
 
 syncer_initial_bootstrap_default_primary_allowed() {

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -65,7 +65,7 @@ spec:
       podService: true
       disableAutoProvision: true
   updateStrategy: BestEffortParallel
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   volumes:
     - name: data
       needSnapshot: true


### PR DESCRIPTION
## Summary
- Change Redis Cluster `ComponentDefinition` pod management policy from `OrderedReady` to `Parallel`.
- This avoids a stop/start deadlock when a shard's first recreated pod is a Redis replica whose master pod has not been recreated yet.
- Fix an existing Redis ShellSpec warning by only writing the start-initialized marker after its directory is successfully created. This is needed because the Redis script tests are triggered by this PR and CI treats ShellSpec warnings as failures.
- Keep chart version and release notes unchanged; this is a minimal runtime policy fix.

## Evidence
On the onsite cluster `kubeblocks-cloud-ns/wheat-684cf86f58`:
- Cluster uses `redis-cluster-1.0.3` cluster chart and `redis-cluster-8-1.0.4` component definition.
- After parameter reconfiguration and Stop/Start, OpsRequest `wheat-684cf86f58-start-4gknv` stayed `Running` at `4/6`.
- `InstanceSet/wheat-684cf86f58-shard-ff9` had `spec.replicas=2`, but only pod `wheat-684cf86f58-shard-ff9-0` existed; pod `-1` was still pending creation.
- The InstanceSet rendered with `podManagementPolicy=OrderedReady`, so pod `-1` could not be created until pod `-0` became ready.
- Pod `wheat-684cf86f58-shard-ff9-0` was labeled/role-probed as `secondary`, and Redis readiness failed because the master was absent. Redis returned `MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'.`
- The rendered Redis config confirmed `replica-serve-stale-data no`; this is a valid Redis parameter, but it exposes the ordered-start deadlock when a replica is started before its master.

## Why this fix
Redis Cluster shard creation/start should not serialize pods by ordinal. The sharding definition is already parallel, and Redis roles can move across ordinals after lifecycle operations. Starting both shard pods in parallel lets the master and replica come up together instead of blocking on a replica readiness check that requires the master.

## Validation
- `git diff --check`
- `helm dependency build addons/redis`
- `helm lint addons/redis`
- `helm template kb-addon-redis addons/redis --namespace kb-system`
- Rendered check: `redis-cluster-5/6/7/8-1.0.4` all render `podManagementPolicy: Parallel` and keep `updateStrategy: BestEffortParallel`.
- `bash -n` for Redis cluster startup/readiness scripts and `addons/redis/scripts/redis-start.sh`.
- Tried local `make scripts-test-kcov`, but local run cannot install ShellSpec because sudo requires a password. GitHub CI is the source of truth for ShellSpec.

Live cluster mutation/regression was not performed; onsite Kubernetes access was kept read-only while collecting evidence.
