### PR TITLE
fix(kafka): remove containerName from resourceFieldRef to fix backup pod failure

### DIFF
--- a/addons/kafka/templates/cmpd-broker-27.yaml
+++ b/addons/kafka/templates/cmpd-broker-27.yaml
@@ -233,7 +233,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE

--- a/addons/kafka/templates/cmpd-broker.yaml
+++ b/addons/kafka/templates/cmpd-broker.yaml
@@ -205,7 +205,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE

--- a/addons/kafka/templates/cmpd-combine.yaml
+++ b/addons/kafka/templates/cmpd-combine.yaml
@@ -206,7 +206,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE

--- a/addons/kafka/templates/cmpd-controller.yaml
+++ b/addons/kafka/templates/cmpd-controller.yaml
@@ -117,7 +117,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE


### PR DESCRIPTION
## Summary
- Backup job pods fail with CreateContainerConfigError: container kafka not found because resourceFieldRef.containerName=kafka references a container that does not exist in the backup pod context
- DP controller propagates env specs from source container to backup job pods; backup pods only have backupdata and manager containers
- Fix: remove containerName: kafka from all 4 ComponentDefinition templates; without containerName, Kubernetes defaults to the current container, which resolves correctly in both normal pod and backup pod contexts
- 4 files changed, 4 lines removed

## Test plan
- [ ] Verify normal kafka pod still gets correct KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB value (heap ratio unchanged)
- [ ] Verify backup job pod no longer fails with CreateContainerConfigError
- [ ] Run backup-runtime suite end-to-end