### PR TITLE
fix(pulsar): move env: inside debugEnabled conditional to avoid null

### DIFF
--- a/addons/pulsar/templates/cmpd-bookies-recovery-2.yaml
+++ b/addons/pulsar/templates/cmpd-bookies-recovery-2.yaml
@@ -70,8 +70,8 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/check-bookies.sh
-        env:
         {{- if .Values.debugEnabled }}
+        env:
           - name: PULSAR_LOG_ROOT_LEVEL
             value: DEBUG
           - name: PULSAR_LOG_LEVEL

--- a/addons/pulsar/templates/cmpd-bookies-recovery-3.yaml
+++ b/addons/pulsar/templates/cmpd-bookies-recovery-3.yaml
@@ -70,8 +70,8 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/check-bookies.sh
-        env:
         {{- if .Values.debugEnabled }}
+        env:
           - name: PULSAR_LOG_ROOT_LEVEL
             value: DEBUG
           - name: PULSAR_LOG_LEVEL

--- a/addons/pulsar/templates/cmpd-bookies-recovery-4.yaml
+++ b/addons/pulsar/templates/cmpd-bookies-recovery-4.yaml
@@ -54,8 +54,8 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - /kb-scripts/check-bookies.sh
-        env:
         {{- if .Values.debugEnabled }}
+        env:
           - name: PULSAR_LOG_ROOT_LEVEL
             value: DEBUG
           - name: PULSAR_LOG_LEVEL

--- a/addons/pulsar/templates/cmpd-proxy-2.yaml
+++ b/addons/pulsar/templates/cmpd-proxy-2.yaml
@@ -80,8 +80,8 @@ spec:
             mountPath: /kb-scripts
           - name: pulsar-proxy-config
             mountPath: /opt/pulsar/conf
-        env:
         {{- if .Values.debugEnabled }}
+        env:
           - name: PULSAR_LOG_ROOT_LEVEL
             value: DEBUG
           - name: PULSAR_LOG_LEVEL

--- a/addons/pulsar/templates/cmpd-proxy-3.yaml
+++ b/addons/pulsar/templates/cmpd-proxy-3.yaml
@@ -80,8 +80,8 @@ spec:
             mountPath: /kb-scripts
           - name: pulsar-proxy-config
             mountPath: /opt/pulsar/conf
-        env:
         {{- if .Values.debugEnabled }}
+        env:
           - name: PULSAR_LOG_ROOT_LEVEL
             value: DEBUG
           - name: PULSAR_LOG_LEVEL

--- a/addons/pulsar/templates/cmpd-proxy-4.yaml
+++ b/addons/pulsar/templates/cmpd-proxy-4.yaml
@@ -65,8 +65,8 @@ spec:
             mountPath: /kb-scripts
           - name: pulsar-proxy-config
             mountPath: /opt/pulsar/conf
-        env:
         {{- if .Values.debugEnabled }}
+        env:
           - name: PULSAR_LOG_ROOT_LEVEL
             value: DEBUG
           - name: PULSAR_LOG_LEVEL


### PR DESCRIPTION
## Summary
- When `debugEnabled=false` (default), initContainers in proxy and bookies-recovery ComponentDefinitions rendered `env:` with no items, producing YAML null
- K8s API rejects: `initContainers[0].env must be of type array: "null"`
- Move `env:` inside the `{{- if .Values.debugEnabled }}` conditional so the key only appears when debug env vars exist

Affects 6 templates: `cmpd-proxy-{2,3,4}.yaml`, `cmpd-bookies-recovery-{2,3,4}.yaml`

## Test plan
- [ ] `helm template` renders without `env: null` when `debugEnabled=false`
- [ ] `helm template --set debugEnabled=true` renders `env:` with debug vars
- [ ] Diana re-run hscale suite after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)