### PR TITLE
chore(starrocks-ce): add podManagementPolicy Parallel for FE quorum

### DIFF
--- a/addons/starrocks-ce/templates/cmpd-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpd-fe.yaml
@@ -11,6 +11,7 @@ spec:
   description: A StarRocks FE component definition for Kubernetes
   # The FE can only perform leader election when the majority of members are active.
   updateStrategy: Parallel
+  podManagementPolicy: Parallel
   serviceKind: starrocks-fe
   services:
   - name: fe


### PR DESCRIPTION
## Summary
- Add `podManagementPolicy: Parallel` to StarRocks-CE FE ComponentDefinition
- StarRocks FE uses BDBJE for metadata consensus requiring majority quorum (2/3 for 3-member group)
- Without this, Stop/Start creates FE pods sequentially (OrderedReady default), causing FE-0 to deadlock waiting for quorum while FE-1/FE-2 are not created
- `updateStrategy: Parallel` alone is insufficient — it controls update behavior, not pod creation order

## Evidence
- T05 (stop/start) FAIL: FE-0 stuck in UNKNOWN state for 22+ minutes waiting for BDBJE quorum
- Live InstanceSet shows `podManagementPolicy: OrderedReady`, `status.replicas: 1` (only FE-0 created)
- FE-1/FE-2 never created because KB waits for FE-0 Ready (OrderedReady semantics)
- KB controller logs confirm no attempt to create FE-1/FE-2
- Frozen scene: `srce-smk-9459` in `starrocks-ce-test`, artifacts: `20260622-072525/`

## Test plan
- [ ] Verify live CmpD shows `podManagementPolicy: Parallel`
- [ ] Verify live InstanceSet shows `podManagementPolicy: Parallel`
- [ ] T05 (stop/start) passes with 3 FE replicas
- [ ] Full smoke T01-T08 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)