### PR TITLE
chore(valkey): exclude lost+found from restore safety check

### DIFF
--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -16,7 +16,7 @@ mkdir -p "${DATA_DIR}"
 # Safety check: refuse to restore into a non-empty data directory.
 # Use -maxdepth 1 to check for any real data entry directly inside DATA_DIR.
 placeholder="${DATA_DIR}/.kb-data-protection"
-unexpected_entries=$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name ".kb-data-protection")
+unexpected_entries=$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name ".kb-data-protection" ! -name "lost+found")
 if [ -n "${unexpected_entries}" ]; then
   echo "ERROR: ${DATA_DIR} is not empty. Remove all data before restoring." >&2
   exit 1


### PR DESCRIPTION
## Summary

Deep review W4: the restore `prepareData` safety check refuses to proceed if DATA_DIR is non-empty, but ext4 filesystems automatically create a `lost+found` directory on mount. This causes restore to fail on freshly mounted ext4 volumes with `ERROR: DATA_DIR is not empty`.

**Fix:** exclude `lost+found` alongside the existing `.kb-data-protection` placeholder in the `find` command.

## Changes

- `addons/valkey/dataprotection/restore.sh`: add `! -name "lost+found"` to the safety check `find`

## Test plan

- [x] `bash -n` static check PASS
- [x] ShellSpec restore_contract_spec 3 examples, 0 failures
- [ ] Emily runtime validation: restore on ext4 volume