### PR TITLE
fix(milvus): add services to standalone CmpD for Expose support

### DIFF
--- a/addons/milvus/templates/cmpd-standalone.yaml
+++ b/addons/milvus/templates/cmpd-standalone.yaml
@@ -10,6 +10,19 @@ spec:
   provider: ApeCloud
   description: {{ .Chart.Description }}
   serviceKind: {{ .Chart.Name }}
+  services:
+    - name: milvus
+      spec:
+        type: ClusterIP
+        ports:
+          - name: milvus
+            port: 19530
+            protocol: TCP
+            targetPort: milvus
+          - name: metrics
+            port: 9091
+            protocol: TCP
+            targetPort: metrics
   configs:
     {{- include "milvus.config.standalone" . | indent 4 }}
   vars:


### PR DESCRIPTION
## Summary
- Standalone ComponentDefinition was missing `services` section, causing KB Expose OpsRequest to fail with `component service is not defined, expose operation is not supported`
- Adds `services` block with `milvus:19530` + `metrics:9091`, aligned with proxy CmpD pattern
- Enables Expose OpsRequest (NodePort enable/disable) on standalone topology

## Evidence
- EX01 FAIL on live alpha.2: `component service is not defined, expose operation is not supported, cluster: mvs-exp-5093, component: milvus`
- Root cause: `cmpd-standalone.yaml` has container ports but no `spec.services`
- Proxy CmpD already has correct `services` definition

## Test plan
- [ ] Diana rerun Expose EX00-EX05 with this fix
- [ ] EX01: OpsRequest creates NodePort Service
- [ ] EX03: OpsRequest removes NodePort Service
- [ ] EX05: 0 residual resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)