### PR TITLE
chore(valkey): add io-threads to staticParameters in ParametersDefinition

### DIFF
--- a/addons/valkey/templates/paramsdef.yaml
+++ b/addons/valkey/templates/paramsdef.yaml
@@ -24,6 +24,8 @@ spec:
     - logfile
     - aclfile
     - tcp-backlog
+    - io-threads
+    - io-threads-do-reads
   dynamicParameters:
     - acllog-max-len
     - activedefrag


### PR DESCRIPTION
## Summary
- `io-threads` and `io-threads-do-reads` require a restart to take effect but were missing from `staticParameters`.
- The config template renders them, so they should be explicitly classified as static.
- Currently works by accident (unlisted params default to static when `dynamicParameters` is non-empty), but this is fragile.
- Found during deep code review (task #331 in #valkey).

## Test plan
- [ ] Full acceptance test suite (`-t all`) on IDC vcluster