### PR TITLE
fix(etcd): remove null serviceName from peer service definition

### DIFF
--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -132,7 +132,6 @@ spec:
             targetPort: client
       disableAutoProvision: true
     - name: peer
-      serviceName:
       spec:
         ports:
           - name: peer

--- a/addons/milvus/templates/cmpd-proxy.yaml
+++ b/addons/milvus/templates/cmpd-proxy.yaml
@@ -20,7 +20,6 @@ spec:
         letterCase: MixedCases
   services:
     - name: milvus
-      serviceName:  # use default name
       spec:
         type: ClusterIP
         ports:


### PR DESCRIPTION
## Summary
- Same pattern as milvus proxy fix (#2883): empty `serviceName:` in `cmpd.yaml` renders as `null`, which CRD schema rejects (`type: string` required)
- Discovered during live testing of milvus standalone topology on IDC vcluster — etcd addon install fails with server-side apply validation error

## Test plan
- [ ] Diana re-runs smoke suite with etcd addon install on IDC vcluster
- [ ] Verify etcd ComponentDefinition registers without CRD validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)