### PR TITLE
fix(postgresql): add rewind fallback config to DCS for KB 1.0

### DIFF
--- a/addons/postgresql/config/patroni-yaml.tpl
+++ b/addons/postgresql/config/patroni-yaml.tpl
@@ -4,3 +4,6 @@ retry_timeout: 10
 maximum_lag_on_failover: 1048576
 max_timelines_history: 0
 check_timeline: true
+postgresql:
+  remove_data_directory_on_rewind_failure: true
+  remove_data_directory_on_diverged_timelines: true


### PR DESCRIPTION
## Summary
- KB 1.0 `patroni-yaml.tpl` lacks `remove_data_directory_on_rewind_failure` and `remove_data_directory_on_diverged_timelines` entirely
- When pg_rewind fails after timeline divergence (e.g. after Restart/Switchover), Patroni cannot auto-reinitialize the data directory, leaving the replica stuck
- Port the same DCS config approach from PR #2848 (KB 1.1 `ce76b4f3`): add these two settings under `postgresql:` in `patroni-yaml.tpl` so they enter `bootstrap.dcs.postgresql` (Patroni dynamic configuration)
- KB 1.0 never had the `PATRONI_POSTGRESQL_*` env vars that KB 1.1 had, so only `patroni-yaml.tpl` needs the change (1 file, +3 lines)

## Test plan
- [ ] Deploy updated chart to `pg-kb10-release-vc` and read back generated ConfigMap to confirm `remove_data_directory_on_rewind_failure: true` and `remove_data_directory_on_diverged_timelines: true` are present in Patroni DCS config
- [ ] Run T08 Restart suite to verify replica recovers after timeline divergence
- [ ] KB 1.0 release-final 10-round acceptance (blocked until deploy + readback)