### PR TITLE
test(redis): add shellspec tests for ping and pre-stop lifecycle scripts

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_ping_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_ping_spec.sh
@@ -1,0 +1,194 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_ping_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis Ping Script Tests"
+  Include ../scripts/redis-ping.sh
+  Include $common_library_file
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "check_redis_ok()"
+    setup_env() {
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD="testpass"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when redis returns PONG with password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when redis returns PONG without password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_no_password() {
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      BeforeEach 'setup_no_password'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when redis returns non-PONG response"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "NOAUTH Authentication required."
+        return 0
+      }
+
+      It "returns failure with error"
+        When call check_redis_ok
+        The status should be failure
+        The stderr should include "redis ping failed"
+        The stderr should include "NOAUTH"
+      End
+    End
+
+    Context "when redis-cli times out (exit 124)"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        return 124
+      }
+
+      It "returns failure with timeout message"
+        When call check_redis_ok
+        The status should be failure
+        The stderr should include "Timed out"
+      End
+    End
+
+    Context "when using custom port"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_custom_port() {
+        export SERVICE_PORT="6380"
+      }
+      BeforeEach 'setup_custom_port'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when TLS is enabled"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_tls() {
+        export REDIS_CLI_TLS_CMD="--tls --insecure"
+      }
+      BeforeEach 'setup_tls'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+  End
+
+  Describe "retry_check_redis_ok()"
+    setup_env() {
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD="testpass"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when redis is healthy"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call retry_check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when redis is permanently down"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "Could not connect" >&2
+        return 1
+      }
+
+      It "returns failure after retries"
+        When call retry_check_redis_ok
+        The status should be failure
+        The stderr should include "Redis is not running"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_pre_stop_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_pre_stop_spec.sh
@@ -1,0 +1,161 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_pre_stop_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis Pre-Stop Script Tests"
+  Include ../scripts/redis-pre-stop.sh
+  Include $common_library_file
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "acl_save_before_stop()"
+    setup_env() {
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD="testpass123"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when acl save succeeds with password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "returns success and masks password in log"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "acl save command:"
+        The output should include "********"
+        The output should not include "testpass123"
+        The output should include "executed successfully"
+      End
+    End
+
+    Context "when acl save succeeds without password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_no_password() {
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      BeforeEach 'setup_no_password'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "returns success without -a flag"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "acl save command:"
+        The output should not include " -a "
+        The output should include "executed successfully"
+      End
+    End
+
+    Context "when acl save fails"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "ERR operation not permitted" >&2
+        return 1
+      }
+
+      It "exits with failure"
+        When run acl_save_before_stop
+        The status should be failure
+        The output should include "failed to execute acl save command"
+      End
+    End
+
+    Context "when using custom port"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_custom_port() {
+        export SERVICE_PORT="6380"
+      }
+      BeforeEach 'setup_custom_port'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "uses the custom port"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "-p 6380"
+      End
+    End
+
+    Context "when SERVICE_PORT is not set"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_default_port() {
+        unset SERVICE_PORT
+      }
+      BeforeEach 'setup_default_port'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "defaults to port 6379"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "-p 6379"
+      End
+    End
+
+    Context "when TLS is enabled"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_tls() {
+        export REDIS_CLI_TLS_CMD="--tls --insecure"
+      }
+      BeforeEach 'setup_tls'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "includes TLS flags in command"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "--tls --insecure"
+        The output should include "executed successfully"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_sentinel_ping_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_sentinel_ping_spec.sh
@@ -1,0 +1,167 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_sentinel_ping_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis Sentinel Ping Script Tests"
+  Include ../scripts/redis-sentinel-ping.sh
+  Include $common_library_file
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "check_redis_sentinel_ok()"
+    setup_env() {
+      export SENTINEL_SERVICE_PORT="26379"
+      export SENTINEL_PASSWORD="sentinelpass"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SENTINEL_SERVICE_PORT SENTINEL_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when sentinel returns PONG with password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_sentinel_ok
+        The status should be success
+      End
+    End
+
+    Context "when sentinel returns PONG without password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_no_password() {
+        unset SENTINEL_PASSWORD
+      }
+      BeforeEach 'setup_no_password'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_sentinel_ok
+        The status should be success
+      End
+    End
+
+    Context "when sentinel returns non-PONG response"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "NOAUTH Authentication required."
+        return 0
+      }
+
+      It "returns failure with error"
+        When call check_redis_sentinel_ok
+        The status should be failure
+        The stderr should include "redis sentinel ping failed"
+        The stderr should include "NOAUTH"
+      End
+    End
+
+    Context "when redis-cli times out (exit 124)"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        return 124
+      }
+
+      It "returns failure with timeout message"
+        When call check_redis_sentinel_ok
+        The status should be failure
+        The stderr should include "timed out"
+      End
+    End
+
+    Context "when using default port"
+      cleanup_env_no_port() {
+        unset SENTINEL_SERVICE_PORT SENTINEL_PASSWORD REDIS_CLI_TLS_CMD
+      }
+      BeforeEach 'cleanup_env_no_port'
+      AfterEach 'cleanup_env_no_port'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "defaults to port 26379"
+        When call check_redis_sentinel_ok
+        The status should be success
+      End
+    End
+  End
+
+  Describe "retry_check_redis_sentinel_ok()"
+    setup_env() {
+      export SENTINEL_SERVICE_PORT="26379"
+      export SENTINEL_PASSWORD="sentinelpass"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SENTINEL_SERVICE_PORT SENTINEL_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when sentinel is healthy"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call retry_check_redis_sentinel_ok
+        The status should be success
+      End
+    End
+
+    Context "when sentinel is permanently down"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "Could not connect" >&2
+        return 1
+      }
+
+      It "returns failure after retries"
+        When call retry_check_redis_sentinel_ok
+        The status should be failure
+        The stderr should include "Redis sentinel is not running"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_sentinel_post_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_sentinel_post_start_spec.sh
@@ -1,0 +1,114 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_sentinel_post_start_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis Sentinel Post-Start Script Tests"
+  Include ../scripts/redis-sentinel-post-start.sh
+  Include $common_library_file
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "acl_set_user_for_redis_sentinel()"
+    setup_env() {
+      export SENTINEL_PASSWORD="sentpass123"
+      export SENTINEL_USER="sentinel_user"
+      export SENTINEL_SERVICE_PORT="26379"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SENTINEL_PASSWORD SENTINEL_USER SENTINEL_SERVICE_PORT REDIS_CLI_TLS_CMD
+    }
+
+    Context "when sentinel password is set"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "sets ACL user and saves"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The output should include "redis sentinel user and password set successfully"
+      End
+    End
+
+    Context "when sentinel password is not set"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_no_password() {
+        unset SENTINEL_PASSWORD
+      }
+      BeforeEach 'setup_no_password'
+
+      It "does nothing"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The output should eq ""
+      End
+    End
+
+    Context "when TLS is enabled"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_tls() {
+        export REDIS_CLI_TLS_CMD="--tls --insecure"
+      }
+      BeforeEach 'setup_tls'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "sets ACL user successfully"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The output should include "redis sentinel user and password set successfully"
+      End
+    End
+
+    Context "when using default sentinel port"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_default_port() {
+        unset SENTINEL_SERVICE_PORT
+      }
+      BeforeEach 'setup_default_port'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "defaults to port 26379"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The output should include "redis sentinel user and password set successfully"
+      End
+    End
+  End
+End


### PR DESCRIPTION
## Summary
- Add shellspec unit tests for three previously uncovered Redis lifecycle scripts:
  - `redis-ping.sh`: health probe (PONG/non-PONG/timeout, retry wrapper, with/without password, TLS, custom port)
  - `redis-sentinel-ping.sh`: sentinel health probe (same coverage as redis-ping)
  - `redis-pre-stop.sh`: ACL save before pod termination (success/failure, password masking, TLS, custom port)

- 21 new examples, full Redis suite 219/0/0

## Test plan
- [x] `shellspec --load-path shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_pre_stop_spec.sh` → 6/0/0
- [x] `shellspec --load-path shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_ping_spec.sh` → 8/0/0
- [x] `shellspec --load-path shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_sentinel_ping_spec.sh` → 7/0/0
- [x] Full Redis suite → 219/0/0
- [x] `bash -n` all new files → PASS
- [x] `git diff --check` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)