### PR TITLE
chore(etcd): set peer serviceName in ComponentDefinition

### DIFF
--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -132,7 +132,7 @@ spec:
             targetPort: client
       disableAutoProvision: true
     - name: peer
-      serviceName:
+      serviceName: peer
       spec:
         ports:
           - name: peer


### PR DESCRIPTION
## Summary
- Set etcd peer service `serviceName` to `peer` instead of rendering an empty YAML value.
- Fixes helm install/server-side validation failure where the ComponentDefinition receives `serviceName: null`.

## Evidence
Reported during dedicated etcd vcluster setup:

```text
ComponentDefinition.apps.kubeblocks.io "etcd-3-1.2.0-alpha.0" is invalid:
spec.services[1].serviceName: Invalid value: "null":
spec.services[1].serviceName in body must be of type string: "null"
```

Local static checks:
- `git diff --check` passed.
- Confirmed no empty `serviceName:` remains in `addons/etcd/templates/cmpd.yaml`.
- Could not run `helm template` locally because `helm` is not installed on this machine.

## Runtime validation plan
Susan will re-run `helm install etcd` in the dedicated `etcd-idc4-vc` environment after this patch, then continue the etcd test gate.
