### PR TITLE
chore(valkey): add memberLeave and roleProbe image keys to ComponentVersion

### DIFF
--- a/addons/valkey/templates/cmpv.yaml
+++ b/addons/valkey/templates/cmpv.yaml
@@ -37,6 +37,8 @@ spec:
         accountProvision: {{ $valkeyRepo }}:{{ .imageTag }}
         switchover: {{ $valkeyRepo }}:{{ .imageTag }}
         memberJoin: {{ $valkeyRepo }}:{{ .imageTag }}
+        memberLeave: {{ $valkeyRepo }}:{{ .imageTag }}
+        roleProbe: {{ $valkeyRepo }}:{{ .imageTag }}
     {{- end }}
     {{- end }}
 


### PR DESCRIPTION
## Summary
- All exec-based lifecycle actions should have consistent image keys for version tracking.
- `memberLeave` and `roleProbe` were missing while `postProvision`, `accountProvision`, `switchover`, and `memberJoin` were already present.
- No functional impact (exec-based actions run inside existing containers), but KB can now verify these actions' compatibility during version upgrade.
- Found during deep code review (task #331 in #valkey).

## Test plan
- [ ] Full acceptance test suite (`-t all`) on IDC vcluster