### PR TITLE
fix(oceanbase-ce): read reconfigure params from kbagent env

### DIFF
--- a/addons/oceanbase-ce/reloader/update-parameters.sh
+++ b/addons/oceanbase-ce/reloader/update-parameters.sh
@@ -5,12 +5,19 @@ OB_CLI="/kb_tools/obtools"
 paramName="${1:?missing config}"
 paramValue="${2:?missing value}"
 
+case "$paramName" in
+  ""|"_"|KB_*|*[!abcdefghijklmnopqrstuvwxyz0123456789_]*)
+    echo "invalid oceanbase parameter name: $paramName" >&2
+    exit 1
+    ;;
+esac
+
 #The effective scope of the parameter modification. Valid values:
 #  * MEMORY: specifies to modify only parameters in the memory, and the modification takes effect immediately. The modification becomes invalid after the server is restarted. However, no parameter supports this mode.
 #  * SPFILE: specifies to modify only parameters in the configuration table. The modification takes effect after the server is restarted.
 #  * BOTH: specifies to modify parameters in both the configuration table and the memory. The modification takes effect immediately and remains effective after the server is restarted.
-obcli_cmd='$OB_CLI --host 127.0.0.1 -uroot -P ${OB_SERVICE_PORT} param-update --set "${paramName}=${paramValue}" --scope BOTH'
-if [ -n "${OB_ROOT_PASSWD}" ]; then
-  obcli_cmd="$obcli_cmd -p '${OB_ROOT_PASSWD}'"
+if [ -n "${OB_ROOT_PASSWD:-}" ]; then
+  "$OB_CLI" --host 127.0.0.1 -uroot -P "${OB_SERVICE_PORT}" param-update --set "${paramName}=${paramValue}" --scope BOTH -p "${OB_ROOT_PASSWD}"
+else
+  "$OB_CLI" --host 127.0.0.1 -uroot -P "${OB_SERVICE_PORT}" param-update --set "${paramName}=${paramValue}" --scope BOTH
 fi
-eval $obcli_cmd

--- a/addons/oceanbase-ce/reloader/update-sysvars.sh
+++ b/addons/oceanbase-ce/reloader/update-sysvars.sh
@@ -5,5 +5,17 @@ OB_CLI="/kb_tools/obtools"
 paramName="${1:?missing config}"
 paramValue="${2:?missing value}"
 
-$OB_CLI --host 127.0.0.1 -uroot -P ${OB_SERVICE_PORT} var-update --set ${paramName}=\'${paramValue}\' -p ${OB_ROOT_PASSWD} ||
-$OB_CLI --host 127.0.0.1 -uroot -P ${OB_SERVICE_PORT} var-update --set ${paramName}=${paramValue} -p ${OB_ROOT_PASSWD}
+case "$paramName" in
+  ""|"_"|KB_*|*[!abcdefghijklmnopqrstuvwxyz0123456789_]*)
+    echo "invalid oceanbase sysvar name: $paramName" >&2
+    exit 1
+    ;;
+esac
+
+if [ -n "${OB_ROOT_PASSWD:-}" ]; then
+  "$OB_CLI" --host 127.0.0.1 -uroot -P "${OB_SERVICE_PORT}" var-update --set "${paramName}='${paramValue}'" -p "${OB_ROOT_PASSWD}" ||
+  "$OB_CLI" --host 127.0.0.1 -uroot -P "${OB_SERVICE_PORT}" var-update --set "${paramName}=${paramValue}" -p "${OB_ROOT_PASSWD}"
+else
+  "$OB_CLI" --host 127.0.0.1 -uroot -P "${OB_SERVICE_PORT}" var-update --set "${paramName}='${paramValue}'" ||
+  "$OB_CLI" --host 127.0.0.1 -uroot -P "${OB_SERVICE_PORT}" var-update --set "${paramName}=${paramValue}"
+fi

--- a/addons/oceanbase-ce/templates/_helpers.tpl
+++ b/addons/oceanbase-ce/templates/_helpers.tpl
@@ -95,8 +95,31 @@ reconfigure:
       - |
         set -eu
 
-        /scripts/{{ .script }} "$1" "$2"
-      - --
+        env_file="/tmp/oceanbase-reconfigure-env.$$"
+        trap 'rm -f "$env_file"' EXIT
+        tr '\0' '\n' < /proc/self/environ > "$env_file"
+
+        rc=0
+        matched=0
+        while IFS= read -r line; do
+          paramName="${line%%=*}"
+          paramValue="${line#*=}"
+          [ "$paramName" != "$line" ] || continue
+          case "$paramName" in
+            ""|"_"|KB_*|*[!abcdefghijklmnopqrstuvwxyz0123456789_]*)
+              continue
+              ;;
+          esac
+
+          matched=$((matched + 1))
+          /scripts/{{ .script }} "$paramName" "$paramValue" || rc=$?
+        done < "$env_file"
+
+        if [ "$matched" -eq 0 ]; then
+          echo "no reconfigure parameters found in kbagent environment" >&2
+          exit 1
+        fi
+        exit "$rc"
 {{- end -}}
 
 


### PR DESCRIPTION
## Problem
OBCE N7 reached OpsRequest Reconfiguring, then the reconfigure action stayed Running. Evidence from Eve's frozen N7 window:

- OpsRequest: `obce-ops-2322-reconfig-160204`, Type=Reconfiguring, phase=Running, progress `-/-`
- KB controller log: `udf-reconfigure-cmpd-oceanbase-config` failed with `line 2: 1: parameter not set`
- Current action called `/scripts/update-parameters.sh "$1" "$2"`, but kbagent did not pass positional args.

## Fix
- Read raw kbagent environment entries from `/proc/self/environ` in the reconfigure action wrapper.
- Filter OB parameter/sysvar names and call the existing per-parameter scripts with explicit argv.
- Keep failure propagation across all changed parameters.
- Remove `eval` from parameter application and make root password handling nounset-safe.

## Validation
- `sh -n addons/oceanbase-ce/reloader/update-parameters.sh addons/oceanbase-ce/reloader/update-sysvars.sh`
- `bash -n oceanbase-ce/tests/static.sh`
- `ADDONS_REPO=$PWD/worktrees/kubeblocks-addons-2723 bash worktrees/kubeblocks-tests-oceanbase-ce/oceanbase-ce/tests/static.sh` -> `PASS=88 FAIL=0 SKIP=0`
- `git diff --check`

## Runtime boundary
No local Kubernetes runtime was used. This PR is ready for Eve's N8 validation against the preserved OBCE idc3 lane.
