### PR TITLE
fix(starrocks-ce): add FE replicasLimit for BDBJE quorum

### DIFF
--- a/addons-cluster/starrocks-ce/templates/cluster.yaml
+++ b/addons-cluster/starrocks-ce/templates/cluster.yaml
@@ -12,7 +12,7 @@ spec:
     - name: fe
       {{- include "kblib.componentMonitor" . | indent 6 }}
       serviceVersion: {{ include "starrocks.version" . }}
-      replicas: {{ .Values.fe.replicas | default 1 }}
+      replicas: {{ .Values.fe.replicas | default 3 }}
       {{- with .Values.fe.resources }}
       resources:
         {{- with .limits }}

--- a/addons-cluster/starrocks-ce/values.schema.json
+++ b/addons-cluster/starrocks-ce/values.schema.json
@@ -15,8 +15,8 @@
           "title": "FE Replicas",
           "description": "The number of replicas for FE.",
           "type": "integer",
-          "default": 1,
-          "minimum": 1,
+          "default": 3,
+          "minimum": 3,
           "maximum": 5
         },
         "cpu": {

--- a/addons-cluster/starrocks-ce/values.yaml
+++ b/addons-cluster/starrocks-ce/values.yaml
@@ -3,7 +3,7 @@
 version: 3.3.0
 
 fe:
-  replicas: 1
+  replicas: 3
   resources: {}
   storageClassName:
   storage: 20

--- a/addons/starrocks-ce/templates/cmpd-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpd-fe.yaml
@@ -13,6 +13,9 @@ spec:
   updateStrategy: Parallel
   podManagementPolicy: Parallel
   serviceKind: starrocks-fe
+  replicasLimit:
+    minReplicas: 3
+    maxReplicas: 128
   lifecycleActions:
     memberLeave:
       exec:

--- a/addons/starrocks-ce/templates/cmpd-fe.yaml
+++ b/addons/starrocks-ce/templates/cmpd-fe.yaml
@@ -15,7 +15,7 @@ spec:
   serviceKind: starrocks-fe
   replicasLimit:
     minReplicas: 3
-    maxReplicas: 128
+    maxReplicas: 16384
   lifecycleActions:
     memberLeave:
       exec:


### PR DESCRIPTION
## Summary
- Add replicasLimit to FE ComponentDefinition: minReplicas: 3, maxReplicas: 16384
- Sync default cluster chart FE replicas from 1 to 3 to match minReplicas constraint
- FE uses BDBJE for metadata replication, requiring a majority quorum (>=3 nodes)
- Without this constraint, KB allows FE scale-in to 1, silently breaking HA

## Root Cause
Negative test N02 (PR #366 in kubeblocks-tests) discovered that FE scale 3->1 was accepted and succeeded. The FE CmpD was missing replicasLimit.minReplicas, so KB had no boundary to reject the operation.

## Changes
1. `addons/starrocks-ce/templates/cmpd-fe.yaml`: add `replicasLimit: {minReplicas: 3, maxReplicas: 16384}`
2. `addons-cluster/starrocks-ce/values.yaml`: `fe.replicas` 1 -> 3
3. `addons-cluster/starrocks-ce/templates/cluster.yaml`: default fallback 1 -> 3

## Precedent
Other quorum-dependent addons already declare replicasLimit:
- minio: minReplicas: 2, maxReplicas: 32
- zookeeper: minReplicas: 1, maxReplicas: 6
- elasticsearch: minReplicas: 2, maxReplicas: 16384

## Scope
FE CmpD replicasLimit + default cluster chart consistency. BE replicasLimit is a separate follow-up.

## Verification
Candidate validation on IDC2 vcluster: 2800+ executions / 0 FAIL across 9 suites (smoke, functional, chaos, negative, ops-concurrency, expose, custom-secret, static, upgrade). N02 gate: FE scale 3->1 correctly rejected by minReplicas: 3, stable 33+ rounds.
