### PR TITLE
chore(valkey): add replicasLimit to data and sentinel cmpd

### DIFF
--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -36,6 +36,10 @@ spec:
   updateStrategy: BestEffortParallel
   minReadySeconds: 10
 
+  replicasLimit:
+    minReplicas: 3
+    maxReplicas: 128
+
   # Sentinel state is persisted in the data volume so the conf survives restarts.
   volumes:
     - name: data

--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -38,7 +38,7 @@ spec:
 
   replicasLimit:
     minReplicas: 3
-    maxReplicas: 128
+    maxReplicas: 16384
 
   # Sentinel state is persisted in the data volume so the conf survives restarts.
   volumes:

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -41,7 +41,7 @@ spec:
 
   replicasLimit:
     minReplicas: 1
-    maxReplicas: 128
+    maxReplicas: 16384
 
   # ── TLS ────────────────────────────────────────────────────────────────
   tls:

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -39,6 +39,10 @@ spec:
   # This dampens false positives during cluster formation.
   minReadySeconds: 10
 
+  replicasLimit:
+    minReplicas: 1
+    maxReplicas: 128
+
   # ── TLS ────────────────────────────────────────────────────────────────
   tls:
     volumeName: tls


### PR DESCRIPTION
## Summary
- Add `replicasLimit` to Valkey data component: `minReplicas=1`, `maxReplicas=16384`
- Add `replicasLimit` to Valkey Sentinel component: `minReplicas=3`, `maxReplicas=16384`

## Rationale
The lower bounds reject component sizes that are not valid Valkey deployments:
- `0` data replicas = no Valkey data pod / no usable service
- `1` or `2` sentinels = cannot provide the intended sentinel quorum shape; the minimum HA sentinel set is 3

`maxReplicas` is kept at `16384`, the previous KubeBlocks effective upper bound, so this PR does not introduce a new Valkey product scale-out cap. A lower Valkey-specific upper bound should be added only after the addon/product contract defines and validates that supported maximum.

## Files changed
- `addons/valkey/templates/cmpd.yaml` — data component replicasLimit
- `addons/valkey/templates/cmpd-valkey-sentinel.yaml` — sentinel component replicasLimit

## Test plan
- [x] `git diff --check`
- [x] `helm template valkey addons/valkey --namespace kb-system`
- [x] `helm lint addons/valkey`
- [ ] CI checks

Co-authored-by: Alice <alice@apecloud.com>
