### PR TITLE
fix(tidb): PD roleProbe peer fallback + remove externalManaged

### DIFF
--- a/addons/tidb/scripts-ut-spec/pd_role_probe_spec.sh
+++ b/addons/tidb/scripts-ut-spec/pd_role_probe_spec.sh
@@ -1,0 +1,123 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317
+
+Describe "pd_role_probe tests"
+    Include ../scripts/pd_role_probe.sh
+
+    setup() {
+        HOSTNAME="tidb-cluster-tidb-pd-0"
+        PD_POD_FQDN_LIST="tidb-cluster-tidb-pd-0.tidb-cluster-tidb-pd-headless.default.svc.cluster.local,tidb-cluster-tidb-pd-1.tidb-cluster-tidb-pd-headless.default.svc.cluster.local,tidb-cluster-tidb-pd-2.tidb-cluster-tidb-pd-headless.default.svc.cluster.local"
+    }
+
+    BeforeEach 'setup'
+
+    Describe "local API success — leader"
+        timeout() {
+            shift
+            echo '{"leader":{"name":"tidb-cluster-tidb-pd-0"},"members":[{"name":"tidb-cluster-tidb-pd-0"},{"name":"tidb-cluster-tidb-pd-1"},{"name":"tidb-cluster-tidb-pd-2"}]}'
+        }
+
+        It "returns leader when HOSTNAME matches leader.name"
+            When call pd_role_probe
+            The status should be success
+            The stdout should equal "leader"
+        End
+    End
+
+    Describe "local API success — follower"
+        timeout() {
+            shift
+            echo '{"leader":{"name":"tidb-cluster-tidb-pd-1"},"members":[{"name":"tidb-cluster-tidb-pd-0"},{"name":"tidb-cluster-tidb-pd-1"},{"name":"tidb-cluster-tidb-pd-2"}]}'
+        }
+
+        It "returns follower when HOSTNAME is not leader but is member"
+            When call pd_role_probe
+            The status should be success
+            The stdout should equal "follower"
+        End
+    End
+
+    Describe "peer fallback success"
+        peer_call_count=0
+
+        timeout() {
+            shift
+            if [ "$1" = "/pd-ctl" ] && [ "${2:-}" != "-u" ]; then
+                return 1
+            fi
+            echo '{"leader":{"name":"tidb-cluster-tidb-pd-1"},"members":[{"name":"tidb-cluster-tidb-pd-0"},{"name":"tidb-cluster-tidb-pd-1"},{"name":"tidb-cluster-tidb-pd-2"}]}'
+        }
+
+        It "falls back to peer and returns follower"
+            When call pd_role_probe
+            The status should be success
+            The stdout should equal "follower"
+        End
+    End
+
+    Describe "current pod absent from member list"
+        timeout() {
+            shift
+            echo '{"leader":{"name":"tidb-cluster-tidb-pd-1"},"members":[{"name":"tidb-cluster-tidb-pd-1"},{"name":"tidb-cluster-tidb-pd-2"}]}'
+        }
+
+        It "returns failure when HOSTNAME not in members"
+            When call pd_role_probe
+            The status should be failure
+            The stdout should equal ""
+        End
+    End
+
+    Describe "no leader in response"
+        timeout() {
+            shift
+            echo '{"members":[{"name":"tidb-cluster-tidb-pd-0"},{"name":"tidb-cluster-tidb-pd-1"}]}'
+        }
+
+        It "returns failure when no leader field"
+            When call pd_role_probe
+            The status should be failure
+            The stdout should equal ""
+        End
+    End
+
+    Describe "invalid JSON"
+        timeout() {
+            shift
+            echo 'not valid json at all'
+        }
+
+        It "returns failure on invalid JSON"
+            When call pd_role_probe
+            The status should be failure
+            The stdout should equal ""
+        End
+    End
+
+    Describe "all endpoints unreachable"
+        timeout() {
+            shift
+            return 1
+        }
+
+        It "returns failure when all endpoints fail"
+            When call pd_role_probe
+            The status should be failure
+            The stdout should equal ""
+        End
+    End
+
+    Describe "empty PD_POD_FQDN_LIST with local failure"
+        timeout() {
+            shift
+            return 1
+        }
+
+        It "returns failure when no peers and local fails"
+            PD_POD_FQDN_LIST=""
+            When call pd_role_probe
+            The status should be failure
+            The stdout should equal ""
+        End
+    End
+End

--- a/addons/tidb/scripts/pd_role_probe.sh
+++ b/addons/tidb/scripts/pd_role_probe.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+pd_role_probe() {
+    RESULT=$(timeout 2 /pd-ctl member 2>/dev/null || true)
+    if ! echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
+        for fqdn in $(echo "$PD_POD_FQDN_LIST" | tr ',' ' '); do
+            RESULT=$(timeout 2 /pd-ctl -u "http://${fqdn}:2379" member 2>/dev/null || true)
+            if echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
+                break
+            fi
+            RESULT=""
+        done
+    fi
+    LEADER_NAME=$(echo "$RESULT" | jq -r '.leader.name // empty' 2>/dev/null)
+    if [ -z "$LEADER_NAME" ]; then
+        return 1
+    fi
+    IS_MEMBER=$(echo "$RESULT" | jq -r --arg h "$HOSTNAME" '.members[]?.name // empty | select(. == $h)' 2>/dev/null)
+    if [ -z "$IS_MEMBER" ]; then
+        return 1
+    fi
+    if [ "$LEADER_NAME" == "$HOSTNAME" ]; then
+        echo -n "leader"
+    else
+        echo -n "follower"
+    fi
+}
+
+# shellspec source guard
+${__SOURCED__:+false} : || return 0
+
+pd_role_probe || exit 1

--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -86,34 +86,13 @@ spec:
       participatesInQuorum: true
   lifecycleActions:
     roleProbe:
+      timeoutSeconds: 5
       exec:
         command:
           - bash
           - -c
           - |
-            RESULT=$(timeout 2 /pd-ctl member 2>/dev/null || true)
-            if ! echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
-                for fqdn in $(echo "$PD_POD_FQDN_LIST" | tr ',' ' '); do
-                    RESULT=$(timeout 2 /pd-ctl -u "http://${fqdn}:2379" member 2>/dev/null || true)
-                    if echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
-                        break
-                    fi
-                    RESULT=""
-                done
-            fi
-            LEADER_NAME=$(echo "$RESULT" | jq -r '.leader.name // empty' 2>/dev/null)
-            if [ -z "$LEADER_NAME" ]; then
-                exit 1
-            fi
-            IS_MEMBER=$(echo "$RESULT" | jq -r --arg h "$HOSTNAME" '.members[]?.name // empty | select(. == $h)' 2>/dev/null)
-            if [ -z "$IS_MEMBER" ]; then
-                exit 1
-            fi
-            if [ "$LEADER_NAME" == "$HOSTNAME" ]; then
-                echo -n "leader"
-            else
-                echo -n "follower"
-            fi
+            {{- .Files.Get "scripts/pd_role_probe.sh" | nindent 12 }}
     memberLeave:
       exec:
         command:

--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -91,10 +91,10 @@ spec:
           - bash
           - -c
           - |
-            RESULT=$(/pd-ctl member 2>/dev/null || true)
+            RESULT=$(timeout 2 /pd-ctl member 2>/dev/null || true)
             if ! echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
                 for fqdn in $(echo "$PD_POD_FQDN_LIST" | tr ',' ' '); do
-                    RESULT=$(/pd-ctl -u "http://${fqdn}:2379" member 2>/dev/null || true)
+                    RESULT=$(timeout 2 /pd-ctl -u "http://${fqdn}:2379" member 2>/dev/null || true)
                     if echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
                         break
                     fi
@@ -103,6 +103,10 @@ spec:
             fi
             LEADER_NAME=$(echo "$RESULT" | jq -r '.leader.name // empty' 2>/dev/null)
             if [ -z "$LEADER_NAME" ]; then
+                exit 1
+            fi
+            IS_MEMBER=$(echo "$RESULT" | jq -r --arg h "$HOSTNAME" '.members[]?.name // empty | select(. == $h)' 2>/dev/null)
+            if [ -z "$IS_MEMBER" ]; then
                 exit 1
             fi
             if [ "$LEADER_NAME" == "$HOSTNAME" ]; then

--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -63,7 +63,6 @@ spec:
       template: {{ include "tidb.pd.configTplName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: config
-      externalManaged: true
       reconfigure:
         exec:
           container: pd
@@ -92,7 +91,20 @@ spec:
           - bash
           - -c
           - |
-            LEADER_NAME=$(/pd-ctl member | jq -r '.leader.name')
+            RESULT=$(/pd-ctl member 2>/dev/null || true)
+            if ! echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
+                for fqdn in $(echo "$PD_POD_FQDN_LIST" | tr ',' ' '); do
+                    RESULT=$(/pd-ctl -u "http://${fqdn}:2379" member 2>/dev/null || true)
+                    if echo "$RESULT" | jq -e '.leader.name' >/dev/null 2>&1; then
+                        break
+                    fi
+                    RESULT=""
+                done
+            fi
+            LEADER_NAME=$(echo "$RESULT" | jq -r '.leader.name // empty' 2>/dev/null)
+            if [ -z "$LEADER_NAME" ]; then
+                exit 1
+            fi
             if [ "$LEADER_NAME" == "$HOSTNAME" ]; then
                 echo -n "leader"
             else

--- a/addons/tidb/templates/cmpd-tidb.yaml
+++ b/addons/tidb/templates/cmpd-tidb.yaml
@@ -90,7 +90,6 @@ spec:
       template: {{ include "tidb.tidb.configTplName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: config
-      externalManaged: true
   systemAccounts:
     - name: root
       initAccount: true

--- a/addons/tidb/templates/cmpd-tikv.yaml
+++ b/addons/tidb/templates/cmpd-tikv.yaml
@@ -78,7 +78,6 @@ spec:
       template: {{ include "tidb.tikv.configTplName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: config
-      externalManaged: true
   lifecycleActions:
     memberLeave:
       exec:


### PR DESCRIPTION
## Summary

- **PD roleProbe chicken-and-egg fix**: When PD-0 local API is unresponsive during initial bootstrap (stuck in region sync), the roleProbe now falls back to querying peer endpoints via PD_POD_FQDN_LIST. This lets PD-0 get its follower role even when its own server has not fully started, unblocking KB controller component Running judgment and allowing TiKV creation to proceed.
- **Remove externalManaged: true** from PD, TiKV, and TiDB ComponentDefinitions. Without an external provisioner, the controller clears the config template and precheck fails.

## Root cause evidence

Kate IDC vcluster testing found:
1. 3 PD pods all Running (2/2), InstanceSet 3/3 Ready
2. PD-1=leader, PD-2=follower, PD-0=no role (probe timeout)
3. KB controller: status conditions, creating: true, its running: false
4. PD-0 logs: region sync with leader meet error: server not started
5. Topology ordering blocks TiKV until PD Running - chicken-and-egg deadlock

## Test plan
- [ ] Kate redeploys TiDB addon with this chart fix on IDC vcluster
- [ ] Verify PD component reaches Running with all 3 pods having roles
- [ ] Verify TiKV and TiDB pods are created after PD Running
- [ ] Run full test suite