### PR TITLE
fix(pulsar): use static zookeeper config templates

### DIFF
--- a/addons/pulsar/templates/cmpd-zookeeper-2.yaml
+++ b/addons/pulsar/templates/cmpd-zookeeper-2.yaml
@@ -26,7 +26,6 @@ spec:
       template: {{ include "pulsar2.zookeeperTplName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: zookeeper-config
-      externalManaged: true
   scripts:
     - name: pulsar-scripts
       template: {{ include "pulsar.scriptsTplName" . }}

--- a/addons/pulsar/templates/cmpd-zookeeper-3.yaml
+++ b/addons/pulsar/templates/cmpd-zookeeper-3.yaml
@@ -26,7 +26,6 @@ spec:
       template: {{ include "pulsar3.zookeeperTplName" . }}
       namespace: {{ .Release.Namespace }}
       volumeName: zookeeper-config
-      externalManaged: true
   scripts:
     - name: pulsar-scripts
       template: {{ include "pulsar.scriptsTplName" . }}


### PR DESCRIPTION
## Summary
- remove `externalManaged: true` from Pulsar v2/v3 zookeeper ComponentDefinition configs
- keep the existing `pulsar2/3-zookeeper-conf-tpl` static ConfigMap templates

## Why
HS00 rerun6 observed Pulsar zookeeper stuck before pods became Ready with:

`config/script template has no template specified: zookeeper-config`

In that run, the live ComponentDefinition still had `template: pulsar2-zookeeper-conf-tpl`, and the source ConfigMap existed in `kb-system`. The zookeeper config path has no ParametersDefinition/PCR/external provisioner chain, so marking it `externalManaged: true` makes the controller treat the template as externally supplied and the rendered config loses the concrete template.

This PR keeps zookeeper as a static chart-provided config template. It does not change broker/bookies/proxy external-managed config paths.

## Validation
- `git diff --check`
- `helm dependency build addons/pulsar`
- `helm lint addons/pulsar`
- `helm template pulsar addons/pulsar --namespace kb-system >/tmp/pulsar-template-pr-zk-static.yaml`
- rendered Pulsar zookeeper v2/v3 ComponentDefinitions keep `template: pulsar{2,3}-zookeeper-conf-tpl` and no longer render `externalManaged: true`

## Follow-up
After merge, Diana should fresh rerun Milvus hscale HS00-HS04 from addons main and keep the usual boundary evidence. The rerun6 failure remains a Layer 5 Pulsar addon chart contract blocker and is not a Milvus hscale PASS/FAIL sample.
