### PR TITLE
chore(redis): enable switchover result check for without-candidate path

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_switchover_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_switchover_spec.sh
@@ -412,6 +412,16 @@ master_host:redis-master"
         The stdout should equal ""
       End
 
+      It "should fail when result check fails"
+        check_redis_kernel_status() {
+          echo "redis1"
+        }
+        execute_sentinel_failover() { return 0; }
+        check_switchover_result() { return 1; }
+        When call switchover_without_candidate
+        The status should be failure
+      End
+
     End
 
     Context "check_switchover_result()"

--- a/addons/redis/scripts/redis-switchover.sh
+++ b/addons/redis/scripts/redis-switchover.sh
@@ -356,9 +356,7 @@ switchover_without_candidate() {
   # do switchover
   execute_sentinel_failover "$CUSTOM_SENTINEL_MASTER_NAME" || return 1
 
-  # check switchover result using initial_master
-  # if no candidate specified, skip check
-  # check_switchover_result "" "$initial_master" || return 1
+  check_switchover_result "" "$initial_master" || return 1
 }
 
 # This is magic for shellspec ut framework.


### PR DESCRIPTION
## Problem

`switchover_without_candidate()` had the `check_switchover_result` call commented out.
After `SENTINEL FAILOVER`, it returns success immediately without verifying the switchover actually happened.

## Fix

Uncomment `check_switchover_result "" "$initial_master" || return 1` so the without-candidate
path polls for master change (up to 300s) and returns failure if the switchover did not complete.

## Test

Added ShellSpec test: when `check_switchover_result` returns failure, `switchover_without_candidate` also returns failure.

Local validation:
- Focused switchover spec: 27/0
- Full Redis scripts suite: 411/0
- `bash -n` PASS, `git diff --check` PASS