### PR TITLE
chore(valkey): add targetPodSelector to accountProvision

### DIFF
--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -446,6 +446,8 @@ spec:
           - sh
           - -c
           - /scripts/account-provision.sh
+        targetPodSelector: Role
+        matchingKey: primary
 
     # switchover: when Sentinel is present, delegates to SENTINEL FAILOVER.
     # When absent (standalone), performs a direct REPLICAOF NO ONE.


### PR DESCRIPTION
## Summary
- accountProvision was missing `targetPodSelector: Role` / `matchingKey: primary`, which could cause account provisioning to execute on a replica where ACL changes are local-only and won't propagate to the primary.
- postProvision already correctly uses these fields. This aligns accountProvision with the same pattern.
- Found during deep code review (task #331 in #valkey).

## Test plan
- [ ] Full acceptance test suite (`-t all`) on IDC vcluster