### PR TITLE
test(redis): add shellspec tests for sync-acl.sh

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_sync_acl_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_sync_acl_spec.sh
@@ -1,0 +1,417 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_sync_acl_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "sync-acl.sh Tests"
+  Include ../scripts/sync-acl.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "sync_acl()"
+    Context "happy path: single non-default user synced"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "syncs one user and saves ACL"
+        redis-cli() {
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo "user admin on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should include "OK"
+      End
+    End
+
+    Context "self pod skipped in source loop"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "skips self and fetches ACL from other pod"
+        redis-cli() {
+          if echo "$*" | grep -q "ACL LIST"; then
+            if echo "$*" | grep -q "pod1.redis.svc"; then
+              return 1
+            fi
+            echo "user myuser on ~keys:* +get +set"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should include "OK"
+      End
+    End
+
+    Context "fallback to second peer"
+      setup() {
+        export REDIS_POD_FQDN_LIST="peer1.redis.svc,peer2.redis.svc,peer3.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="peer3.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "falls back to second peer when first fails"
+        redis-cli() {
+          if echo "$*" | grep -q "ACL LIST"; then
+            if echo "$*" | grep -q "peer1.redis.svc"; then
+              return 1
+            fi
+            echo "user backup on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should include "OK"
+      End
+    End
+
+    Context "all peers fail"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod3.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "exits with failure when all ACL LIST calls fail"
+        redis-cli() {
+          return 1
+        }
+        When run sync_acl
+        The status should be failure
+        The stderr should include "Failed to get ACL LIST from other pods"
+      End
+    End
+
+    Context "empty ACL list"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "exits success when ACL list is empty"
+        redis-cli() {
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo ""
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stderr should include "No ACL rules found in other pods, skip synchronization"
+      End
+    End
+
+    Context "default user filtered"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "skips default user, only calls ACL save"
+        redis-cli() {
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo "user default on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "SETUSER-SHOULD-NOT-BE-CALLED" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should not include "SETUSER-SHOULD-NOT-BE-CALLED"
+        The stderr should include "OK"
+      End
+    End
+
+    Context "multiple non-default users"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "syncs admin and readonly, skips default"
+        redis-cli() {
+          if echo "$*" | grep -q "ACL LIST"; then
+            printf "user admin on ~* +@all\nuser default on ~* +@all\nuser readonly on ~keys:* +get"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "SETUSER:$*" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should include "admin"
+        The stderr should include "readonly"
+        The stderr should not include "SETUSER default"
+      End
+    End
+
+    Context "with password"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="mypassword"
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "includes -a flag when password is set"
+        redis-cli() {
+          if ! echo "$*" | grep -q "\-a mypassword"; then
+            echo "MISSING_PASSWORD_FLAG" >&2
+            return 1
+          fi
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo "user testuser on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should not include "MISSING_PASSWORD_FLAG"
+        The stderr should include "OK"
+      End
+    End
+
+    Context "without password"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD=""
+        unset SERVICE_PORT
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD
+      }
+      After 'cleanup'
+
+      It "omits -a flag when password is empty"
+        redis-cli() {
+          if echo "$*" | grep -q " -a "; then
+            echo "UNEXPECTED_PASSWORD_FLAG" >&2
+            return 1
+          fi
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo "user testuser on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should not include "UNEXPECTED_PASSWORD_FLAG"
+        The stderr should include "OK"
+      End
+    End
+
+    Context "TLS flags"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        export REDIS_CLI_TLS_CMD="--tls --cert /certs/tls.crt --key /certs/tls.key --cacert /certs/ca.crt"
+        unset SERVICE_PORT
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+      }
+      After 'cleanup'
+
+      It "includes TLS flags in redis-cli command"
+        redis-cli() {
+          if ! echo "$*" | grep -q "\-\-tls"; then
+            echo "MISSING_TLS_FLAG" >&2
+            return 1
+          fi
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo "user tlsuser on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should not include "MISSING_TLS_FLAG"
+        The stderr should include "OK"
+      End
+    End
+
+    Context "custom port"
+      setup() {
+        export REDIS_POD_FQDN_LIST="pod1.redis.svc,pod2.redis.svc"
+        export KB_JOIN_MEMBER_POD_FQDN="pod1.redis.svc"
+        export REDIS_DEFAULT_PASSWORD="secret"
+        export SERVICE_PORT="6380"
+        unset REDIS_CLI_TLS_CMD
+      }
+      Before 'setup'
+
+      cleanup() {
+        unset REDIS_POD_FQDN_LIST KB_JOIN_MEMBER_POD_FQDN REDIS_DEFAULT_PASSWORD SERVICE_PORT
+      }
+      After 'cleanup'
+
+      It "uses custom port in redis-cli command"
+        redis-cli() {
+          if ! echo "$*" | grep -q "\-p 6380"; then
+            echo "WRONG_PORT" >&2
+            return 1
+          fi
+          if echo "$*" | grep -q "ACL LIST"; then
+            echo "user portuser on ~* +@all"
+            return 0
+          elif echo "$*" | grep -q "ACL SETUSER"; then
+            echo "OK" >&2
+            return 0
+          elif echo "$*" | grep -qi "ACL save"; then
+            echo "OK" >&2
+            return 0
+          fi
+        }
+        When run sync_acl
+        The status should be success
+        The stdout should eq ""
+        The stderr should not include "WRONG_PORT"
+        The stderr should include "OK"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts/sync-acl.sh
+++ b/addons/redis/scripts/sync-acl.sh
@@ -1,52 +1,67 @@
 #!/bin/bash
 
-service_port=${SERVICE_PORT:-6379}
-redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a $REDIS_DEFAULT_PASSWORD"
-if [ -z "$REDIS_DEFAULT_PASSWORD" ]; then
-   redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $service_port"
-fi
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
 
-is_ok=false
-acl_list=""
-# 1. get acl list from other pods
-for pod_fqdn in $(echo "$REDIS_POD_FQDN_LIST" | tr ',' '\n'); do
+sync_acl() {
+  service_port=${SERVICE_PORT:-6379}
+  # shellcheck disable=SC2086
+  redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a $REDIS_DEFAULT_PASSWORD"
+  if [ -z "$REDIS_DEFAULT_PASSWORD" ]; then
+    # shellcheck disable=SC2086
+    redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $service_port"
+  fi
+
+  is_ok=false
+  acl_list=""
+  for pod_fqdn in $(echo "$REDIS_POD_FQDN_LIST" | tr ',' '\n'); do
     if [[ "$pod_fqdn" == "$KB_JOIN_MEMBER_POD_FQDN" ]]; then
-        continue
+      continue
     fi
+    # shellcheck disable=SC2086
     acl_list=$($redis_base_cmd -h "$pod_fqdn" ACL LIST)
     if [ $? -eq 0 ]; then
-        is_ok=true
-        break
+      is_ok=true
+      break
     fi
-done
+  done
 
-if [ "$is_ok" = false ]; then
+  if [ "$is_ok" = false ]; then
     echo "Failed to get ACL LIST from other pods" >&2
     exit 1
-fi
+  fi
 
-if [ -z "$acl_list" ]; then
+  if [ -z "$acl_list" ]; then
     echo "No ACL rules found in other pods, skip synchronization" >&2
     exit 0
-fi
+  fi
 
-set -e
-# 2. apply acl list to current pod
-while IFS= read -r user_rule; do
+  set -e
+  while IFS= read -r user_rule; do
     [[ -z "$user_rule" ]] && continue
 
     if [[ "$user_rule" =~ ^user[[:space:]]+([^[:space:]]+) ]]; then
-        username="${BASH_REMATCH[1]}"
+      username="${BASH_REMATCH[1]}"
     else
-      # skip invalid user rule
       continue
     fi
 
     if [[ "$username" == "default" ]]; then
-        continue
+      continue
     fi
     rule_part="${user_rule#user $username }"
-    $redis_base_cmd -h $KB_JOIN_MEMBER_POD_FQDN ACL SETUSER "$username" $rule_part >&2
-done <<< "$acl_list"
+    # shellcheck disable=SC2086
+    $redis_base_cmd -h "$KB_JOIN_MEMBER_POD_FQDN" ACL SETUSER "$username" $rule_part >&2
+  done <<< "$acl_list"
 
-$redis_base_cmd -h $KB_JOIN_MEMBER_POD_FQDN ACL save >&2
+  # shellcheck disable=SC2086
+  $redis_base_cmd -h "$KB_JOIN_MEMBER_POD_FQDN" ACL save >&2
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+sync_acl


### PR DESCRIPTION
## Summary
- Refactor `sync-acl.sh` to be shellspec-testable: wrap logic in `sync_acl()` with ut_mode guard and SOURCED guard
- Add 11 shellspec test cases covering: happy path ACL sync, self-pod skip, peer fallback, all-peers-fail, empty ACL list, default user filtering, multi-user sync, password/no-password flags, TLS flags, custom port
- Quote `$KB_JOIN_MEMBER_POD_FQDN` for safety, add SC2086 disables for intentional word splitting

## Test plan
- [ ] CI shellspec passes
- [ ] CI shell-check passes