### PR TITLE
fix(valkey): push ACL to all data pods in accountProvision

### DIFF
--- a/addons/valkey/scripts/account-provision.sh
+++ b/addons/valkey/scripts/account-provision.sh
@@ -75,14 +75,14 @@ while IFS= read -r line; do
       if [ "${state}" = "online" ]; then
         online_ips+=("${ip}")
       else
-        echo "WARNING: replica ${ip} state=${state}, skipping ACL push" >&2
+        echo "WARNING: replica ${ip} state=${state}, not online" >&2
       fi
       ;;
   esac
 done <<< "${repl_info}"
 
-if [ "${slave_count}" -gt 0 ] && [ "${#online_ips[@]}" -eq 0 ]; then
-  echo "ERROR: ${slave_count} replica(s) connected but none in online state — cannot propagate ACL" >&2
+if [ "${slave_count}" -gt 0 ] && [ "${#online_ips[@]}" -ne "${slave_count}" ]; then
+  echo "ERROR: ${slave_count} replica(s) connected but only ${#online_ips[@]} online — cannot guarantee all replicas receive ACL" >&2
   exit 1
 fi
 

--- a/addons/valkey/scripts/account-provision.sh
+++ b/addons/valkey/scripts/account-provision.sh
@@ -65,17 +65,26 @@ repl_info=$("${_cli[@]}" INFO REPLICATION 2>&1) || {
 repl_info="${repl_info//$'\r'/}"
 
 online_ips=()
+slave_count=0
 while IFS= read -r line; do
   case "${line}" in
     slave[0-9]*:*)
+      slave_count=$((slave_count + 1))
       ip=$(echo "${line}" | sed 's/.*ip=\([^,]*\).*/\1/')
       state=$(echo "${line}" | sed 's/.*state=\([^,]*\).*/\1/')
       if [ "${state}" = "online" ]; then
         online_ips+=("${ip}")
+      else
+        echo "WARNING: replica ${ip} state=${state}, skipping ACL push" >&2
       fi
       ;;
   esac
 done <<< "${repl_info}"
+
+if [ "${slave_count}" -gt 0 ] && [ "${#online_ips[@]}" -eq 0 ]; then
+  echo "ERROR: ${slave_count} replica(s) connected but none in online state — cannot propagate ACL" >&2
+  exit 1
+fi
 
 for ip in "${online_ips[@]}"; do
   apply_acl "${ip}" "replica(${ip})"

--- a/addons/valkey/scripts/account-provision.sh
+++ b/addons/valkey/scripts/account-provision.sh
@@ -55,51 +55,27 @@ apply_acl() {
 # Apply on the local primary first.
 apply_acl "127.0.0.1" "primary(local)"
 
-# For multi-node deployments, discover connected replicas via INFO
-# REPLICATION and push the ACL to each.  Fail-closed: if we cannot confirm
-# that every expected replica received the ACL, the action fails so
-# KubeBlocks can surface the inconsistency.
-expected_replicas=$(( ${COMPONENT_REPLICAS:-1} - 1 ))
-if [ "${expected_replicas}" -le 0 ]; then
-  exit 0
-fi
-
-deadline=$((SECONDS + 30))
-online_ips=()
-
-while [ $SECONDS -lt $deadline ]; do
-  build_cli "127.0.0.1"
-  repl_info=$("${_cli[@]}" INFO REPLICATION 2>&1) || {
-    echo "INFO: INFO REPLICATION failed, retrying..." >&2
-    sleep 3
-    continue
-  }
-  repl_info="${repl_info//$'\r'/}"
-
-  online_ips=()
-  while IFS= read -r line; do
-    case "${line}" in
-      slave[0-9]*:*)
-        ip=$(echo "${line}" | sed 's/.*ip=\([^,]*\).*/\1/')
-        state=$(echo "${line}" | sed 's/.*state=\([^,]*\).*/\1/')
-        if [ "${state}" = "online" ]; then
-          online_ips+=("${ip}")
-        fi
-        ;;
-    esac
-  done <<< "${repl_info}"
-
-  if [ ${#online_ips[@]} -ge ${expected_replicas} ]; then
-    break
-  fi
-  echo "INFO: waiting for replicas (online=${#online_ips[@]} expected=${expected_replicas})..." >&2
-  sleep 3
-done
-
-if [ ${#online_ips[@]} -lt ${expected_replicas} ]; then
-  echo "ERROR: not enough online replicas after 30s (online=${#online_ips[@]} expected=${expected_replicas})" >&2
+# Discover connected replicas via INFO REPLICATION and push the ACL to each.
+# Uses only real-time data from the engine — no stale env vars.
+build_cli "127.0.0.1"
+repl_info=$("${_cli[@]}" INFO REPLICATION 2>&1) || {
+  echo "ERROR: INFO REPLICATION failed" >&2
   exit 1
-fi
+}
+repl_info="${repl_info//$'\r'/}"
+
+online_ips=()
+while IFS= read -r line; do
+  case "${line}" in
+    slave[0-9]*:*)
+      ip=$(echo "${line}" | sed 's/.*ip=\([^,]*\).*/\1/')
+      state=$(echo "${line}" | sed 's/.*state=\([^,]*\).*/\1/')
+      if [ "${state}" = "online" ]; then
+        online_ips+=("${ip}")
+      fi
+      ;;
+  esac
+done <<< "${repl_info}"
 
 for ip in "${online_ips[@]}"; do
   apply_acl "${ip}" "replica(${ip})"

--- a/addons/valkey/scripts/account-provision.sh
+++ b/addons/valkey/scripts/account-provision.sh
@@ -2,53 +2,105 @@
 set -e
 # account-provision.sh — called by KubeBlocks to create/update a database account.
 #
-# Learning note:
-#   KubeBlocks injects three special variables before calling this action:
-#     KB_ACCOUNT_NAME      - logical account name (e.g., "default")
-#     KB_ACCOUNT_PASSWORD  - generated password (from passwordGenerationPolicy)
-#     KB_ACCOUNT_STATEMENT - the command to execute, built by KubeBlocks
+# KubeBlocks injects:
+#   KB_ACCOUNT_NAME      - logical account name (e.g., "default")
+#   KB_ACCOUNT_PASSWORD  - generated password (from passwordGenerationPolicy)
+#   KB_ACCOUNT_STATEMENT - the command to execute (ACL SETUSER ...)
 #
-#   For Redis/Valkey, KB_ACCOUNT_STATEMENT is an ACL SETUSER command:
-#     e.g. "ACL SETUSER myuser on >password ~* +@all"
-#
-#   Because Valkey's auth model is ACL-based (not SQL), the provision script
-#   simply passes KB_ACCOUNT_STATEMENT verbatim to valkey-cli and then
-#   calls ACL SAVE to persist the ACL file to disk.
-#
-#   The `initAccount: true` flag on the systemAccount means KubeBlocks
-#   calls this action once during cluster initialisation, using the
-#   "default" user.  Subsequent ACL changes go through OpsRequest.
+# With targetPodSelector: Role / matchingKey: primary, this runs on the
+# primary pod.  After applying the ACL locally, the script pushes the same
+# ACL rule to all connected replicas (discovered via INFO REPLICATION).
+# Valkey ACL is not replicated via the native replication stream — each
+# node maintains its own users.acl.
 
 port="${SERVICE_PORT:-6379}"
 
-base_cmd=(valkey-cli --no-auth-warning -p "${port}")
-if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
-  base_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
-fi
-if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
-  # shellcheck disable=SC2206
-  base_cmd+=(${VALKEY_CLI_TLS_ARGS})
+build_cli() {
+  local host="${1:-127.0.0.1}"
+  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
+  if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
+    _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
+    # shellcheck disable=SC2206
+    _cli+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+apply_acl() {
+  local host="${1}" label="${2}"
+  build_cli "${host}"
+
+  local output
+  output=$(echo "${KB_ACCOUNT_STATEMENT}" | "${_cli[@]}" 2>&1) || {
+    echo "ERROR: account statement failed on ${label} (${host}): ${output}" >&2
+    return 1
+  }
+  if [ "${output}" != "OK" ]; then
+    echo "ERROR: account statement returned unexpected response on ${label} (${host}): ${output}" >&2
+    return 1
+  fi
+
+  local acl_save_out
+  acl_save_out=$("${_cli[@]}" ACL SAVE 2>&1) || {
+    echo "ERROR: ACL SAVE failed on ${label} (${host}): ${acl_save_out}" >&2
+    return 1
+  }
+  if [ "${acl_save_out}" != "OK" ]; then
+    echo "ERROR: ACL SAVE returned unexpected response on ${label} (${host}): ${acl_save_out}" >&2
+    return 1
+  fi
+}
+
+# Apply on the local primary first.
+apply_acl "127.0.0.1" "primary(local)"
+
+# For multi-node deployments, discover connected replicas via INFO
+# REPLICATION and push the ACL to each.  Fail-closed: if we cannot confirm
+# that every expected replica received the ACL, the action fails so
+# KubeBlocks can surface the inconsistency.
+expected_replicas=$(( ${COMPONENT_REPLICAS:-1} - 1 ))
+if [ "${expected_replicas}" -le 0 ]; then
+  exit 0
 fi
 
-# Execute the statement provided by KubeBlocks.
-# Pipe via stdin so that '>' in ACL password syntax (e.g. >mypassword) is not
-# misinterpreted as a shell output-redirect operator.
-# valkey-cli exits 0 even for protocol errors; capture output and check content.
-output=$(echo "${KB_ACCOUNT_STATEMENT}" | "${base_cmd[@]}" 2>&1) || {
-  echo "ERROR: account statement failed: ${output}" >&2
-  exit 1
-}
-if [ "${output}" != "OK" ]; then
-  echo "ERROR: account statement returned unexpected response: ${output}" >&2
+deadline=$((SECONDS + 30))
+online_ips=()
+
+while [ $SECONDS -lt $deadline ]; do
+  build_cli "127.0.0.1"
+  repl_info=$("${_cli[@]}" INFO REPLICATION 2>&1) || {
+    echo "INFO: INFO REPLICATION failed, retrying..." >&2
+    sleep 3
+    continue
+  }
+  repl_info="${repl_info//$'\r'/}"
+
+  online_ips=()
+  while IFS= read -r line; do
+    case "${line}" in
+      slave[0-9]*:*)
+        ip=$(echo "${line}" | sed 's/.*ip=\([^,]*\).*/\1/')
+        state=$(echo "${line}" | sed 's/.*state=\([^,]*\).*/\1/')
+        if [ "${state}" = "online" ]; then
+          online_ips+=("${ip}")
+        fi
+        ;;
+    esac
+  done <<< "${repl_info}"
+
+  if [ ${#online_ips[@]} -ge ${expected_replicas} ]; then
+    break
+  fi
+  echo "INFO: waiting for replicas (online=${#online_ips[@]} expected=${expected_replicas})..." >&2
+  sleep 3
+done
+
+if [ ${#online_ips[@]} -lt ${expected_replicas} ]; then
+  echo "ERROR: not enough online replicas after 30s (online=${#online_ips[@]} expected=${expected_replicas})" >&2
   exit 1
 fi
 
-# Persist ACL to disk so it survives pod restarts
-acl_save_out=$("${base_cmd[@]}" ACL SAVE 2>&1) || {
-  echo "ERROR: ACL SAVE failed: ${acl_save_out}" >&2
-  exit 1
-}
-if [ "${acl_save_out}" != "OK" ]; then
-  echo "ERROR: ACL SAVE returned unexpected response: ${acl_save_out}" >&2
-  exit 1
-fi
+for ip in "${online_ips[@]}"; do
+  apply_acl "${ip}" "replica(${ip})"
+done

--- a/addons/valkey/scripts/account-provision.sh
+++ b/addons/valkey/scripts/account-provision.sh
@@ -7,85 +7,37 @@ set -e
 #   KB_ACCOUNT_PASSWORD  - generated password (from passwordGenerationPolicy)
 #   KB_ACCOUNT_STATEMENT - the command to execute (ACL SETUSER ...)
 #
-# With targetPodSelector: Role / matchingKey: primary, this runs on the
-# primary pod.  After applying the ACL locally, the script pushes the same
-# ACL rule to all connected replicas (discovered via INFO REPLICATION).
-# Valkey ACL is not replicated via the native replication stream — each
-# node maintains its own users.acl.
+# With targetPodSelector: All, KubeBlocks runs this on every pod.
+# Each pod applies the ACL locally via ACL SETUSER + ACL SAVE.
+# Valkey ACL is not replicated via the native replication stream —
+# each node maintains its own users.acl, so every pod must be
+# provisioned independently.
 
 port="${SERVICE_PORT:-6379}"
 
-build_cli() {
-  local host="${1:-127.0.0.1}"
-  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
-  if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
-    _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
-  fi
-  if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
-    # shellcheck disable=SC2206
-    _cli+=(${VALKEY_CLI_TLS_ARGS})
-  fi
-}
+cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
+if [ -n "${VALKEY_DEFAULT_PASSWORD}" ]; then
+  cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+fi
+if [ -n "${VALKEY_CLI_TLS_ARGS}" ]; then
+  # shellcheck disable=SC2206
+  cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
+fi
 
-apply_acl() {
-  local host="${1}" label="${2}"
-  build_cli "${host}"
-
-  local output
-  output=$(echo "${KB_ACCOUNT_STATEMENT}" | "${_cli[@]}" 2>&1) || {
-    echo "ERROR: account statement failed on ${label} (${host}): ${output}" >&2
-    return 1
-  }
-  if [ "${output}" != "OK" ]; then
-    echo "ERROR: account statement returned unexpected response on ${label} (${host}): ${output}" >&2
-    return 1
-  fi
-
-  local acl_save_out
-  acl_save_out=$("${_cli[@]}" ACL SAVE 2>&1) || {
-    echo "ERROR: ACL SAVE failed on ${label} (${host}): ${acl_save_out}" >&2
-    return 1
-  }
-  if [ "${acl_save_out}" != "OK" ]; then
-    echo "ERROR: ACL SAVE returned unexpected response on ${label} (${host}): ${acl_save_out}" >&2
-    return 1
-  fi
-}
-
-# Apply on the local primary first.
-apply_acl "127.0.0.1" "primary(local)"
-
-# Discover connected replicas via INFO REPLICATION and push the ACL to each.
-# Uses only real-time data from the engine — no stale env vars.
-build_cli "127.0.0.1"
-repl_info=$("${_cli[@]}" INFO REPLICATION 2>&1) || {
-  echo "ERROR: INFO REPLICATION failed" >&2
+output=$(echo "${KB_ACCOUNT_STATEMENT}" | "${cli_cmd[@]}" 2>&1) || {
+  echo "ERROR: account statement failed: ${output}" >&2
   exit 1
 }
-repl_info="${repl_info//$'\r'/}"
-
-online_ips=()
-slave_count=0
-while IFS= read -r line; do
-  case "${line}" in
-    slave[0-9]*:*)
-      slave_count=$((slave_count + 1))
-      ip=$(echo "${line}" | sed 's/.*ip=\([^,]*\).*/\1/')
-      state=$(echo "${line}" | sed 's/.*state=\([^,]*\).*/\1/')
-      if [ "${state}" = "online" ]; then
-        online_ips+=("${ip}")
-      else
-        echo "WARNING: replica ${ip} state=${state}, not online" >&2
-      fi
-      ;;
-  esac
-done <<< "${repl_info}"
-
-if [ "${slave_count}" -gt 0 ] && [ "${#online_ips[@]}" -ne "${slave_count}" ]; then
-  echo "ERROR: ${slave_count} replica(s) connected but only ${#online_ips[@]} online — cannot guarantee all replicas receive ACL" >&2
+if [ "${output}" != "OK" ]; then
+  echo "ERROR: account statement returned unexpected response: ${output}" >&2
   exit 1
 fi
 
-for ip in "${online_ips[@]}"; do
-  apply_acl "${ip}" "replica(${ip})"
-done
+acl_save_out=$("${cli_cmd[@]}" ACL SAVE 2>&1) || {
+  echo "ERROR: ACL SAVE failed: ${acl_save_out}" >&2
+  exit 1
+}
+if [ "${acl_save_out}" != "OK" ]; then
+  echo "ERROR: ACL SAVE returned unexpected response: ${acl_save_out}" >&2
+  exit 1
+fi

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -446,8 +446,7 @@ spec:
           - sh
           - -c
           - /scripts/account-provision.sh
-        targetPodSelector: Role
-        matchingKey: primary
+        targetPodSelector: All
 
     # switchover: when Sentinel is present, delegates to SENTINEL FAILOVER.
     # When absent (standalone), performs a direct REPLICAOF NO ONE.


### PR DESCRIPTION
## Summary
- Valkey ACL rules are not replicated via native replication — each node has its own users.acl
- account-provision.sh previously only ran ACL SETUSER + ACL SAVE on the local primary pod
- After applying locally, discovers all connected replicas via INFO REPLICATION and pushes the same ACL to each
- Uses COMPONENT_REPLICAS to validate expected replica count; bounded retry (30s) waits for enough online replicas
- Fail-closed: INFO REPLICATION failure, insufficient online replicas, or any replica ACL SAVE failure causes exit non-zero
- Standalone (COMPONENT_REPLICAS=1) exits immediately after local apply

INFO REPLICATION replaces VALKEY_POD_FQDN_LIST enumeration because the FQDN list is fixed at pod creation time and may be stale after scale-out — new pods would not appear in the primary's list.

Companion to #2865 (targetPodSelector). Together they ensure: accountProvision runs on primary (#2865), and the ACL propagates to all existing replicas (this PR).

**Merge order**: merge #2865 first, then rebase this PR to drop the shared commit before merging.

## Test plan
- T08-A: static CMPD assertion for targetPodSelector (guards #2865)
- T08-B: create account via account-provision.sh on primary, verify ACL LIST + --user auth on all data pods (guards this PR)
- kubeblocks-tests PR #270 contains both assertions
