### PR TITLE
fix(pulsar): use broker health probe endpoint

### DIFF
--- a/addons/pulsar/templates/cmpd-broker-2.yaml
+++ b/addons/pulsar/templates/cmpd-broker-2.yaml
@@ -246,7 +246,7 @@ spec:
         livenessProbe:
           failureThreshold: 30
           httpGet:
-            path: /status.html
+            path: /admin/v2/brokers/health
             port: http
             scheme: HTTP
           initialDelaySeconds: 5
@@ -256,7 +256,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status.html
+            path: /admin/v2/brokers/health
             port: http
             scheme: HTTP
           initialDelaySeconds: 30
@@ -266,7 +266,7 @@ spec:
         startupProbe:
           failureThreshold: 30
           httpGet:
-            path: /status.html
+            path: /admin/v2/brokers/health
             port: http
             scheme: HTTP
           initialDelaySeconds: 5

--- a/addons/pulsar/templates/cmpd-broker-3.yaml
+++ b/addons/pulsar/templates/cmpd-broker-3.yaml
@@ -246,7 +246,7 @@ spec:
         livenessProbe:
           failureThreshold: 30
           httpGet:
-            path: /status.html
+            path: /admin/v2/brokers/health
             port: http
             scheme: HTTP
           initialDelaySeconds: 5
@@ -256,7 +256,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /status.html
+            path: /admin/v2/brokers/health
             port: http
             scheme: HTTP
           initialDelaySeconds: 30
@@ -266,7 +266,7 @@ spec:
         startupProbe:
           failureThreshold: 30
           httpGet:
-            path: /status.html
+            path: /admin/v2/brokers/health
             port: http
             scheme: HTTP
           initialDelaySeconds: 5


### PR DESCRIPTION
## Summary
- change Pulsar broker v2/v3 liveness, readiness, and startup probes from `/status.html` to `/admin/v2/brokers/health`
- leave proxy probes unchanged; this PR only targets the broker failure observed in Milvus hscale rerun8

## Why
Milvus hscale rerun8 reached HS00 with the zookeeper and ClusterDefinition gates fixed, then stopped because Pulsar broker `mvs-hpl-8259-broker-0` did not become Ready. The startup probe hit `http://:8080/status.html` and returned HTTP 404.

The existing Pulsar broker v4 ComponentDefinition already uses `/admin/v2/brokers/health`. This PR aligns broker v2/v3 with that broker health endpoint so Pulsar 2.11.2 does not fail startup on a stale `/status.html` probe path.

Rerun8 evidence path from Diana:
- `workspace/results/alpha2-hscale-rerun8-20260623-131918/artifacts/hs00-broker-pod-describe.txt`
- `workspace/results/alpha2-hscale-rerun8-20260623-131918/artifacts/hs00-broker-pod.yaml`
- `workspace/results/alpha2-hscale-rerun8-20260623-131918/artifacts/hs00-broker-container-logs.txt`
- `workspace/results/alpha2-hscale-rerun8-20260623-131918/artifacts/hs00-events.txt`

## Validation
- `git diff --check`
- `helm lint addons/pulsar`
- `helm template pulsar addons/pulsar --namespace kb-system >/tmp/pulsar-template-pr-broker-health.yaml`
- rendered broker v2/v3/v4 ComponentDefinitions all use `path: /admin/v2/brokers/health` for liveness/readiness/startup probes
