### PR TITLE
feat(milvus): add ParametersDefinition for standalone reconfigure

### DIFF
--- a/addons/milvus/templates/_helpers.tpl
+++ b/addons/milvus/templates/_helpers.tpl
@@ -347,6 +347,7 @@ Milvus user config - standalone
   volumeName: milvus-config
   namespace: {{.Release.Namespace}}
   defaultMode: 420
+  externalManaged: true
   restartOnFileChange: true
 - name: scripts
   template: {{ include "milvus-scripts.configTemplateName" . }}

--- a/addons/milvus/templates/paramdef-standalone.yaml
+++ b/addons/milvus/templates/paramdef-standalone.yaml
@@ -1,0 +1,40 @@
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: milvus-standalone-pd-{{ .Chart.Version }}
+  labels:
+    {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+    {{- include "milvus.annotations" . | nindent 4 }}
+spec:
+  componentDef: {{ include "milvus-standalone.cmpdRegexpPattern" . }}
+  templateName: config
+  fileName: user.yaml
+  fileFormatConfig:
+    format: yaml
+  parametersSchema:
+    topLevelKey: MilvusStandaloneParameter
+    cue: |-
+      #MilvusStandaloneParameter: {
+        ...
+        log?: {
+          ...
+          level?: string & ("debug" | "info" | "warn" | "error" | "panic" | "fatal") | *"info"
+        }
+        proxy?: {
+          ...
+          maxNameLength?: int & >=1 & <=32768 | *255
+          maxFieldNum?: int & >=1 & <=2048 | *64
+          maxDimension?: int & >=1 & <=32768 | *32768
+        }
+        common?: {
+          ...
+          gracefulTime?: int & >=0 & <=600000 | *5000
+        }
+      }
+  staticParameters:
+    - log.level
+    - proxy.maxNameLength
+    - proxy.maxFieldNum
+    - proxy.maxDimension
+    - common.gracefulTime


### PR DESCRIPTION
## Summary
- Add `paramdef-standalone.yaml` — ParametersDefinition for milvus-standalone enabling Reconfiguring OpsRequest
- Add `externalManaged: true` to standalone CMPD configSpecs to enable the parameters controller chain
- CUE schema with 5 static parameters: `log.level`, `proxy.maxNameLength`, `proxy.maxFieldNum`, `proxy.maxDimension`, `common.gracefulTime`
- All parameters are static (pod restart via `restartOnFileChange: true`)

## Contract compliance
- `templateName: config` matches CMPD `configSpecs[0].name`
- `fileName: user.yaml` matches template ConfigMap data key
- `externalManaged: true` required per `docs/addon-api/08-parameters-and-config.md`
- CUE ranges verified against Milvus 2.5.x official config docs

## Test plan
- [ ] Helm template render: `helm template` succeeds with PD resource
- [ ] PD registers in cluster: `kubectl get parametersdefinition` shows `milvus-standalone-pd-*`
- [ ] Reconfiguring OpsRequest works end-to-end (covered by companion PR in kubeblocks-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)