### PR TITLE
chore(oceanbase): only add s3_region for AWS provider

### DIFF
--- a/addons/oceanbase-ce/dataprotection/common-scripts.sh
+++ b/addons/oceanbase-ce/dataprotection/common-scripts.sh
@@ -224,10 +224,10 @@ function getDestURL() {
      destPrefix="oss"
   fi
   destUrl="${destPrefix}://${bucket}${destPath}/${tenantName}/${tenantId}?host=${host}&access_id=${access_key_id}&access_key=${secret_access_key}"
-  if [[ ${destPrefix} == "s3" ]]; then
+  if [[ ${destPrefix} == "s3" && ${provider} == "AWS" ]]; then
      storageRegion=${region:-${DP_STORAGE_REGION:-}}
      if [[ -z ${storageRegion} ]]; then
-        echo "ERROR: s3_region is required for S3-compatible storage"
+        echo "ERROR: s3_region is required for AWS S3 storage"
         exit 1
      fi
      destUrl="${destUrl}&s3_region=${storageRegion}"


### PR DESCRIPTION
## Summary
- Follow-up fix for PR #2719: restrict `s3_region` URL parameter to AWS provider only
- Per wangyelei review on enterprise PR #1434: non-AWS S3-compatible storage (MinIO, etc.) does not need the `s3_region` parameter
- Changed condition from `destPrefix == "s3"` to `destPrefix == "s3" && provider == "AWS"`

## Test plan
- [ ] Verify backup with AWS S3 provider still includes s3_region
- [ ] Verify backup with non-AWS S3-compatible storage (MinIO) no longer requires s3_region

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>