### PR TITLE
fix(milvus): make post_provision.py TLS-aware

### DIFF
--- a/addons/milvus/scripts/post_provision.py
+++ b/addons/milvus/scripts/post_provision.py
@@ -2,11 +2,25 @@ import os
 
 from pymilvus import MilvusClient
 
-uri = "http://localhost:19530"
+TLS_ENABLED = os.environ.get("TLS_ENABLED", "").lower() in ("true", "1", "yes")
+TLS_CA_PATH = "/etc/pki/tls/ca.pem"
+
+def _uri():
+    if TLS_ENABLED:
+        return "https://localhost:19530"
+    return "http://localhost:19530"
+
+def _client(token: str) -> MilvusClient:
+    kwargs = {"uri": _uri(), "token": token}
+    if TLS_ENABLED:
+        kwargs["secure"] = True
+        kwargs["server_pem_path"] = TLS_CA_PATH
+        kwargs["server_name"] = "localhost"
+    return MilvusClient(**kwargs)
 
 def can_auth(username: str, password: str) -> bool:
     try:
-        client = MilvusClient(uri=uri, token=f"{username}:{password}")
+        client = _client(f"{username}:{password}")
         client.list_users()
         return True
     except Exception:
@@ -20,7 +34,7 @@ def main():
         print(f"password for root is already in sync")
         return
 
-    client = MilvusClient(uri=uri, token=f"{username}:{old_password}")
+    client = _client(f"{username}:{old_password}")
     client.update_password(
         user_name=username,
         old_password=old_password,


### PR DESCRIPTION
## Summary
- `post_provision.py` hardcoded `http://localhost:19530`, failing in retry loop when proxy has `TLS_ENABLED=true` (`tlsMode: 1`)
- Now checks `TLS_ENABLED` env var and uses `https://localhost:19530` + `secure=True` + `server_pem_path` + `server_name` when TLS is enabled
- Non-TLS path unchanged

## Evidence
- TLS suite live test: proxy component stuck in post-provision retry loop, kbagent log shows `Fail connecting to server on localhost:19530, illegal connection params`
- `TLS_ENABLED=true` is injected by KB via `tlsVarRef` in proxy CmpD
- TLS cert SAN includes `DNS:localhost,IP:127.0.0.1`

## Test plan
- [ ] Diana rerun TLS TLS00-TLS04 with this fix + PR #2896
- [ ] TLS00: cluster reaches Running (post-provision succeeds)
- [ ] TLS01-TLS03: TLS connection, plaintext rejection, data path
- [ ] TLS04: 0 residual resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)