### PR TITLE
chore(valkey): reduce sentinel-ping retry budget to fit probe timeout

### DIFF
--- a/addons/valkey/scripts/valkey-sentinel-ping.sh
+++ b/addons/valkey/scripts/valkey-sentinel-ping.sh
@@ -26,4 +26,4 @@ check_sentinel_ok() {
   fi
 }
 
-call_func_with_retry 3 3 check_sentinel_ok || exit 1
+call_func_with_retry 2 1 check_sentinel_ok || exit 1


### PR DESCRIPTION
## Summary
- Change `call_func_with_retry 3 3` to `call_func_with_retry 2 1` in sentinel-ping.sh

## Rationale
The liveness/readiness probe `timeoutSeconds` is 5, but the old retry budget
(`call_func_with_retry 3 3` = up to 9s of sleep) exceeds this. K8s SIGKILL
at 5 seconds makes retries 2-3 unreachable dead code.

New budget: 2 retries × 1s sleep = 2s sleep + ~1s execution ≈ 3s worst case,
well within the 5-second probe timeout.

## Files changed
- `addons/valkey/scripts/valkey-sentinel-ping.sh` — retry parameters only

## Test plan
- [ ] Sentinel liveness/readiness probes pass in normal operation
- [ ] Probes detect actual Sentinel failure (kill process, verify probe fails)
- [ ] Full suite regression (`-t all`)

Co-authored-by: Alice <alice@apecloud.com>