### PR TITLE
chore(mongodb): read PBM path style from datasafed config

### DIFF
--- a/addons/mongodb/dataprotection/common-scripts.sh
+++ b/addons/mongodb/dataprotection/common-scripts.sh
@@ -62,8 +62,24 @@ function getToolConfigValue() {
   cat "$toolConfig" | grep "$var" | awk '{print $NF}'
 }
 
+function normalizeBoolValue() {
+  local value
+  value=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+  case "$value" in
+    true | 1 | yes | y | on)
+      echo "true"
+      ;;
+    false | 0 | no | n | off)
+      echo "false"
+      ;;
+    *)
+      echo "$value"
+      ;;
+  esac
+}
+
 function set_backup_config_env() {
-  toolConfig=/etc/datasafed/datasafed.conf
+  toolConfig=${DATASAFED_CONFIG_FILE:-/etc/datasafed/datasafed.conf}
   if [ ! -f ${toolConfig} ]; then
     DP_error_log "Config file not found: ${toolConfig}"
     exit 1
@@ -75,6 +91,7 @@ function set_backup_config_env() {
   local region=""
   local endpoint=""
   local bucket=""
+  local force_path_style=""
 
   IFS=$'\n'
   for line in $(cat ${toolConfig}); do
@@ -91,6 +108,8 @@ function set_backup_config_env() {
       bucket=$(getToolConfigValue "$line")
     elif [[ $line == "provider"* ]]; then
       provider=$(getToolConfigValue "$line")
+    elif [[ $line == "force_path_style"* ]]; then
+      force_path_style=$(getToolConfigValue "$line")
     fi
   done
 
@@ -118,6 +137,9 @@ function set_backup_config_env() {
     export S3_FORCE_PATH_STYLE="true"
   else
     echo "Unsupported provider: $provider"
+  fi
+  if [ -n "$force_path_style" ]; then
+    export S3_FORCE_PATH_STYLE="$(normalizeBoolValue "$force_path_style")"
   fi
   backup_path=$(dirname "$DP_BACKUP_BASE_PATH")
 

--- a/addons/mongodb/dataprotection/common-scripts.sh
+++ b/addons/mongodb/dataprotection/common-scripts.sh
@@ -205,11 +205,13 @@ function sync_pbm_storage_config() {
     current_region=$(echo "$check_config" | jq -r '.storage.s3.region')
     current_bucket=$(echo "$check_config" | jq -r '.storage.s3.bucket')
     current_prefix=$(echo "$check_config" | jq -r '.storage.s3.prefix')
+    current_force_path_style=$(echo "$check_config" | jq -r '.storage.s3.forcePathStyle')
     echo "INFO: Current PBM storage endpoint: $current_endpoint"
     echo "INFO: Current PBM storage region: $current_region"
     echo "INFO: Current PBM storage bucket: $current_bucket"
     echo "INFO: Current PBM storage prefix: $current_prefix"
-    if [ "$current_prefix" = "$S3_PREFIX" ] && [ "$current_region" = "$S3_REGION" ] && [ "$current_bucket" = "$S3_BUCKET" ] && [ "$current_endpoint" = "$S3_ENDPOINT" ]; then
+    echo "INFO: Current PBM storage forcePathStyle: $current_force_path_style"
+    if [ "$current_prefix" = "$S3_PREFIX" ] && [ "$current_region" = "$S3_REGION" ] && [ "$current_bucket" = "$S3_BUCKET" ] && [ "$current_endpoint" = "$S3_ENDPOINT" ] && [ "$current_force_path_style" = "${S3_FORCE_PATH_STYLE:-false}" ]; then
       echo "INFO: PBM storage config already exists."
     else
       pbm_config_exists=false

--- a/addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh
@@ -1,0 +1,66 @@
+# shellcheck shell=bash
+
+Describe "MongoDB dataprotection common scripts"
+  setup_config_env() {
+    export DATASAFED_CONFIG_FILE="./datasafed-test.conf"
+    export DP_BACKUP_BASE_PATH="/mongodb-test/backup-name"
+    export PBM_BACKUP_DIR_NAME="pbm"
+    unset S3_FORCE_PATH_STYLE
+  }
+  Before "setup_config_env"
+
+  cleanup_config_env() {
+    rm -f "$DATASAFED_CONFIG_FILE"
+    unset DATASAFED_CONFIG_FILE
+    unset DP_BACKUP_BASE_PATH
+    unset PBM_BACKUP_DIR_NAME
+    unset S3_FORCE_PATH_STYLE
+  }
+  After "cleanup_config_env"
+
+  run_set_backup_config_env() {
+    source ../dataprotection/common-scripts.sh
+    set_backup_config_env >/dev/null
+    echo "force_path_style=${S3_FORCE_PATH_STYLE:-}"
+  }
+
+  write_datasafed_config() {
+    cat > "$DATASAFED_CONFIG_FILE" <<EOF
+type = s3
+provider = $1
+access_key_id = access-key
+secret_access_key = secret-key
+region = us-east-1
+endpoint = http://minio.example.com
+root = mongodb-bucket
+$2
+EOF
+  }
+
+  It "uses explicit force_path_style=false from datasafed config"
+    write_datasafed_config "Minio" "force_path_style = false"
+
+    When call run_set_backup_config_env
+
+    The output should include "force_path_style=false"
+    The status should be success
+  End
+
+  It "uses explicit force_path_style=true from datasafed config"
+    write_datasafed_config "Alibaba" "force_path_style = true"
+
+    When call run_set_backup_config_env
+
+    The output should include "force_path_style=true"
+    The status should be success
+  End
+
+  It "keeps Minio provider fallback when force_path_style is absent"
+    write_datasafed_config "Minio" ""
+
+    When call run_set_backup_config_env
+
+    The output should include "force_path_style=true"
+    The status should be success
+  End
+End

--- a/addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh
@@ -2,7 +2,8 @@
 
 Describe "MongoDB dataprotection common scripts"
   setup_config_env() {
-    export DATASAFED_CONFIG_FILE="./datasafed-test.conf"
+    export DATASAFED_CONFIG_FILE="./datasafed-test-${$}.conf"
+    export PBM_CONFIG_FILE="./pbm-config-${$}.yaml"
     export DP_BACKUP_BASE_PATH="/mongodb-test/backup-name"
     export PBM_BACKUP_DIR_NAME="pbm"
     unset S3_FORCE_PATH_STYLE
@@ -11,10 +12,19 @@ Describe "MongoDB dataprotection common scripts"
 
   cleanup_config_env() {
     rm -f "$DATASAFED_CONFIG_FILE"
+    rm -f "$PBM_CONFIG_FILE"
     unset DATASAFED_CONFIG_FILE
+    unset PBM_CONFIG_FILE
     unset DP_BACKUP_BASE_PATH
     unset PBM_BACKUP_DIR_NAME
     unset S3_FORCE_PATH_STYLE
+    unset PBM_MONGODB_URI
+    unset S3_REGION
+    unset S3_ENDPOINT
+    unset S3_BUCKET
+    unset S3_PREFIX
+    unset S3_ACCESS_KEY
+    unset S3_SECRET_KEY
   }
   After "cleanup_config_env"
 
@@ -61,6 +71,39 @@ EOF
     When call run_set_backup_config_env
 
     The output should include "force_path_style=true"
+    The status should be success
+  End
+
+  run_sync_pbm_storage_config_with_stale_force_path_style() {
+    source ../dataprotection/common-scripts.sh
+    export PBM_MONGODB_URI="mongodb://mongodb.example/admin"
+    export S3_REGION="us-east-1"
+    export S3_ENDPOINT="http://minio.example.com"
+    export S3_BUCKET="mongodb-bucket"
+    export S3_PREFIX="mongodb-test/pbm"
+    export S3_ACCESS_KEY="access-key"
+    export S3_SECRET_KEY="secret-key"
+    export S3_FORCE_PATH_STYLE="true"
+
+    pbm() {
+      if [[ "$*" == *"-o json"* ]]; then
+        cat <<'EOF'
+{"storage":{"s3":{"region":"us-east-1","endpointUrl":"http://minio.example.com","bucket":"mongodb-bucket","prefix":"mongodb-test/pbm","forcePathStyle":false}}}
+EOF
+      else
+        cat > "$PBM_CONFIG_FILE"
+      fi
+    }
+
+    sync_pbm_storage_config
+    cat "$PBM_CONFIG_FILE"
+  }
+
+  It "rewrites PBM storage config when only forcePathStyle changed"
+    When call run_sync_pbm_storage_config_with_stale_force_path_style
+
+    The output should include "INFO: Current PBM storage forcePathStyle: false"
+    The output should include "forcePathStyle: true"
     The status should be success
   End
 End


### PR DESCRIPTION
## Summary

- Parse `force_path_style` from `/etc/datasafed/datasafed.conf` and use it for PBM `storage.s3.forcePathStyle`.
- Keep the existing Minio provider fallback when `force_path_style` is absent, so old datasafed configs keep current behavior.
- Add MongoDB shellspec coverage for explicit `force_path_style=true`, explicit `force_path_style=false`, and legacy Minio fallback.

## Why

MongoDB PBM backup config previously inferred S3 path-style behavior from `provider == Minio`. That is too rigid for S3-compatible providers because datasafed is rclone-based, and rclone exposes this as the `force_path_style` config option. Prefer the explicit datasafed/rclone config when it is present; fall back to provider inference only for backwards compatibility.

## Verification

- `bash -n addons/mongodb/dataprotection/common-scripts.sh addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh`
- `shellspec --load-path ./shellspec --shell bash addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh`
- `shellspec --load-path ./shellspec --shell bash addons/mongodb/scripts-ut-spec`
- `git diff --cached --check`

## Boundary

Offline script/unit coverage only. No Kubernetes backup runtime was launched from this PR branch.
