### PR TITLE
chore(redis): mock start marker in release-1.0 shellspec

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_start_spec.sh
@@ -83,6 +83,7 @@ Describe "Redis Start Bash Script Tests"
         build_replicaof_config() { :; }
         rebuild_redis_acl_file() { :; }
         build_redis_default_accounts() { :; }
+        mark_redis_start_initialized() { :; }
       }
       Before "setup"
 


### PR DESCRIPTION
## What

Fix release-1.0 Redis ShellSpec warning that made `shellspec-test` / `shellspec-test-pr` fail with exit 101.

## Root cause

`build_redis_conf()` on release-1.0 calls `mark_redis_start_initialized`, while the focused `redis_start_spec.sh` test already mocks the other helper functions called from `build_redis_conf()`. In CI, the unmocked helper tries to write `/data/.kb_redis_start_initialized`, emits unexpected stderr, and ShellSpec treats the warning as a failed suite.

## Fix

Mock `mark_redis_start_initialized()` only inside the existing `build_redis_conf()` test setup. Production Redis startup behavior is unchanged.

## Verification

- `shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_start_spec.sh` => 49 examples, 0 failures
- `make scripts-test` => 147 examples, 0 failures, 13 skips on macOS bash 3
- `shellspec --load-path ./shellspec --default-path "**/scripts-ut-spec" --shell /opt/homebrew/bin/bash` => 462 examples, 0 failures
- `git diff --check` => PASS
