### PR TITLE
chore(qdrant): use KB_LEAVE_MEMBER_POD_FQDN for memberLeave cluster check

### DIFF
--- a/addons/qdrant/scripts/qdrant-member-leave.sh
+++ b/addons/qdrant/scripts/qdrant-member-leave.sh
@@ -13,7 +13,9 @@ load_common_library() {
 }
 
 load_common_library
-current_pod_fqdn=$(get_target_pod_fqdn_from_pod_fqdn_vars "$QDRANT_POD_FQDN_LIST" "$CURRENT_POD_NAME")
+
+CURL=/qdrant/tools/curl
+JQ=/qdrant/tools/jq
 
 if [ "${TLS_ENABLED:-}" = "true" ]; then
   SCHEME="https"
@@ -23,48 +25,136 @@ else
   CURL_TLS=""
 fi
 
-curl $CURL_TLS ${SCHEME}://${current_pod_fqdn}:6333/cluster | grep $KB_LEAVE_MEMBER_POD_NAME
-# if the member is not in the cluster, exit directly
-if [ $? -ne 0 ]; then
-  echo "member ${KB_LEAVE_MEMBER_POD_NAME} is not in the cluster"
+# Use the first live pod from QDRANT_POD_FQDN_LIST as the control plane endpoint.
+# The leaving pod may already be shutting down; admin operations (move shard,
+# DELETE peer) must go through a known-live peer.
+control_fqdn=$(echo "$QDRANT_POD_FQDN_LIST" | tr ',' '\n' | head -1)
+if [ -z "$control_fqdn" ]; then
+  echo "ERROR: QDRANT_POD_FQDN_LIST is empty"
+  exit 1
+fi
+control_uri=${SCHEME}://${control_fqdn}:6333
+
+# Query cluster state from a live peer.
+cluster_info=$($CURL $CURL_TLS -sf --max-time 10 ${control_uri}/cluster)
+if [ $? -ne 0 ] || [ -z "$cluster_info" ]; then
+  echo "ERROR: failed to query cluster info from ${control_uri}"
+  exit 1
+fi
+
+# Validate cluster response has a parseable peers object.
+peers_type=$(echo "$cluster_info" | $JQ -r '.result.peers | type' 2>/dev/null)
+if [ $? -ne 0 ] || [ "$peers_type" != "object" ]; then
+  echo "ERROR: cluster response missing or malformed .result.peers (type=${peers_type:-null})"
+  exit 1
+fi
+
+# Find the leaving peer's ID by matching KB_LEAVE_MEMBER_POD_NAME in peer URIs.
+# Two-step: first confirm peers is valid (above), then match. Only "valid peers +
+# zero matches" is idempotent exit 0; parse failures always exit 1.
+leave_peer_id=$(echo "$cluster_info" | $JQ -r \
+  --arg name "$KB_LEAVE_MEMBER_POD_NAME" \
+  '.result.peers | to_entries[] | select(.value.uri | contains($name)) | .key')
+jq_rc=$?
+
+if [ $jq_rc -ne 0 ]; then
+  echo "ERROR: jq failed while searching for ${KB_LEAVE_MEMBER_POD_NAME} in peers (rc=${jq_rc})"
+  exit 1
+fi
+
+if [ -z "$leave_peer_id" ]; then
+  echo "member ${KB_LEAVE_MEMBER_POD_NAME} is not in the cluster (not found in peer URIs)"
   exit 0
 fi
 
+# Guard against multiple matches or non-numeric peer ID.
+peer_count=$(echo "$leave_peer_id" | wc -l | tr -d ' ')
+if [ "$peer_count" -ne 1 ]; then
+  echo "ERROR: expected 1 matching peer for ${KB_LEAVE_MEMBER_POD_NAME}, found ${peer_count}"
+  exit 1
+fi
+if ! [[ "$leave_peer_id" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: leave_peer_id '${leave_peer_id}' is not a valid numeric peer ID"
+  exit 1
+fi
+
+echo "leaving peer: ${KB_LEAVE_MEMBER_POD_NAME}, peer_id=${leave_peer_id}"
+leader_peer_id=$(echo "$cluster_info" | $JQ -r .result.raft_info.leader)
+echo "leader peer_id=${leader_peer_id}"
+
+# The leaving peer's HTTP endpoint for shard queries. KB calls memberLeave
+# before pod termination, so this should be reachable.
 leave_peer_uri=${SCHEME}://${KB_LEAVE_MEMBER_POD_FQDN}:6333
-cluster_info=`curl $CURL_TLS -s ${leave_peer_uri}/cluster`
-leave_peer_id=`echo "${cluster_info}"| jq -r .result.peer_id`
-leader_peer_id=`echo "${cluster_info}" | jq -r .result.raft_info.leader`
 
 move_shards() {
-    cols=`curl $CURL_TLS -s ${leave_peer_uri}/collections`
-    col_count=`echo ${cols} | jq -r '.result.collections | length'`
+    local cols col_count col_names
+
+    cols=$($CURL $CURL_TLS -sf ${control_uri}/collections)
+    if [ $? -ne 0 ]; then
+      echo "ERROR: failed to list collections from ${control_uri}"
+      return 1
+    fi
+
+    col_count=$(echo ${cols} | $JQ -r '.result.collections | length')
     if [[ ${col_count} -eq 0 ]]; then
         echo "no collections found in the cluster"
         return
     fi
-    col_names=`echo ${cols} | jq -r '.result.collections[].name'`
+
+    col_names=$(echo ${cols} | $JQ -r '.result.collections[].name')
     for col_name in ${col_names}; do
-        col_cluster_info=`curl $CURL_TLS -s ${leave_peer_uri}/collections/${col_name}/cluster`
-        col_shard_count=`echo ${col_cluster_info} | jq -r '.result.local_shards[] | length'`
-        if [[ ${col_shard_count} -eq 0 ]]; then
-            echo "no shards found in collection ${col_name}"
+        # Query the leaving peer for its local shards (still alive during memberLeave).
+        local col_cluster_info
+        col_cluster_info=$($CURL $CURL_TLS -sf ${leave_peer_uri}/collections/${col_name}/cluster)
+        if [ $? -ne 0 ]; then
+          echo "ERROR: failed to get collection cluster info from leaving peer for ${col_name}"
+          return 1
+        fi
+
+        local leave_shard_ids
+        leave_shard_ids=$(echo ${col_cluster_info} | $JQ -r '.result.local_shards[].shard_id')
+        if [ -z "${leave_shard_ids}" ]; then
+            echo "no local shards on leaving peer for collection ${col_name}"
             continue
         fi
 
-        leave_shard_ids=`echo ${col_cluster_info} | jq -r '.result.local_shards[].shard_id'`
         for shard_id in ${leave_shard_ids}; do
-            echo "move shard ${shard_id} in col_name ${col_name} from ${leave_peer_id} to ${leader_peer_id}"
-            curl $CURL_TLS -s -X POST -H "Content-Type: application/json" \
+            echo "move shard ${shard_id} in ${col_name} from peer ${leave_peer_id} to peer ${leader_peer_id}"
+            # Submit move_shard via control endpoint (cluster-wide API).
+            $CURL $CURL_TLS -sf -X POST -H "Content-Type: application/json" \
                 -d '{"move_shard":{"shard_id": '${shard_id}',"to_peer_id": '${leader_peer_id}',"from_peer_id": '${leave_peer_id}}}'' \
-                ${leave_peer_uri}/collections/${col_name}/cluster
+                ${control_uri}/collections/${col_name}/cluster
+            if [ $? -ne 0 ]; then
+              echo "ERROR: failed to initiate shard ${shard_id} move in ${col_name}"
+              return 1
+            fi
         done
 
+        # Wait for all shards to finish moving off the leaving peer.
         while true; do
-            col_cluster_info=`curl $CURL_TLS -s ${leave_peer_uri}/collections/${col_name}/cluster`
-            leave_shard_ids=`echo ${col_cluster_info} | jq -r '.result.local_shards[].shard_id'`
-            if [ -z "${leave_shard_ids}" ]; then
-                echo "all shards in collection ${col_name} has been moved"
+            col_cluster_info=$($CURL $CURL_TLS -sf ${leave_peer_uri}/collections/${col_name}/cluster 2>/dev/null) || true
+            if [ -n "$col_cluster_info" ]; then
+              leave_shard_ids=$(echo ${col_cluster_info} | $JQ -r '.result.local_shards[].shard_id')
+              if [ -z "${leave_shard_ids}" ]; then
+                  echo "all shards in collection ${col_name} have been moved"
+                  break
+              fi
+            else
+              # Leaving peer unreachable during transfer — verify from control endpoint.
+              col_cluster_info=$($CURL $CURL_TLS -sf ${control_uri}/collections/${col_name}/cluster)
+              if [ $? -ne 0 ]; then
+                echo "ERROR: cannot check shard status for ${col_name} from either endpoint"
+                return 1
+              fi
+              local remaining
+              remaining=$(echo ${col_cluster_info} | $JQ -r \
+                --arg pid "$leave_peer_id" \
+                '[(.result.remote_shards // [])[] | select(.peer_id == ($pid | tonumber))] | length')
+              if [ "${remaining}" = "0" ]; then
+                echo "all shards in collection ${col_name} moved off peer ${leave_peer_id} (verified from control)"
                 break
+              fi
+              echo "waiting for ${remaining} shards in ${col_name} to finish transfer..."
             fi
             sleep 1
         done
@@ -73,12 +163,20 @@ move_shards() {
 
 remove_peer() {
     echo "remove peer ${leave_peer_id} from cluster"
-    curl $CURL_TLS -v -XDELETE ${leave_peer_uri}/cluster/peer/${leave_peer_id}
+    # Use control endpoint — the leaving peer may be unreachable after shard migration.
+    $CURL $CURL_TLS -sf -v -XDELETE ${control_uri}/cluster/peer/${leave_peer_id}
+    if [ $? -ne 0 ]; then
+      echo "ERROR: failed to remove peer ${leave_peer_id} from cluster"
+      return 1
+    fi
+    echo "peer ${leave_peer_id} removed successfully"
 }
 
 leave_member() {
-    echo "scaling in, we need to move local shards to other peers and remove local peer from the cluster"
-    echo "cluster info: ${cluster_info}"
+    echo "scaling in: move local shards and remove peer from cluster"
+    echo "control endpoint: ${control_uri}"
+    echo "leaving peer: ${KB_LEAVE_MEMBER_POD_NAME} (id=${leave_peer_id}, uri=${leave_peer_uri})"
+    echo "leader peer id: ${leader_peer_id}"
     move_shards
     remove_peer
 }


### PR DESCRIPTION
## Summary

Fix `memberLeave` lifecycle action false-success bug in Qdrant addon. The script silently exits 0 without removing the departing Raft peer during horizontal scale-in.

## Root Cause

**Direct cause**: `member-leave.sh` uses bare `curl` and `jq` commands, but the Qdrant container only has these tools at `/qdrant/tools/curl` and `/qdrant/tools/jq`. When bare `curl` fails (exit 127, command not found), the pipeline `curl ... | grep` returns non-zero, and the script incorrectly treats this as "member already absent" → `exit 0`. KB controller reports the action as successful, but no shard migration or peer removal actually occurs.

**Contract issue**: The script conflates "command execution failed" with "member not in cluster", allowing a false-success exit 0 path. Additionally, `curl` without `--fail` does not return non-zero on HTTP 4xx/5xx, so Qdrant-side rejections (e.g., DELETE a peer that still has shards) would also be silently swallowed.

### Evidence Chain

| Step | Evidence |
|------|----------|
| PATH check on qdrant pod | `curl` and `jq` not in PATH; exist at `/qdrant/tools/` |
| kbagent action log | `memberLeave` result = `"member qdr-smoke-2604-qdrant-3 is not in the cluster\n"` |
| Post scale-in Raft state | 4 peers remain (qdrant-3 still present) |
| Action execution pod | qdrant-0 (targetPodSelector: Any) |

## Fix

1. **Tool paths**: Replace all bare `curl` → `/qdrant/tools/curl` and `jq` → `/qdrant/tools/jq`
2. **Control plane separation**: Use a live peer from `QDRANT_POD_FQDN_LIST` as the control endpoint; the leaving pod may be shutting down. Admin operations (move_shard, DELETE peer) go through the live control endpoint.
3. **Structured membership check**: Find leaving peer ID via `jq` on `/cluster` peer URIs — curl failures can no longer be mistaken for "member absent". Only when the peer is structurally confirmed absent from the cluster JSON does the script exit 0.
4. **HTTP error handling**: `curl -sf` (--silent --fail) catches HTTP 4xx/5xx errors, preventing false-success on Qdrant-side rejections.
5. **Error path discipline**: All error conditions exit/return non-zero with diagnostic messages.
6. **Shard transfer fallback**: Primary shard query goes to the leaving peer (alive during memberLeave); falls back to control endpoint if leaving peer becomes unreachable during transfer.

## Test Plan

- [ ] Manually verify DELETE peer API on frozen vcluster cluster
- [ ] Deploy patched addon chart to vcluster
- [ ] Rerun full smoke suite (S01-S20) — S13 scale-in must show 3 Raft peers after completion