### PR TITLE
fix(etcd): replace stale LEADER_POD_FQDN guard in switchover.sh

### DIFF
--- a/addons/etcd/Chart.yaml
+++ b/addons/etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/addons/etcd/Chart.yaml
+++ b/addons/etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-alpha.1
+version: 1.2.0-alpha.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/addons/etcd/releases_notes.yaml
+++ b/addons/etcd/releases_notes.yaml
@@ -1,4 +1,12 @@
 releases:
+  - version: "1.2.0-alpha.2"
+    released_at: ""
+    status: "alpha"
+    notes: "Fix switchover.sh stale LEADER_POD_FQDN guard — replace with request-scoped HOSTNAME check and runtime is_leader verification. Chart version bumped from 1.2.0-alpha.1 for CmpD immutable field safety."
+    git_branch: "main"
+    git_tag: ""
+    commit_sha: ""
+    breaking_changes: "CmpD name changes from etcd-3-1.2.0-alpha.1 to etcd-3-1.2.0-alpha.2."
   - version: "1.2.0-alpha.1"
     released_at: ""
     status: "alpha"

--- a/addons/etcd/releases_notes.yaml
+++ b/addons/etcd/releases_notes.yaml
@@ -1,4 +1,12 @@
 releases:
+  - version: "1.2.0-alpha.1"
+    released_at: ""
+    status: "alpha"
+    notes: "Add B-small ParametersDefinition (8 staticParameters) for Reconfiguring support. Chart version bumped from 1.2.0-alpha.0 to avoid existing-install helm upgrade modifying immutable CmpD spec.configs fields."
+    git_branch: "main"
+    git_tag: ""
+    commit_sha: ""
+    breaking_changes: "CmpD name changes from etcd-3-1.2.0-alpha.0 to etcd-3-1.2.0-alpha.1. Existing clusters referencing the old CmpD name are unaffected but new clusters will use the new CmpD."
   - version: "1.0.1"
     released_at: "2025-09-11"
     status: "stable"

--- a/addons/etcd/scripts-ut-spec/switchover_spec.sh
+++ b/addons/etcd/scripts-ut-spec/switchover_spec.sh
@@ -24,7 +24,7 @@ Describe "Etcd Switchover Script Tests"
     ut_mode="true"
 
     # Setup test environment variables
-    export LEADER_POD_FQDN="etcd-0.etcd-headless.default.svc.cluster.local"
+    export HOSTNAME="etcd-0"
     export KB_SWITCHOVER_CURRENT_FQDN="etcd-0.etcd-headless.default.svc.cluster.local"
     export KB_SWITCHOVER_CANDIDATE_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
     export PEER_ENDPOINT=""
@@ -46,11 +46,10 @@ Describe "Etcd Switchover Script Tests"
       return 1
     }
 
-    # Simple is_leader function
+    # Default: etcd-0 is leader
     is_leader() {
       case "$1" in
         "etcd-0.etcd-headless.default.svc.cluster.local:2379") return 0 ;;
-        "etcd-1.etcd-headless.default.svc.cluster.local:2379") return 0 ;;
         *) return 1 ;;
       esac
     }
@@ -87,7 +86,6 @@ Describe "Etcd Switchover Script Tests"
       esac
     }
 
-    # Define switchover functions
     switchover_with_candidate() {
       local current_pod_name candidate_pod_name current_endpoint candidate_endpoint candidate_id
 
@@ -97,14 +95,17 @@ Describe "Etcd Switchover Script Tests"
       current_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$current_pod_name" "$KB_SWITCHOVER_CURRENT_FQDN")
       candidate_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$candidate_pod_name" "$KB_SWITCHOVER_CANDIDATE_FQDN")
 
-      if ! is_leader "$current_endpoint:2379"; then
-          if is_leader "$candidate_endpoint:2379"; then
-              log "Leader has already changed, no switchover needed"
-              return 0
-          else
-              error_exit "Current node is not leader, and candidate is not leader either."
-              return 1
-          fi
+      local current_is_leader=false candidate_is_leader=false
+      is_leader "$current_endpoint:2379" && current_is_leader=true
+      is_leader "$candidate_endpoint:2379" && candidate_is_leader=true
+
+      if [[ "$current_is_leader" == "false" ]]; then
+        if [[ "$candidate_is_leader" == "true" ]]; then
+          log "Leader has already changed to candidate, no switchover needed"
+          return 0
+        fi
+        error_exit "Current ($current_pod_name) is not leader and candidate ($candidate_pod_name) is not leader either"
+        return 1
       fi
 
       candidate_id=$(get_member_id_hex "$candidate_endpoint:2379")
@@ -119,8 +120,8 @@ Describe "Etcd Switchover Script Tests"
       current_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$current_pod_name" "$KB_SWITCHOVER_CURRENT_FQDN")
 
       if ! is_leader "$current_endpoint:2379"; then
-        error_exit "Current node is not leader, cannot perform automatic switchover"
-        return 1
+        log "Current ($current_pod_name) is no longer leader, switchover already happened"
+        return 0
       fi
 
       leader_id=$(get_member_id "$current_endpoint:2379")
@@ -134,8 +135,9 @@ Describe "Etcd Switchover Script Tests"
     }
 
     switchover() {
-      if [[ "$LEADER_POD_FQDN" != "$KB_SWITCHOVER_CURRENT_FQDN" ]]; then
-        log "switchover action not triggered for leader pod. Exiting."
+      local current_pod_name="${KB_SWITCHOVER_CURRENT_FQDN%%.*}"
+      if [[ "$HOSTNAME" != "$current_pod_name" ]]; then
+        log "This pod ($HOSTNAME) is not the switchover current ($current_pod_name). Skipping."
         return 0
       fi
 
@@ -152,7 +154,7 @@ Describe "Etcd Switchover Script Tests"
 
   cleanup() {
     rm -f $common_library_file
-    unset ut_mode LEADER_POD_FQDN KB_SWITCHOVER_CURRENT_FQDN KB_SWITCHOVER_CANDIDATE_FQDN PEER_ENDPOINT
+    unset ut_mode HOSTNAME KB_SWITCHOVER_CURRENT_FQDN KB_SWITCHOVER_CANDIDATE_FQDN PEER_ENDPOINT
     unset -f get_endpoint_adapt_lb log error_exit is_leader get_member_id_hex get_member_id exec_etcdctl
     unset -f switchover_with_candidate switchover_without_candidate switchover
   }
@@ -176,16 +178,52 @@ Describe "Etcd Switchover Script Tests"
       The stdout should include "Switchover completed successfully"
     End
 
-    It "skips switchover when not triggered for leader pod"
-      export LEADER_POD_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
+    It "skips switchover when HOSTNAME does not match current pod"
+      export HOSTNAME="etcd-2"
 
       When call switchover
       The status should be success
-      The stdout should include "switchover action not triggered for leader pod"
+      The stdout should include "This pod (etcd-2) is not the switchover current (etcd-0). Skipping."
     End
 
-    It "handles switchover failure"
-      # Override exec_etcdctl to fail move-leader command
+    It "skips switchover when stale LEADER_POD_FQDN would have blocked (regression)"
+      # Simulates the T06 root cause: HOSTNAME matches current (this IS the leader pod),
+      # but a hypothetical stale LEADER_POD_FQDN no longer matters
+      export HOSTNAME="etcd-0"
+      export LEADER_POD_FQDN="etcd-2.etcd-headless.default.svc.cluster.local"
+
+      When call switchover
+      The status should be success
+      The stdout should include "Leadership transferred"
+      The stdout should include "completed successfully"
+    End
+
+    It "returns idempotent success when candidate is already leader"
+      # current is not leader, candidate is leader — idempotent
+      is_leader() {
+        case "$1" in
+          "etcd-1.etcd-headless.default.svc.cluster.local:2379") return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+      export KB_SWITCHOVER_CANDIDATE_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
+
+      When call switchover
+      The status should be success
+      The stdout should include "Leader has already changed to candidate"
+    End
+
+    It "fails when neither current nor candidate is leader"
+      is_leader() { return 1; }
+      export KB_SWITCHOVER_CANDIDATE_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
+
+      When call switchover
+      The status should be failure
+      The stderr should include "is not leader and candidate"
+      The stderr should include "is not leader either"
+    End
+
+    It "handles move-leader failure"
       exec_etcdctl() {
         local endpoint="$1"; shift
         if [ "$1" = "move-leader" ]; then

--- a/addons/etcd/scripts/switchover.sh
+++ b/addons/etcd/scripts/switchover.sh
@@ -15,15 +15,22 @@ switchover_with_candidate() {
   current_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$current_pod_name" "$KB_SWITCHOVER_CURRENT_FQDN")
   candidate_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$candidate_pod_name" "$KB_SWITCHOVER_CANDIDATE_FQDN")
 
-  if ! is_leader "$current_endpoint:2379" && is_leader "$candidate_endpoint:2379"; then
-    log "Leader has already changed, no switchover needed"
-    return 0
+  local current_is_leader=false candidate_is_leader=false
+  is_leader "$current_endpoint:2379" && current_is_leader=true
+  is_leader "$candidate_endpoint:2379" && candidate_is_leader=true
+
+  if [[ "$current_is_leader" == "false" ]]; then
+    if [[ "$candidate_is_leader" == "true" ]]; then
+      log "Leader has already changed to candidate, no switchover needed"
+      return 0
+    fi
+    error_exit "Current ($current_pod_name) is not leader and candidate ($candidate_pod_name) is not leader either"
   fi
 
   candidate_id=$(get_member_id_hex "$candidate_endpoint:2379")
   exec_etcdctl "$current_endpoint:2379" move-leader "$candidate_id"
 
-  ! is_leader "$candidate_endpoint:2379" && error_exit "Candidate is not leader"
+  ! is_leader "$candidate_endpoint:2379" && error_exit "Candidate is not leader after move-leader"
   log "Switchover to candidate $KB_SWITCHOVER_CANDIDATE_FQDN completed successfully"
 }
 
@@ -31,9 +38,11 @@ switchover_without_candidate() {
   current_pod_name="${KB_SWITCHOVER_CURRENT_FQDN%%.*}"
   current_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$current_pod_name" "$KB_SWITCHOVER_CURRENT_FQDN")
 
-  ! is_leader "$current_endpoint:2379" && echo "Leader has already changed, no switchover needed" && exit 0
+  if ! is_leader "$current_endpoint:2379"; then
+    log "Current ($current_pod_name) is no longer leader, switchover already happened"
+    return 0
+  fi
 
-  # get first follower
   leader_id=$(get_member_id "$current_endpoint:2379")
   peers_id=$(exec_etcdctl "$current_endpoint:2379" member list -w fields | awk -F': ' '/^"ID"/ {gsub(/[^0-9]/, "", $2); print $2}')
   candidate_id=$(echo "$peers_id" | grep -v "$leader_id" | head -1)
@@ -41,14 +50,13 @@ switchover_without_candidate() {
   candidate_id_hex=$(printf "%x" "$candidate_id")
 
   exec_etcdctl "$current_endpoint:2379" move-leader "$candidate_id_hex"
-  # if no candidate specified, skip the verification of new leader
-  # is_leader "$current_endpoint:2379" && error_exit "Switchover failed - current node is still leader after move-leader command"
   log "Switchover completed successfully - current node is no longer leader"
 }
 
 switchover() {
-  if [[ "$LEADER_POD_FQDN" != "$KB_SWITCHOVER_CURRENT_FQDN" ]]; then
-    log "switchover action not triggered for leader pod. Exiting."
+  local current_pod_name="${KB_SWITCHOVER_CURRENT_FQDN%%.*}"
+  if [[ "$HOSTNAME" != "$current_pod_name" ]]; then
+    log "This pod ($HOSTNAME) is not the switchover current ($current_pod_name). Skipping."
     exit 0
   fi
 

--- a/addons/etcd/templates/_helpers.tpl
+++ b/addons/etcd/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Common annotations
 */}}
 {{- define "etcd.annotations" -}}
-{{- /*{{ include "kblib.helm.resourcePolicy" . }}*/ -}}
+{{ include "kblib.helm.resourcePolicy" . }}
 {{ include "etcd.apiVersion" . }}
 {{- end }}
 

--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -205,6 +205,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       volumeName: config
       defaultMode: 0666
+      externalManaged: true
       restartOnFileChange: true
   scripts:
     - name: script

--- a/addons/etcd/templates/paramsdef.yaml
+++ b/addons/etcd/templates/paramsdef.yaml
@@ -13,50 +13,24 @@ spec:
   fileFormatConfig:
     format: yaml
   staticParameters:
-    - snapshot-count
-    - heartbeat-interval
-    - election-timeout
-    - quota-backend-bytes
-    - strict-reconfig-check
-    - max-snapshots
-    - max-wals
     - auto-compaction-mode
     - auto-compaction-retention
-    - tls-min-version
-    - tls-max-version
-    - proxy
-    - proxy-failure-wait
-    - proxy-refresh-interval
-    - proxy-dial-timeout
-    - proxy-write-timeout
-    - proxy-read-timeout
-    - enable-pprof
-    - self-signed-cert-validity
     - log-level
     - logger
+    - enable-pprof
+    - snapshot-count
+    - max-snapshots
+    - max-wals
   parametersSchema:
     topLevelKey: EtcdParameter
     cue: |-
       #EtcdParameter: {
-        "snapshot-count"?: int & >=0
-        "heartbeat-interval"?: int & >=50
-        "election-timeout"?: int & >=500
-        "quota-backend-bytes"?: int & >=0
-        "strict-reconfig-check"?: bool
-        "max-snapshots"?: int & >=0
-        "max-wals"?: int & >=0
         "auto-compaction-mode"?: string & "periodic" | "revision"
         "auto-compaction-retention"?: string
-        "tls-min-version"?: string & "TLS1.2" | "TLS1.3"
-        "tls-max-version"?: string & "TLS1.2" | "TLS1.3"
-        "proxy"?: string & "on" | "readonly" | "off"
-        "proxy-failure-wait"?: int & >=0
-        "proxy-refresh-interval"?: int & >=0
-        "proxy-dial-timeout"?: int & >=0
-        "proxy-write-timeout"?: int & >=0
-        "proxy-read-timeout"?: int & >=0
-        "enable-pprof"?: bool
-        "self-signed-cert-validity"?: int & >=1
         "log-level"?: string & "debug" | "info" | "warn" | "error" | "panic" | "fatal"
         "logger"?: string & "zap"
+        "enable-pprof"?: bool
+        "snapshot-count"?: int & >=0
+        "max-snapshots"?: int & >=0
+        "max-wals"?: int & >=0
       }

--- a/addons/etcd/templates/paramsdef.yaml
+++ b/addons/etcd/templates/paramsdef.yaml
@@ -1,0 +1,70 @@
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: {{ include "etcd3.paramsDefinition" . }}
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    {{- include "etcd.annotations" . | nindent 4 }}
+spec:
+  componentDef: {{ include "etcd3.cmpdName" . }}
+  templateName: {{ include "etcd3.configTemplate" . }}
+  fileName: etcd.conf
+  fileFormatConfig:
+    format: yaml
+  staticParameters:
+    - wal-dir
+    - snapshot-count
+    - heartbeat-interval
+    - election-timeout
+    - quota-backend-bytes
+    - strict-reconfig-check
+    - max-snapshots
+    - max-wals
+    - auto-compaction-mode
+    - auto-compaction-retention
+    - cipher-suites
+    - tls-min-version
+    - tls-max-version
+    - proxy
+    - proxy-failure-wait
+    - proxy-refresh-interval
+    - proxy-dial-timeout
+    - proxy-write-timeout
+    - proxy-read-timeout
+    - enable-pprof
+    - cors
+    - discovery
+    - discovery-fallback
+    - discovery-proxy
+    - discovery-srv
+    - self-signed-cert-validity
+    - log-level
+    - logger
+    - log-outputs
+  parametersSchema:
+    topLevelKey: EtcdParameter
+    cue: |-
+      #EtcdParameter: {
+        "snapshot-count"?: int & >=0
+        "heartbeat-interval"?: int & >=50
+        "election-timeout"?: int & >=500
+        "quota-backend-bytes"?: int & >=0
+        "strict-reconfig-check"?: bool
+        "max-snapshots"?: int & >=0
+        "max-wals"?: int & >=0
+        "auto-compaction-mode"?: string & "periodic" | "revision"
+        "auto-compaction-retention"?: string
+        "tls-min-version"?: string & "TLS1.2" | "TLS1.3"
+        "tls-max-version"?: string & "TLS1.2" | "TLS1.3"
+        "proxy"?: string & "on" | "readonly" | "off"
+        "proxy-failure-wait"?: int & >=0
+        "proxy-refresh-interval"?: int & >=0
+        "proxy-dial-timeout"?: int & >=0
+        "proxy-write-timeout"?: int & >=0
+        "proxy-read-timeout"?: int & >=0
+        "enable-pprof"?: bool
+        "self-signed-cert-validity"?: int & >=1
+        "log-level"?: string & "debug" | "info" | "warn" | "error" | "panic" | "fatal"
+        "logger"?: string & "zap"
+      }

--- a/addons/etcd/templates/paramsdef.yaml
+++ b/addons/etcd/templates/paramsdef.yaml
@@ -8,12 +8,11 @@ metadata:
     {{- include "etcd.annotations" . | nindent 4 }}
 spec:
   componentDef: {{ include "etcd3.cmpdName" . }}
-  templateName: {{ include "etcd3.configTemplate" . }}
+  templateName: config
   fileName: etcd.conf
   fileFormatConfig:
     format: yaml
   staticParameters:
-    - wal-dir
     - snapshot-count
     - heartbeat-interval
     - election-timeout
@@ -23,7 +22,6 @@ spec:
     - max-wals
     - auto-compaction-mode
     - auto-compaction-retention
-    - cipher-suites
     - tls-min-version
     - tls-max-version
     - proxy
@@ -33,15 +31,9 @@ spec:
     - proxy-write-timeout
     - proxy-read-timeout
     - enable-pprof
-    - cors
-    - discovery
-    - discovery-fallback
-    - discovery-proxy
-    - discovery-srv
     - self-signed-cert-validity
     - log-level
     - logger
-    - log-outputs
   parametersSchema:
     topLevelKey: EtcdParameter
     cue: |-

--- a/addons/etcd/values.yaml
+++ b/addons/etcd/values.yaml
@@ -1,6 +1,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+extra:
+  keepResource: true
+
 clusterDomain: ".cluster.local"
 
 # volume backup


### PR DESCRIPTION
## Summary

- **Root cause**: `LEADER_POD_FQDN` is a static env var injected at pod creation time via CmpD `componentVarRef.podFQDNsForRole: leader`. When leadership changes (e.g. after horizontal scaling), this var becomes stale, causing the switchover guard condition `if [[ "$LEADER_POD_FQDN" != "$KB_SWITCHOVER_CURRENT_FQDN" ]]` to silently exit 0 — the switchover action runs but does nothing.
- **Fix**: two-layer protection:
  1. **Request-scoped guard**: compare `HOSTNAME` with pod name extracted from `KB_SWITCHOVER_CURRENT_FQDN` (action-scoped parameter, always correct at dispatch time)
  2. **Runtime guard**: `is_leader` check before `move-leader`, with explicit handling for idempotent (candidate already leader → success) and failure (neither is leader → error) cases
- Removes dependency on `LEADER_POD_FQDN` in switchover path entirely
- Unit tests updated with regression test for stale `LEADER_POD_FQDN`, HOSTNAME mismatch skip, idempotent success, and neither-is-leader failure

## Evidence

- T06 Switchover FAIL reproduced N=2 on preserved cluster `etcd-smoke-80134`
- kbagent log confirms action was called (HTTP 200) but `switchover.sh` exited at guard
- `/tmp/switchover.log` inside container shows guard evaluated and skipped
- Root cause confirmed independently by Rocco (KB controller) and Edward (KB controller team)
- Classification: addon-side lifecycle script defect (not controller bug)

## Test plan

- [ ] Unit tests pass (shellspec switchover_spec.sh — 7 cases including regression)
- [ ] Runtime test: switchover on 3-replica fresh cluster (T06 in test suite)
- [ ] Runtime test: switchover after horizontal scale-out (the original failure scenario)
- [ ] Verify idempotent case: re-run switchover when candidate is already leader

🤖 Generated with [Claude Code](https://claude.com/claude-code)