### PR TITLE
fix(qdrant): add memberLeave timeoutSeconds and diagnostic logging

### DIFF
--- a/addons/qdrant/scripts/qdrant-member-leave.sh
+++ b/addons/qdrant/scripts/qdrant-member-leave.sh
@@ -49,6 +49,13 @@ if [ $? -ne 0 ] || [ "$peers_type" != "object" ]; then
   exit 1
 fi
 
+# Log peer URIs for diagnosis before attempting match.
+echo "KB_LEAVE_MEMBER_POD_NAME=${KB_LEAVE_MEMBER_POD_NAME}"
+echo "KB_LEAVE_MEMBER_POD_FQDN=${KB_LEAVE_MEMBER_POD_FQDN}"
+peer_uris=$(echo "$cluster_info" | $JQ -r '.result.peers | to_entries[] | "\(.key): \(.value.uri)"')
+echo "cluster peers:"
+echo "$peer_uris"
+
 # Find the leaving peer's ID by matching KB_LEAVE_MEMBER_POD_NAME in peer URIs.
 # Two-step: first confirm peers is valid (above), then match. Only "valid peers +
 # zero matches" is idempotent exit 0; parse failures always exit 1.

--- a/addons/qdrant/templates/cmpd.yaml
+++ b/addons/qdrant/templates/cmpd.yaml
@@ -71,6 +71,7 @@ spec:
       value: {{ .Values.tlsMountPath }}
   lifecycleActions:
     memberLeave:
+      timeoutSeconds: 300
       exec:
         command:
           - /bin/bash


### PR DESCRIPTION
## Summary
- Add `timeoutSeconds: 300` to CMPD `memberLeave` lifecycle action — kbagent defaults to 30s when unset, but shard migration during scale-in can take minutes
- Add diagnostic logging before peer URI matching: prints `KB_LEAVE_MEMBER_POD_NAME`, `KB_LEAVE_MEMBER_POD_FQDN`, and all cluster peer URIs for self-diagnosis

## Context
S13 HScale-in was failing because the test cluster was running the pre-PR #2882 addon script, where `current_pod_fqdn` resolution fails when `QDRANT_POD_FQDN_LIST` excludes the leaving pod during scale-in. PR #2882 already fixed the identity matching by switching to `QDRANT_POD_FQDN_LIST | head -1` as control endpoint.

This PR adds two independent hardening measures on top of #2882:
1. **Timeout**: prevents kbagent 30s default from killing the script during legitimate shard migration
2. **Diagnostic logging**: if a future peer matching failure occurs, the kbagent log will contain the actual values for immediate root cause identification

## Evidence
- S13 kbagent trace (idc1, N=3 repro): 12ms exit, `"member ... is not in the cluster"`, `move_shards`/`remove_peer` never executed
- Controller team confirmed kbagent is blocking (`NonBlocking=nil`), 14ms HTTP response = script exited in 14ms
- `timeoutSeconds` reference: Nebula `cmpd-storaged.yaml` uses `timeoutSeconds: 120` at memberLeave level

## Test plan
- [ ] Install updated addon chart (including #2882 + this PR) on idc1 vcluster
- [ ] Run S13 HScale-in: memberLeave log shows endpoint/peer_id, `remove_peer` executes with 2xx
- [ ] OpsRequest Succeed, Raft peers converge to 3, data read/write + Raft stable pass
