### PR TITLE
chore(clickhouse): guard logConfigs block to prevent YAML null rendering

### DIFF
--- a/addons/clickhouse/templates/cmpd-ch.yaml
+++ b/addons/clickhouse/templates/cmpd-ch.yaml
@@ -94,11 +94,13 @@ spec:
       - name: shared-tools
         emptyDir: {}
   updateStrategy: BestEffortParallel
+  {{- if .Values.logConfigs }}
   logConfigs:
     {{- range $name, $pattern := .Values.logConfigs }}
     - name: {{ $name }}
       filePathPattern: {{ $pattern }}
     {{- end }}
+  {{- end }}
   exporter:
     scrapePath: /metrics
     scrapePort: "8001"

--- a/addons/clickhouse/templates/cmpd-ch.yaml
+++ b/addons/clickhouse/templates/cmpd-ch.yaml
@@ -94,7 +94,7 @@ spec:
       - name: shared-tools
         emptyDir: {}
   updateStrategy: BestEffortParallel
-  {{- if .Values.logConfigs }}
+  {{- if not (empty .Values.logConfigs) }}
   logConfigs:
     {{- range $name, $pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -116,7 +116,7 @@ spec:
           - name: tcp-secure
             targetPort: tcp-secure
             port: 9440
-  {{- if .Values.logConfigs }}
+  {{- if not (empty .Values.logConfigs) }}
   logConfigs:
     {{- range $name, $pattern := .Values.logConfigs }}
     - name: {{ $name }}

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -116,11 +116,13 @@ spec:
           - name: tcp-secure
             targetPort: tcp-secure
             port: 9440
+  {{- if .Values.logConfigs }}
   logConfigs:
     {{- range $name, $pattern := .Values.logConfigs }}
     - name: {{ $name }}
       filePathPattern: {{ $pattern }}
     {{- end }}
+  {{- end }}
   exporter:
     scrapePath: /metrics
     scrapePort: "8001"

--- a/addons/clickhouse/values.yaml
+++ b/addons/clickhouse/values.yaml
@@ -9,7 +9,8 @@ fullnameOverride: ""
 ##
 commonLabels: {}
 
-logConfigs: {}
+logConfigs:
+  error: /bitnami/clickhouse/log/*.err.log
 
 commonAnnotations: {}
 


### PR DESCRIPTION
## Summary
- When `logConfigs: {}` in `values.yaml`, the template renders `logConfigs:\n` which YAML parses as null, causing CRD validation errors on ComponentDefinition
- Guard the `logConfigs` block in both `cmpd-ch.yaml` and `cmpd-keeper.yaml` with `{{- if .Values.logConfigs }}`
- Set a sensible default: `error: /bitnami/clickhouse/log/*.err.log` (glob covers both `clickhouse-server.err.log` and `keeper-server.err.log`)

## Changes
- `addons/clickhouse/values.yaml`: `logConfigs: {}` → `logConfigs: {error: /bitnami/clickhouse/log/*.err.log}`
- `addons/clickhouse/templates/cmpd-ch.yaml`: guard logConfigs with `{{- if .Values.logConfigs }}`
- `addons/clickhouse/templates/cmpd-keeper.yaml`: same guard

## Acceptance criteria
- Default install: renders `logConfigs: [{name: error, filePathPattern: /bitnami/clickhouse/log/*.err.log}]`
- `--set logConfigs=null` or `logConfigs: {}`: block not rendered, no YAML null
- Explicit custom path: renders custom pattern correctly

## Test plan
- [ ] `helm template` with default values renders valid logConfigs
- [ ] `helm template` with `--set logConfigs=null` omits logConfigs block
- [ ] `helm template` with explicit custom logConfigs renders correctly
- [ ] vcluster install gate: addon installs cleanly with new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)