### PR TITLE
test(redis): add shellspec tests for reset-master.sh

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_reset_master_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reset_master_spec.sh
@@ -1,0 +1,192 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_reset_master_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Reset Master Script Tests"
+  Include ../scripts/reset-master.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "reset_master_in_sentinels()"
+    Context "when SENTINEL_POD_NAME_LIST is empty"
+      setup() {
+        export SENTINEL_POD_NAME_LIST=""
+      }
+      Before "setup"
+
+      It "exits successfully with no action"
+        When run reset_master_in_sentinels
+        The status should be success
+      End
+    End
+
+    Context "when single sentinel resets successfully"
+      redis-cli() {
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "resets and exits successfully"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "reset master in sentinel sentinel-0..."
+        The stdout should include "reset master in sentinel sentinel-0 succeeded"
+      End
+    End
+
+    Context "when first sentinel fails but second succeeds"
+      call_count=0
+      redis-cli() {
+        call_count=$((call_count + 1))
+        if [ "$call_count" -eq 1 ]; then
+          echo "ERR No such master"
+          return 1
+        fi
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0,sentinel-1"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "falls through to second sentinel"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "reset master in sentinel sentinel-1 succeeded"
+      End
+    End
+
+    Context "when all sentinels fail"
+      redis-cli() {
+        echo "ERR No such master"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0,sentinel-1"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run reset_master_in_sentinels
+        The status should be failure
+        The stdout should include "reset master in sentinel failed"
+      End
+    End
+
+    Context "with sentinel password"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a sentinelpw"; then
+          echo "1"
+          return 0
+        fi
+        echo "NOAUTH"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD="sentinelpw"
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "includes -a flag with password"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "succeeded"
+      End
+    End
+
+    Context "without sentinel password"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a"; then
+          echo "UNEXPECTED_AUTH"
+          return 1
+        fi
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "does not include -a flag"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "succeeded"
+        The stdout should not include "UNEXPECTED_AUTH"
+      End
+    End
+
+    Context "with multiple sentinels in comma-separated list"
+      redis-cli() {
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0,sentinel-1,sentinel-2"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "exits after first successful reset"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "reset master in sentinel sentinel-0 succeeded"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts/reset-master.sh
+++ b/addons/redis/scripts/reset-master.sh
@@ -9,6 +9,7 @@ test || __() {
 sentinel_service_port=${SENTINEL_SERVICE_PORT:-26379}
 
 reset_master_in_sentinels() {
+  set -e
   if [ -z "${SENTINEL_POD_NAME_LIST}" ]; then
     exit 0
   fi

--- a/addons/redis/scripts/reset-master.sh
+++ b/addons/redis/scripts/reset-master.sh
@@ -1,20 +1,37 @@
 #!/bin/bash
-if [ -z "${SENTINEL_POD_NAME_LIST}" ]; then
-   exit 0
-fi
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
+
 sentinel_service_port=${SENTINEL_SERVICE_PORT:-26379}
-for sentinel_pod in $(echo ${SENTINEL_POD_NAME_LIST} | tr ',' '\n'); do
-    echo "reset master in sentinel ${pod}..."
+
+reset_master_in_sentinels() {
+  if [ -z "${SENTINEL_POD_NAME_LIST}" ]; then
+    exit 0
+  fi
+  # shellcheck disable=SC2086
+  for sentinel_pod in $(echo ${SENTINEL_POD_NAME_LIST} | tr ',' '\n'); do
+    echo "reset master in sentinel ${sentinel_pod}..."
     fqdn="$sentinel_pod.$SENTINEL_HEADLESS_SERVICE_NAME.$CLUSTER_NAMESPACE.svc.cluster.local"
+    # shellcheck disable=SC2086
     if [ -n "${SENTINEL_PASSWORD}" ]; then
-        redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port -a ${SENTINEL_PASSWORD} sentinel reset ${REDIS_COMPONENT_NAME}
+      redis-cli $REDIS_CLI_TLS_CMD -h "$fqdn" -p "$sentinel_service_port" -a "${SENTINEL_PASSWORD}" sentinel reset "${REDIS_COMPONENT_NAME}"
     else
-        redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port sentinel reset ${REDIS_COMPONENT_NAME}
+      redis-cli $REDIS_CLI_TLS_CMD -h "$fqdn" -p "$sentinel_service_port" sentinel reset "${REDIS_COMPONENT_NAME}"
     fi
     if [ $? -eq 0 ]; then
-        echo "reset master in sentinel ${pod} succeeded"
-        exit 0
+      echo "reset master in sentinel ${sentinel_pod} succeeded"
+      exit 0
     fi
-done
-echo "reset master in sentinel failed"
-exit 1
+  done
+  echo "reset master in sentinel failed"
+  exit 1
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+reset_master_in_sentinels


### PR DESCRIPTION
## Summary
- Wrap top-level logic in `reset_master_in_sentinels()` function with ut_mode guard for shellspec testability
- Fix pre-existing typo: `${pod}` → `${sentinel_pod}` in echo messages (undefined variable)
- Add 7 shellspec test examples covering:
  - Empty sentinel list (graceful exit)
  - Single sentinel success, failover to second sentinel, all-fail
  - With/without sentinel password
  - Multi-sentinel early exit on first success

## Test plan
- [ ] CI shellspec-test workflow passes
- [ ] CI shellcheck passes
- [ ] No regression in existing Redis shellspec tests