### PR TITLE
chore(milvus): remove null serviceName from proxy ComponentDefinition

### DIFF
--- a/addons/milvus/templates/cmpd-proxy.yaml
+++ b/addons/milvus/templates/cmpd-proxy.yaml
@@ -20,7 +20,6 @@ spec:
         letterCase: MixedCases
   services:
     - name: milvus
-      serviceName:  # use default name
       spec:
         type: ClusterIP
         ports:


### PR DESCRIPTION
## Summary

- Removes explicit `serviceName:  # use default name` from `cmpd-proxy.yaml`
- Helm renders empty YAML value as `null`, but CRD schema requires `type: string`
- Server-side apply rejects: `spec.services[0].serviceName: Invalid value: "null": must be of type string`
- Omitting the field lets KubeBlocks use the default service name as documented

## Root cause

Found during live Milvus addon smoke test (T01 addon install) on vcluster with KB 1.x main branch.

## Test plan

- [ ] `helm template milvus addons/milvus` renders without `serviceName: null`
- [ ] Addon install succeeds on KB 1.x vcluster
- [ ] Milvus standalone cluster creates and reaches Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)