### PR TITLE
fix(redis): fail closed on stale reconfigure projection

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -323,6 +323,8 @@ Describe "Redis Reconfigure Config Script Tests"
       freshness_check=false
       projection_fresh_age_seconds=10
       projection_wait_seconds=0
+      applied_marker_file=""
+      applied_marker_max_age_seconds=600
       tmp_config=$(mktemp)
       config_file="$tmp_config"
     }
@@ -362,6 +364,7 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
+        applied_marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
@@ -421,6 +424,7 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
+        applied_marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
@@ -466,10 +470,11 @@ Describe "Redis Reconfigure Config Script Tests"
         The variable set_called_with should equal "maxmemory-policy=allkeys-lru;"
         The stderr should include "INFO: applied 1 parameter"
         The stderr should not include "ERROR: projected config did not refresh"
+        The path "$tmp_dir/marker" should be file
       End
     End
 
-    Context "old stable already-applied file has stale marker"
+    Context "old stable already-applied file has an expired marker"
       set_called_with=""
       tmp_dir=""
       mock_now=100
@@ -480,14 +485,17 @@ Describe "Redis Reconfigure Config Script Tests"
         freshness_check=true
         dynamic_allowlist="maxmemory-policy"
         projection_wait_seconds=0
+        applied_marker_max_age_seconds=10
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
+        applied_marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
         printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
-        config_fingerprint "$tmp_config" > "$tmp_dir/marker"
+        current_projection_token > "$applied_marker_file"
+        printf '%s\n' 0 >> "$applied_marker_file"
       }
       Before "setup"
 
@@ -520,12 +528,75 @@ Describe "Redis Reconfigure Config Script Tests"
         return 0
       }
 
-      It "does not trust a previous marker as current request target proof"
+      It "does not trust an expired previous marker as current request target proof"
         When call reconfigure_from_config_file
         The status should be failure
         The variable set_called_with should equal ""
         The stderr should include "ERROR: projected config did not refresh"
         The stderr should not include "INFO: applied 0 parameter"
+      End
+    End
+
+    Context "controller retry after successful apply"
+      set_called_with=""
+      tmp_dir=""
+      mock_now=100
+      mock_mtime=0
+
+      setup() {
+        setup_base
+        freshness_check=true
+        dynamic_allowlist="maxmemory-policy"
+        projection_wait_seconds=0
+        tmp_dir=$(mktemp -d)
+        tmp_config="$tmp_dir/redis.conf"
+        config_file="$tmp_config"
+        applied_marker_file="$tmp_dir/marker"
+        ln -s "..2026_06_21_04_39_50.3648217067" "$tmp_dir/..data"
+
+        set_called_with=""
+        printf '%s\n' "maxmemory-policy allkeys-lru" > "$tmp_config"
+        current_projection_token > "$applied_marker_file"
+        printf '%s\n' 95 >> "$applied_marker_file"
+      }
+      Before "setup"
+
+      cleanup() {
+        cleanup_base
+        [ -z "$tmp_dir" ] || rm -rf "$tmp_dir"
+      }
+      After "cleanup"
+
+      now_seconds() {
+        echo "$mock_now"
+      }
+
+      file_mtime() {
+        echo "$mock_mtime"
+      }
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory-policy" "allkeys-lru"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "accepts one same-fingerprint retry after a verified apply"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable set_called_with should equal ""
+        The stderr should include "INFO: mounted config already applied by previous action invocation"
+        The stderr should include "INFO: applied 0 parameter"
+        The path "$tmp_dir/marker" should not be exist
       End
     End
 

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -250,6 +250,7 @@ Describe "Redis Reconfigure Config Script Tests"
         When call ensure_projected_config_fresh
         The status should be success
         The variable sleep_called should equal 0
+        The stderr should include "INFO: projected config is fresh"
       End
     End
 
@@ -356,10 +357,12 @@ Describe "Redis Reconfigure Config Script Tests"
       setup() {
         setup_base
         freshness_check=true
+        dynamic_allowlist="maxmemory-policy"
         projection_wait_seconds=0
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
+        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
@@ -405,7 +408,7 @@ Describe "Redis Reconfigure Config Script Tests"
       End
     End
 
-    Context "stale projected file different from engine"
+    Context "old stable target file different from engine"
       set_called_with=""
       tmp_dir=""
       mock_now=100
@@ -414,14 +417,16 @@ Describe "Redis Reconfigure Config Script Tests"
       setup() {
         setup_base
         freshness_check=true
+        dynamic_allowlist="maxmemory-policy"
         projection_wait_seconds=0
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
+        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
-        printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
+        printf '%s\n' "maxmemory-policy allkeys-lru" > "$tmp_config"
       }
       Before "setup"
 
@@ -444,6 +449,9 @@ Describe "Redis Reconfigure Config Script Tests"
         key=$(_redis_cli_get_key "$@")
         case "$key" in
           "'*'"|"*")
+            printf '%s\n' "maxmemory-policy" "volatile-lru"
+            ;;
+          maxmemory-policy)
             printf '%s\n' "maxmemory-policy" "allkeys-lru"
             ;;
         esac
@@ -454,11 +462,74 @@ Describe "Redis Reconfigure Config Script Tests"
         return 0
       }
 
-      It "still exits non-zero before CONFIG SET"
+      It "applies without waiting for freshness because mounted target differs from engine"
         When call reconfigure_from_config_file
-        The status should be failure
+        The status should be success
+        The variable set_called_with should equal "maxmemory-policy=allkeys-lru;"
+        The stderr should include "INFO: applied 1 parameter"
+        The stderr should not include "ERROR: projected config did not refresh"
+      End
+    End
+
+    Context "old stable already-applied file has marker"
+      set_called_with=""
+      tmp_dir=""
+      mock_now=100
+      mock_mtime=0
+
+      setup() {
+        setup_base
+        freshness_check=true
+        dynamic_allowlist="maxmemory-policy"
+        projection_wait_seconds=0
+        tmp_dir=$(mktemp -d)
+        tmp_config="$tmp_dir/redis.conf"
+        config_file="$tmp_config"
+        marker_file="$tmp_dir/marker"
+        ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
+
+        set_called_with=""
+        printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
+        config_fingerprint "$tmp_config" > "$marker_file"
+      }
+      Before "setup"
+
+      cleanup() {
+        cleanup_base
+        [ -z "$tmp_dir" ] || rm -rf "$tmp_dir"
+      }
+      After "cleanup"
+
+      now_seconds() {
+        echo "$mock_now"
+      }
+
+      file_mtime() {
+        echo "$mock_mtime"
+      }
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory-policy" "volatile-lru"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "accepts the no-op as converged without requiring a fresh ..data mtime"
+        When call reconfigure_from_config_file
+        The status should be success
         The variable set_called_with should equal ""
-        The stderr should include "ERROR: projected config did not refresh"
+        The stderr should include "INFO: projected config already applied according to marker"
+        The stderr should include "INFO: applied 0 parameter"
+        The stderr should not include "ERROR"
       End
     End
 
@@ -476,6 +547,7 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
+        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
         printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
         projection_wait_seconds=1

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -362,7 +362,6 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
-        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
@@ -422,7 +421,6 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
-        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
@@ -471,7 +469,7 @@ Describe "Redis Reconfigure Config Script Tests"
       End
     End
 
-    Context "old stable already-applied file has marker"
+    Context "old stable already-applied file has stale marker"
       set_called_with=""
       tmp_dir=""
       mock_now=100
@@ -485,12 +483,11 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
-        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
 
         set_called_with=""
         printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
-        config_fingerprint "$tmp_config" > "$marker_file"
+        config_fingerprint "$tmp_config" > "$tmp_dir/marker"
       }
       Before "setup"
 
@@ -523,13 +520,12 @@ Describe "Redis Reconfigure Config Script Tests"
         return 0
       }
 
-      It "accepts the no-op as converged without requiring a fresh ..data mtime"
+      It "does not trust a previous marker as current request target proof"
         When call reconfigure_from_config_file
-        The status should be success
+        The status should be failure
         The variable set_called_with should equal ""
-        The stderr should include "INFO: projected config already applied according to marker"
-        The stderr should include "INFO: applied 0 parameter"
-        The stderr should not include "ERROR"
+        The stderr should include "ERROR: projected config did not refresh"
+        The stderr should not include "INFO: applied 0 parameter"
       End
     End
 
@@ -547,7 +543,6 @@ Describe "Redis Reconfigure Config Script Tests"
         tmp_dir=$(mktemp -d)
         tmp_config="$tmp_dir/redis.conf"
         config_file="$tmp_config"
-        marker_file="$tmp_dir/marker"
         ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
         printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
         projection_wait_seconds=1

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -198,6 +198,120 @@ Describe "Redis Reconfigure Config Script Tests"
     End
   End
 
+  Describe "ensure_projected_config_fresh()"
+    tmp_config=""
+    tmp_dir=""
+    sleep_called=0
+    mock_now=100
+    mock_mtime=0
+
+    setup_base() {
+      tmp_dir=$(mktemp -d)
+      tmp_config="$tmp_dir/redis.conf"
+      config_file="$tmp_config"
+      ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
+      freshness_check=true
+      projection_fresh_age_seconds=10
+      projection_wait_seconds=0
+      sleep_called=0
+      mock_now=100
+      mock_mtime=0
+      printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
+    }
+
+    cleanup_base() {
+      [ -z "$tmp_dir" ] || rm -rf "$tmp_dir"
+    }
+
+    now_seconds() {
+      echo "$mock_now"
+    }
+
+    file_mtime() {
+      echo "$mock_mtime"
+    }
+
+    Context "when projected volume was refreshed recently"
+      setup() {
+        setup_base
+        mock_now=100
+        mock_mtime=95
+        projection_wait_seconds=3
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      sleep() {
+        sleep_called=$((sleep_called + 1))
+      }
+
+      It "returns success without waiting"
+        When call ensure_projected_config_fresh
+        The status should be success
+        The variable sleep_called should equal 0
+      End
+    End
+
+    Context "when projected volume does not refresh before timeout"
+      setup() {
+        setup_base
+        projection_wait_seconds=0
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      It "fails closed with retry-safe diagnostics"
+        When call ensure_projected_config_fresh
+        The status should be failure
+        The stderr should include "ERROR: projected config did not refresh"
+        The stderr should include "retry-safe: yes"
+      End
+    End
+
+    Context "when projected volume changes during bounded wait"
+      setup() {
+        setup_base
+        projection_wait_seconds=1
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      sleep() {
+        sleep_called=$((sleep_called + 1))
+        printf '%s\n' "maxmemory-policy allkeys-lru" > "$config_file"
+        ln -sfn "..2026_06_20_00_00_01.000000000" "$tmp_dir/..data"
+      }
+
+      It "proceeds after observing projected content movement"
+        When call ensure_projected_config_fresh
+        The status should be success
+        The variable sleep_called should equal 1
+        The stderr should include "INFO: projected config changed after 1s"
+      End
+    End
+
+    Context "when projected-volume marker does not exist"
+      setup() {
+        setup_base
+        rm -f "$tmp_dir/..data"
+        projection_wait_seconds=0
+      }
+      Before "setup"
+
+      After "cleanup_base"
+
+      It "fails closed instead of trusting a plain file"
+        When call ensure_projected_config_fresh
+        The status should be failure
+        The stderr should include "ERROR: projected config freshness check failed"
+        The stderr should include "retry-safe: yes"
+      End
+    End
+  End
+
   Describe "reconfigure_from_config_file()"
     tmp_config=""
 
@@ -205,6 +319,9 @@ Describe "Redis Reconfigure Config Script Tests"
       service_port=6379
       auth_arg=""
       dynamic_allowlist="maxmemory,hz,loglevel,hash-max-listpack-entries"
+      freshness_check=false
+      projection_fresh_age_seconds=10
+      projection_wait_seconds=0
       tmp_config=$(mktemp)
       config_file="$tmp_config"
     }
@@ -227,6 +344,191 @@ Describe "Redis Reconfigure Config Script Tests"
         When call reconfigure_from_config_file
         The status should be failure
         The stderr should include "ERROR: rendered config not found"
+      End
+    End
+
+    Context "stale projected file equal to engine"
+      set_called_with=""
+      tmp_dir=""
+      mock_now=100
+      mock_mtime=0
+
+      setup() {
+        setup_base
+        freshness_check=true
+        projection_wait_seconds=0
+        tmp_dir=$(mktemp -d)
+        tmp_config="$tmp_dir/redis.conf"
+        config_file="$tmp_config"
+        ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
+
+        set_called_with=""
+        printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
+      }
+      Before "setup"
+
+      cleanup() {
+        cleanup_base
+        [ -z "$tmp_dir" ] || rm -rf "$tmp_dir"
+      }
+      After "cleanup"
+
+      now_seconds() {
+        echo "$mock_now"
+      }
+
+      file_mtime() {
+        echo "$mock_mtime"
+      }
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory-policy" "volatile-lru"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "exits non-zero before CONFIG SET"
+        When call reconfigure_from_config_file
+        The status should be failure
+        The variable set_called_with should equal ""
+        The stderr should include "ERROR: projected config did not refresh"
+        The stderr should not include "INFO: applied 0 parameter"
+      End
+    End
+
+    Context "stale projected file different from engine"
+      set_called_with=""
+      tmp_dir=""
+      mock_now=100
+      mock_mtime=0
+
+      setup() {
+        setup_base
+        freshness_check=true
+        projection_wait_seconds=0
+        tmp_dir=$(mktemp -d)
+        tmp_config="$tmp_dir/redis.conf"
+        config_file="$tmp_config"
+        ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
+
+        set_called_with=""
+        printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
+      }
+      Before "setup"
+
+      cleanup() {
+        cleanup_base
+        [ -z "$tmp_dir" ] || rm -rf "$tmp_dir"
+      }
+      After "cleanup"
+
+      now_seconds() {
+        echo "$mock_now"
+      }
+
+      file_mtime() {
+        echo "$mock_mtime"
+      }
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory-policy" "allkeys-lru"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "still exits non-zero before CONFIG SET"
+        When call reconfigure_from_config_file
+        The status should be failure
+        The variable set_called_with should equal ""
+        The stderr should include "ERROR: projected config did not refresh"
+      End
+    End
+
+    Context "projected file changes during wait"
+      set_called_with=""
+      tmp_dir=""
+      sleep_called=0
+      mock_now=100
+      mock_mtime=0
+
+      setup() {
+        setup_base
+        freshness_check=true
+        dynamic_allowlist="maxmemory-policy"
+        tmp_dir=$(mktemp -d)
+        tmp_config="$tmp_dir/redis.conf"
+        config_file="$tmp_config"
+        ln -s "..2026_06_20_00_00_00.000000000" "$tmp_dir/..data"
+        printf '%s\n' "maxmemory-policy volatile-lru" > "$tmp_config"
+        projection_wait_seconds=1
+        set_called_with=""
+        sleep_called=0
+      }
+      Before "setup"
+
+      cleanup() {
+        cleanup_base
+        [ -z "$tmp_dir" ] || rm -rf "$tmp_dir"
+      }
+      After "cleanup"
+
+      now_seconds() {
+        echo "$mock_now"
+      }
+
+      file_mtime() {
+        echo "$mock_mtime"
+      }
+
+      sleep() {
+        sleep_called=$((sleep_called + 1))
+        printf '%s\n' "maxmemory-policy allkeys-lru" > "$config_file"
+        ln -sfn "..2026_06_20_00_00_01.000000000" "$tmp_dir/..data"
+      }
+
+      redis-cli() {
+        local key
+        key=$(_redis_cli_get_key "$@")
+        case "$key" in
+          "'*'"|"*")
+            printf '%s\n' "maxmemory-policy" "volatile-lru"
+            ;;
+          maxmemory-policy)
+            printf '%s\n' "maxmemory-policy" "allkeys-lru"
+            ;;
+        esac
+      }
+
+      reload_parameter() {
+        set_called_with="${set_called_with}${1}=${2};"
+        return 0
+      }
+
+      It "applies only after the target file is mounted"
+        When call reconfigure_from_config_file
+        The status should be success
+        The variable sleep_called should equal 1
+        The variable set_called_with should equal "maxmemory-policy=allkeys-lru;"
+        The stderr should include "INFO: projected config changed after 1s"
+        The stderr should include "INFO: applied 1 parameter"
       End
     End
 

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -4,6 +4,7 @@ init_reconfigure_env() {
   config_file="/etc/conf/redis.conf"
   dynamic_allowlist="${DYNAMIC_ALLOWLIST:-}"
   freshness_check="${REDIS_RECONFIGURE_FRESHNESS_CHECK:-true}"
+  marker_file="${REDIS_RECONFIGURE_MARKER_FILE:-/data/.redis-reconfigure-config.fingerprint}"
   projection_fresh_age_seconds="${REDIS_RECONFIGURE_PROJECTION_FRESH_AGE_SECONDS:-10}"
   projection_wait_seconds="${REDIS_RECONFIGURE_PROJECTION_WAIT_SECONDS:-15}"
   service_port=${SERVICE_PORT:-6379}
@@ -88,10 +89,27 @@ config_fingerprint() {
   cksum "$1" 2>/dev/null | awk '{print $1 ":" $2}'
 }
 
+marker_matches() {
+  [ -n "$1" ] || return 1
+  [ -f "$marker_file" ] || return 1
+  [ "$(cat "$marker_file" 2>/dev/null)" = "$1" ]
+}
+
+write_marker() {
+  [ -n "$1" ] || return 0
+  _wm_dir=$(dirname "$marker_file")
+  mkdir -p "$_wm_dir" 2>/dev/null || true
+  if ! printf '%s\n' "$1" > "$marker_file" 2>/dev/null; then
+    echo "WARN: failed to write reconfigure marker: $marker_file" >&2
+  fi
+}
+
 ensure_projected_config_fresh() {
   freshness_check="${freshness_check:-true}"
+  marker_file="${marker_file:-/data/.redis-reconfigure-config.fingerprint}"
   projection_fresh_age_seconds="${projection_fresh_age_seconds:-10}"
   projection_wait_seconds="${projection_wait_seconds:-15}"
+  projection_changed=false
 
   [ "$freshness_check" = "false" ] && return 0
 
@@ -113,6 +131,7 @@ ensure_projected_config_fresh() {
   if [ -n "$_epcf_mtime" ]; then
     _epcf_age=$((_epcf_now - _epcf_mtime))
     if [ "$_epcf_age" -le "$projection_fresh_age_seconds" ]; then
+      echo "INFO: projected config is fresh: dataLink='${_epcf_initial_link}', age='${_epcf_age}', mounted='${_epcf_current}'" >&2
       return 0
     fi
   else
@@ -126,6 +145,7 @@ ensure_projected_config_fresh() {
     _epcf_link=$(readlink_target "$_epcf_data_link")
     _epcf_after=$(config_fingerprint "$config_file") || _epcf_after=""
     if [ "$_epcf_link" != "$_epcf_initial_link" ] || [ "$_epcf_after" != "$_epcf_current" ]; then
+      projection_changed=true
       echo "INFO: projected config changed after ${_epcf_waited}s; proceeding with reconfigure" >&2
       return 0
     fi
@@ -143,6 +163,8 @@ apply_config_diff() {
 
   _acd_rc=0
   _rcf_applied_count=0
+  _rcf_checkable_count=0
+  _rcf_config_fingerprint=$(config_fingerprint "$config_file") || _rcf_config_fingerprint=""
   while IFS= read -r line; do
     case "$line" in '#'*|''|include\ *|loadmodule\ *) continue ;; esac
     key="${line%% *}"
@@ -153,6 +175,7 @@ apply_config_diff() {
     is_dynamic "$key" || continue
     engine_has_key "$key" || continue
 
+    _rcf_checkable_count=$((_rcf_checkable_count + 1))
     current=$(engine_value "$key")
     values_match "$value" "$current" && continue
 
@@ -160,6 +183,28 @@ apply_config_diff() {
     verify_engine_state "$key" "$value" || { _acd_rc=1; echo "ERROR: post-set verification for $key failed" >&2; }
     _rcf_applied_count=$((_rcf_applied_count + 1))
   done < "$config_file"
+
+  if [ "$_acd_rc" -ne 0 ]; then
+    echo "INFO: applied $_rcf_applied_count parameter(s)" >&2
+    return "$_acd_rc"
+  fi
+
+  if [ "$_rcf_applied_count" -gt 0 ]; then
+    [ "$freshness_check" = "false" ] || write_marker "$_rcf_config_fingerprint"
+  elif [ "$_rcf_checkable_count" -gt 0 ] && [ "$freshness_check" != "false" ]; then
+    projection_changed=false
+    if marker_matches "$_rcf_config_fingerprint"; then
+      echo "INFO: projected config already applied according to marker: $_rcf_config_fingerprint" >&2
+    elif ensure_projected_config_fresh; then
+      if [ "$projection_changed" = "true" ]; then
+        apply_config_diff
+        return $?
+      fi
+      write_marker "$_rcf_config_fingerprint"
+    else
+      return 1
+    fi
+  fi
 
   echo "INFO: applied $_rcf_applied_count parameter(s)" >&2
   return "$_acd_rc"
@@ -171,7 +216,6 @@ reconfigure_from_config_file() {
     return 1
   fi
 
-  ensure_projected_config_fresh || return 1
   apply_config_diff
 }
 

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -4,7 +4,6 @@ init_reconfigure_env() {
   config_file="/etc/conf/redis.conf"
   dynamic_allowlist="${DYNAMIC_ALLOWLIST:-}"
   freshness_check="${REDIS_RECONFIGURE_FRESHNESS_CHECK:-true}"
-  marker_file="${REDIS_RECONFIGURE_MARKER_FILE:-/data/.redis-reconfigure-config.fingerprint}"
   projection_fresh_age_seconds="${REDIS_RECONFIGURE_PROJECTION_FRESH_AGE_SECONDS:-10}"
   projection_wait_seconds="${REDIS_RECONFIGURE_PROJECTION_WAIT_SECONDS:-15}"
   service_port=${SERVICE_PORT:-6379}
@@ -89,24 +88,8 @@ config_fingerprint() {
   cksum "$1" 2>/dev/null | awk '{print $1 ":" $2}'
 }
 
-marker_matches() {
-  [ -n "$1" ] || return 1
-  [ -f "$marker_file" ] || return 1
-  [ "$(cat "$marker_file" 2>/dev/null)" = "$1" ]
-}
-
-write_marker() {
-  [ -n "$1" ] || return 0
-  _wm_dir=$(dirname "$marker_file")
-  mkdir -p "$_wm_dir" 2>/dev/null || true
-  if ! printf '%s\n' "$1" > "$marker_file" 2>/dev/null; then
-    echo "WARN: failed to write reconfigure marker: $marker_file" >&2
-  fi
-}
-
 ensure_projected_config_fresh() {
   freshness_check="${freshness_check:-true}"
-  marker_file="${marker_file:-/data/.redis-reconfigure-config.fingerprint}"
   projection_fresh_age_seconds="${projection_fresh_age_seconds:-10}"
   projection_wait_seconds="${projection_wait_seconds:-15}"
   projection_changed=false
@@ -164,7 +147,6 @@ apply_config_diff() {
   _acd_rc=0
   _rcf_applied_count=0
   _rcf_checkable_count=0
-  _rcf_config_fingerprint=$(config_fingerprint "$config_file") || _rcf_config_fingerprint=""
   while IFS= read -r line; do
     case "$line" in '#'*|''|include\ *|loadmodule\ *) continue ;; esac
     key="${line%% *}"
@@ -189,18 +171,13 @@ apply_config_diff() {
     return "$_acd_rc"
   fi
 
-  if [ "$_rcf_applied_count" -gt 0 ]; then
-    [ "$freshness_check" = "false" ] || write_marker "$_rcf_config_fingerprint"
-  elif [ "$_rcf_checkable_count" -gt 0 ] && [ "$freshness_check" != "false" ]; then
+  if [ "$_rcf_applied_count" -eq 0 ] && [ "$_rcf_checkable_count" -gt 0 ] && [ "$freshness_check" != "false" ]; then
     projection_changed=false
-    if marker_matches "$_rcf_config_fingerprint"; then
-      echo "INFO: projected config already applied according to marker: $_rcf_config_fingerprint" >&2
-    elif ensure_projected_config_fresh; then
+    if ensure_projected_config_fresh; then
       if [ "$projection_changed" = "true" ]; then
         apply_config_diff
         return $?
       fi
-      write_marker "$_rcf_config_fingerprint"
     else
       return 1
     fi

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -3,6 +3,9 @@
 init_reconfigure_env() {
   config_file="/etc/conf/redis.conf"
   dynamic_allowlist="${DYNAMIC_ALLOWLIST:-}"
+  freshness_check="${REDIS_RECONFIGURE_FRESHNESS_CHECK:-true}"
+  projection_fresh_age_seconds="${REDIS_RECONFIGURE_PROJECTION_FRESH_AGE_SECONDS:-10}"
+  projection_wait_seconds="${REDIS_RECONFIGURE_PROJECTION_WAIT_SECONDS:-15}"
   service_port=${SERVICE_PORT:-6379}
   auth_arg=""
   [ -z "${REDIS_DEFAULT_PASSWORD:-}" ] || auth_arg="-a ${REDIS_DEFAULT_PASSWORD}"
@@ -69,6 +72,69 @@ reload_parameter() {
   /scripts/reload-parameter.sh "$@"
 }
 
+now_seconds() {
+  date +%s
+}
+
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
+}
+
+readlink_target() {
+  readlink "$1" 2>/dev/null
+}
+
+config_fingerprint() {
+  cksum "$1" 2>/dev/null | awk '{print $1 ":" $2}'
+}
+
+ensure_projected_config_fresh() {
+  freshness_check="${freshness_check:-true}"
+  projection_fresh_age_seconds="${projection_fresh_age_seconds:-10}"
+  projection_wait_seconds="${projection_wait_seconds:-15}"
+
+  [ "$freshness_check" = "false" ] && return 0
+
+  _epcf_current=$(config_fingerprint "$config_file") || {
+    echo "ERROR: cannot fingerprint rendered config: $config_file" >&2
+    return 1
+  }
+
+  _epcf_config_dir=$(dirname "$config_file")
+  _epcf_data_link="${_epcf_config_dir}/..data"
+  if [ ! -L "$_epcf_data_link" ]; then
+    echo "ERROR: projected config freshness check failed: $_epcf_data_link is not a symlink, mounted='$_epcf_current', retry-safe: yes" >&2
+    return 1
+  fi
+
+  _epcf_initial_link=$(readlink_target "$_epcf_data_link")
+  _epcf_mtime=$(file_mtime "$_epcf_data_link") || _epcf_mtime=""
+  _epcf_now=$(now_seconds)
+  if [ -n "$_epcf_mtime" ]; then
+    _epcf_age=$((_epcf_now - _epcf_mtime))
+    if [ "$_epcf_age" -le "$projection_fresh_age_seconds" ]; then
+      return 0
+    fi
+  else
+    _epcf_age="unknown"
+  fi
+
+  _epcf_waited=0
+  while [ "$_epcf_waited" -lt "$projection_wait_seconds" ]; do
+    sleep 1
+    _epcf_waited=$((_epcf_waited + 1))
+    _epcf_link=$(readlink_target "$_epcf_data_link")
+    _epcf_after=$(config_fingerprint "$config_file") || _epcf_after=""
+    if [ "$_epcf_link" != "$_epcf_initial_link" ] || [ "$_epcf_after" != "$_epcf_current" ]; then
+      echo "INFO: projected config changed after ${_epcf_waited}s; proceeding with reconfigure" >&2
+      return 0
+    fi
+  done
+
+  echo "ERROR: projected config did not refresh after ${projection_wait_seconds}s: dataLink='${_epcf_initial_link}', age='${_epcf_age}', mounted='${_epcf_current}', retry-safe: yes" >&2
+  return 1
+}
+
 apply_config_diff() {
   engine_dump=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET '*' 2>/dev/null) || {
     echo "ERROR: redis-cli CONFIG GET * failed" >&2
@@ -105,6 +171,7 @@ reconfigure_from_config_file() {
     return 1
   fi
 
+  ensure_projected_config_fresh || return 1
   apply_config_diff
 }
 

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -6,6 +6,8 @@ init_reconfigure_env() {
   freshness_check="${REDIS_RECONFIGURE_FRESHNESS_CHECK:-true}"
   projection_fresh_age_seconds="${REDIS_RECONFIGURE_PROJECTION_FRESH_AGE_SECONDS:-10}"
   projection_wait_seconds="${REDIS_RECONFIGURE_PROJECTION_WAIT_SECONDS:-15}"
+  applied_marker_file="${REDIS_RECONFIGURE_APPLIED_MARKER_FILE:-/tmp/.kb_redis_reconfigure_applied_fingerprint}"
+  applied_marker_max_age_seconds="${REDIS_RECONFIGURE_APPLIED_MARKER_MAX_AGE_SECONDS:-120}"
   service_port=${SERVICE_PORT:-6379}
   auth_arg=""
   [ -z "${REDIS_DEFAULT_PASSWORD:-}" ] || auth_arg="-a ${REDIS_DEFAULT_PASSWORD}"
@@ -86,6 +88,54 @@ readlink_target() {
 
 config_fingerprint() {
   cksum "$1" 2>/dev/null | awk '{print $1 ":" $2}'
+}
+
+current_projection_token() {
+  _cpt_fingerprint=$(config_fingerprint "$config_file") || return 1
+  _cpt_config_dir=$(dirname "$config_file")
+  _cpt_data_link="${_cpt_config_dir}/..data"
+  _cpt_target=$(readlink_target "$_cpt_data_link") || _cpt_target=""
+  printf '%s|%s\n' "$_cpt_fingerprint" "$_cpt_target"
+}
+
+record_applied_marker() {
+  [ -n "${applied_marker_file:-}" ] || return 0
+
+  _ram_token=$(current_projection_token) || return 0
+  _ram_dir=$(dirname "$applied_marker_file")
+  mkdir -p "$_ram_dir" 2>/dev/null || return 0
+  _ram_tmp="${applied_marker_file}.$$"
+  {
+    printf '%s\n' "$_ram_token"
+    now_seconds
+  } > "$_ram_tmp" 2>/dev/null && mv "$_ram_tmp" "$applied_marker_file" 2>/dev/null || {
+    rm -f "$_ram_tmp" 2>/dev/null || true
+    return 0
+  }
+}
+
+consume_applied_marker() {
+  [ -n "${applied_marker_file:-}" ] || return 1
+  [ -f "$applied_marker_file" ] || return 1
+
+  _cam_expected=$(current_projection_token) || return 1
+  _cam_token=$(sed -n '1p' "$applied_marker_file" 2>/dev/null)
+  _cam_written_at=$(sed -n '2p' "$applied_marker_file" 2>/dev/null)
+  [ "$_cam_token" = "$_cam_expected" ] || return 1
+
+  case "$_cam_written_at" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  _cam_now=$(now_seconds)
+  _cam_age=$((_cam_now - _cam_written_at))
+  if [ "$_cam_age" -gt "${applied_marker_max_age_seconds:-600}" ]; then
+    return 1
+  fi
+
+  rm -f "$applied_marker_file" 2>/dev/null || true
+  echo "INFO: mounted config already applied by previous action invocation: token='${_cam_expected}', markerAge='${_cam_age}'" >&2
+  return 0
 }
 
 ensure_projected_config_fresh() {
@@ -171,7 +221,16 @@ apply_config_diff() {
     return "$_acd_rc"
   fi
 
+  if [ "$_rcf_applied_count" -gt 0 ]; then
+    record_applied_marker
+  fi
+
   if [ "$_rcf_applied_count" -eq 0 ] && [ "$_rcf_checkable_count" -gt 0 ] && [ "$freshness_check" != "false" ]; then
+    if consume_applied_marker; then
+      echo "INFO: applied $_rcf_applied_count parameter(s)" >&2
+      return 0
+    fi
+
     projection_changed=false
     if ensure_projected_config_fresh; then
       if [ "$projection_changed" = "true" ]; then


### PR DESCRIPTION
## Summary
- narrow Redis rendered-config reconfigure freshness proof to the no-op success path
- apply mounted-file dynamic diffs first and verify Redis readback, so old-but-correct stable projections are not blocked by mtime age
- fail closed before `INFO: applied 0` when the mounted file is a stale no-op and current projected-volume freshness cannot be proven
- remove the persistent marker shortcut because it proves only that an old mounted file was applied before, not that the current request target is that file
- rerun diff/apply when `/etc/conf/..data` or mounted content moves during the bounded wait
- add focused ShellSpec coverage for target-diff apply, stale no-op fail-closed, stale-marker reuse fail-closed, fresh projection, missing `..data`, and projection movement

## Evidence
- `sh -n addons/redis/scripts/redis-reconfigure-config.sh`
- `git diff --check -- addons/redis`
- `git diff --check origin/main...HEAD -- addons/redis`
- `/opt/homebrew/bin/shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh` => 43 examples, 0 failures
- `helm dependency build addons/redis`
- `helm lint addons/redis`
- `helm template redis addons/redis`
- rendered output has no `timeoutSeconds:-1`, no `timeoutSeconds:180`, no `RECONFIGURE_WAIT_TIMEOUT`
- direct `/bin/sh` target-diff probe: old `..data`, mounted target `allkeys-lru`, live Redis `volatile-lru` -> applies `maxmemory-policy=allkeys-lru`
- direct `/bin/sh` stale-marker-reuse probe: old `..data`, mounted/live Redis `volatile-lru`, stale marker file present -> rc=1 before `INFO: applied 0`
- GitHub checks all green on head `5061380ca0ade20d8533d2d7e22f7951e460bfc2`, including `shellspec-test`
- Slock-side focused reviews: Jade APPROVE and Blake APPROVE on head `5061380ca0ade20d8533d2d7e22f7951e460bfc2`

## Runtime evidence
Focused runtime gate passed on Saiyin:
- scope: Redis Parameters × replication-twemproxy
- head: `5061380ca0ade20d8533d2d7e22f7951e460bfc2`
- controller image: `docker.io/library/kubeblocks:pr-10401-5c5c2a0-stella`
- controller imageID: `sha256:f4584d503aba16f3cc28d4057dbba319e6c73a71607d73f94e0314853bdb51d1`
- result: PASS 34 / FAIL 0 / SKIP 0
- evidence package: `redis-pr2864-5061380ca-parameters-twemproxy-20260620T0700.tgz`
- sha256: `2dab47966b06d987e88759750724bdec3d43f4d71b1a07343d10d0dd0bf31fdd`
- cleanup: namespace NotFound, no PV residue

The previously observed #2819 failure was: OpsRequest Succeed, rendered target `allkeys-lru`, live Redis stayed `volatile-lru` until manual rerun after mount sync. This PR's exact-head focused runtime shows the dynamic `maxmemory-policy -> allkeys-lru` case reaches live Redis values without Redis pod UID changes and without kbagent `timedOut`.

## Boundary
This is the exact-head focused gate for task #60 / PR #2864, not full Redis release acceptance. Base is #2819 branch `redis-reconfigure-config-file-contract`, so this PR only shows the freshness delta.
