### PR TITLE
feat(starrocks-ce): add FE memberLeave lifecycle action

### DIFF
--- a/addons/starrocks-ce/scripts/fe-member-leave.sh
+++ b/addons/starrocks-ce/scripts/fe-member-leave.sh
@@ -67,7 +67,7 @@ if [[ "${leader_host}" == "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
   log "waiting for leadership transfer (timeout ${LEADER_TRANSFER_TIMEOUT_SECS}s)"
   elapsed=0
   while true; do
-    new_leader=$(query_frontends | grep 'LEADER' | awk '{print $2}')
+    new_leader=$(query_frontends | awk '$7 == "LEADER" {print $2}')
     if [[ -n "${new_leader}" && "${new_leader}" != "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
       leader_host=${new_leader}
       log "leadership transferred to ${leader_host}"

--- a/addons/starrocks-ce/scripts/fe-member-leave.sh
+++ b/addons/starrocks-ce/scripts/fe-member-leave.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+log() {
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+query_frontends() {
+  mysql -N -B -h "${FE_DISCOVERY_SERVICE_NAME}" -P 9030 \
+    -u"${STARROCKS_USER}" -p"${STARROCKS_PASSWORD}" \
+    -e "SHOW FRONTENDS"
+}
+
+leave_host=""
+leave_port=""
+leader_host=""
+helper_endpoints=""
+candidate_names=""
+
+output=$(query_frontends)
+while IFS= read -r line; do
+  name=$(echo "$line" | awk '{print $1}')
+  ip=$(echo "$line" | awk '{print $2}')
+  edit_log_port=$(echo "$line" | awk '{print $3}')
+  role=$(echo "$line" | awk '{print $7}')
+
+  if [[ "${ip}" == "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
+    leave_host=${ip}
+    leave_port=${edit_log_port}
+  else
+    if [ -n "${helper_endpoints}" ]; then
+      helper_endpoints="${helper_endpoints},${ip}:${edit_log_port}"
+      candidate_names="${candidate_names},${name}"
+    else
+      helper_endpoints="${ip}:${edit_log_port}"
+      candidate_names="${name}"
+    fi
+  fi
+
+  if [ "${role}" == "LEADER" ]; then
+    leader_host=${ip}
+  fi
+done <<< "$output"
+
+log "leaving member: ${leave_host}:${leave_port}"
+log "current leader: ${leader_host}"
+log "helper endpoints: ${helper_endpoints}"
+log "transfer candidates: ${candidate_names}"
+
+if [ -z "${leave_host}" ] || [ -z "${leave_port}" ]; then
+  log "leaving member ${KB_LEAVE_MEMBER_POD_NAME} not found in SHOW FRONTENDS — already removed"
+  exit 0
+fi
+
+if [[ "${leader_host}" == "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
+  log "leaving member is the current leader — transferring leadership via BDBJE"
+  java -jar /opt/starrocks/fe/lib/starrocks-bdb-je*.jar \
+    DbGroupAdmin \
+    -helperHosts "${helper_endpoints}" \
+    -groupName PALO_JOURNAL_GROUP \
+    -transferMaster \
+    -force "${candidate_names}" 5000
+
+  log "waiting for leadership transfer to complete"
+  until [[ $(query_frontends | grep 'LEADER' | awk '{print $2}') != "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; do
+    sleep 5
+    log "leader still on leaving member, waiting..."
+  done
+  leader_host=$(query_frontends | grep 'LEADER' | awk '{print $2}')
+  log "leadership transferred to ${leader_host}"
+fi
+
+log "dropping follower ${leave_host}:${leave_port} from FE cluster"
+mysql -h "${leader_host}" -P 9030 \
+  -u"${STARROCKS_USER}" -p"${STARROCKS_PASSWORD}" \
+  -e "ALTER SYSTEM DROP FOLLOWER '${leave_host}:${leave_port}';"
+
+log "member leave completed for ${KB_LEAVE_MEMBER_POD_NAME}"

--- a/addons/starrocks-ce/scripts/fe-member-leave.sh
+++ b/addons/starrocks-ce/scripts/fe-member-leave.sh
@@ -53,6 +53,8 @@ if [ -z "${leave_host}" ] || [ -z "${leave_port}" ]; then
   exit 0
 fi
 
+LEADER_TRANSFER_TIMEOUT_SECS=120
+
 if [[ "${leader_host}" == "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
   log "leaving member is the current leader — transferring leadership via BDBJE"
   java -jar /opt/starrocks/fe/lib/starrocks-bdb-je*.jar \
@@ -62,16 +64,34 @@ if [[ "${leader_host}" == "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
     -transferMaster \
     -force "${candidate_names}" 5000
 
-  log "waiting for leadership transfer to complete"
-  until [[ $(query_frontends | grep 'LEADER' | awk '{print $2}') != "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; do
+  log "waiting for leadership transfer (timeout ${LEADER_TRANSFER_TIMEOUT_SECS}s)"
+  elapsed=0
+  while true; do
+    new_leader=$(query_frontends | grep 'LEADER' | awk '{print $2}')
+    if [[ -n "${new_leader}" && "${new_leader}" != "${KB_LEAVE_MEMBER_POD_NAME}"* ]]; then
+      leader_host=${new_leader}
+      log "leadership transferred to ${leader_host}"
+      break
+    fi
+    if [ ${elapsed} -ge ${LEADER_TRANSFER_TIMEOUT_SECS} ]; then
+      log "ERROR: leader transfer did not complete within ${LEADER_TRANSFER_TIMEOUT_SECS}s"
+      log "SHOW FRONTENDS at timeout:"
+      query_frontends || true
+      exit 1
+    fi
     sleep 5
-    log "leader still on leaving member, waiting..."
+    elapsed=$((elapsed + 5))
+    log "leader still on leaving member, elapsed ${elapsed}s..."
   done
-  leader_host=$(query_frontends | grep 'LEADER' | awk '{print $2}')
-  log "leadership transferred to ${leader_host}"
 fi
 
-log "dropping follower ${leave_host}:${leave_port} from FE cluster"
+if [ -z "${leader_host}" ]; then
+  log "ERROR: no leader found after transfer — cannot drop follower safely"
+  query_frontends || true
+  exit 1
+fi
+
+log "dropping follower ${leave_host}:${leave_port} from FE cluster via leader ${leader_host}"
 mysql -h "${leader_host}" -P 9030 \
   -u"${STARROCKS_USER}" -p"${STARROCKS_PASSWORD}" \
   -e "ALTER SYSTEM DROP FOLLOWER '${leave_host}:${leave_port}';"

--- a/addons/starrocks-ce/templates/cmpd-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpd-fe.yaml
@@ -12,6 +12,15 @@ spec:
   # The FE can only perform leader election when the majority of members are active.
   updateStrategy: Parallel
   serviceKind: starrocks-fe
+  lifecycleActions:
+    memberLeave:
+      exec:
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/fe-member-leave.sh
+        targetPodSelector: Any
+        container: fe
   services:
   - name: fe
     serviceName: fe

--- a/addons/starrocks-ce/templates/cmpd-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpd-fe.yaml
@@ -11,6 +11,7 @@ spec:
   description: A StarRocks FE component definition for Kubernetes
   # The FE can only perform leader election when the majority of members are active.
   updateStrategy: Parallel
+  podManagementPolicy: Parallel
   serviceKind: starrocks-fe
   lifecycleActions:
     memberLeave:

--- a/addons/starrocks-ce/templates/cmpv-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpv-fe.yaml
@@ -18,7 +18,9 @@ spec:
     serviceVersion: 3.2.2
     images:
       fe: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.fe.repository }}:3.2.2
+      memberLeave: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.fe.repository }}:3.2.2
   - name: 3.3.0
     serviceVersion: 3.3.0
     images:
       fe: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.fe.repository }}:3.3.0
+      memberLeave: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.fe.repository }}:3.3.0

--- a/addons/starrocks-ce/templates/scripts-template.yaml
+++ b/addons/starrocks-ce/templates/scripts-template.yaml
@@ -7,3 +7,5 @@ metadata:
 data:
   fe-post-start.sh: |-
     {{- .Files.Get "scripts/fe-post-start.sh" | nindent 4 }}
+  fe-member-leave.sh: |-
+    {{- .Files.Get "scripts/fe-member-leave.sh" | nindent 4 }}


### PR DESCRIPTION
## Summary

- Add `lifecycleActions.memberLeave` to StarRocks-CE FE ComponentDefinition for safe FE scale-in
- New `fe-member-leave.sh` script that handles BDBJE leader transfer before dropping the leaving follower
- Without this, FE scale-in removes nodes from the BDBJE metadata cluster without proper handoff, risking cluster corruption

## Changes

1. `scripts/fe-member-leave.sh` — new script:
   - Queries `SHOW FRONTENDS` to identify the leaving member and current leader
   - If the leaving member is the BDBJE leader, transfers leadership via `starrocks-bdb-je*.jar DbGroupAdmin -transferMaster`
   - Waits for leadership transfer, then drops the follower with `ALTER SYSTEM DROP FOLLOWER`

2. `templates/cmpd-fe.yaml` — adds `lifecycleActions.memberLeave` with `targetPodSelector: Any, container: fe`

3. `templates/scripts-template.yaml` — includes the new script in the scripts ConfigMap

## Context

Enterprise addon already has this capability. The CE version is written from scratch following the same BDBJE protocol (standard StarRocks, not enterprise-only). Confirmed by @Mark that all three operations (`SHOW FRONTENDS`, BDBJE `DbGroupAdmin`, `ALTER SYSTEM DROP FOLLOWER`) work identically in CE.

## Test plan

- [ ] Deploy 3-FE StarRocks-CE cluster on vcluster
- [ ] Scale in FE from 3→2 — verify memberLeave runs, follower is dropped cleanly
- [ ] Scale in FE when leader is the leaving member — verify leadership transfers first
- [ ] Verify remaining FE cluster is healthy after scale-in (`SHOW FRONTENDS` shows correct members)
- [ ] Add FE HorizontalScaling smoke test to kubeblocks-tests PR #285 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)