### PR TITLE
chore(valkey): add per-sentinel timeout to roleProbe check-role.sh

### DIFF
--- a/addons/valkey/scripts-ut-spec/check_role_spec.sh
+++ b/addons/valkey/scripts-ut-spec/check_role_spec.sh
@@ -953,6 +953,16 @@ Describe "Valkey Check-Role Bash Script Tests"
     End
   End
 
+  Describe "per-sentinel timeout guard"
+    check_role_script="../scripts/check-role.sh"
+
+    It "wraps the sentinel masters query with timeout"
+      When call grep -E 'timeout [0-9]+ valkey-cli.*sentinel masters' "${check_role_script}"
+      The status should be success
+      The stdout should include "timeout"
+    End
+  End
+
   Describe "fork-safety contract — no pipeline parsing of INFO replication"
     # Background: `valkey-cli ... info replication | grep ... | tr ...`
     # spawns three subprocess children per probe call. When kbagent

--- a/addons/valkey/scripts/check-role.sh
+++ b/addons/valkey/scripts/check-role.sh
@@ -247,7 +247,7 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
     sentinel_query_success_count=0
     sentinel_master_config_count=0
     for s in "${sentinel_fqdns[@]}"; do
-      sentinel_out=$(valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" "${sentinel_auth_args[@]}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
+      sentinel_out=$(timeout 1 valkey-cli --no-auth-warning -h "${s}" -p "${sentinel_port}" "${sentinel_auth_args[@]}" ${sentinel_tls_args} sentinel masters 2>/dev/null) || continue
       sentinel_query_success_count=$((sentinel_query_success_count + 1))
       sentinel_has_master_config=0
       ce_marker=""


### PR DESCRIPTION
## Summary

Deep review W3: the sentinel `masters` query in `check-role.sh` has no per-call timeout. If a single sentinel hangs (TCP level), the script blocks until kbagent SIGKILLs it at the roleProbe `timeoutSeconds` (3s), preventing the remaining sentinels from being queried.

**Fix:** wrap each `valkey-cli sentinel masters` call with `timeout 1` so a hung sentinel fails fast after 1s. With 3 sentinels the worst-case loop budget is 3s, fitting within the 3s probe timeout.

## Changes

- `addons/valkey/scripts/check-role.sh`: add `timeout 1` before `valkey-cli` in sentinel query loop
- `addons/valkey/scripts-ut-spec/check_role_spec.sh`: add structural test asserting the timeout wrapper

## Test plan

- [x] `bash -n` static check PASS
- [x] ShellSpec 83 examples, 0 failures (bash 5.3.12)
- [ ] Emily runtime validation on vcluster