### PR TITLE
chore(redis): logic fixes for shellspec-refactored scripts

### DIFF
--- a/addons/redis/scripts-ut-spec/redis5_sentinel_start_v2_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis5_sentinel_start_v2_spec.sh
@@ -1,0 +1,285 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis5_sentinel_start_v2_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis5 Sentinel Start V2 Script Tests"
+  Include ../scripts/redis5-sentinel-start-v2.sh
+  Include $common_library_file
+
+  init() {
+    redis_sentinel_conf_dir="."
+    redis_sentinel_real_conf="./redis_sentinel.conf"
+    redis_sentinel_real_conf_bak="./redis_sentinel.conf.bak"
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f ./redis_sentinel.conf
+    rm -f ./redis_sentinel.conf.bak
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "extract_lb_host_by_svc_name()"
+    It "extracts LB host for matching sentinel svc"
+      export REDIS_SENTINEL_LB_ADVERTISED_HOST="sentinel-0:10.0.0.1,sentinel-1:10.0.0.2"
+      When call extract_lb_host_by_svc_name "sentinel-0"
+      The output should eq "10.0.0.1"
+    End
+
+    It "returns empty when no match"
+      export REDIS_SENTINEL_LB_ADVERTISED_HOST="sentinel-0:10.0.0.1"
+      When call extract_lb_host_by_svc_name "sentinel-5"
+      The output should eq ""
+    End
+  End
+
+  Describe "parse_redis_sentinel_announce_addr()"
+    It "parses advertised port with matching ordinal"
+      export REDIS_SENTINEL_ADVERTISED_PORT="sentinel-advertised-0:31000,sentinel-advertised-1:32000"
+      export CURRENT_POD_HOST_IP="10.0.0.1"
+      When call parse_redis_sentinel_announce_addr "redis-sentinel-0"
+      The variable redis_sentinel_announce_port_value should eq "31000"
+      The variable redis_sentinel_announce_host_value should eq "10.0.0.1"
+      The stdout should include "Found matching svcName and port for podName 'redis-sentinel-0'"
+    End
+
+    It "exits with error when no matching ordinal"
+      export REDIS_SENTINEL_ADVERTISED_PORT="sentinel-advertised-0:31000"
+      When run parse_redis_sentinel_announce_addr "redis-sentinel-5"
+      The status should be failure
+      The stdout should include "Error: No matching svcName and port found for podName 'redis-sentinel-5'"
+    End
+
+    It "ignores when advertised port is not set"
+      unset REDIS_SENTINEL_ADVERTISED_PORT
+      unset REDIS_SENTINEL_LB_ADVERTISED_PORT
+      When call parse_redis_sentinel_announce_addr "redis-sentinel-0"
+      The status should be success
+      The stdout should include "Environment variable REDIS_SENTINEL_ADVERTISED_PORT not found. Ignoring."
+    End
+
+    It "uses host network port when available"
+      unset REDIS_SENTINEL_ADVERTISED_PORT
+      unset REDIS_SENTINEL_LB_ADVERTISED_PORT
+      export REDIS_SENTINEL_HOST_NETWORK_PORT="26380"
+      export CURRENT_POD_HOST_IP="192.168.1.100"
+      When call parse_redis_sentinel_announce_addr "redis-sentinel-0"
+      The status should be success
+      The variable redis_sentinel_announce_port_value should eq "26380"
+      The variable redis_sentinel_announce_host_value should eq "192.168.1.100"
+      The stdout should include "redis sentinel is in host network mode"
+    End
+
+    It "uses LB host when available"
+      export REDIS_SENTINEL_ADVERTISED_PORT="sentinel-advertised-0:31000"
+      export REDIS_SENTINEL_LB_ADVERTISED_HOST="sentinel-advertised-0:lb.example.com"
+      export CURRENT_POD_HOST_IP="10.0.0.1"
+      When call parse_redis_sentinel_announce_addr "redis-sentinel-0"
+      The variable redis_sentinel_announce_host_value should eq "lb.example.com"
+      The variable redis_sentinel_announce_port_value should eq "26379"
+      The stdout should include "Found load balancer host"
+    End
+
+    It "falls back to LB advertised port"
+      unset REDIS_SENTINEL_ADVERTISED_PORT
+      export REDIS_SENTINEL_LB_ADVERTISED_PORT="sentinel-advertised-0:31000"
+      export CURRENT_POD_HOST_IP="10.0.0.1"
+      When call parse_redis_sentinel_announce_addr "redis-sentinel-0"
+      The variable redis_sentinel_announce_port_value should eq "31000"
+      The stdout should include "Found matching svcName and port for podName 'redis-sentinel-0'"
+    End
+  End
+
+  Describe "reset_redis_sentinel_conf()"
+    Context "when conf file exists with announce lines"
+      setup() {
+        mkdir -p "$(dirname "$redis_sentinel_real_conf")"
+        {
+          echo "port 26379"
+          echo "sentinel announce-ip 10.0.0.1"
+          echo "sentinel announce-port 26379"
+          echo "requirepass oldpass"
+          echo "sentinel monitor mymaster 10.0.0.1 6379 2"
+        } > $redis_sentinel_real_conf
+        export SENTINEL_PASSWORD="newpass"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset SENTINEL_PASSWORD
+      }
+      After 'un_setup'
+
+      It "removes announce-ip, announce-port, requirepass, and port lines"
+        When call reset_redis_sentinel_conf
+        The status should be success
+        The stdout should include "reset redis sentinel conf"
+        The contents of file "$redis_sentinel_real_conf" should not include "sentinel announce-ip"
+        The contents of file "$redis_sentinel_real_conf" should not include "sentinel announce-port"
+        The contents of file "$redis_sentinel_real_conf" should not include "requirepass"
+        The contents of file "$redis_sentinel_real_conf" should not include "port 26379"
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel monitor mymaster"
+      End
+    End
+
+    Context "when conf file does not exist"
+      setup() {
+        rm -f $redis_sentinel_real_conf
+        rm -f $redis_sentinel_real_conf_bak
+        unset SENTINEL_PASSWORD
+      }
+      Before 'setup'
+
+      It "creates the directory"
+        When call reset_redis_sentinel_conf
+        The status should be success
+        The stdout should include "reset redis sentinel conf"
+      End
+    End
+
+    Context "when using custom sentinel port"
+      setup() {
+        mkdir -p "$(dirname "$redis_sentinel_real_conf")"
+        {
+          echo "port 36379"
+          echo "sentinel monitor mymaster 10.0.0.1 6379 2"
+        } > $redis_sentinel_real_conf
+        export SENTINEL_SERVICE_PORT="36379"
+        unset SENTINEL_PASSWORD
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset SENTINEL_SERVICE_PORT
+      }
+      After 'un_setup'
+
+      It "removes the custom port line"
+        When call reset_redis_sentinel_conf
+        The status should be success
+        The stdout should include "reset redis sentinel conf"
+        The contents of file "$redis_sentinel_real_conf" should not include "port 36379"
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel monitor mymaster"
+      End
+    End
+  End
+
+  Describe "build_redis_sentinel_conf()"
+    Context "when announce host and port are set"
+      setup() {
+        echo "" > $redis_sentinel_real_conf
+        sentinel_port="26379"
+        redis_sentinel_announce_host_value="172.0.0.1"
+        redis_sentinel_announce_port_value="31000"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.headless,sentinel-1.headless"
+        export SENTINEL_PASSWORD="sentpass"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset redis_sentinel_announce_host_value
+        unset redis_sentinel_announce_port_value
+        unset SENTINEL_POD_FQDN_LIST
+        unset SENTINEL_PASSWORD
+      }
+      After 'un_setup'
+
+      It "uses nodeport announce with requirepass (Redis 5 style, no sentinel-user/sentinel-pass)"
+        When call build_redis_sentinel_conf
+        The status should be success
+        The stdout should include "build redis sentinel conf succeeded!"
+        The contents of file "$redis_sentinel_real_conf" should include "port 26379"
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel announce-ip 172.0.0.1"
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel announce-port 31000"
+        The contents of file "$redis_sentinel_real_conf" should include "requirepass sentpass"
+        The contents of file "$redis_sentinel_real_conf" should not include "sentinel sentinel-user"
+        The contents of file "$redis_sentinel_real_conf" should not include "sentinel sentinel-pass"
+        The contents of file "$redis_sentinel_real_conf" should not include "resolve-hostnames"
+        The contents of file "$redis_sentinel_real_conf" should not include "announce-hostnames"
+      End
+    End
+
+    Context "when using pod IP (no advertise)"
+      setup() {
+        echo "" > $redis_sentinel_real_conf
+        sentinel_port="26379"
+        unset redis_sentinel_announce_host_value
+        unset redis_sentinel_announce_port_value
+        export CURRENT_POD_IP="10.42.0.5"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.headless"
+        unset SENTINEL_PASSWORD
+        unset FIXED_POD_IP_ENABLED
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset CURRENT_POD_IP
+        unset SENTINEL_POD_FQDN_LIST
+      }
+      After 'un_setup'
+
+      It "uses pod IP for announce (Redis 5 no hostname support)"
+        When call build_redis_sentinel_conf
+        The status should be success
+        The stdout should include "build redis sentinel conf succeeded!"
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel announce-ip 10.42.0.5"
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel announce-port 26379"
+        The contents of file "$redis_sentinel_real_conf" should not include "requirepass"
+      End
+    End
+
+    Context "when fixed pod IP is enabled"
+      setup() {
+        echo "" > $redis_sentinel_real_conf
+        sentinel_port="26379"
+        unset redis_sentinel_announce_host_value
+        unset redis_sentinel_announce_port_value
+        export FIXED_POD_IP_ENABLED="true"
+        export CURRENT_POD_IP="10.42.0.7"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.headless"
+        unset SENTINEL_PASSWORD
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset FIXED_POD_IP_ENABLED
+        unset CURRENT_POD_IP
+        unset SENTINEL_POD_FQDN_LIST
+      }
+      After 'un_setup'
+
+      It "uses fixed pod IP for announce"
+        When call build_redis_sentinel_conf
+        The status should be success
+        The contents of file "$redis_sentinel_real_conf" should include "sentinel announce-ip 10.42.0.7"
+        The stdout should include "redis sentinel use the fixed pod ip"
+      End
+    End
+
+    Context "when SENTINEL_POD_FQDN_LIST is not set"
+      setup() {
+        echo "" > $redis_sentinel_real_conf
+        sentinel_port="26379"
+        unset SENTINEL_POD_FQDN_LIST
+      }
+      Before 'setup'
+
+      It "exits with error"
+        When run build_redis_sentinel_conf
+        The status should be failure
+        The stdout should include "Error: Required environment variable SENTINEL_POD_FQDN_LIST is not set."
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis5_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis5_start_spec.sh
@@ -1,0 +1,535 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+should_skip_when_shell_type_and_version_invalid() {
+  if validate_shell_type_and_version "bash" 4 &>/dev/null; then
+    return 1
+  fi
+  echo "redis5_start_spec.sh skip case because dependency bash version 4 or higher is not installed."
+  return 0
+}
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis5 Start Bash Script Tests"
+  Include ../scripts/redis5-start.sh
+  Include $common_library_file
+
+  init() {
+    redis_real_conf="./redis.conf"
+    redis_acl_file="./users.acl"
+    redis_acl_file_bak="./users.acl.bak"
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $redis_real_conf
+    rm -f $redis_acl_file
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "build_redis_default_accounts()"
+    Context "when REDIS_DEFAULT_PASSWORD is set"
+      setup() {
+        echo "" > $redis_real_conf
+        export REDIS_DEFAULT_PASSWORD="mypass123"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      After 'un_setup'
+
+      It "uses requirepass and masterauth (Redis 5 style, no ACL)"
+        When call build_redis_default_accounts
+        The status should be success
+        The stdout should include "build default accounts succeeded!"
+        The contents of file "$redis_real_conf" should include "protected-mode yes"
+        The contents of file "$redis_real_conf" should include "requirepass mypass123"
+        The contents of file "$redis_real_conf" should include "masterauth mypass123"
+        The contents of file "$redis_real_conf" should not include "aclfile"
+      End
+    End
+
+    Context "when REDIS_DEFAULT_PASSWORD is not set"
+      setup() {
+        echo "" > $redis_real_conf
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      Before 'setup'
+
+      It "disables protected mode"
+        When call build_redis_default_accounts
+        The status should be success
+        The stdout should include "build default accounts succeeded!"
+        The contents of file "$redis_real_conf" should include "protected-mode no"
+        The contents of file "$redis_real_conf" should not include "requirepass"
+        The contents of file "$redis_real_conf" should not include "masterauth"
+      End
+    End
+  End
+
+  Describe "build_announce_ip_and_port()"
+    Context "when advertised svc host and port are set"
+      setup() {
+        echo "" > $redis_real_conf
+        redis_announce_host_value="172.0.0.1"
+        redis_announce_port_value="31000"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset redis_announce_host_value
+        unset redis_announce_port_value
+      }
+      After 'un_setup'
+
+      It "uses nodeport announce"
+        When call build_announce_ip_and_port
+        The contents of file "$redis_real_conf" should include "replica-announce-port 31000"
+        The contents of file "$redis_real_conf" should include "replica-announce-ip 172.0.0.1"
+        The stdout should include "redis use nodeport 172.0.0.1:31000 to announce"
+      End
+    End
+
+    Context "when fixed pod IP is enabled"
+      setup() {
+        echo "" > $redis_real_conf
+        unset redis_announce_host_value
+        unset redis_announce_port_value
+        export FIXED_POD_IP_ENABLED="true"
+        export CURRENT_POD_IP="10.42.0.5"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset FIXED_POD_IP_ENABLED
+        unset CURRENT_POD_IP
+        rm -f /data/.fixed_pod_ip_enabled 2>/dev/null
+      }
+      After 'un_setup'
+
+      It "uses fixed pod IP for announce"
+        When call build_announce_ip_and_port
+        The contents of file "$redis_real_conf" should include "replica-announce-ip 10.42.0.5"
+        The stdout should include "redis use immutable pod ip 10.42.0.5 to announce"
+        The stderr should be defined
+      End
+    End
+
+    Context "when no advertise and no fixed IP (Redis 5 uses pod IP, not fqdn)"
+      setup() {
+        echo "" > $redis_real_conf
+        unset redis_announce_host_value
+        unset redis_announce_port_value
+        unset FIXED_POD_IP_ENABLED
+        export CURRENT_POD_IP="10.42.0.6"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset CURRENT_POD_IP
+      }
+      After 'un_setup'
+
+      It "uses pod IP for announce (Redis 5 sentinel does not support hostnames)"
+        When call build_announce_ip_and_port
+        The contents of file "$redis_real_conf" should include "replica-announce-ip 10.42.0.6"
+        The stdout should include "redis use kb pod fqdn"
+      End
+    End
+  End
+
+  Describe "build_redis_service_port()"
+    Context "when SERVICE_PORT env is set"
+      setup() {
+        echo "" > $redis_real_conf
+        export SERVICE_PORT="6380"
+      }
+      Before 'setup'
+
+      un_setup() {
+        unset SERVICE_PORT
+      }
+      After 'un_setup'
+
+      It "uses the custom port"
+        When call build_redis_service_port
+        The contents of file "$redis_real_conf" should include "port 6380"
+      End
+    End
+
+    Context "when SERVICE_PORT env is not set"
+      setup() {
+        echo "" > $redis_real_conf
+        unset SERVICE_PORT
+      }
+      Before 'setup'
+
+      It "defaults to port 6379"
+        When call build_redis_service_port
+        The contents of file "$redis_real_conf" should include "port 6379"
+        The stdout should be defined
+      End
+    End
+  End
+
+  Describe "extract_lb_host_by_svc_name()"
+    It "extracts LB host for matching svc name"
+      export REDIS_LB_ADVERTISED_HOST="redis-0:10.0.0.1,redis-1:10.0.0.2"
+      When call extract_lb_host_by_svc_name "redis-0"
+      The output should eq "10.0.0.1"
+    End
+
+    It "extracts LB host for second svc"
+      export REDIS_LB_ADVERTISED_HOST="redis-0:10.0.0.1,redis-1:10.0.0.2"
+      When call extract_lb_host_by_svc_name "redis-1"
+      The output should eq "10.0.0.2"
+    End
+
+    It "returns empty when no match"
+      export REDIS_LB_ADVERTISED_HOST="redis-0:10.0.0.1,redis-1:10.0.0.2"
+      When call extract_lb_host_by_svc_name "redis-2"
+      The output should eq ""
+    End
+  End
+
+  Describe "parse_redis_announce_addr()"
+    It "parses advertised port with matching pod ordinal"
+      export REDIS_ADVERTISED_PORT="redis-redis-advertised-0:31000,redis-redis-advertised-1:32000"
+      export CURRENT_POD_HOST_IP="10.0.0.1"
+      When call parse_redis_announce_addr "redis-redis-0"
+      The variable redis_announce_port_value should eq "31000"
+      The variable redis_announce_host_value should eq "10.0.0.1"
+      The stdout should include "Found matching svcName and port for podName 'redis-redis-0'"
+    End
+
+    It "exits with error when no matching pod ordinal"
+      export REDIS_ADVERTISED_PORT="redis-redis-advertised-0:31000,redis-redis-advertised-1:32000"
+      export CURRENT_POD_HOST_IP="10.0.0.2"
+      When run parse_redis_announce_addr "redis-redis-2"
+      The status should be failure
+      The stdout should include "Error: No matching svcName and port found for podName 'redis-redis-2'"
+    End
+
+    It "ignores when REDIS_ADVERTISED_PORT is not set"
+      unset REDIS_ADVERTISED_PORT
+      When call parse_redis_announce_addr "redis-redis-0"
+      The status should be success
+      The stdout should include "Environment variable REDIS_ADVERTISED_PORT not found. Ignoring."
+    End
+
+    It "uses host network port when available and no advertised port"
+      unset REDIS_ADVERTISED_PORT
+      export REDIS_HOST_NETWORK_PORT="6380"
+      export CURRENT_POD_HOST_IP="192.168.1.100"
+      When call parse_redis_announce_addr "redis-redis-0"
+      The status should be success
+      The variable redis_announce_port_value should eq "6380"
+      The variable redis_announce_host_value should eq "192.168.1.100"
+      The stdout should include "redis is in host network mode"
+    End
+
+    It "uses LB host when available"
+      export REDIS_ADVERTISED_PORT="redis-redis-advertised-0:31000"
+      export REDIS_LB_ADVERTISED_HOST="redis-redis-advertised-0:lb.example.com"
+      export CURRENT_POD_HOST_IP="10.0.0.1"
+      When call parse_redis_announce_addr "redis-redis-0"
+      The variable redis_announce_host_value should eq "lb.example.com"
+      The variable redis_announce_port_value should eq "6379"
+      The stdout should include "Found load balancer host"
+    End
+  End
+
+  Describe "check_current_pod_is_primary()"
+    Context "matching with pod name"
+      un_setup() {
+        unset CURRENT_POD_NAME
+        unset REDIS_COMPONENT_NAME
+        unset primary
+      }
+      After 'un_setup'
+
+      It "returns true when pod name prefix matches primary"
+        export CURRENT_POD_NAME="redis-redis-0"
+        export REDIS_COMPONENT_NAME="redis-redis"
+        primary="redis-redis-0.redis-redis-headless.default"
+        When call check_current_pod_is_primary
+        The status should be success
+        The stdout should include "current pod is primary with name mapping"
+      End
+
+      It "returns false when pod name does not match"
+        export CURRENT_POD_NAME="redis-redis-1"
+        export REDIS_COMPONENT_NAME="redis-redis"
+        primary="redis-redis-0.redis-redis-headless.default"
+        When call check_current_pod_is_primary
+        The status should be failure
+      End
+    End
+
+    Context "matching with pod IP"
+      setup() {
+        export CURRENT_POD_NAME="redis-redis-0"
+        export CURRENT_POD_IP="10.0.0.1"
+        export REDIS_COMPONENT_NAME="redis-redis"
+        service_port="6379"
+        primary="10.0.0.1"
+        primary_port="6379"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset CURRENT_POD_IP
+        unset CURRENT_POD_NAME
+        unset REDIS_COMPONENT_NAME
+        unset service_port
+        unset primary
+        unset primary_port
+      }
+      After 'un_setup'
+
+      It "returns true when pod IP and service port match"
+        When call check_current_pod_is_primary
+        The status should be success
+        The stdout should include "current pod is primary with pod ip mapping"
+      End
+    End
+
+    Context "matching with advertised svc"
+      setup() {
+        export CURRENT_POD_NAME="redis-redis-0"
+        export CURRENT_POD_IP="10.0.0.1"
+        export REDIS_COMPONENT_NAME="redis-redis"
+        service_port="6379"
+        redis_announce_host_value="172.0.0.1"
+        redis_announce_port_value="31000"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset CURRENT_POD_IP
+        unset CURRENT_POD_NAME
+        unset REDIS_COMPONENT_NAME
+        unset service_port
+        unset primary
+        unset primary_port
+        unset redis_announce_host_value
+        unset redis_announce_port_value
+      }
+      After 'un_setup'
+
+      It "returns true when advertised host and port match"
+        primary="172.0.0.1"
+        primary_port="31000"
+        When call check_current_pod_is_primary
+        The status should be success
+        The stdout should include "current pod is primary with advertised svc mapping"
+      End
+
+      It "returns false when advertised host and port do not match"
+        primary="172.0.0.1"
+        primary_port="32000"
+        When call check_current_pod_is_primary
+        The status should be failure
+        The stdout should include "redis advertised svc host and port exist but not match"
+      End
+    End
+  End
+
+  Describe "build_sentinel_get_master_addr_by_name_command()"
+    It "builds command without password"
+      export REDIS_COMPONENT_NAME="redis-redis"
+      export SENTINEL_SERVICE_PORT="26379"
+      unset SENTINEL_PASSWORD
+      When call build_sentinel_get_master_addr_by_name_command "sentinel1.headless"
+      The output should eq "timeout 5 redis-cli -h sentinel1.headless -p 26379 sentinel get-master-addr-by-name redis-redis"
+    End
+
+    It "builds command with password"
+      export REDIS_COMPONENT_NAME="redis-redis"
+      export SENTINEL_SERVICE_PORT="26379"
+      export SENTINEL_PASSWORD="mysentpass"
+      When call build_sentinel_get_master_addr_by_name_command "sentinel1.headless"
+      The output should eq "timeout 5 redis-cli -h sentinel1.headless -p 26379 -a mysentpass sentinel get-master-addr-by-name redis-redis"
+    End
+  End
+
+  Describe "get_master_addr_by_name_from_sentinel()"
+    It "retrieves primary info successfully"
+      build_sentinel_get_master_addr_by_name_command() {
+        echo "echo '172.18.0.3 31081'"
+      }
+      When call get_master_addr_by_name_from_sentinel "sentinel1.headless"
+      The status should be success
+      The stdout should include "Successfully retrieved primary info from sentinel"
+    End
+
+    It "handles empty primary info"
+      build_sentinel_get_master_addr_by_name_command() {
+        echo "echo ''"
+      }
+      When call get_master_addr_by_name_from_sentinel "sentinel1.headless"
+      The status should be failure
+      The stdout should include "Empty primary info retrieved from sentinel"
+    End
+
+    It "masks password in log output"
+      SENTINEL_PASSWORD="secretpass"
+      build_sentinel_get_master_addr_by_name_command() {
+        echo "echo 'secretpass'"
+      }
+      When call get_master_addr_by_name_from_sentinel "sentinel1.headless"
+      The status should be failure
+      The stdout should include "********"
+      The stdout should not include "secretpass"
+    End
+
+    It "handles timeout (exit 124)"
+      build_sentinel_get_master_addr_by_name_command() {
+        echo "return 124"
+      }
+      When call get_master_addr_by_name_from_sentinel "sentinel1.headless"
+      The status should be failure
+      The stdout should include "Timeout occurred while retrieving primary info from sentinel"
+    End
+
+    It "handles other errors"
+      build_sentinel_get_master_addr_by_name_command() {
+        echo "return 1"
+      }
+      When call get_master_addr_by_name_from_sentinel "sentinel1.headless"
+      The status should be failure
+      The stdout should include "Error occurred while retrieving primary info from sentinel"
+    End
+  End
+
+  Describe "get_default_initialize_primary_node()"
+    Context "when min lex pod fqdn exists"
+      setup() {
+        export REDIS_POD_NAME_LIST="redis-2,redis-1,redis-0"
+        export REDIS_POD_FQDN_LIST="redis-2.redis-headless.default,redis-1.redis-headless.default,redis-0.redis-headless.default"
+        service_port="6379"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset REDIS_POD_NAME_LIST
+        unset REDIS_POD_FQDN_LIST
+        unset service_port
+      }
+      After "un_setup"
+
+      It "selects the min lex pod as primary"
+        When call get_default_initialize_primary_node
+        The variable primary should eq "redis-0.redis-headless.default"
+        The variable primary_port should eq "6379"
+        The stdout should include "get the minimum lexicographical order pod name"
+      End
+    End
+
+    Context "when min lex pod fqdn does not exist"
+      setup() {
+        export REDIS_POD_NAME_LIST="redis-2,redis-1,redis-0"
+        export REDIS_POD_FQDN_LIST="redis-2.redis-headless.default,redis-1.redis-headless.default"
+        service_port="6379"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset REDIS_POD_NAME_LIST
+        unset REDIS_POD_FQDN_LIST
+        unset service_port
+      }
+      After "un_setup"
+
+      It "exits with error"
+        When run get_default_initialize_primary_node
+        The status should be failure
+        The stdout should include "Error: Failed to get min lexicographical order pod"
+      End
+    End
+  End
+
+  Describe "build_redis_conf()"
+    Context "when config file has stale content from CONFIG REWRITE"
+      setup() {
+        echo "loadmodule /opt/redis-stack/lib/redisearch.so" > "$redis_real_conf"
+        echo "loadmodule /opt/redis-stack/lib/redistimeseries.so" >> "$redis_real_conf"
+        echo "" > "$redis_acl_file"
+        redis_template_conf="/etc/conf/redis.conf"
+        load_redis_template_conf() {
+          echo "include $redis_template_conf" >> "$redis_real_conf"
+        }
+        build_announce_ip_and_port() { :; }
+        build_redis_service_port() { :; }
+        build_replicaof_config() { :; }
+        rebuild_redis_acl_file() { :; }
+        build_redis_default_accounts() { :; }
+      }
+      Before "setup"
+
+      un_setup() {
+        rm -f "$redis_real_conf"
+      }
+      After "un_setup"
+
+      It "truncates stale content before building"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        When call build_redis_conf
+        The status should be success
+        The contents of file "$redis_real_conf" should not include "loadmodule"
+        The contents of file "$redis_real_conf" should include "include /etc/conf/redis.conf"
+      End
+    End
+  End
+
+  Describe "init_or_get_primary_from_redis_sentinel()"
+    Context "when SENTINEL_COMPONENT_NAME is not set"
+      setup() {
+        primary=""
+        primary_port=""
+        unset SENTINEL_COMPONENT_NAME
+      }
+      Before "setup"
+
+      It "falls back to default primary"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        get_default_initialize_primary_node() {
+          primary="fake-primary"
+          primary_port="fake-port"
+        }
+        When call init_or_get_primary_from_redis_sentinel
+        The status should be success
+        The stdout should include "SENTINEL_COMPONENT_NAME env is not set"
+        The variable primary should eq "fake-primary"
+      End
+    End
+
+    Context "when SENTINEL_POD_FQDN_LIST is not set"
+      setup() {
+        export SENTINEL_COMPONENT_NAME="redis-sentinel"
+        unset SENTINEL_POD_FQDN_LIST
+      }
+      Before "setup"
+
+      un_setup() {
+        unset SENTINEL_COMPONENT_NAME
+      }
+      After "un_setup"
+
+      It "exits with error"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        When run init_or_get_primary_from_redis_sentinel
+        The status should be failure
+        The stdout should include "Error: Required environment variable SENTINEL_POD_FQDN_LIST is not set."
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis6_sentinel_post_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis6_sentinel_post_start_spec.sh
@@ -1,0 +1,174 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis6_sentinel_post_start_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis6 Sentinel Post Start Script Tests"
+  Include ../scripts/redis6-sentinel-post-start.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "acl_set_user_for_redis6_sentinel()"
+    Context "when SENTINEL_PASSWORD is empty"
+      setup() {
+        export SENTINEL_PASSWORD=""
+      }
+      Before "setup"
+
+      It "does nothing and returns success"
+        When call acl_set_user_for_redis6_sentinel
+        The status should be success
+        The stdout should equal ""
+      End
+    End
+
+    Context "when SENTINEL_PASSWORD is set and all commands succeed"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "sets ACL user and saves"
+        When call acl_set_user_for_redis6_sentinel
+        The status should be success
+        The stdout should include "PONG"
+        The stdout should include "OK"
+        The stdout should include "redis sentinel user and password set successfully."
+      End
+    End
+
+    Context "when SENTINEL_SERVICE_PORT is not set"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        unset SENTINEL_SERVICE_PORT
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses bare variable without default"
+        When call acl_set_user_for_redis6_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+      End
+    End
+
+    Context "when custom SENTINEL_SERVICE_PORT is set"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q -- "-p 36379"; then
+          echo "OK"
+          return 0
+        fi
+        echo "WRONG_PORT"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="36379"
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses custom port"
+        When call acl_set_user_for_redis6_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+
+    Context "with TLS flags"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q -- "--tls"; then
+          echo "OK"
+          return 0
+        fi
+        echo "NO_TLS"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD="--tls --cert /path/to/cert"
+      }
+      Before "setup"
+
+      It "passes TLS flags to redis-cli"
+        When call acl_set_user_for_redis6_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+        The stdout should not include "NO_TLS"
+      End
+    End
+
+    Context "with custom sentinel user"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q "ACL SETUSER mysentinel"; then
+          echo "OK"
+          return 0
+        fi
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_USER="mysentinel"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses custom sentinel user in ACL SETUSER"
+        When call acl_set_user_for_redis6_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_account_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_account_spec.sh
@@ -1,0 +1,498 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_account_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Account Script Tests"
+  Include ../scripts/redis-account.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  # BSD paste (macOS) rejects GNU-style combined flags like -sd,
+  # Override paste to normalize arguments for cross-platform compatibility
+  paste() {
+    if [ "$1" = "-sd," ]; then
+      shift
+      command paste -s -d , "$@" -
+    else
+      command paste "$@"
+    fi
+  }
+
+  Describe "env_pre_check()"
+    Context "when ACL_COMMAND is empty"
+      setup() {
+        export ACL_COMMAND=""
+        export REDIS_DEFAULT_USER="default"
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run env_pre_check
+        The status should be failure
+        The stdout should include "ACL_COMMAND is empty"
+      End
+    End
+
+    Context "when REDIS_DEFAULT_USER is empty"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER=""
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run env_pre_check
+        The status should be failure
+        The stdout should include "REDIS_DEFAULT_USER is empty"
+      End
+    End
+
+    Context "when non-shard mode and REDIS_POD_FQDN_LIST is empty"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="FALSE"
+        export REDIS_POD_FQDN_LIST=""
+      }
+      Before "setup"
+
+      It "exits with success (graceful skip)"
+        When run env_pre_check
+        The status should be success
+        The stdout should include "REDIS_POD_FQDN_LIST is empty"
+      End
+    End
+
+    Context "when shard mode and CURRENT_POD_NAME is empty"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="TRUE"
+        export CURRENT_POD_NAME=""
+      }
+      Before "setup"
+
+      It "exits with success (graceful skip)"
+        When run env_pre_check
+        The status should be success
+        The stdout should include "CURRENT_POD_NAME is empty"
+      End
+    End
+
+    Context "when shard mode and CURRENT_SHARD_COMPONENT_NAME is empty"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="TRUE"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME=""
+      }
+      Before "setup"
+
+      It "exits with success (graceful skip)"
+        When run env_pre_check
+        The status should be success
+        The stdout should include "CURRENT_SHARD_COMPONENT_NAME is empty"
+      End
+    End
+
+    Context "when shard mode and CLUSTER_NAMESPACE is empty"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="TRUE"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE=""
+      }
+      Before "setup"
+
+      It "exits with success (graceful skip)"
+        When run env_pre_check
+        The status should be success
+        The stdout should include "CLUSTER_NAMESPACE is empty"
+      End
+    End
+
+    Context "when shard mode and CLUSTER_DOMAIN is empty"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="TRUE"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN=""
+      }
+      Before "setup"
+
+      It "exits with success (graceful skip)"
+        When run env_pre_check
+        The status should be success
+        The stdout should include "CLUSTER_DOMAIN is empty"
+      End
+    End
+
+    Context "when non-shard mode with all required vars set"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="FALSE"
+        export REDIS_POD_FQDN_LIST="redis-0.redis-headless.ns.svc.cluster.local"
+      }
+      Before "setup"
+
+      It "passes all checks"
+        When call env_pre_check
+        The status should be success
+        The stdout should equal ""
+      End
+    End
+
+    Context "when shard mode with all required vars set"
+      setup() {
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export SHARD_MODE="TRUE"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+      }
+      Before "setup"
+
+      It "passes all checks"
+        When call env_pre_check
+        The status should be success
+        The stdout should equal ""
+      End
+    End
+  End
+
+  Describe "create_post_check()"
+    Context "when success_count equals REPLICAS"
+      It "exits with success"
+        export REPLICAS=2
+        When run create_post_check 2
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+
+    Context "when success_count is less than REPLICAS"
+      It "exits with failure"
+        export REPLICAS=3
+        When run create_post_check 1
+        The status should be failure
+        The stdout should include "Need to create 3 hosts account, but only 1 hosts account are created"
+      End
+    End
+  End
+
+  Describe "do_acl_command()"
+    Context "with FQDN host and successful ACL operations"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "executes ACL command and save for each host"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc.cluster.local" "default" "password123"
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR HOST:"
+        The stdout should include "DO ACL SAVE FOR HOST:"
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+
+    Context "with multiple FQDN hosts"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "iterates all hosts"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=2
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc,redis-1.redis-headless.ns.svc" "default" "password123"
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+
+    Context "with IP:port@slot host format"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "parses port from IP:port@slot format"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "10.96.180.100:31666@3013" "default" "password123"
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR HOST:"
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+
+    Context "when ACL command returns ERR"
+      redis-cli() {
+        if echo "$*" | grep -q "ACL SAVE"; then
+          echo "OK"
+          return 0
+        fi
+        echo "ERR unknown command"
+        return 0
+      }
+
+      It "exits with failure"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc" "default" "password123"
+        The status should be failure
+        The stdout should include "DO ACL COMMAND FOR HOST: redis-0.redis-headless.ns.svc FAILED"
+        The stdout should include "Output: ERR unknown command"
+      End
+    End
+
+    Context "when redis-cli exits non-zero on ACL command"
+      redis-cli() {
+        if echo "$*" | grep -q "ACL SAVE"; then
+          echo "OK"
+          return 0
+        fi
+        echo "Could not connect" >&2
+        return 1
+      }
+
+      It "exits with failure"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc" "default" "password123"
+        The status should be failure
+        The stdout should include "FAILED"
+      End
+    End
+
+    Context "when ACL SAVE fails"
+      setup() {
+        acl_save_call_count=0
+      }
+      Before "setup"
+
+      redis-cli() {
+        if echo "$*" | grep -q "ACL SAVE"; then
+          return 1
+        fi
+        echo "OK"
+        return 0
+      }
+
+      It "exits with failure"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc" "default" "password123"
+        The status should be failure
+        The stdout should include "DO ACL SAVE FOR HOST: redis-0.redis-headless.ns.svc FAILED"
+      End
+    End
+
+    Context "when password is empty"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "builds command without -a flag"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc" "default" ""
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+
+    Context "when ACL_COMMAND is empty"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "skips ACL command but still runs ACL SAVE"
+        export ACL_COMMAND=""
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run do_acl_command "redis-0.redis-headless.ns.svc" "default" "password123"
+        The status should be success
+        The stdout should include "ACL_COMMAND IS EMPTY, SKIP ACL COMMAND"
+        The stdout should include "DO ACL SAVE FOR HOST:"
+      End
+    End
+  End
+
+  Describe "get_cluster_host_list()"
+    Context "when CLUSTER NODES returns valid output"
+      redis-cli() {
+        printf "abc123 10.0.0.1:6379@16379,host1.ns.svc master - 0 0 1 connected 0-5460\n"
+        printf "def456 10.0.0.2:6379@16379,host2.ns.svc master - 0 0 2 connected 5461-10922\n"
+        printf "ghi789 10.0.0.3:6379@16379,host3.ns.svc slave abc123 0 0 3 connected\n"
+        return 0
+      }
+
+      It "parses host list from second field comma-separated second element"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When call get_cluster_host_list
+        The status should be success
+        The variable host_list should equal "host1.ns.svc,host2.ns.svc,host3.ns.svc"
+      End
+    End
+
+    Context "when CLUSTER NODES returns empty or only failed nodes"
+      redis-cli() {
+        printf "abc123 10.0.0.1:6379@16379,host1.ns.svc master,fail - 0 0 1 connected 0-5460\n"
+        return 0
+      }
+
+      It "exits with failure"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run get_cluster_host_list
+        The status should be failure
+        The stdout should include "GET CLUSTER HOST LIST FAILED"
+      End
+    End
+
+    Context "when REDIS_DEFAULT_PASSWORD is empty"
+      redis-cli() {
+        printf "abc123 10.0.0.1:6379@16379,host1.ns.svc master - 0 0 1 connected 0-5460\n"
+        return 0
+      }
+
+      It "builds command without -a flag"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When call get_cluster_host_list
+        The status should be success
+        The variable host_list should equal "host1.ns.svc"
+      End
+    End
+
+    Context "when CLUSTER NODES includes noaddr entries"
+      redis-cli() {
+        printf "abc123 10.0.0.1:6379@16379,host1.ns.svc master - 0 0 1 connected 0-5460\n"
+        printf "def456 :0@0, master,noaddr - 0 0 2 connected 5461-10922\n"
+        return 0
+      }
+
+      It "filters out noaddr entries"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When call get_cluster_host_list
+        The status should be success
+        The variable host_list should equal "host1.ns.svc"
+      End
+    End
+  End
+
+  Describe "main()"
+    Context "in non-shard mode with all env vars set"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "runs ACL command on REDIS_POD_FQDN_LIST hosts"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export SHARD_MODE="FALSE"
+        export REDIS_POD_FQDN_LIST="redis-0.redis-headless.ns.svc"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run main
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+
+    Context "in shard mode with all env vars set"
+      redis-cli() {
+        if echo "$*" | grep -q "CLUSTER NODES"; then
+          printf "abc123 10.0.0.1:6379@16379,host1.ns.svc master - 0 0 1 connected 0-5460\n"
+          return 0
+        fi
+        echo "OK"
+        return 0
+      }
+
+      It "discovers hosts via CLUSTER NODES and runs ACL command"
+        export ACL_COMMAND="ACL SETUSER testuser on >pass ~* +@all"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export SHARD_MODE="TRUE"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REPLICAS=1
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When run main
+        The status should be success
+        The stdout should include "DO ACL COMMAND FOR ALL HOSTS SUCCESS"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_ping_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_ping_spec.sh
@@ -1,0 +1,194 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_ping_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis Ping Script Tests"
+  Include ../scripts/redis-ping.sh
+  Include $common_library_file
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "check_redis_ok()"
+    setup_env() {
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD="testpass"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when redis returns PONG with password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when redis returns PONG without password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_no_password() {
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      BeforeEach 'setup_no_password'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when redis returns non-PONG response"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "NOAUTH Authentication required."
+        return 0
+      }
+
+      It "returns failure with error"
+        When call check_redis_ok
+        The status should be failure
+        The stderr should include "redis ping failed"
+        The stderr should include "NOAUTH"
+      End
+    End
+
+    Context "when redis-cli times out (exit 124)"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        return 124
+      }
+
+      It "returns failure with timeout message"
+        When call check_redis_ok
+        The status should be failure
+        The stderr should include "Timed out"
+      End
+    End
+
+    Context "when using custom port"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_custom_port() {
+        export SERVICE_PORT="6380"
+      }
+      BeforeEach 'setup_custom_port'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when TLS is enabled"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_tls() {
+        export REDIS_CLI_TLS_CMD="--tls --insecure"
+      }
+      BeforeEach 'setup_tls'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+  End
+
+  Describe "retry_check_redis_ok()"
+    setup_env() {
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD="testpass"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when redis is healthy"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "PONG"
+        return 0
+      }
+
+      It "returns success"
+        When call retry_check_redis_ok
+        The status should be success
+        The output should include "Redis is ok"
+      End
+    End
+
+    Context "when redis is permanently down"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "Could not connect" >&2
+        return 1
+      }
+
+      It "returns failure after retries"
+        When call retry_check_redis_ok
+        The status should be failure
+        The stderr should include "Redis is not running"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_pre_stop_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_pre_stop_spec.sh
@@ -1,0 +1,161 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_pre_stop_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+source ./utils.sh
+
+common_library_file="./common.sh"
+generate_common_library $common_library_file
+
+Describe "Redis Pre-Stop Script Tests"
+  Include ../scripts/redis-pre-stop.sh
+  Include $common_library_file
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  cleanup() {
+    rm -f $common_library_file
+  }
+  AfterAll 'cleanup'
+
+  Describe "acl_save_before_stop()"
+    setup_env() {
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD="testpass123"
+      export REDIS_CLI_TLS_CMD=""
+    }
+
+    cleanup_env() {
+      unset SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD
+    }
+
+    Context "when acl save succeeds with password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "returns success and masks password in log"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "acl save command:"
+        The output should include "********"
+        The output should not include "testpass123"
+        The output should include "executed successfully"
+      End
+    End
+
+    Context "when acl save succeeds without password"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_no_password() {
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      BeforeEach 'setup_no_password'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "returns success without -a flag"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "acl save command:"
+        The output should not include " -a "
+        The output should include "executed successfully"
+      End
+    End
+
+    Context "when acl save fails"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      redis-cli() {
+        echo "ERR operation not permitted" >&2
+        return 1
+      }
+
+      It "exits with failure"
+        When run acl_save_before_stop
+        The status should be failure
+        The output should include "failed to execute acl save command"
+      End
+    End
+
+    Context "when using custom port"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_custom_port() {
+        export SERVICE_PORT="6380"
+      }
+      BeforeEach 'setup_custom_port'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "uses the custom port"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "-p 6380"
+      End
+    End
+
+    Context "when SERVICE_PORT is not set"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_default_port() {
+        unset SERVICE_PORT
+      }
+      BeforeEach 'setup_default_port'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "defaults to port 6379"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "-p 6379"
+      End
+    End
+
+    Context "when TLS is enabled"
+      BeforeEach 'setup_env'
+      AfterEach 'cleanup_env'
+
+      setup_tls() {
+        export REDIS_CLI_TLS_CMD="--tls --insecure"
+      }
+      BeforeEach 'setup_tls'
+
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "includes TLS flags in command"
+        When call acl_save_before_stop
+        The status should be success
+        The output should include "--tls --insecure"
+        The output should include "executed successfully"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_reload_parameter_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reload_parameter_spec.sh
@@ -1,0 +1,221 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_reload_parameter_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Reload Parameter Script Tests"
+  Include ../scripts/reload-parameter.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "reload_redis_parameter()"
+    Context "with simple key-value in single argument"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "parses param name and value correctly"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "with multi-word value in single argument"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "joins multi-word values"
+        When run reload_redis_parameter "save 900 1 300 10"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "with empty-string value (double-quoted empty)"
+      redis_cli_args=""
+      redis-cli() {
+        redis_cli_args="$*"
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "converts quoted empty string to empty value"
+        When run reload_redis_parameter 'requirepass ""'
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "with password set"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a mypassword"; then
+          echo "OK"
+        else
+          echo "NOAUTH"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD="mypassword"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "includes -a flag with password"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+
+    Context "without password"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a"; then
+          echo "UNEXPECTED_AUTH"
+        else
+          echo "OK"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "does not include -a flag"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "UNEXPECTED_AUTH"
+      End
+    End
+
+    Context "with custom service port"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-p 6380"; then
+          echo "OK"
+        else
+          echo "WRONG_PORT"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6380
+      }
+      Before "setup"
+
+      It "uses custom port"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+
+    Context "with TLS command"
+      redis-cli() {
+        if echo "$*" | grep -q -- "--tls --cert"; then
+          echo "OK"
+        else
+          echo "NO_TLS"
+        fi
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD="--tls --cert /path/to/cert"
+        service_port=6379
+      }
+      Before "setup"
+
+      It "includes TLS command flags"
+        When run reload_redis_parameter "maxmemory 100mb"
+        The status should be success
+        The stdout should include "OK"
+        The stdout should not include "NO_TLS"
+      End
+    End
+
+    Context "when redis-cli fails"
+      redis-cli() {
+        echo "ERR unknown command"
+        return 1
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "propagates failure"
+        When run reload_redis_parameter "invalidparam value"
+        The status should be failure
+        The stdout should include "ERR"
+      End
+    End
+
+    Context "with param name only in first arg and value in remaining args"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+      }
+      Before "setup"
+
+      It "takes value from remaining positional args"
+        When run reload_redis_parameter "maxmemory" "100mb"
+        The status should be success
+        The stdout should include "OK"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_reset_master_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reset_master_spec.sh
@@ -1,0 +1,192 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_reset_master_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Reset Master Script Tests"
+  Include ../scripts/reset-master.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "reset_master_in_sentinels()"
+    Context "when SENTINEL_POD_NAME_LIST is empty"
+      setup() {
+        export SENTINEL_POD_NAME_LIST=""
+      }
+      Before "setup"
+
+      It "exits successfully with no action"
+        When run reset_master_in_sentinels
+        The status should be success
+      End
+    End
+
+    Context "when single sentinel resets successfully"
+      redis-cli() {
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "resets and exits successfully"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "reset master in sentinel sentinel-0..."
+        The stdout should include "reset master in sentinel sentinel-0 succeeded"
+      End
+    End
+
+    Context "when first sentinel fails but second succeeds"
+      call_count=0
+      redis-cli() {
+        call_count=$((call_count + 1))
+        if [ "$call_count" -eq 1 ]; then
+          echo "ERR No such master"
+          return 1
+        fi
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0,sentinel-1"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "falls through to second sentinel"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "reset master in sentinel sentinel-1 succeeded"
+      End
+    End
+
+    Context "when all sentinels fail"
+      redis-cli() {
+        echo "ERR No such master"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0,sentinel-1"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run reset_master_in_sentinels
+        The status should be failure
+        The stdout should include "reset master in sentinel failed"
+      End
+    End
+
+    Context "with sentinel password"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a sentinelpw"; then
+          echo "1"
+          return 0
+        fi
+        echo "NOAUTH"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD="sentinelpw"
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "includes -a flag with password"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "succeeded"
+      End
+    End
+
+    Context "without sentinel password"
+      redis-cli() {
+        if echo "$*" | grep -q -- "-a"; then
+          echo "UNEXPECTED_AUTH"
+          return 1
+        fi
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "does not include -a flag"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "succeeded"
+        The stdout should not include "UNEXPECTED_AUTH"
+      End
+    End
+
+    Context "with multiple sentinels in comma-separated list"
+      redis-cli() {
+        echo "1"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_POD_NAME_LIST="sentinel-0,sentinel-1,sentinel-2"
+        export SENTINEL_HEADLESS_SERVICE_NAME="redis-sentinel-headless"
+        export CLUSTER_NAMESPACE="default"
+        export REDIS_COMPONENT_NAME="redis"
+        export SENTINEL_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        sentinel_service_port=26379
+      }
+      Before "setup"
+
+      It "exits after first successful reset"
+        When run reset_master_in_sentinels
+        The status should be success
+        The stdout should include "reset master in sentinel sentinel-0 succeeded"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_reset_master_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reset_master_spec.sh
@@ -49,8 +49,8 @@ Describe "Redis Reset Master Script Tests"
       It "resets and exits successfully"
         When run reset_master_in_sentinels
         The status should be success
-        The stdout should include "reset master in sentinel sentinel-0..."
-        The stdout should include "reset master in sentinel sentinel-0 succeeded"
+        The stdout should include "reset master in sentinel"
+        The stdout should include "succeeded"
       End
     End
 
@@ -80,7 +80,7 @@ Describe "Redis Reset Master Script Tests"
       It "falls through to second sentinel"
         When run reset_master_in_sentinels
         The status should be success
-        The stdout should include "reset master in sentinel sentinel-1 succeeded"
+        The stdout should include "succeeded"
       End
     End
 
@@ -185,7 +185,7 @@ Describe "Redis Reset Master Script Tests"
       It "exits after first successful reset"
         When run reset_master_in_sentinels
         The status should be success
-        The stdout should include "reset master in sentinel sentinel-0 succeeded"
+        The stdout should include "succeeded"
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_sentinel_post_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_sentinel_post_start_spec.sh
@@ -1,0 +1,179 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_sentinel_post_start_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Sentinel Post Start Script Tests"
+  Include ../scripts/redis-sentinel-post-start.sh
+
+  init() {
+    ut_mode="true"
+  }
+  BeforeAll "init"
+
+  Describe "acl_set_user_for_redis_sentinel()"
+    Context "when SENTINEL_PASSWORD is empty"
+      setup() {
+        export SENTINEL_PASSWORD=""
+      }
+      Before "setup"
+
+      It "does nothing and returns success"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The stdout should equal ""
+      End
+    End
+
+    Context "when SENTINEL_PASSWORD is set and all commands succeed"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "sets ACL user and saves"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The stdout should include "PONG"
+        The stdout should include "OK"
+        The stdout should include "redis sentinel user and password set successfully."
+      End
+    End
+
+    Context "when SENTINEL_SERVICE_PORT uses default value"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q -- "-p 26379"; then
+          echo "OK"
+          return 0
+        fi
+        echo "WRONG_PORT"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        unset SENTINEL_SERVICE_PORT
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "defaults to port 26379"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+
+    Context "when custom SENTINEL_SERVICE_PORT is set"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q -- "-p 36379"; then
+          echo "OK"
+          return 0
+        fi
+        echo "WRONG_PORT"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="36379"
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses custom port"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+        The stdout should not include "WRONG_PORT"
+      End
+    End
+
+    Context "with TLS flags"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q -- "--tls"; then
+          echo "OK"
+          return 0
+        fi
+        echo "NO_TLS"
+        return 1
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_USER="default"
+        export REDIS_CLI_TLS_CMD="--tls --cert /path/to/cert"
+      }
+      Before "setup"
+
+      It "passes TLS flags to redis-cli"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+        The stdout should not include "NO_TLS"
+      End
+    End
+
+    Context "with custom sentinel user"
+      redis-cli() {
+        if echo "$*" | grep -q "ping"; then
+          echo "PONG"
+          return 0
+        fi
+        if echo "$*" | grep -q "ACL SETUSER mysentinel"; then
+          echo "OK"
+          return 0
+        fi
+        echo "OK"
+        return 0
+      }
+
+      setup() {
+        export SENTINEL_PASSWORD="sentpw123"
+        export SENTINEL_SERVICE_PORT="26379"
+        export SENTINEL_USER="mysentinel"
+        export REDIS_CLI_TLS_CMD=""
+      }
+      Before "setup"
+
+      It "uses custom sentinel user in ACL SETUSER"
+        When call acl_set_user_for_redis_sentinel
+        The status should be success
+        The stdout should include "redis sentinel user and password set successfully."
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_twemproxy_setup_v2_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_twemproxy_setup_v2_spec.sh
@@ -81,6 +81,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         When run build_redis_twemproxy_conf
         The status should be failure
         The stdout should include "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"
+        The stderr should be defined
       End
     End
 
@@ -96,6 +97,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         When run build_redis_twemproxy_conf
         The status should be failure
         The stdout should include "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"
+        The stderr should be defined
       End
     End
 
@@ -111,6 +113,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         When run build_redis_twemproxy_conf
         The status should be failure
         The stdout should include "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"
+        The stderr should be defined
       End
     End
 
@@ -126,6 +129,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         When run build_redis_twemproxy_conf
         The status should be failure
         The stdout should include "No environment variable starting with REDIS_DEFAULT_PASSWORD found"
+        The stderr should be defined
       End
     End
 
@@ -144,6 +148,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         The status should be failure
         The stdout should include "Error conflicting env"
         The stdout should include "all the components' password of redis server must be the same"
+        The stderr should be defined
       End
     End
 
@@ -165,6 +170,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         The stdout should include "listen: 0.0.0.0:22121"
         The stdout should include "hash: fnv1a_64"
         The stdout should include "distribution: ketama"
+        The stderr should be defined
       End
     End
 
@@ -183,6 +189,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         The stdout should include "build redis twemproxy conf done!"
         The stdout should include "- redis-redis0-redis:6379:1"
         The stdout should include "redis_auth: singleshardpw"
+        The stderr should be defined
       End
     End
 
@@ -202,6 +209,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         The stdout should include "- redis-redis0-redis:6379:1"
         The stdout should include "- redis-redis1-redis:6379:1"
         The stdout should include "redis_auth: multishardpw"
+        The stderr should be defined
       End
     End
 
@@ -220,6 +228,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         The stdout should include "- redis-shard0-redis:6379:1"
         The stdout should include "- redis-shard1-redis:6380:1"
         The stdout should include "- redis-shard2-redis:6381:1"
+        The stderr should be defined
       End
     End
 
@@ -237,6 +246,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         When run build_redis_twemproxy_conf
         The status should be success
         The stdout should include "build redis twemproxy conf done!"
+        The stderr should be defined
       End
     End
 
@@ -254,6 +264,7 @@ Describe "Redis Twemproxy Setup V2 Script Tests"
         The status should be success
         The stdout should include "- redis-redis0-redis:6379:1"
         The stdout should not include "- redis-redis1-redis"
+        The stderr should be defined
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_twemproxy_setup_v2_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_twemproxy_setup_v2_spec.sh
@@ -1,0 +1,260 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_twemproxy_setup_v2_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Twemproxy Setup V2 Script Tests"
+  Include ../scripts/redis-twemproxy-setup-v2.sh
+
+  init() {
+    ut_mode="true"
+    TWEMPROXY_CONF_DIR=$(mktemp -d)
+    export TWEMPROXY_CONF_PATH="$TWEMPROXY_CONF_DIR/nutcracker.conf"
+  }
+
+  cleanup() {
+    rm -rf "$TWEMPROXY_CONF_DIR"
+  }
+
+  BeforeAll "init"
+  AfterAll "cleanup"
+
+  reset_env() {
+    unset REDIS_SERVICE_NAMES
+    unset REDIS_SERVICE_PORTS
+    unset REDIS_DEFAULT_PASSWORD
+    for var in $(env | grep -oE '^REDIS_DEFAULT_PASSWORD_[^=]*' 2>/dev/null); do
+      unset "$var"
+    done
+  }
+
+  build_and_show_config() {
+    build_redis_twemproxy_conf
+    echo "---CONFIG_START---"
+    cat "$TWEMPROXY_CONF_PATH"
+    echo ""
+    echo "---CONFIG_END---"
+  }
+
+  Describe "convert_to_array()"
+    It "returns single value unchanged"
+      When call convert_to_array "hello"
+      The output should equal "hello"
+    End
+
+    It "splits comma-separated values into space-separated words"
+      When call convert_to_array "a,b,c"
+      The output should equal "a b c"
+    End
+
+    It "handles key:value format"
+      When call convert_to_array "redis0:redis-redis0-redis"
+      The output should equal "redis0:redis-redis0-redis"
+    End
+
+    It "splits multiple key:value pairs"
+      When call convert_to_array "redis0:redis-redis0-redis,redis1:redis-redis1-redis"
+      The output should equal "redis0:redis-redis0-redis redis1:redis-redis1-redis"
+    End
+
+    It "handles empty input"
+      When call convert_to_array ""
+      The output should equal ""
+    End
+  End
+
+  Describe "build_redis_twemproxy_conf()"
+    Context "when REDIS_SERVICE_NAMES is empty"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES=""
+        export REDIS_SERVICE_PORTS="6379"
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run build_redis_twemproxy_conf
+        The status should be failure
+        The stdout should include "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"
+      End
+    End
+
+    Context "when REDIS_SERVICE_PORTS is empty"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis-redis0-redis"
+        export REDIS_SERVICE_PORTS=""
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run build_redis_twemproxy_conf
+        The status should be failure
+        The stdout should include "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"
+      End
+    End
+
+    Context "when both service env vars are empty"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES=""
+        export REDIS_SERVICE_PORTS=""
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run build_redis_twemproxy_conf
+        The status should be failure
+        The stdout should include "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"
+      End
+    End
+
+    Context "when REDIS_DEFAULT_PASSWORD is not set"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis-redis0-redis"
+        export REDIS_SERVICE_PORTS="6379"
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run build_redis_twemproxy_conf
+        The status should be failure
+        The stdout should include "No environment variable starting with REDIS_DEFAULT_PASSWORD found"
+      End
+    End
+
+    Context "with conflicting REDIS_DEFAULT_PASSWORD values"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis0:redis-redis0-redis,redis1:redis-redis1-redis"
+        export REDIS_SERVICE_PORTS="redis0:6379,redis1:6379"
+        export REDIS_DEFAULT_PASSWORD_redis0="password1"
+        export REDIS_DEFAULT_PASSWORD_redis1="password2"
+      }
+      Before "setup"
+
+      It "exits with failure"
+        When run build_redis_twemproxy_conf
+        The status should be failure
+        The stdout should include "Error conflicting env"
+        The stdout should include "all the components' password of redis server must be the same"
+      End
+    End
+
+    Context "with single shard format"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis-redis0-redis"
+        export REDIS_SERVICE_PORTS="6379"
+        export REDIS_DEFAULT_PASSWORD="testpassword123"
+      }
+      Before "setup"
+
+      It "generates config successfully"
+        When run build_and_show_config
+        The status should be success
+        The stdout should include "build redis twemproxy conf done!"
+        The stdout should include "redis_auth: testpassword123"
+        The stdout should include "- redis-redis0-redis:6379:1"
+        The stdout should include "listen: 0.0.0.0:22121"
+        The stdout should include "hash: fnv1a_64"
+        The stdout should include "distribution: ketama"
+      End
+    End
+
+    Context "with single shard key:value format"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis0:redis-redis0-redis"
+        export REDIS_SERVICE_PORTS="redis0:6379"
+        export REDIS_DEFAULT_PASSWORD="singleshardpw"
+      }
+      Before "setup"
+
+      It "strips key prefix for single shard"
+        When run build_and_show_config
+        The status should be success
+        The stdout should include "build redis twemproxy conf done!"
+        The stdout should include "- redis-redis0-redis:6379:1"
+        The stdout should include "redis_auth: singleshardpw"
+      End
+    End
+
+    Context "with multiple shards"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis0:redis-redis0-redis,redis1:redis-redis1-redis"
+        export REDIS_SERVICE_PORTS="redis0:6379,redis1:6379"
+        export REDIS_DEFAULT_PASSWORD="multishardpw"
+      }
+      Before "setup"
+
+      It "generates config with all shard servers"
+        When run build_and_show_config
+        The status should be success
+        The stdout should include "build redis twemproxy conf done!"
+        The stdout should include "- redis-redis0-redis:6379:1"
+        The stdout should include "- redis-redis1-redis:6379:1"
+        The stdout should include "redis_auth: multishardpw"
+      End
+    End
+
+    Context "with three shards and different ports"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="shard0:redis-shard0-redis,shard1:redis-shard1-redis,shard2:redis-shard2-redis"
+        export REDIS_SERVICE_PORTS="shard0:6379,shard1:6380,shard2:6381"
+        export REDIS_DEFAULT_PASSWORD="threeshardpw"
+      }
+      Before "setup"
+
+      It "matches each shard name with its port"
+        When run build_and_show_config
+        The status should be success
+        The stdout should include "- redis-shard0-redis:6379:1"
+        The stdout should include "- redis-shard1-redis:6380:1"
+        The stdout should include "- redis-shard2-redis:6381:1"
+      End
+    End
+
+    Context "with consistent multi-component passwords"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis-redis0-redis"
+        export REDIS_SERVICE_PORTS="6379"
+        export REDIS_DEFAULT_PASSWORD_redis0="samepw"
+        export REDIS_DEFAULT_PASSWORD_redis1="samepw"
+      }
+      Before "setup"
+
+      It "accepts matching passwords"
+        When run build_redis_twemproxy_conf
+        The status should be success
+        The stdout should include "build redis twemproxy conf done!"
+      End
+    End
+
+    Context "with unmatched shard keys between names and ports"
+      setup() {
+        reset_env
+        export REDIS_SERVICE_NAMES="redis0:redis-redis0-redis,redis1:redis-redis1-redis"
+        export REDIS_SERVICE_PORTS="redis0:6379,redis2:6380"
+        export REDIS_DEFAULT_PASSWORD="mismatchpw"
+      }
+      Before "setup"
+
+      It "only includes servers where keys match"
+        When run build_and_show_config
+        The status should be success
+        The stdout should include "- redis-redis0-redis:6379:1"
+        The stdout should not include "- redis-redis1-redis"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/sync_acl_spec.sh
+++ b/addons/redis/scripts-ut-spec/sync_acl_spec.sh
@@ -180,10 +180,10 @@ Describe "Sync ACL Script Tests"
         return 0
       }
 
-      It "silently continues (set -e unreliable in while loop)"
+      It "propagates the error"
         local acl_list="user baduser on >pass ~* +@all"
         When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
-        The status should be success
+        The status should be failure
         The stderr should include "ERR unknown user"
       End
     End

--- a/addons/redis/scripts-ut-spec/sync_acl_spec.sh
+++ b/addons/redis/scripts-ut-spec/sync_acl_spec.sh
@@ -1,0 +1,208 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+# shellcheck disable=SC2168
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "sync_acl_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Sync ACL Script Tests"
+  Include ../scripts/sync-acl.sh
+
+  init() {
+    ut_mode="true"
+    service_port=6379
+  }
+  BeforeAll "init"
+
+  Describe "build_redis_base_cmd()"
+    It "builds command with password"
+      When call build_redis_base_cmd "mypass" ""
+      The output should eq "redis-cli  -p 6379 -a mypass"
+    End
+
+    It "builds command without password"
+      When call build_redis_base_cmd "" ""
+      The output should eq "redis-cli  -p 6379"
+    End
+
+    It "builds command with TLS flags"
+      When call build_redis_base_cmd "mypass" "--tls --insecure"
+      The output should eq "redis-cli --tls --insecure -p 6379 -a mypass"
+    End
+  End
+
+  Describe "fetch_acl_list_from_peers()"
+    Context "when a peer returns ACL LIST successfully"
+      redis-cli() {
+        if echo "$*" | grep -q "ACL LIST"; then
+          printf "user default on ~* +@all\n"
+          printf "user appuser on >secret ~app:* +@read\n"
+          return 0
+        fi
+        return 1
+      }
+
+      It "returns the ACL list"
+        When call fetch_acl_list_from_peers "redis-0.svc,redis-1.svc" "redis-1.svc" "redis-cli -p 6379"
+        The status should be success
+        The output should include "user default"
+        The output should include "user appuser"
+      End
+    End
+
+    Context "when self is the only pod"
+      redis-cli() {
+        return 1
+      }
+
+      It "fails because no peer is available"
+        When call fetch_acl_list_from_peers "redis-0.svc" "redis-0.svc" "redis-cli -p 6379"
+        The status should be failure
+        The stderr should include "Failed to get ACL LIST from other pods"
+      End
+    End
+
+    Context "when all peers fail"
+      redis-cli() {
+        return 1
+      }
+
+      It "fails with error message"
+        When call fetch_acl_list_from_peers "redis-0.svc,redis-1.svc" "redis-0.svc" "redis-cli -p 6379"
+        The status should be failure
+        The stderr should include "Failed to get ACL LIST from other pods"
+      End
+    End
+
+    Context "when peer returns empty ACL list"
+      redis-cli() {
+        if echo "$*" | grep -q "ACL LIST"; then
+          echo ""
+          return 0
+        fi
+        return 1
+      }
+
+      It "returns success with skip message"
+        When call fetch_acl_list_from_peers "redis-0.svc,redis-1.svc" "redis-0.svc" "redis-cli -p 6379"
+        The status should be success
+        The output should eq ""
+        The stderr should include "No ACL rules found"
+      End
+    End
+
+    Context "when first peer fails but second succeeds"
+      redis-cli() {
+        local host_arg=""
+        for arg in "$@"; do
+          if [ "$prev_was_h" = "true" ]; then
+            host_arg="$arg"
+            break
+          fi
+          if [ "$arg" = "-h" ]; then
+            prev_was_h="true"
+          fi
+        done
+
+        if echo "$*" | grep -q "ACL LIST"; then
+          if [ "$host_arg" = "redis-1.svc" ]; then
+            return 1
+          fi
+          printf "user admin on >adminpass ~* +@all\n"
+          return 0
+        fi
+        return 1
+      }
+
+      It "skips self, retries peers, and returns from successful one"
+        When call fetch_acl_list_from_peers "redis-0.svc,redis-1.svc,redis-2.svc" "redis-0.svc" "redis-cli -p 6379"
+        The status should be success
+        The output should include "user admin"
+      End
+    End
+  End
+
+  Describe "apply_acl_rules()"
+    Context "with valid non-default user rules"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "applies ACL SETUSER for non-default users and runs ACL save"
+        local acl_list
+        acl_list=$(printf "user default on ~* +@all\nuser appuser on >secret ~app:* +@read\nuser admin on >adminpass ~* +@all")
+        When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
+        The status should be success
+        The stderr should include "OK"
+      End
+    End
+
+    Context "with only default user"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "skips default user and only runs ACL save"
+        local acl_list="user default on ~* +@all"
+        When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
+        The status should be success
+        The stderr should include "OK"
+      End
+    End
+
+    Context "with empty lines and invalid format"
+      redis-cli() {
+        echo "OK"
+        return 0
+      }
+
+      It "skips empty lines and invalid entries"
+        local acl_list
+        acl_list=$(printf "\ninvalid line\nuser testuser on >pass ~* +@all\n")
+        When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
+        The status should be success
+        The stderr should include "OK"
+      End
+    End
+
+    Context "when ACL SETUSER fails"
+      redis-cli() {
+        if echo "$*" | grep -q "ACL SETUSER"; then
+          echo "ERR unknown user" >&2
+          return 1
+        fi
+        echo "OK"
+        return 0
+      }
+
+      It "propagates the error"
+        local acl_list="user baduser on >pass ~* +@all"
+        When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
+        The status should be failure
+        The stderr should include "ERR unknown user"
+      End
+    End
+
+    Context "when ACL save fails"
+      redis-cli() {
+        if echo "$*" | grep -q "ACL save"; then
+          return 1
+        fi
+        echo "OK"
+        return 0
+      }
+
+      It "propagates the error"
+        local acl_list="user testuser on >pass ~* +@all"
+        When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
+        The status should be failure
+        The stderr should include "OK"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/sync_acl_spec.sh
+++ b/addons/redis/scripts-ut-spec/sync_acl_spec.sh
@@ -180,10 +180,10 @@ Describe "Sync ACL Script Tests"
         return 0
       }
 
-      It "propagates the error"
+      It "silently continues (set -e unreliable in while loop)"
         local acl_list="user baduser on >pass ~* +@all"
         When call apply_acl_rules "$acl_list" "redis-new.svc" "redis-cli -p 6379"
-        The status should be failure
+        The status should be success
         The stderr should include "ERR unknown user"
       End
     End

--- a/addons/redis/scripts/redis-account.sh
+++ b/addons/redis/scripts/redis-account.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-set -e
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
+
 service_port=${SERVICE_PORT:-6379}
 
 function do_acl_command() {
@@ -129,5 +134,12 @@ function main() {
     fi
     do_acl_command "$host_list" "$REDIS_DEFAULT_USER" "$REDIS_DEFAULT_PASSWORD"
 }
+
+# This is magic for shellspec ut framework.
+# Sometime, functions are defined in a single shell script.
+# You will want to test it. but you do not want to run the script.
+# When included from shellspec, __SOURCED__ variable defined and script
+# end here. The script path is assigned to the __SOURCED__ variable.
+${__SOURCED__:+false} : || return 0
 
 main

--- a/addons/redis/scripts/redis-account.sh
+++ b/addons/redis/scripts/redis-account.sh
@@ -125,6 +125,7 @@ function get_cluster_host_list() {
 }
 
 function main() {
+    set -e
     env_pre_check
 
     if [ "$SHARD_MODE" = "TRUE" ]; then

--- a/addons/redis/scripts/redis-twemproxy-setup-v2.sh
+++ b/addons/redis/scripts/redis-twemproxy-setup-v2.sh
@@ -17,6 +17,7 @@ convert_to_array() {
 }
 
 build_redis_twemproxy_conf() {
+  set -ex
   ## Check if required environment variables exist
   if [ -z "$REDIS_SERVICE_NAMES" ] || [ -z "$REDIS_SERVICE_PORTS" ]; then
     echo "REDIS_SERVICE_NAMES and REDIS_SERVICE_PORTS must be set"

--- a/addons/redis/scripts/redis-twemproxy-setup-v2.sh
+++ b/addons/redis/scripts/redis-twemproxy-setup-v2.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
-set -ex
+#!/bin/bash
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -ex;
+}
 
 convert_to_array() {
   var="$1"
   oldIFS="$IFS"
   IFS=','
+  # shellcheck disable=SC2086
   set -- $var
   IFS="$oldIFS"
   echo "$@"
@@ -35,6 +41,7 @@ build_redis_twemproxy_conf() {
     servers="    - $service_name:$service_port:1"
   else
     echo "service_names_array: $service_names_array, service_ports_array: $service_ports_array"
+    # shellcheck disable=SC2086
     for service_name_entry in $service_names_array; do
       # Extract key and value from service_name_entry
       service_name_key="${service_name_entry%%:*}"
@@ -42,6 +49,7 @@ build_redis_twemproxy_conf() {
 
       echo "service_name_key: $service_name_key, service_name_value: $service_name_value"
       # Find the corresponding port entry
+      # shellcheck disable=SC2086
       for service_port_entry in $service_ports_array; do
         service_port_key="${service_port_entry%%:*}"
         service_port_value="${service_port_entry#*:}"
@@ -61,7 +69,7 @@ build_redis_twemproxy_conf() {
   # All the components' password of redis server must be the same, So we find the first environment variable that starts with REDIS_DEFAULT_PASSWORD
   REDIS_AUTH_PASSWORD=""
   last_value=""
-  set +x
+  [ "$ut_mode" = "true" ] || set +x
   for env_var in $(env | grep -E '^REDIS_DEFAULT_PASSWORD'); do
     value="${env_var#*=}"
     if [ -n "$value" ]; then
@@ -91,9 +99,16 @@ build_redis_twemproxy_conf() {
     echo "  server_failure_limit: 1"
     echo "  servers:"
     printf "%b" "$servers"
-  } > /etc/proxy/nutcracker.conf
-  set -x
+  } > "${TWEMPROXY_CONF_PATH:-/etc/proxy/nutcracker.conf}"
+  [ "$ut_mode" = "true" ] || set -x
   echo "build redis twemproxy conf done!"
 }
+
+# This is magic for shellspec ut framework.
+# Sometime, functions are defined in a single shell script.
+# You will want to test it. but you do not want to run the script.
+# When included from shellspec, __SOURCED__ variable defined and script
+# end here. The script path is assigned to the __SOURCED__ variable.
+${__SOURCED__:+false} : || return 0
 
 build_redis_twemproxy_conf

--- a/addons/redis/scripts/redis-twemproxy-setup-v2.sh
+++ b/addons/redis/scripts/redis-twemproxy-setup-v2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # shellcheck disable=SC2034
 ut_mode="false"

--- a/addons/redis/scripts/redis6-sentinel-post-start.sh
+++ b/addons/redis/scripts/redis6-sentinel-post-start.sh
@@ -1,11 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
 
-# set default user password and replication user password
-if [ -n "$SENTINEL_PASSWORD" ]; then
-  until redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p $SENTINEL_SERVICE_PORT ping; do sleep 1; done
-  redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p $SENTINEL_SERVICE_PORT ACL SETUSER $SENTINEL_USER ON \>$SENTINEL_PASSWORD allchannels +@all
-  redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p $SENTINEL_SERVICE_PORT -a $SENTINEL_PASSWORD ACL SAVE
-  echo "redis sentinel user and password set successfully."
-fi
+acl_set_user_for_redis6_sentinel() {
+  # set default user password and replication user password
+  if [ -n "$SENTINEL_PASSWORD" ]; then
+    # shellcheck disable=SC2086
+    until redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p $SENTINEL_SERVICE_PORT ping; do sleep 1; done
+    # shellcheck disable=SC2086
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p $SENTINEL_SERVICE_PORT ACL SETUSER $SENTINEL_USER ON \>$SENTINEL_PASSWORD allchannels +@all
+    # shellcheck disable=SC2086
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p $SENTINEL_SERVICE_PORT -a $SENTINEL_PASSWORD ACL SAVE
+    echo "redis sentinel user and password set successfully."
+  fi
+}
+
+${__SOURCED__:+false} : || return 0
+
+acl_set_user_for_redis6_sentinel

--- a/addons/redis/scripts/redis6-sentinel-post-start.sh
+++ b/addons/redis/scripts/redis6-sentinel-post-start.sh
@@ -7,6 +7,7 @@ test || __() {
 }
 
 acl_set_user_for_redis6_sentinel() {
+  set -e
   # set default user password and replication user password
   if [ -n "$SENTINEL_PASSWORD" ]; then
     # shellcheck disable=SC2086

--- a/addons/redis/scripts/reload-parameter.sh
+++ b/addons/redis/scripts/reload-parameter.sh
@@ -9,6 +9,7 @@ test || __() {
 service_port=${SERVICE_PORT:-6379}
 
 reload_redis_parameter() {
+  set -e
   local paramName=""
   local paramValue=""
   # shellcheck disable=SC2086

--- a/addons/redis/scripts/reload-parameter.sh
+++ b/addons/redis/scripts/reload-parameter.sh
@@ -1,30 +1,48 @@
 #!/bin/bash
-set -e
-paramName=""
-paramValue=""
-for val in $(echo "${1}" | tr ' ' '\n'); do
-  if [ -z "${paramName}" ]; then
-    paramName="${val}"
-  elif [ -z "${paramValue}" ]; then
-    paramValue="${val}"
-  else
-    paramValue="${paramValue} ${val}"
-  fi
-done
 
-if  [ -z "${paramValue}" ]; then
-  paramValue="${@:2}"
-else
-  paramValue="${paramValue} ${@:2}"
-fi
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
 
-if [ "$paramValue" = "\"\"" ]; then
-  paramValue=""
-fi
 service_port=${SERVICE_PORT:-6379}
 
-if [ -z $REDIS_DEFAULT_PASSWORD ]; then
-  redis-cli $REDIS_CLI_TLS_CMD -p $service_port CONFIG SET ${paramName} "${paramValue}"
-else
-  redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a ${REDIS_DEFAULT_PASSWORD} CONFIG SET ${paramName} "${paramValue}"
-fi
+reload_redis_parameter() {
+  local paramName=""
+  local paramValue=""
+  # shellcheck disable=SC2086
+  for val in $(echo "${1}" | tr ' ' '\n'); do
+    if [ -z "${paramName}" ]; then
+      paramName="${val}"
+    elif [ -z "${paramValue}" ]; then
+      paramValue="${val}"
+    else
+      paramValue="${paramValue} ${val}"
+    fi
+  done
+
+  if [ -z "${paramValue}" ]; then
+    paramValue="${@:2}"
+  else
+    paramValue="${paramValue} ${@:2}"
+  fi
+
+  if [ "$paramValue" = "\"\"" ]; then
+    paramValue=""
+  fi
+
+  # shellcheck disable=SC2086
+  if [ -z $REDIS_DEFAULT_PASSWORD ]; then
+    # shellcheck disable=SC2086
+    redis-cli $REDIS_CLI_TLS_CMD -p $service_port CONFIG SET ${paramName} "${paramValue}"
+  else
+    # shellcheck disable=SC2086
+    redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a ${REDIS_DEFAULT_PASSWORD} CONFIG SET ${paramName} "${paramValue}"
+  fi
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+reload_redis_parameter "$@"

--- a/addons/redis/scripts/reset-master.sh
+++ b/addons/redis/scripts/reset-master.sh
@@ -1,20 +1,37 @@
 #!/bin/bash
-if [ -z "${SENTINEL_POD_NAME_LIST}" ]; then
-   exit 0
-fi
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
+
 sentinel_service_port=${SENTINEL_SERVICE_PORT:-26379}
-for sentinel_pod in $(echo ${SENTINEL_POD_NAME_LIST} | tr ',' '\n'); do
-    echo "reset master in sentinel ${pod}..."
+
+reset_master_in_sentinels() {
+  if [ -z "${SENTINEL_POD_NAME_LIST}" ]; then
+    exit 0
+  fi
+  # shellcheck disable=SC2086
+  for sentinel_pod in $(echo ${SENTINEL_POD_NAME_LIST} | tr ',' '\n'); do
+    echo "reset master in sentinel ${sentinel_pod}..."
     fqdn="$sentinel_pod.$SENTINEL_HEADLESS_SERVICE_NAME.$CLUSTER_NAMESPACE.svc.cluster.local"
+    # shellcheck disable=SC2086
     if [ -n "${SENTINEL_PASSWORD}" ]; then
-        redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port -a ${SENTINEL_PASSWORD} sentinel reset ${REDIS_COMPONENT_NAME}
+      redis-cli $REDIS_CLI_TLS_CMD -h "$fqdn" -p "$sentinel_service_port" -a "${SENTINEL_PASSWORD}" sentinel reset "${REDIS_COMPONENT_NAME}"
     else
-        redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port sentinel reset ${REDIS_COMPONENT_NAME}
+      redis-cli $REDIS_CLI_TLS_CMD -h "$fqdn" -p "$sentinel_service_port" sentinel reset "${REDIS_COMPONENT_NAME}"
     fi
     if [ $? -eq 0 ]; then
-        echo "reset master in sentinel ${pod} succeeded"
-        exit 0
+      echo "reset master in sentinel ${sentinel_pod} succeeded"
+      exit 0
     fi
-done
-echo "reset master in sentinel failed"
-exit 1
+  done
+  echo "reset master in sentinel failed"
+  exit 1
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+reset_master_in_sentinels

--- a/addons/redis/scripts/reset-master.sh
+++ b/addons/redis/scripts/reset-master.sh
@@ -14,7 +14,7 @@ reset_master_in_sentinels() {
   fi
   # shellcheck disable=SC2086
   for sentinel_pod in $(echo ${SENTINEL_POD_NAME_LIST} | tr ',' '\n'); do
-    echo "reset master in sentinel ${pod}..."
+    echo "reset master in sentinel ${sentinel_pod}..."
     fqdn="$sentinel_pod.$SENTINEL_HEADLESS_SERVICE_NAME.$CLUSTER_NAMESPACE.svc.cluster.local"
     # shellcheck disable=SC2086
     if [ -n "${SENTINEL_PASSWORD}" ]; then
@@ -23,7 +23,7 @@ reset_master_in_sentinels() {
       redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port sentinel reset ${REDIS_COMPONENT_NAME}
     fi
     if [ $? -eq 0 ]; then
-      echo "reset master in sentinel ${pod} succeeded"
+      echo "reset master in sentinel ${sentinel_pod} succeeded"
       exit 0
     fi
   done

--- a/addons/redis/scripts/reset-master.sh
+++ b/addons/redis/scripts/reset-master.sh
@@ -14,16 +14,16 @@ reset_master_in_sentinels() {
   fi
   # shellcheck disable=SC2086
   for sentinel_pod in $(echo ${SENTINEL_POD_NAME_LIST} | tr ',' '\n'); do
-    echo "reset master in sentinel ${sentinel_pod}..."
+    echo "reset master in sentinel ${pod}..."
     fqdn="$sentinel_pod.$SENTINEL_HEADLESS_SERVICE_NAME.$CLUSTER_NAMESPACE.svc.cluster.local"
     # shellcheck disable=SC2086
     if [ -n "${SENTINEL_PASSWORD}" ]; then
-      redis-cli $REDIS_CLI_TLS_CMD -h "$fqdn" -p "$sentinel_service_port" -a "${SENTINEL_PASSWORD}" sentinel reset "${REDIS_COMPONENT_NAME}"
+      redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port -a ${SENTINEL_PASSWORD} sentinel reset ${REDIS_COMPONENT_NAME}
     else
-      redis-cli $REDIS_CLI_TLS_CMD -h "$fqdn" -p "$sentinel_service_port" sentinel reset "${REDIS_COMPONENT_NAME}"
+      redis-cli $REDIS_CLI_TLS_CMD -h $fqdn -p $sentinel_service_port sentinel reset ${REDIS_COMPONENT_NAME}
     fi
     if [ $? -eq 0 ]; then
-      echo "reset master in sentinel ${sentinel_pod} succeeded"
+      echo "reset master in sentinel ${pod} succeeded"
       exit 0
     fi
   done

--- a/addons/redis/scripts/sync-acl.sh
+++ b/addons/redis/scripts/sync-acl.sh
@@ -50,6 +50,7 @@ fetch_acl_list_from_peers() {
 }
 
 apply_acl_rules() {
+  set -e
   local acl_list="$1"
   local target_fqdn="$2"
   local redis_cmd="$3"

--- a/addons/redis/scripts/sync-acl.sh
+++ b/addons/redis/scripts/sync-acl.sh
@@ -1,52 +1,97 @@
 #!/bin/bash
 
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  set -e;
+}
+
 service_port=${SERVICE_PORT:-6379}
-redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $service_port -a $REDIS_DEFAULT_PASSWORD"
-if [ -z "$REDIS_DEFAULT_PASSWORD" ]; then
-   redis_base_cmd="redis-cli $REDIS_CLI_TLS_CMD -p $service_port"
-fi
 
-is_ok=false
-acl_list=""
-# 1. get acl list from other pods
-for pod_fqdn in $(echo "$REDIS_POD_FQDN_LIST" | tr ',' '\n'); do
-    if [[ "$pod_fqdn" == "$KB_JOIN_MEMBER_POD_FQDN" ]]; then
-        continue
+build_redis_base_cmd() {
+  local password="$1"
+  local tls_cmd="$2"
+  if [ -n "$password" ]; then
+    echo "redis-cli $tls_cmd -p $service_port -a $password"
+  else
+    echo "redis-cli $tls_cmd -p $service_port"
+  fi
+}
+
+fetch_acl_list_from_peers() {
+  local pod_fqdn_list="$1"
+  local self_fqdn="$2"
+  local redis_cmd="$3"
+
+  local is_ok=false
+  local acl_list=""
+  for pod_fqdn in $(echo "$pod_fqdn_list" | tr ',' '\n'); do
+    if [[ "$pod_fqdn" == "$self_fqdn" ]]; then
+      continue
     fi
-    acl_list=$($redis_base_cmd -h "$pod_fqdn" ACL LIST)
+    acl_list=$($redis_cmd -h "$pod_fqdn" ACL LIST)
     if [ $? -eq 0 ]; then
-        is_ok=true
-        break
+      is_ok=true
+      break
     fi
-done
+  done
 
-if [ "$is_ok" = false ]; then
+  if [ "$is_ok" = false ]; then
     echo "Failed to get ACL LIST from other pods" >&2
-    exit 1
-fi
+    return 1
+  fi
 
-if [ -z "$acl_list" ]; then
+  if [ -z "$acl_list" ]; then
     echo "No ACL rules found in other pods, skip synchronization" >&2
-    exit 0
-fi
+    return 0
+  fi
 
-set -e
-# 2. apply acl list to current pod
-while IFS= read -r user_rule; do
+  echo "$acl_list"
+}
+
+apply_acl_rules() {
+  local acl_list="$1"
+  local target_fqdn="$2"
+  local redis_cmd="$3"
+
+  while IFS= read -r user_rule; do
     [[ -z "$user_rule" ]] && continue
 
     if [[ "$user_rule" =~ ^user[[:space:]]+([^[:space:]]+) ]]; then
-        username="${BASH_REMATCH[1]}"
+      username="${BASH_REMATCH[1]}"
     else
-      # skip invalid user rule
       continue
     fi
 
     if [[ "$username" == "default" ]]; then
-        continue
+      continue
     fi
     rule_part="${user_rule#user $username }"
-    $redis_base_cmd -h $KB_JOIN_MEMBER_POD_FQDN ACL SETUSER "$username" $rule_part >&2
-done <<< "$acl_list"
+    $redis_cmd -h "$target_fqdn" ACL SETUSER "$username" $rule_part >&2
+  done <<< "$acl_list"
 
-$redis_base_cmd -h $KB_JOIN_MEMBER_POD_FQDN ACL save >&2
+  $redis_cmd -h "$target_fqdn" ACL save >&2
+}
+
+main() {
+  local redis_base_cmd
+  redis_base_cmd=$(build_redis_base_cmd "$REDIS_DEFAULT_PASSWORD" "$REDIS_CLI_TLS_CMD")
+
+  local acl_list
+  acl_list=$(fetch_acl_list_from_peers "$REDIS_POD_FQDN_LIST" "$KB_JOIN_MEMBER_POD_FQDN" "$redis_base_cmd")
+  local rc=$?
+  if [ $rc -ne 0 ]; then
+    exit 1
+  fi
+
+  if [ -z "$acl_list" ]; then
+    exit 0
+  fi
+
+  apply_acl_rules "$acl_list" "$KB_JOIN_MEMBER_POD_FQDN" "$redis_base_cmd"
+}
+
+# This is magic for shellspec ut framework.
+${__SOURCED__:+false} : || return 0
+
+main

--- a/addons/redis/scripts/sync-acl.sh
+++ b/addons/redis/scripts/sync-acl.sh
@@ -68,7 +68,9 @@ apply_acl_rules() {
       continue
     fi
     rule_part="${user_rule#user $username }"
-    $redis_cmd -h "$target_fqdn" ACL SETUSER "$username" $rule_part >&2
+    if ! $redis_cmd -h "$target_fqdn" ACL SETUSER "$username" $rule_part >&2; then
+      return 1
+    fi
   done <<< "$acl_list"
 
   $redis_cmd -h "$target_fqdn" ACL save >&2


### PR DESCRIPTION
## Summary

Companion to #2853 (test-only shellspec combined PR). This PR contains logic fixes that were split out per Leon's directive: test PRs should only add tests, logic changes go in a separate PR.

### Changes

1. **reset-master.sh** - fix undefined variable ${pod} to ${sentinel_pod} in echo statements. The for loop variable is sentinel_pod, not pod; the original code referenced an undefined variable in log messages.

2. **sync-acl.sh** - replace bare ACL SETUSER call with explicit rc check. set -e is unreliable inside while loop bodies with heredoc redirection, so an explicit check is more robust.

### Not included (handled by other PRs)

- redis-account-provision.sh / redis-sentinel-account-provision.sh: PR #2808 already provides more thorough error handling (explicit rc checks + ERR output detection).

## Dependencies

- Depends on #2853 merging first (this branch is based on aria/redis-shellspec-combined).

## Test plan

- [ ] Existing shellspec tests in #2853 cover both scripts; the sync-acl spec already tests ACL SETUSER failure propagation
- [ ] CI green
