### PR TITLE
test(redis): add shellspec tests for reload-parameter.sh

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_reload_parameter_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reload_parameter_spec.sh
@@ -1,0 +1,221 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_reload_parameter_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Reload Parameter Script Tests"
+  Include ../scripts/reload-parameter.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "reload_redis_parameter()"
+    Context "with simple key-value in single argument"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "parses param name and value correctly"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "with multi-word value in single argument"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "joins multi-word values"
+        When run reload_redis_parameter "save 900 1 300 10"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "with empty-string value (double-quoted empty)"
+      redis_cli_args=""
+      redis-cli() {
+        redis_cli_args="$*"
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "converts quoted empty string to empty value"
+        When run reload_redis_parameter 'requirepass ""'
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "with password set"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a mypassword"; then
+          echo "OK"
+        else
+          echo "NOAUTH"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD="mypassword"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "includes -a flag with password"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "without password"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a"; then
+          echo "UNEXPECTED_AUTH"
+        else
+          echo "OK"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "does not include -a flag"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "UNEXPECTED_AUTH"
+      End
+    End
+
+    Context "with custom service port"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-p 6380"; then
+          echo "OK"
+        else
+          echo "WRONG_PORT"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6380
+      }
+      Before "setup"
+
+      It "uses custom port"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+
+    Context "with TLS command"
+      redis-cli() {
+        if echo "$*" | grep -q -- "--tls --cert"; then
+          echo "OK"
+        else
+          echo "NO_TLS"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD="--tls --cert /path/to/cert"
+        service_port=6379
+      }
+      Before "setup"
+
+      It "includes TLS command flags"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "NO_TLS"
+      End
+    End
+
+    Context "when redis-cli fails"
+      redis-cli() {
+        echo "ERR unknown command"
+        return 1
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "propagates failure"
+        When run reload_redis_parameter "invalidparam value"
+        The status should be failure
+        The stdout should include "ERR"
+      End
+    End
+
+    Context "with param name only in first arg and value in remaining args"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "takes value from remaining positional args"
+        When run reload_redis_parameter "maxmemory" "100mb"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_reload_parameter_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reload_parameter_spec.sh
@@ -58,9 +58,7 @@ Describe "Redis Reload Parameter Script Tests"
     End
 
     Context "with empty-string value (double-quoted empty)"
-      redis_cli_args=""
       redis-cli() {
-        redis_cli_args="$*"
         echo "OK"
         return 0
       }

--- a/addons/redis/scripts/reload-parameter.sh
+++ b/addons/redis/scripts/reload-parameter.sh
@@ -9,6 +9,7 @@ test || __() {
 service_port=${SERVICE_PORT:-6379}
 
 reload_redis_parameter() {
+  set -e
   local paramName=""
   local paramValue=""
   # shellcheck disable=SC2086

--- a/addons/redis/scripts/reload-parameter.sh
+++ b/addons/redis/scripts/reload-parameter.sh
@@ -1,30 +1,48 @@
 #!/bin/bash
-set -e
-paramName=""
-paramValue=""
-for val in $(echo "${1}" | tr ' ' '\n'); do
-  if [ -z "${paramName}" ]; then
-    paramName="${val}"
-  elif [ -z "${paramValue}" ]; then
-    paramValue="${val}"
-  else
-    paramValue="${paramValue} ${val}"
-  fi
-done
 
-if  [ -z "${paramValue}" ]; then
-  paramValue="${@:2}"
-else
-  paramValue="${paramValue} ${@:2}"
-fi
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
 
-if [ "$paramValue" = "\"\"" ]; then
-  paramValue=""
-fi
 service_port=${SERVICE_PORT:-6379}
 
-if [ -z $REDIS_DEFAULT_PASSWORD ]; then
-  redis-cli $REDIS_CLI_TLS_CMD -p $service_port CONFIG SET ${paramName} "${paramValue}"
-else
-  redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a ${REDIS_DEFAULT_PASSWORD} CONFIG SET ${paramName} "${paramValue}"
-fi
+reload_redis_parameter() {
+  local paramName=""
+  local paramValue=""
+  # shellcheck disable=SC2086
+  for val in $(echo "${1}" | tr ' ' '\n'); do
+    if [ -z "${paramName}" ]; then
+      paramName="${val}"
+    elif [ -z "${paramValue}" ]; then
+      paramValue="${val}"
+    else
+      paramValue="${paramValue} ${val}"
+    fi
+  done
+
+  if [ -z "${paramValue}" ]; then
+    paramValue="${@:2}"
+  else
+    paramValue="${paramValue} ${@:2}"
+  fi
+
+  if [ "$paramValue" = "\"\"" ]; then
+    paramValue=""
+  fi
+
+  # shellcheck disable=SC2086
+  if [ -z $REDIS_DEFAULT_PASSWORD ]; then
+    # shellcheck disable=SC2086
+    redis-cli $REDIS_CLI_TLS_CMD -p $service_port CONFIG SET ${paramName} "${paramValue}"
+  else
+    # shellcheck disable=SC2086
+    redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a ${REDIS_DEFAULT_PASSWORD} CONFIG SET ${paramName} "${paramValue}"
+  fi
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+reload_redis_parameter "$@"


### PR DESCRIPTION
## Summary
- Wrap top-level logic in `reload_redis_parameter()` function with ut_mode guard for shellspec testability
- Add 9 shellspec test examples covering:
  - Parameter parsing: simple key-value, multi-word value, empty-string value, split positional args
  - Redis-cli integration: with/without password, custom port, TLS flags, failure propagation

## Test plan
- [ ] CI shellspec-test workflow passes
- [ ] CI shellcheck passes
- [ ] No regression in existing Redis shellspec tests