### PR TITLE
fix(valkey): sync-acl exits non-zero on partial ACL failures

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_sync_acl_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_sync_acl_spec.sh
@@ -161,6 +161,7 @@ Describe "Valkey Sync-ACL Bash Script Tests"
           "valkey-0.headless.default.svc.cluster.local" \
           "valkey-1.headless.default.svc.cluster.local"
         The status should be failure
+        The stdout should include "Syncing ACL"
         The stderr should include "ERROR: ACL SAVE failed"
       End
     End
@@ -187,6 +188,7 @@ Describe "Valkey Sync-ACL Bash Script Tests"
           "valkey-0.headless.default.svc.cluster.local" \
           "valkey-1.headless.default.svc.cluster.local"
         The status should be failure
+        The stdout should include "Syncing ACL"
         The stderr should include "ERROR: failed to set ACL for monitor"
         The stderr should include "ERROR: ACL sync completed with 1 failure(s)"
       End

--- a/addons/valkey/scripts-ut-spec/valkey_sync_acl_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_sync_acl_spec.sh
@@ -107,7 +107,7 @@ Describe "Valkey Sync-ACL Bash Script Tests"
     End
 
     Context "when ACL LIST fails"
-      It "returns failure and logs a warning"
+      It "returns failure and logs an error"
         valkey-cli() {
           case "$@" in
             *"ACL LIST"*)
@@ -120,7 +120,7 @@ Describe "Valkey Sync-ACL Bash Script Tests"
           "valkey-1.headless.default.svc.cluster.local"
         The status should be failure
         The stdout should include "Syncing ACL"
-        The stderr should include "WARNING"
+        The stderr should include "ERROR"
       End
     End
 
@@ -146,7 +146,7 @@ Describe "Valkey Sync-ACL Bash Script Tests"
     End
 
     Context "when ACL SAVE fails"
-      It "prints a warning but does not fail the sync"
+      It "returns failure when ACL SAVE fails"
         valkey-cli() {
           case "$@" in
             *"ACL LIST"*)
@@ -160,9 +160,35 @@ Describe "Valkey Sync-ACL Bash Script Tests"
         When call sync_acl_to_replica \
           "valkey-0.headless.default.svc.cluster.local" \
           "valkey-1.headless.default.svc.cluster.local"
-        The status should be success
-        The stdout should include "ACL sync complete"
-        The stderr should include "WARNING: ACL SAVE failed"
+        The status should be failure
+        The stderr should include "ERROR: ACL SAVE failed"
+      End
+    End
+
+    Context "when ACL SETUSER fails for some users"
+      It "returns failure with partial sync error count"
+        valkey-cli() {
+          case "$@" in
+            *"ACL LIST"*)
+              printf "user default on nopass ~* &* +@all\nuser app on >apppass ~* +@all\nuser monitor on >monpass ~* +@read\n"
+              ;;
+            *"ACL SETUSER app"*)
+              echo "OK"
+              ;;
+            *"ACL SETUSER monitor"*)
+              echo "ERR unknown command"
+              ;;
+            *"ACL SAVE"*)
+              echo "OK"
+              ;;
+          esac
+        }
+        When call sync_acl_to_replica \
+          "valkey-0.headless.default.svc.cluster.local" \
+          "valkey-1.headless.default.svc.cluster.local"
+        The status should be failure
+        The stderr should include "ERROR: failed to set ACL for monitor"
+        The stderr should include "ERROR: ACL sync completed with 1 failure(s)"
       End
     End
   End

--- a/addons/valkey/scripts/sync-acl.sh
+++ b/addons/valkey/scripts/sync-acl.sh
@@ -79,15 +79,16 @@ sync_acl_to_replica() {
   # valkey-cli exits 0 even for server errors; check output for error prefix.
   local acl_list
   acl_list=$("${src_cli[@]}" ACL LIST 2>&1) || {
-    echo "WARNING: could not read ACL LIST from ${src_fqdn}: ${acl_list}" >&2
+    echo "ERROR: could not read ACL LIST from ${src_fqdn}: ${acl_list}" >&2
     return 1
   }
   case "${acl_list}" in
     "(error)"*|"ERR "*)
-      echo "WARNING: ACL LIST from ${src_fqdn} returned error: ${acl_list}" >&2
+      echo "ERROR: ACL LIST from ${src_fqdn} returned error: ${acl_list}" >&2
       return 1 ;;
   esac
 
+  local sync_failures=0
   while IFS= read -r rule; do
     [ -z "${rule}" ] && continue
     # Format: "user <name> <flags...>"
@@ -111,7 +112,8 @@ sync_acl_to_replica() {
     set +f
     case "${setuser_out}" in
       *"ERR"*|*"WRONGTYPE"*|*"error"*)
-        echo "  WARNING: failed to set ACL for ${username}: ${setuser_out}" >&2 ;;
+        echo "  ERROR: failed to set ACL for ${username}: ${setuser_out}" >&2
+        sync_failures=$((sync_failures + 1)) ;;
     esac
   done <<< "${acl_list}"
 
@@ -120,7 +122,13 @@ sync_acl_to_replica() {
   local acl_save_out
   acl_save_out=$("${dst_cli[@]}" ACL SAVE 2>&1) || true
   if [ "${acl_save_out}" != "OK" ]; then
-    echo "WARNING: ACL SAVE failed on ${dst_fqdn}: ${acl_save_out} — rules applied in memory only, will be lost on restart" >&2
+    echo "ERROR: ACL SAVE failed on ${dst_fqdn}: ${acl_save_out} — rules applied in memory only, will be lost on restart" >&2
+    return 1
+  fi
+
+  if [ "${sync_failures}" -gt 0 ]; then
+    echo "ERROR: ACL sync completed with ${sync_failures} failure(s) — replica ACL state is incomplete." >&2
+    return 1
   fi
   echo "ACL sync complete."
 }


### PR DESCRIPTION
## Summary
- Individual `ACL SETUSER` failures and `ACL SAVE` failures now cause `sync_acl_to_replica` to return non-zero.
- Previously, partial failures were logged as WARNING but the script exited 0, causing `memberJoin` to report success even though the replica's ACL state was incomplete.
- On pod restart, the replica would lose any in-memory-only ACL changes.
- Found during deep code review (task #331 in #valkey).

## Test plan
- [ ] Full acceptance test suite (`-t all`) on IDC vcluster