### PR TITLE
chore(redis): preserve cluster account hosts without announce names

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_account_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_account_spec.sh
@@ -380,6 +380,50 @@ Describe "Redis Account Script Tests"
       End
     End
 
+    Context "when CLUSTER NODES has mixed announced hostnames"
+      redis-cli() {
+        printf "abc123 10.0.0.1:6379@16379, master - 0 0 1 connected 0-5460\n"
+        printf "def456 10.0.0.2:6379@16379,host2.ns.svc master - 0 0 2 connected 5461-10922\n"
+        return 0
+      }
+
+      It "falls back to the node address with cluster bus suffix when announced hostname is empty"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When call get_cluster_host_list
+        The status should be success
+        The variable host_list should equal "10.0.0.1:6379@16379,host2.ns.svc"
+      End
+    End
+
+    Context "when CLUSTER NODES has no announced hostnames"
+      redis-cli() {
+        printf "abc123 10.0.0.1:6379@16379, master - 0 0 1 connected 0-5460\n"
+        printf "def456 10.0.0.2:6379@16379, slave abc123 0 0 2 connected\n"
+        return 0
+      }
+
+      It "uses the node addresses with cluster bus suffix instead of returning an empty host list"
+        export CURRENT_POD_NAME="redis-shard-0"
+        export CURRENT_SHARD_COMPONENT_NAME="redis-shard"
+        export CLUSTER_NAMESPACE="default"
+        export CLUSTER_DOMAIN="cluster.local"
+        export REDIS_DEFAULT_USER="default"
+        export REDIS_DEFAULT_PASSWORD="password123"
+        export REDIS_CLI_TLS_CMD=""
+        service_port=6379
+        When call get_cluster_host_list
+        The status should be success
+        The variable host_list should equal "10.0.0.1:6379@16379,10.0.0.2:6379@16379"
+      End
+    End
+
     Context "when CLUSTER NODES returns empty or only failed nodes"
       redis-cli() {
         printf "abc123 10.0.0.1:6379@16379,host1.ns.svc master,fail - 0 0 1 connected 0-5460\n"

--- a/addons/redis/scripts/redis-account.sh
+++ b/addons/redis/scripts/redis-account.sh
@@ -115,8 +115,14 @@ function get_cluster_host_list() {
         CLUSTER NODES |
         grep -v "fail" |
         grep -v "noaddr" |
-        awk '{print $2}' |
-        cut -d ',' -f2 |
+        awk '{
+            split($2, endpoint, ",")
+            if (endpoint[2] != "") {
+                print endpoint[2]
+            } else {
+                print endpoint[1]
+            }
+        }' |
         paste -sd,)
     if [ -z "$host_list" ]; then
         echo "GET CLUSTER HOST LIST FAILED, SKIP ACL OPERATION"


### PR DESCRIPTION
## Summary
- Fix Redis cluster account host parsing when CLUSTER NODES reports an empty announced hostname after the comma.
- Fall back to the node address including the @cport suffix so the existing downstream parser can extract the Redis service port correctly.
- Add ShellSpec coverage for mixed and all-empty announced hostname output.

## Evidence
- Source first-red: #62 1805 all-data-node account gate, package artifacts/redis-accounts-all-data-node-20260621T1805-first-red.tgz, sha 180487ca04179c6a32737e77040684caf56656d2bef4c6af45e2fcd8db1763f7.
- Local: sh -n addons/redis/scripts/redis-account.sh PASS.
- Local: git diff --check PASS.
- Local: focused ShellSpec redis_account_spec.sh 27/0 PASS with /opt/homebrew/bin/bash 5.3.9.
- Local: full Redis scripts ShellSpec 372/0 PASS with /opt/homebrew/bin/bash 5.3.9.
- Local: helm dependency build addons/redis PASS.
- Local: helm template redis addons/redis PASS.

## Boundary
Draft until Max's minimal reproduction confirms the action pod CLUSTER NODES/stdout path and exact-head runtime rerun proves the #62 all-data-node account gate.