### PR TITLE
fix(redis): replace reconfigure action with argv-based script + readback verification

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -361,6 +361,70 @@ Describe "Redis Reconfigure Config (argv-based)"
       End
     End
 
+    Context "subkey parameter (e.g. client-output-buffer-limit normal)"
+      _captured_set_args=""
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET)
+            local n=$#
+            local val="${!n}"
+            local prev=$((n - 1))
+            local key="${!prev}"
+            _captured_set_args="$key|$val"
+            echo "OK"; return 0
+            ;;
+          GET)
+            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            return 0
+            ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+        _captured_set_args=""
+      }
+      Before "setup"
+
+      It "splits subkey from key and prepends to value in CONFIG SET"
+        When call apply_parameter "client-output-buffer-limit normal" "0 0 0"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+        The variable _captured_set_args should eq "client-output-buffer-limit|normal 0 0 0"
+      End
+    End
+
+    Context "subkey parameter readback mismatch"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET)
+            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            return 0
+            ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "fails when subkey value not found in readback"
+        When call apply_parameter "client-output-buffer-limit normal" "999 999 999"
+        The status should be failure
+        The stdout should include "OK"
+        The stderr should include "readback does not contain"
+      End
+    End
+
     Context "setting empty value"
       redis-cli() {
         local op

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -1,0 +1,424 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+# shellcheck disable=SC2154
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_reconfigure_config_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+# Helper: extract CONFIG SET/GET key from redis-cli args
+_redis_cli_last_key() {
+  local n=$#
+  local key="${!n}"
+  echo "$key"
+}
+
+# Helper: extract CONFIG operation (SET or GET) from redis-cli args
+_redis_cli_operation() {
+  for arg in "$@"; do
+    case "$arg" in
+      CONFIG) local found=1 ;;
+      SET|GET) [ "${found:-}" = "1" ] && echo "$arg" && return ;;
+    esac
+  done
+}
+
+Describe "Redis Reconfigure Config (argv-based)"
+  Include ../scripts/redis-reconfigure-config.sh
+
+  Describe "to_bytes()"
+    It "passes plain numbers through"
+      When call to_bytes "67108864"
+      The output should eq "67108864"
+    End
+
+    It "converts kb to bytes"
+      When call to_bytes "64kb"
+      The output should eq "65536"
+    End
+
+    It "converts KB to bytes"
+      When call to_bytes "64KB"
+      The output should eq "65536"
+    End
+
+    It "converts mb to bytes"
+      When call to_bytes "64mb"
+      The output should eq "67108864"
+    End
+
+    It "converts gb to bytes"
+      When call to_bytes "1gb"
+      The output should eq "1073741824"
+    End
+
+    It "converts GB to bytes"
+      When call to_bytes "2GB"
+      The output should eq "2147483648"
+    End
+
+    It "passes non-numeric strings through"
+      When call to_bytes "yes"
+      The output should eq "yes"
+    End
+  End
+
+  Describe "values_match()"
+    It "matches identical strings"
+      When call values_match "100" "100"
+      The status should be success
+    End
+
+    It "rejects different strings"
+      When call values_match "100" "200"
+      The status should be failure
+    End
+
+    It "matches memory format 1gb vs bytes"
+      When call values_match "1073741824" "1gb"
+      The status should be success
+    End
+
+    It "matches memory format bytes vs 1GB"
+      When call values_match "1073741824" "1GB"
+      The status should be success
+    End
+
+    It "matches memory format 64mb vs bytes"
+      When call values_match "67108864" "64mb"
+      The status should be success
+    End
+
+    It "rejects mismatched byte values"
+      When call values_match "67108864" "1gb"
+      The status should be failure
+    End
+
+    It "matches identical non-numeric strings"
+      When call values_match "yes" "yes"
+      The status should be success
+    End
+
+    It "rejects different non-numeric strings"
+      When call values_match "yes" "no"
+      The status should be failure
+    End
+  End
+
+  Describe "apply_parameter()"
+    Context "successful CONFIG SET with matching readback"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET)
+            local key
+            key=$(_redis_cli_last_key "$@")
+            case "$key" in
+              maxclients) printf 'maxclients\n10003\n' ;;
+              maxmemory) printf 'maxmemory\n1073741824\n' ;;
+              hz) printf 'hz\n25\n' ;;
+            esac
+            return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "applies maxclients and verifies readback"
+        When call apply_parameter "maxclients" "10003"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+      End
+
+      It "applies hz and verifies readback"
+        When call apply_parameter "hz" "25"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+      End
+    End
+
+    Context "successful CONFIG SET with memory format readback"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET)
+            printf 'maxmemory\n1073741824\n'
+            return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "matches 1gb value against byte readback"
+        When call apply_parameter "maxmemory" "1gb"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+      End
+    End
+
+    Context "CONFIG SET fails"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "ERR unknown command"; return 1 ;;
+          GET) printf 'maxclients\n10001\n'; return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "returns failure when CONFIG SET returns error"
+        When call apply_parameter "maxclients" "10003"
+        The status should be failure
+        The stdout should include "ERR unknown command"
+        The stderr should include "CONFIG SET maxclients failed"
+      End
+    End
+
+    Context "readback mismatch"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET)
+            printf 'maxclients\n10001\n'
+            return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "returns failure when readback does not match"
+        When call apply_parameter "maxclients" "10003"
+        The status should be failure
+        The stdout should include "OK"
+        The stderr should include "readback mismatch"
+        The stderr should include "engine='10001'"
+        The stderr should include "expected='10003'"
+      End
+    End
+
+    Context "readback returns nothing for non-empty value"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET) printf 'boguskey\n'; return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "returns failure when CONFIG GET returns no value"
+        When call apply_parameter "maxclients" "10003"
+        The status should be failure
+        The stdout should include "OK"
+        The stderr should include "returned nothing after SET"
+      End
+    End
+
+    Context "with auth password"
+      _captured_auth=""
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        for i in $(seq 1 $#); do
+          if [ "${!i}" = "-a" ]; then
+            local next=$((i + 1))
+            _captured_auth="${!next}"
+            break
+          fi
+        done
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET) printf 'maxclients\n10003\n'; return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        export REDIS_DEFAULT_PASSWORD="secret123"
+        auth_arg="-a secret123"
+        _captured_auth=""
+      }
+      Before "setup"
+
+      cleanup() {
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      After "cleanup"
+
+      It "passes auth flag to redis-cli"
+        When call apply_parameter "maxclients" "10003"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+        The variable _captured_auth should eq "secret123"
+      End
+    End
+
+    Context "with TLS"
+      _captured_tls=""
+      redis-cli() {
+        _captured_tls=""
+        for arg in "$@"; do
+          case "$arg" in
+            --tls|--cert|--key|--cacert) _captured_tls="yes"; break ;;
+          esac
+        done
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET) printf 'maxclients\n10003\n'; return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+        export REDIS_CLI_TLS_CMD="--tls --cert /certs/tls.crt --key /certs/tls.key --cacert /certs/ca.crt"
+        _captured_tls=""
+      }
+      Before "setup"
+
+      cleanup() {
+        unset REDIS_CLI_TLS_CMD
+      }
+      After "cleanup"
+
+      It "passes TLS flags to redis-cli"
+        When call apply_parameter "maxclients" "10003"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+        The variable _captured_tls should eq "yes"
+      End
+    End
+
+    Context "with custom port"
+      _captured_port=""
+      redis-cli() {
+        for i in $(seq 1 $#); do
+          if [ "${!i}" = "-p" ]; then
+            local next=$((i + 1))
+            _captured_port="${!next}"
+            break
+          fi
+        done
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET) printf 'maxclients\n10003\n'; return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6380
+        auth_arg=""
+        _captured_port=""
+      }
+      Before "setup"
+
+      It "uses the configured service port"
+        When call apply_parameter "maxclients" "10003"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+        The variable _captured_port should eq "6380"
+      End
+    End
+
+    Context "setting empty value"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET) printf 'notify-keyspace-events\n\n'; return 0 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "handles empty value CONFIG SET and readback"
+        When call apply_parameter "notify-keyspace-events" ""
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+      End
+    End
+  End
+
+  Describe "init_reconfigure_env()"
+    Context "with defaults"
+      setup() {
+        unset SERVICE_PORT
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      Before "setup"
+
+      It "sets default port and empty auth"
+        When call init_reconfigure_env
+        The variable service_port should eq "6379"
+        The variable auth_arg should eq ""
+      End
+    End
+
+    Context "with custom port and password"
+      setup() {
+        export SERVICE_PORT=6380
+        export REDIS_DEFAULT_PASSWORD="mypass"
+      }
+      Before "setup"
+
+      cleanup() {
+        unset SERVICE_PORT
+        unset REDIS_DEFAULT_PASSWORD
+      }
+      After "cleanup"
+
+      It "uses custom port and sets auth"
+        When call init_reconfigure_env
+        The variable service_port should eq "6380"
+        The variable auth_arg should eq "-a mypass"
+      End
+    End
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -398,7 +398,7 @@ Describe "Redis Reconfigure Config (argv-based)"
             echo "OK"; return 0
             ;;
           GET)
-            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            printf 'client-output-buffer-limit\nnormal 0 0 0 slave 268435456 67108864 60 pubsub 33554432 8388608 60\n'
             return 0
             ;;
         esac
@@ -420,7 +420,7 @@ Describe "Redis Reconfigure Config (argv-based)"
       End
     End
 
-    Context "subkey parameter with memory units (replica 256mb 64mb 60)"
+    Context "subkey replica with slave alias in readback (Redis returns slave for replica)"
       _captured_set_args=""
       redis-cli() {
         local op
@@ -435,7 +435,7 @@ Describe "Redis Reconfigure Config (argv-based)"
             echo "OK"; return 0
             ;;
           GET)
-            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            printf 'client-output-buffer-limit\nnormal 0 0 0 slave 268435456 67108864 60 pubsub 33554432 8388608 60\n'
             return 0
             ;;
         esac
@@ -448,12 +448,39 @@ Describe "Redis Reconfigure Config (argv-based)"
       }
       Before "setup"
 
-      It "matches memory-unit value against bytes readback"
+      It "matches replica memory-unit value against slave bytes readback"
         When call apply_parameter "client-output-buffer-limit replica" "256mb 64mb 60"
         The status should be success
         The stdout should include "OK"
         The stderr should include "applied and verified"
         The variable _captured_set_args should eq "client-output-buffer-limit|replica 256mb 64mb 60"
+      End
+    End
+
+    Context "subkey replica with replica in readback (Redis 7+)"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET)
+            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            return 0
+            ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "matches replica memory-unit value against replica bytes readback"
+        When call apply_parameter "client-output-buffer-limit replica" "256mb 64mb 60"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
       End
     End
 
@@ -464,7 +491,7 @@ Describe "Redis Reconfigure Config (argv-based)"
         case "$op" in
           SET) echo "OK"; return 0 ;;
           GET)
-            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            printf 'client-output-buffer-limit\nnormal 0 0 0 slave 268435456 67108864 60 pubsub 33554432 8388608 60\n'
             return 0
             ;;
         esac
@@ -491,7 +518,7 @@ Describe "Redis Reconfigure Config (argv-based)"
         case "$op" in
           SET) echo "OK"; return 0 ;;
           GET)
-            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            printf 'client-output-buffer-limit\nnormal 0 0 0 slave 268435456 67108864 60 pubsub 33554432 8388608 60\n'
             return 0
             ;;
         esac

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -64,6 +64,28 @@ Describe "Redis Reconfigure Config (argv-based)"
     End
   End
 
+  Describe "normalize_tokens()"
+    It "passes plain numbers through"
+      When call normalize_tokens "replica 268435456 67108864 60"
+      The output should eq "replica 268435456 67108864 60"
+    End
+
+    It "converts memory units to bytes"
+      When call normalize_tokens "replica 256mb 64mb 60"
+      The output should eq "replica 268435456 67108864 60"
+    End
+
+    It "handles mixed units"
+      When call normalize_tokens "pubsub 32mb 8mb 60"
+      The output should eq "pubsub 33554432 8388608 60"
+    End
+
+    It "passes all-zero tuple through"
+      When call normalize_tokens "normal 0 0 0"
+      The output should eq "normal 0 0 0"
+    End
+  End
+
   Describe "values_match()"
     It "matches identical strings"
       When call values_match "100" "100"
@@ -395,6 +417,70 @@ Describe "Redis Reconfigure Config (argv-based)"
         The stdout should include "OK"
         The stderr should include "applied and verified"
         The variable _captured_set_args should eq "client-output-buffer-limit|normal 0 0 0"
+      End
+    End
+
+    Context "subkey parameter with memory units (replica 256mb 64mb 60)"
+      _captured_set_args=""
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET)
+            local n=$#
+            local val="${!n}"
+            local prev=$((n - 1))
+            local key="${!prev}"
+            _captured_set_args="$key|$val"
+            echo "OK"; return 0
+            ;;
+          GET)
+            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            return 0
+            ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+        _captured_set_args=""
+      }
+      Before "setup"
+
+      It "matches memory-unit value against bytes readback"
+        When call apply_parameter "client-output-buffer-limit replica" "256mb 64mb 60"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+        The variable _captured_set_args should eq "client-output-buffer-limit|replica 256mb 64mb 60"
+      End
+    End
+
+    Context "subkey parameter with memory units (pubsub 32mb 8mb 60)"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET)
+            printf 'client-output-buffer-limit\nnormal 0 0 0 replica 268435456 67108864 60 pubsub 33554432 8388608 60\n'
+            return 0
+            ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "matches pubsub memory-unit value against bytes readback"
+        When call apply_parameter "client-output-buffer-limit pubsub" "32mb 8mb 60"
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
       End
     End
 

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -568,6 +568,30 @@ Describe "Redis Reconfigure Config (argv-based)"
         The stderr should include "applied and verified"
       End
     End
+
+    Context "CONFIG GET fails"
+      redis-cli() {
+        local op
+        op=$(_redis_cli_operation "$@")
+        case "$op" in
+          SET) echo "OK"; return 0 ;;
+          GET) echo "NOAUTH Authentication required."; return 1 ;;
+        esac
+      }
+
+      setup() {
+        service_port=6379
+        auth_arg=""
+      }
+      Before "setup"
+
+      It "returns failure when CONFIG GET returns error"
+        When call apply_parameter "notify-keyspace-events" ""
+        The status should be failure
+        The stdout should include "OK"
+        The stderr should include "CONFIG GET notify-keyspace-events failed"
+      End
+    End
   End
 
   Describe "init_reconfigure_env()"

--- a/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_reconfigure_config_spec.sh
@@ -383,6 +383,13 @@ Describe "Redis Reconfigure Config (argv-based)"
         The stdout should include "OK"
         The stderr should include "applied and verified"
       End
+
+      It "normalizes literal double-quote pair to empty string"
+        When call apply_parameter "notify-keyspace-events" '""'
+        The status should be success
+        The stdout should include "OK"
+        The stderr should include "applied and verified"
+      End
     End
   End
 

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -54,7 +54,12 @@ apply_parameter() {
     return 1
   }
 
-  _ap_actual=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET "$_ap_key" 2>/dev/null | awk 'NR==2 {print}')
+  # shellcheck disable=SC2086
+  _ap_get_output=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET "$_ap_key" 2>/dev/null) || {
+    echo "ERROR: CONFIG GET $_ap_key failed (redis-cli exit $?)" >&2
+    return 1
+  }
+  _ap_actual=$(printf '%s\n' "$_ap_get_output" | awk 'NR==2 {print}')
   if [ -n "$_ap_subkey" ]; then
     _ap_norm_expected="$(normalize_tokens "$_ap_value")"
     _ap_norm_actual="$(normalize_tokens "$_ap_actual")"

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Controller passes one [key, value] pair per invocation via argv.
+# $1 = parameter name, $2 = parameter value.
+
+init_reconfigure_env() {
+  service_port=${SERVICE_PORT:-6379}
+  auth_arg=""
+  [ -z "${REDIS_DEFAULT_PASSWORD:-}" ] || auth_arg="-a ${REDIS_DEFAULT_PASSWORD}"
+}
+
+to_bytes() {
+  case "$1" in
+    *[kK][bB]) echo $(( ${1%[kK][bB]} * 1024 )) ;;
+    *[mM][bB]) echo $(( ${1%[mM][bB]} * 1024 * 1024 )) ;;
+    *[gG][bB]) echo $(( ${1%[gG][bB]} * 1024 * 1024 * 1024 )) ;;
+    *) echo "$1" ;;
+  esac
+}
+
+values_match() {
+  [ "$1" = "$2" ] && return 0
+  [ "$(to_bytes "$1")" = "$(to_bytes "$2")" ] && return 0
+  return 1
+}
+
+apply_parameter() {
+  _ap_key="$1"
+  _ap_value="$2"
+
+  # shellcheck disable=SC2086
+  redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG SET "$_ap_key" "$_ap_value" || {
+    echo "ERROR: CONFIG SET $_ap_key failed (redis-cli exit $?)" >&2
+    return 1
+  }
+
+  _ap_actual=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET "$_ap_key" 2>/dev/null | awk 'NR==2 {print}')
+  if [ -z "$_ap_actual" ] && [ -n "$_ap_value" ]; then
+    echo "ERROR: CONFIG GET $_ap_key returned nothing after SET" >&2
+    return 1
+  fi
+  if ! values_match "$_ap_actual" "$_ap_value"; then
+    echo "ERROR: CONFIG SET $_ap_key readback mismatch: engine='$_ap_actual', expected='$_ap_value'" >&2
+    return 1
+  fi
+
+  echo "INFO: CONFIG SET $_ap_key='$_ap_value' applied and verified" >&2
+  return 0
+}
+
+${__SOURCED__:+false} : || return 0
+
+if [ $# -lt 2 ]; then
+  echo "ERROR: reconfigure requires key and value arguments (received $# args)" >&2
+  exit 1
+fi
+
+init_reconfigure_env
+apply_parameter "$1" "$2"
+exit $?

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -58,10 +58,23 @@ apply_parameter() {
   if [ -n "$_ap_subkey" ]; then
     _ap_norm_expected="$(normalize_tokens "$_ap_value")"
     _ap_norm_actual="$(normalize_tokens "$_ap_actual")"
+    _ap_readback_ok=0
     case "$_ap_norm_actual" in
-      *"$_ap_norm_expected"*) ;;
-      *) echo "ERROR: CONFIG SET $_ap_key readback does not contain '$_ap_value'" >&2; return 1 ;;
+      *"$_ap_norm_expected"*) _ap_readback_ok=1 ;;
     esac
+    if [ "$_ap_readback_ok" = 0 ]; then
+      case "$_ap_subkey" in
+        replica) _ap_alias_expected="slave ${_ap_norm_expected#replica }" ;;
+        slave)   _ap_alias_expected="replica ${_ap_norm_expected#slave }" ;;
+        *)       _ap_alias_expected="" ;;
+      esac
+      [ -n "$_ap_alias_expected" ] && case "$_ap_norm_actual" in
+        *"$_ap_alias_expected"*) _ap_readback_ok=1 ;;
+      esac
+    fi
+    [ "$_ap_readback_ok" = 1 ] || {
+      echo "ERROR: CONFIG SET $_ap_key readback does not contain '$_ap_value'" >&2; return 1
+    }
   else
     if [ -z "$_ap_actual" ] && [ -n "$_ap_value" ]; then
       echo "ERROR: CONFIG GET $_ap_key returned nothing after SET" >&2

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -18,6 +18,15 @@ to_bytes() {
   esac
 }
 
+normalize_tokens() {
+  set -- $1
+  _nt_out=""
+  for _nt_tok; do
+    _nt_out="${_nt_out:+$_nt_out }$(to_bytes "$_nt_tok")"
+  done
+  echo "$_nt_out"
+}
+
 values_match() {
   [ "$1" = "$2" ] && return 0
   [ "$(to_bytes "$1")" = "$(to_bytes "$2")" ] && return 0
@@ -47,10 +56,11 @@ apply_parameter() {
 
   _ap_actual=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET "$_ap_key" 2>/dev/null | awk 'NR==2 {print}')
   if [ -n "$_ap_subkey" ]; then
-    _ap_expected="$_ap_value"
-    case "$_ap_actual" in
-      *"$_ap_expected"*) ;;
-      *) echo "ERROR: CONFIG SET $_ap_key readback does not contain '$_ap_expected'" >&2; return 1 ;;
+    _ap_norm_expected="$(normalize_tokens "$_ap_value")"
+    _ap_norm_actual="$(normalize_tokens "$_ap_actual")"
+    case "$_ap_norm_actual" in
+      *"$_ap_norm_expected"*) ;;
+      *) echo "ERROR: CONFIG SET $_ap_key readback does not contain '$_ap_value'" >&2; return 1 ;;
     esac
   else
     if [ -z "$_ap_actual" ] && [ -n "$_ap_value" ]; then

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -27,7 +27,17 @@ values_match() {
 apply_parameter() {
   _ap_key="$1"
   _ap_value="$2"
+  _ap_subkey=""
   [ "$_ap_value" = '""' ] && _ap_value=""
+
+  # Handle subkey parameters: "client-output-buffer-limit normal" -> key + subkey
+  case "$_ap_key" in
+    *" "*)
+      _ap_subkey="${_ap_key#* }"
+      _ap_key="${_ap_key%% *}"
+      _ap_value="${_ap_subkey} ${_ap_value}"
+      ;;
+  esac
 
   # shellcheck disable=SC2086
   redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG SET "$_ap_key" "$_ap_value" || {
@@ -36,13 +46,21 @@ apply_parameter() {
   }
 
   _ap_actual=$(redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG GET "$_ap_key" 2>/dev/null | awk 'NR==2 {print}')
-  if [ -z "$_ap_actual" ] && [ -n "$_ap_value" ]; then
-    echo "ERROR: CONFIG GET $_ap_key returned nothing after SET" >&2
-    return 1
-  fi
-  if ! values_match "$_ap_actual" "$_ap_value"; then
-    echo "ERROR: CONFIG SET $_ap_key readback mismatch: engine='$_ap_actual', expected='$_ap_value'" >&2
-    return 1
+  if [ -n "$_ap_subkey" ]; then
+    _ap_expected="$_ap_value"
+    case "$_ap_actual" in
+      *"$_ap_expected"*) ;;
+      *) echo "ERROR: CONFIG SET $_ap_key readback does not contain '$_ap_expected'" >&2; return 1 ;;
+    esac
+  else
+    if [ -z "$_ap_actual" ] && [ -n "$_ap_value" ]; then
+      echo "ERROR: CONFIG GET $_ap_key returned nothing after SET" >&2
+      return 1
+    fi
+    if ! values_match "$_ap_actual" "$_ap_value"; then
+      echo "ERROR: CONFIG SET $_ap_key readback mismatch: engine='$_ap_actual', expected='$_ap_value'" >&2
+      return 1
+    fi
   fi
 
   echo "INFO: CONFIG SET $_ap_key='$_ap_value' applied and verified" >&2

--- a/addons/redis/scripts/redis-reconfigure-config.sh
+++ b/addons/redis/scripts/redis-reconfigure-config.sh
@@ -27,6 +27,7 @@ values_match() {
 apply_parameter() {
   _ap_key="$1"
   _ap_value="$2"
+  [ "$_ap_value" = '""' ] && _ap_value=""
 
   # shellcheck disable=SC2086
   redis-cli ${REDIS_CLI_TLS_CMD:-} -p "$service_port" $auth_arg CONFIG SET "$_ap_key" "$_ap_value" || {

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -202,13 +202,8 @@ reconfigure:
     container: {{ $container }}
     targetPodSelector: All
     command:
-      - /bin/bash
-      - -c
-      - |
-        set -eu
-
-        /scripts/reload-parameter.sh "$1" "$2"
-      - --
+      - /bin/sh
+      - /scripts/redis-reconfigure-config.sh
 {{- end -}}
 
 {{- define "apeDts.reshard.image" -}}


### PR DESCRIPTION
## Summary

Replace the inline `bash -c` wrapper calling `reload-parameter.sh` with a dedicated `redis-reconfigure-config.sh` that receives parameter key/value via kbagent `ActionRequest.Arguments` (`$1`/`$2`).

Changes:
- New `redis-reconfigure-config.sh`: argv-based reconfigure with CONFIG GET readback verification after every CONFIG SET, memory format normalization (kb/mb/gb vs bytes), literal `""` normalization to empty string, subkey parameter handling (e.g. `client-output-buffer-limit normal/replica/pubsub`), `replica`/`slave` class alias handling for readback, fail-closed on missing args
- Template `_helpers.tpl`: simplified `reconfigure.exec.command` to `/bin/sh /scripts/redis-reconfigure-config.sh` (no `bash -c` wrapper, no `--` separator needed)
- 37 ShellSpec unit tests covering: to_bytes, normalize_tokens, values_match, apply_parameter (success/failure/readback mismatch/empty readback/auth/TLS/custom port/empty value/literal `""` normalization/subkey split/subkey memory-unit normalization/subkey replica/slave alias/subkey mismatch), init_reconfigure_env

## Evidence

### Hot-swap 10003 (argv mechanism proof)
- Evidence package: `artifacts/reconfigure-argv-redis-20260622T2236.tgz`
- SHA256: `8a5d70016a25dbbb2bd738888f4ed86a5547200895b2b1b76339f53fb507cead`
- Result: `CONFIG GET maxclients = 10003` after OpsRequest Succeed

### Hot-swap 10004 (PR exact-head script focused acceptance)
- Evidence package: `artifacts/reconfigure-argv-pr2888-20260622T2340.tgz`
- SHA256: `c0007b458c268c93425b335edb6248ab20954e8d0d338c2a9fe02f340ba082d0`
- PR head: `3e2e183`
- Result: `CONFIG GET maxclients = 10004` after OpsRequest Succeed

### Matching-image 10005 (release-scope runtime acceptance)
- Evidence package: `artifacts/reconfigure-argv-pr2888-matching-image-20260623T0140.tgz`
- SHA256: `f901bc0afb12b61378b47e8919ee4704ec4eed71247e56783bf002554785a966`
- Tools image: `kubeblocks-tools:pr-10361-52094ef-stella`
- PR head: `3e2e183`
- Result: `CONFIG GET maxclients = 10005` after OpsRequest Succeed (pod recreated with matching tools image)

### Exact-head `891e2f7` runtime (subkey + alias + memory-unit)
- maxclients=10009: OpsRequest Succeed, readback `10009`. SHA256: `3ad1aa0bb57fd1b28fc3e1997d47c9e6a1684f823d68d92229f2d761a0c4e60c`
- client-output-buffer-limit replica "256mb 64mb 60": OpsRequest Succeed, readback contains `slave 268435456 67108864 60` (alias + bytes match). SHA256: `09c11fe7e0d0077400e0c276782ba7edf4e5c69e41f7e9d814c7dd0bf07491b0`
- client-output-buffer-limit pubsub "64mb 16mb 60": OpsRequest Succeed, readback contains `pubsub 67108864 16777216 60`. SHA256: `6eb39521cd247e25dbaae717e4220363f97c947d6829e69701300102d24c100f`

Root cause of prior `$1: unbound variable`: controller/tools image version mismatch — pod kbagent binary predated PR #10350 which added `ActionRequest.Arguments` support. Not a code logic bug.

## Test plan

- [x] ShellSpec unit tests: 37/0/0 (bash 5.3.9)
- [x] Full Redis ShellSpec suite: 409/0/0
- [x] Existing reload-parameter tests: 9/0/0 (no regression)
- [x] helm lint: PASS
- [x] helm template: reconfigure actions render correctly across all topologies
- [x] Hot-swap runtime 10003: argv mechanism proof PASS
- [x] Hot-swap runtime 10004: PR exact-head script focused acceptance PASS
- [x] Matching-image runtime 10005: release-scope runtime acceptance PASS
- [x] Exact-head `891e2f7` runtime: maxclients PASS, replica subkey+alias+memory-unit PASS, pubsub subkey+memory-unit PASS