### PR TITLE
chore(valkey): correct memberLeave comment — SENTINEL RESET is not called

### DIFF
--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -475,8 +475,9 @@ spec:
         targetPodSelector: Any
 
     # memberLeave: called when a pod is being removed (scale-in / eviction).
-    # Triggers a Sentinel failover if the leaving pod is the primary, then
-    # issues SENTINEL RESET to clean up stale replica entries.
+    # Triggers a Sentinel failover if the leaving pod is the primary.
+    # Sentinel naturally marks the removed pod as s_down after
+    # down-after-milliseconds (SENTINEL RESET is intentionally NOT called).
     memberLeave:
       exec:
         container: valkey


### PR DESCRIPTION
## Summary
- The cmpd.yaml comment for memberLeave said it "issues SENTINEL RESET to clean up stale replica entries", but the script intentionally does NOT call SENTINEL RESET.
- Updated comment to match actual behavior: sentinel naturally marks the removed pod as s_down.
- Found during deep code review (task #331 in #valkey).

## Test plan
- Comment-only change, no behavior change.