### PR TITLE
chore(postgresql): increase roleProbe timeout to prevent false Updating

### DIFF
--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -228,8 +228,8 @@ spec:
     keyFile: key.pem
   lifecycleActions:
     roleProbe:
-      periodSeconds: 1
-      timeoutSeconds: 1
+      periodSeconds: 5
+      timeoutSeconds: 5
       http:
         port: "5001"
         path: "/v1.0/getrole"


### PR DESCRIPTION
## Summary

- Increase roleProbe.periodSeconds and roleProbe.timeoutSeconds from 1 to 5 in PostgreSQL ComponentDefinition
- Root cause: after Stop-Start, the secondary Patroni REST API (port 8008) takes up to 49 seconds to stabilize. With 1s timeout, kbagent probe timedOut continuously, causing controller to revert cluster phase from Running to Updating, blocking subsequent OpsRequests

## Evidence

- KB 1.0 release-final R2 PG14 T08 Restart FAIL (FAIL_ADDON_ROLEPROBE_TIMEOUT)
- Confirmed by focused rerun fr1 with identical failure mode
- Controller log timeline: cluster Running at 04:05:14, pod-1 timedOut continuously, phase reverted to Updating at 04:06:03 (49s later)
- Only secondary (pod-1) affected; primary (pod-0) probes normal after Start

## Boundary

- Patroni own loop_wait=10, ttl=30 -- roleProbe 5s period/timeout is well within these
- Steady-state role detection: 5s vs 1s negligible for database HA (Patroni TTL is 30s)

## Test plan

- [ ] Focused rerun: PG14 T08 Stop-Start-Restart sequence with new chart
- [ ] Full release-final round with updated addon chart