### PR TITLE
chore(redis): add shellspec tests for account provision scripts

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_account_provision_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_account_provision_spec.sh
@@ -1,0 +1,119 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_account_provision_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Account Provision Script Tests"
+  Include ../scripts/redis-account-provision.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "redis_account_provision()"
+    Context "when executing account statement"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SERVICE_PORT="6379"
+        export REDIS_DEFAULT_PASSWORD="mypass"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >password ~* +@all"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "runs statement and saves ACL"
+        When run redis_account_provision
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "when password is included in command"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a mypass"; then
+          echo "OK"
+          return 0
+        fi
+        echo "NOAUTH"
+        return 1
+      }
+
+      setup() {
+        export SERVICE_PORT="6379"
+        export REDIS_DEFAULT_PASSWORD="mypass"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >pw ~* +@all"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "includes -a flag with password"
+        When run redis_account_provision
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "NOAUTH"
+      End
+    End
+
+    Context "with TLS flags"
+      redis-cli() {
+        if echo "$*" | grep -q -- "--tls"; then
+          echo "OK"
+          return 0
+        fi
+        echo "NO_TLS"
+        return 1
+      }
+
+      setup() {
+        export SERVICE_PORT="6379"
+        export REDIS_DEFAULT_PASSWORD="mypass"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >pw ~* +@all"
+        export REDIS_CLI_TLS_CMD="--tls --cert /certs/tls.crt"
+      }
+      Before "setup"
+
+      It "passes TLS flags to redis-cli"
+        When run redis_account_provision
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "NO_TLS"
+      End
+    End
+
+    Context "with custom port"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-p 6380"; then
+          echo "OK"
+          return 0
+        fi
+        echo "WRONG_PORT"
+        return 1
+      }
+
+      setup() {
+        export SERVICE_PORT="6380"
+        export REDIS_DEFAULT_PASSWORD="mypass"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >pw ~* +@all"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses custom port"
+        When run redis_account_provision
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_sentinel_account_provision_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_sentinel_account_provision_spec.sh
@@ -1,0 +1,119 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_sentinel_account_provision_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Sentinel Account Provision Script Tests"
+  Include ../scripts/redis-sentinel-account-provision.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "redis_sentinel_account_provision()"
+    Context "when executing account statement"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_PASSWORD="sentpw"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >password ~* +@all"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "runs statement and saves ACL"
+        When run redis_sentinel_account_provision
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "when password is included in command"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a sentpw"; then
+          echo "OK"
+          return 0
+        fi
+        echo "NOAUTH"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_PASSWORD="sentpw"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >pw ~* +@all"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "includes -a flag with sentinel password"
+        When run redis_sentinel_account_provision
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "NOAUTH"
+      End
+    End
+
+    Context "with TLS flags"
+      redis-cli() {
+        if echo "$*" | grep -q -- "--tls"; then
+          echo "OK"
+          return 0
+        fi
+        echo "NO_TLS"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_PASSWORD="sentpw"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >pw ~* +@all"
+        export REDIS_CLI_TLS_CMD="--tls --cert /certs/tls.crt"
+      }
+      Before "setup"
+
+      It "passes TLS flags to redis-cli"
+        When run redis_sentinel_account_provision
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "NO_TLS"
+      End
+    End
+
+    Context "with custom sentinel port"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-p 36379"; then
+          echo "OK"
+          return 0
+        fi
+        echo "WRONG_PORT"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_SERVICE_PORT="36379"
+        export SENTINEL_PASSWORD="sentpw"
+        export KB_ACCOUNT_STATEMENT="ACL SETUSER testuser ON >pw ~* +@all"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses custom sentinel port"
+        When run redis_sentinel_account_provision
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts/redis-account-provision.sh
+++ b/addons/redis/scripts/redis-account-provision.sh
@@ -7,6 +7,7 @@ test || __() {
 }
 
 redis_account_provision() {
+  set -e
   # shellcheck disable=SC2086
   local redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $SERVICE_PORT -a $REDIS_DEFAULT_PASSWORD"
   # shellcheck disable=SC2086

--- a/addons/redis/scripts/redis-account-provision.sh
+++ b/addons/redis/scripts/redis-account-provision.sh
@@ -1,4 +1,21 @@
-#!/bin/sh
-redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $SERVICE_PORT -a $REDIS_DEFAULT_PASSWORD"
-$redis_base_cmd ${KB_ACCOUNT_STATEMENT}
-$redis_base_cmd acl save
+#!/bin/bash
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
+
+redis_account_provision() {
+  # shellcheck disable=SC2086
+  local redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $SERVICE_PORT -a $REDIS_DEFAULT_PASSWORD"
+  # shellcheck disable=SC2086
+  $redis_base_cmd ${KB_ACCOUNT_STATEMENT}
+  # shellcheck disable=SC2086
+  $redis_base_cmd acl save
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+redis_account_provision

--- a/addons/redis/scripts/redis-sentinel-account-provision.sh
+++ b/addons/redis/scripts/redis-sentinel-account-provision.sh
@@ -1,5 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 
-redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $SENTINEL_SERVICE_PORT -a $SENTINEL_PASSWORD"
-$redis_base_cmd ${KB_ACCOUNT_STATEMENT}
-$redis_base_cmd acl save
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
+
+redis_sentinel_account_provision() {
+  # shellcheck disable=SC2086
+  local redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $SENTINEL_SERVICE_PORT -a $SENTINEL_PASSWORD"
+  # shellcheck disable=SC2086
+  $redis_base_cmd ${KB_ACCOUNT_STATEMENT}
+  # shellcheck disable=SC2086
+  $redis_base_cmd acl save
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+redis_sentinel_account_provision

--- a/addons/redis/scripts/redis-sentinel-account-provision.sh
+++ b/addons/redis/scripts/redis-sentinel-account-provision.sh
@@ -7,6 +7,7 @@ test || __() {
 }
 
 redis_sentinel_account_provision() {
+  set -e
   # shellcheck disable=SC2086
   local redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $SENTINEL_SERVICE_PORT -a $SENTINEL_PASSWORD"
   # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary
- Make `redis-account-provision.sh` and `redis-sentinel-account-provision.sh` shellspec-testable: change shebang to bash, add ut_mode guard, wrap in functions, add SOURCED guard
- Add 4 test cases each (8 total) covering: basic execution, password flag, TLS flags, custom port

## Test plan
- [ ] CI shellspec passes
- [ ] CI shell-check passes