### PR TITLE
fix(clickhouse): parameter pipeline minimum fixes (externalManaged + listen_try CUE)

### DIFF
--- a/addons/clickhouse/configs/00_default_overrides.xml.tpl
+++ b/addons/clickhouse/configs/00_default_overrides.xml.tpl
@@ -6,7 +6,7 @@
 <clickhouse>
   <listen_host replace="replace">::</listen_host>
   <listen_host>0.0.0.0</listen_host>
-  <listen_try replace="replace">1</listen_try>
+  <listen_try>1</listen_try>
   {{- if eq (index $ "TLS_ENABLED") "true" }}
   <https_port replace="replace" from_env="CLICKHOUSE_HTTPS_PORT"/>
   <tcp_port_secure replace="replace" from_env="CLICKHOUSE_TCP_SECURE_PORT"/>

--- a/addons/clickhouse/configs/00_default_overrides.xml.tpl
+++ b/addons/clickhouse/configs/00_default_overrides.xml.tpl
@@ -6,7 +6,7 @@
 <clickhouse>
   <listen_host replace="replace">::</listen_host>
   <listen_host>0.0.0.0</listen_host>
-  <listen_try>1</listen_try>
+  <listen_try>true</listen_try>
   {{- if eq (index $ "TLS_ENABLED") "true" }}
   <https_port replace="replace" from_env="CLICKHOUSE_HTTPS_PORT"/>
   <tcp_port_secure replace="replace" from_env="CLICKHOUSE_TCP_SECURE_PORT"/>

--- a/addons/clickhouse/configs/ch_keeper_00_default_overrides.xml.tpl
+++ b/addons/clickhouse/configs/ch_keeper_00_default_overrides.xml.tpl
@@ -1,7 +1,7 @@
 <clickhouse>
   <listen_host replace="replace">::</listen_host>
   <listen_host>0.0.0.0</listen_host>
-  <listen_try>1</listen_try>
+  <listen_try>true</listen_try>
   {{- if eq (index $ "TLS_ENABLED") "true" }}
   <https_port replace="replace" from_env="CLICKHOUSE_HTTPS_PORT"/>
   <tcp_port_secure replace="replace" from_env="CLICKHOUSE_TCP_SECURE_PORT"/>

--- a/addons/clickhouse/configs/ch_keeper_00_default_overrides.xml.tpl
+++ b/addons/clickhouse/configs/ch_keeper_00_default_overrides.xml.tpl
@@ -1,7 +1,7 @@
 <clickhouse>
   <listen_host replace="replace">::</listen_host>
   <listen_host>0.0.0.0</listen_host>
-  <listen_try replace="replace">1</listen_try>
+  <listen_try>1</listen_try>
   {{- if eq (index $ "TLS_ENABLED") "true" }}
   <https_port replace="replace" from_env="CLICKHOUSE_HTTPS_PORT"/>
   <tcp_port_secure replace="replace" from_env="CLICKHOUSE_TCP_SECURE_PORT"/>

--- a/addons/clickhouse/templates/cmpd-ch.yaml
+++ b/addons/clickhouse/templates/cmpd-ch.yaml
@@ -108,11 +108,13 @@ spec:
       volumeName: config
       namespace: {{ .Release.Namespace }}
       restartOnFileChange: false
+      externalManaged: true
     - name: clickhouse-user-tpl
       template: {{ include "clickhouse.userTplName" . }}
       volumeName: user-config
       namespace: {{ .Release.Namespace }}
       restartOnFileChange: false
+      externalManaged: true
     - name: clickhouse-client-tpl
       template: {{ include "clickhouse.clientTplName" . }}
       volumeName: client-config

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -130,6 +130,7 @@ spec:
       volumeName: config
       namespace: {{ .Release.Namespace }}
       restartOnFileChange: false
+      externalManaged: true
     - name: clickhouse-client-tpl
       template: {{ include "clickhouse.clientTplName" . }}
       volumeName: client-config


### PR DESCRIPTION
## Summary

ClickHouse reconfigure parameter pipeline minimum fixes. Two addon-side blockers on the same pipeline path:

1. **externalManaged**: Add `externalManaged: true` to 3 config entries that have matching ParametersDefinitions. Without this field, `ResolveParameterTemplate()` skips the config → `configItemDetails` stays empty → reconfigure OpsRequest stuck at Running.
   - `cmpd-ch.yaml`: `clickhouse-tpl`, `clickhouse-user-tpl`
   - `cmpd-keeper.yaml`: `clickhouse-keeper-tpl`
   - `clickhouse-client-tpl` excluded (no matching PD)

2. **listen_try CUE validation**: Remove `replace="replace"` attribute from `<listen_try>` in both server and keeper config templates. The mxj XML parser converts attributed elements to structs `{"#text":1,"-replace":"replace"}`, conflicting with the CUE schema that expects `bool`. ClickHouse config.d overrides scalar values by default, so `replace` is unnecessary for this simple boolean.

## Evidence

- `externalManaged` gate: 3/3 PASS (helm template + vcluster install + debug v2 touch)
- `listen_try` gate: pending clean cluster verification

## Test plan

- [ ] Focused review (Kitty)
- [ ] helm template gate: `externalManaged: true` on 3 PD-backed configs, `listen_try` without `replace`, client-tpl unchanged
- [ ] Clean post-fix cluster: debug v2 minimal touch → `configItemDetails > 0`, CUE validation passes
- [ ] If clean cluster has no user-tpl ownership conflict → PR #289 reconfigure full rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)