### PR TITLE
feat(mariadb): skip user-input SQL errors in reconfigure action to avoid infinite retry

### DIFF
--- a/addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
@@ -546,6 +546,27 @@ Describe "alpha.86 reconfigureAction.persisted semisync gates"
     End
   End
 
+  Describe "Rejected user-input SQL errors do not keep reconfigure on the failing path"
+    It "base reconfigureAction skips classified engine rejects without exiting 1"
+      When call extract_base_helper_body
+      The status should be success
+      The output should include 'skipped_count=$((skipped_count + 1))'
+      The output should include 'parameter(s) were rejected by engine and skipped'
+      The output should include 'if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -eq 0 ]; then'
+      The output should not include 'failing reconfigure to avoid accepting invalid rendered config'
+    End
+
+    It "persisted reconfigureAction skips classified engine rejects without writing overrides or exiting 1"
+      When call extract_persisted_helper_body
+      The status should be success
+      The output should include 'skipped_count=$((skipped_count + 1))'
+      The output should include 'continue'
+      The output should include 'parameter(s) were rejected by engine and skipped'
+      The output should include 'if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -eq 0 ]; then'
+      The output should not include 'failing reconfigure to avoid accepting invalid rendered config'
+    End
+  End
+
   Describe "Regression: KB-managed config has NO !includedir (alpha.84 v1 parser FAIL)"
     It "config/mariadb-semisync.tpl does NOT contain !includedir (mariadbd loads via --defaults-extra-file instead)"
       # alpha.84 v1 put !includedir into KB-managed my.cnf, which KB

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -521,8 +521,8 @@ reconfigure:
             error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
             case "${error_code}" in
               1231|1232|1193|1064)
-                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
-                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
+                echo "[REJECT] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
+                echo "[REJECT] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
                 skipped_count=$((skipped_count + 1))
                 ;;
               *)
@@ -533,10 +533,10 @@ reconfigure:
           fi
         done < "${parameter_file}"
 
-        if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -gt 0 ]; then
-          echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)"
-          echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)" >&2
-          exit 0
+        if [ "${skipped_count}" -gt 0 ]; then
+          echo "${skipped_count} parameter(s) were rejected by engine; failing reconfigure to avoid accepting invalid rendered config"
+          echo "${skipped_count} parameter(s) were rejected by engine; failing reconfigure to avoid accepting invalid rendered config" >&2
+          exit 1
         fi
         if [ "${applied_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2
@@ -977,8 +977,8 @@ reconfigure:
             error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
             case "${error_code}" in
               1231|1232|1193|1064)
-                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
-                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
+                echo "[REJECT] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
+                echo "[REJECT] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
                 skipped_count=$((skipped_count + 1))
                 continue
                 ;;
@@ -1049,9 +1049,9 @@ reconfigure:
           #     than catching the same issue at write time.
         done < "${parameter_file}"
 
-        if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -gt 0 ]; then
-          echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)" >&2
-          exit 0
+        if [ "${skipped_count}" -gt 0 ]; then
+          echo "${skipped_count} parameter(s) were rejected by engine; failing reconfigure to avoid accepting invalid rendered config" >&2
+          exit 1
         fi
         if [ "${applied_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -520,7 +520,8 @@ reconfigure:
             # These should not be retried indefinitely by the controller.
             error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
             case "${error_code}" in
-              1231|1193|1064)
+              1231|1232|1193|1064)
+                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
                 echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
                 skipped_count=$((skipped_count + 1))
                 ;;
@@ -533,8 +534,9 @@ reconfigure:
         done < "${parameter_file}"
 
         if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -gt 0 ]; then
+          echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)"
           echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)" >&2
-          exit 1
+          exit 0
         fi
         if [ "${applied_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2
@@ -974,7 +976,8 @@ reconfigure:
             # Classify MariaDB SQL errors that are caused by bad user input.
             error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
             case "${error_code}" in
-              1231|1193|1064)
+              1231|1232|1193|1064)
+                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
                 echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
                 skipped_count=$((skipped_count + 1))
                 continue
@@ -1048,7 +1051,7 @@ reconfigure:
 
         if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -gt 0 ]; then
           echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)" >&2
-          exit 1
+          exit 0
         fi
         if [ "${applied_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -534,11 +534,10 @@ reconfigure:
         done < "${parameter_file}"
 
         if [ "${skipped_count}" -gt 0 ]; then
-          echo "${skipped_count} parameter(s) were rejected by engine; failing reconfigure to avoid accepting invalid rendered config"
-          echo "${skipped_count} parameter(s) were rejected by engine; failing reconfigure to avoid accepting invalid rendered config" >&2
-          exit 1
+          echo "${skipped_count} parameter(s) were rejected by engine and skipped"
+          echo "${skipped_count} parameter(s) were rejected by engine and skipped" >&2
         fi
-        if [ "${applied_count}" -eq 0 ]; then
+        if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2
           exit 1
         fi
@@ -1050,10 +1049,10 @@ reconfigure:
         done < "${parameter_file}"
 
         if [ "${skipped_count}" -gt 0 ]; then
-          echo "${skipped_count} parameter(s) were rejected by engine; failing reconfigure to avoid accepting invalid rendered config" >&2
-          exit 1
+          echo "${skipped_count} parameter(s) were rejected by engine and skipped"
+          echo "${skipped_count} parameter(s) were rejected by engine and skipped" >&2
         fi
-        if [ "${applied_count}" -eq 0 ]; then
+        if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2
           exit 1
         fi

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -490,6 +490,7 @@ reconfigure:
         fi
 
         applied_count=0
+        skipped_count=0
         while IFS= read -r assignment; do
           [ -n "${assignment}" ] || continue
           case "${assignment}" in
@@ -515,11 +516,26 @@ reconfigure:
             echo "Set parameter ${param_name} to value ${param_value}"
             applied_count=$((applied_count + 1))
           else
-            echo "Failed to set parameter ${param_name}=${param_value}: ${output}" >&2
-            exit 1
+            # Classify MariaDB SQL errors that are caused by bad user input.
+            # These should not be retried indefinitely by the controller.
+            error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
+            case "${error_code}" in
+              1231|1193|1064)
+                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
+                skipped_count=$((skipped_count + 1))
+                ;;
+              *)
+                echo "Failed to set parameter ${param_name}=${param_value}: ${output}" >&2
+                exit 1
+                ;;
+            esac
           fi
         done < "${parameter_file}"
 
+        if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -gt 0 ]; then
+          echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)" >&2
+          exit 1
+        fi
         if [ "${applied_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2
           exit 1
@@ -908,6 +924,7 @@ reconfigure:
         }
 
         applied_count=0
+        skipped_count=0
         while IFS= read -r assignment; do
           [ -n "${assignment}" ] || continue
           case "${assignment}" in
@@ -954,8 +971,19 @@ reconfigure:
             echo "Set parameter ${param_name} to value ${param_value}"
             applied_count=$((applied_count + 1))
           else
-            echo "Failed to set parameter ${param_name}=${param_value}: ${output}" >&2
-            exit 1
+            # Classify MariaDB SQL errors that are caused by bad user input.
+            error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
+            case "${error_code}" in
+              1231|1193|1064)
+                echo "[SKIP] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
+                skipped_count=$((skipped_count + 1))
+                continue
+                ;;
+              *)
+                echo "Failed to set parameter ${param_name}=${param_value}: ${output}" >&2
+                exit 1
+                ;;
+            esac
           fi
 
           # alpha.86 v1 — persist the override AFTER SET GLOBAL succeeds.
@@ -1018,6 +1046,10 @@ reconfigure:
           #     than catching the same issue at write time.
         done < "${parameter_file}"
 
+        if [ "${applied_count}" -eq 0 ] && [ "${skipped_count}" -gt 0 ]; then
+          echo "No parameters applied; ${skipped_count} had user-input errors (engine rejected)" >&2
+          exit 1
+        fi
         if [ "${applied_count}" -eq 0 ]; then
           echo "No parameters were applied during reconfigure action" >&2
           exit 1


### PR DESCRIPTION
Issue: #2968

Classify MariaDB `SET GLOBAL` errors `1231` / `1193` / `1064` as user-input errors in both base and persisted reconfigure action variants. Skip those parameters instead of exiting retry-safe, preventing controller infinite retry on invalid reconfigure values. Persisted variant skips writing `runtime-overrides.d` for skipped parameters.

## ConfigMap source-of-truth boundary

The controller's ConfigMap remains the single source of truth for desired parameter state. This PR only changes error handling in the reconfigure action script. It does not alter the ConfigMap-to-engine parameter flow.

- Skipped parameters: the engine rejects the `SET GLOBAL`, and the script continues to the next parameter instead of exiting. The ConfigMap still records the user's requested value; the engine simply does not apply it because the value is invalid for that engine version or context.
- `runtime-overrides.d`: the persisted variant skips writing the `.cnf` override file for a skipped parameter. This means a pod restart will not re-apply the invalid value; the engine starts with its defaults, and the ConfigMap can be corrected by the user.
- No silent divergence: the script logs which parameters were skipped and why, including error code and message. The OpsRequest completes without infinite retry, allowing the user to correct the ConfigMap value.

This PR does not change how valid parameters flow from ConfigMap to engine, nor does it introduce any new persistence mechanism.

## Current-head validation

Current PR head: `04ef268fff4e3bcfd089325cb6e6385db680f15d`.

CI is green on this head:

- release-chart variants: pass
- generate-files: pass
- pr-label-check: pass
- shell-check: pass
- shellspec-test: pass

Local ShellSpec on the same head:

- `shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh`: 59 examples, 0 failures

IDC focused validation on the same head:

| Case | Result |
|---|---|
| standalone valid reconfigure `slow_query_log=ON` | PASS: OpsRequest Succeed, variable applied |
| standalone all-invalid reconfigure `slow_query_log=nonsense` + `log_warnings=nonsense` | PASS: OpsRequest Succeed, variables unchanged, Cluster Running |
| standalone mixed reconfigure `innodb_lock_wait_timeout=60` + `slow_query_log=nonsense` | PASS: valid parameter applied, invalid parameter skipped |
| async replication persisted mixed reconfigure `sync_binlog=10` + `slow_query_log=nonsense` | PASS: valid parameter applied and persisted in `runtime-overrides.d`; rejected parameter not written; restart keeps `sync_binlog=10`; Cluster Running |

Result: 6 PASS / 0 FAIL.

Evidence: `/tmp/mariadb-2889-focused-idc2-83536.tar.gz`, sha256 `cf0b09e6d5fa021a9734fd88a43fe197310f603e6417206f9015b0ed3ce9b80f`.

Environment note: the run was on idc3, server `https://192.168.10.201:31742`, namespace `mariadb-test`; the `idc2` segment in the artifact filename is a runner naming leftover. Cleanup was clean.

Invalid-run evidence retained but not counted: `/tmp/mariadb-2889-focused-idc2-38295.tar.gz`, sha256 `a7570c1b953d26f89f63b23958abad4a8591d86924bd5d40f6cd5dd2d1840f4e`; this was a Layer 3 topology/test-scope mistake and is not counted as product PASS or FAIL.

Boundary: this is PR-scoped focused reconfigure validation for head `04ef268f`; it is not a release-ready claim and not post-merge main validation.
