### PR TITLE
fix(tidb): ensure PD address for BR restore

### DIFF
--- a/addons/tidb/dataprotection/common.sh
+++ b/addons/tidb/dataprotection/common.sh
@@ -27,6 +27,28 @@ function setStorageVar() {
   export DATASAFED_BACKEND_BASE_PATH=${DP_BACKUP_BASE_PATH}
 }
 
+function ensurePDAddress() {
+  if [[ -n "${PD_ADDRESS:-}" ]]; then
+    export PD_ADDRESS
+    return 0
+  fi
+
+  local firstPD="${PD_POD_FQDN_LIST%%,*}"
+  if [[ -n "$firstPD" ]]; then
+    if [[ "$firstPD" == *:* ]]; then
+      PD_ADDRESS="$firstPD"
+    else
+      PD_ADDRESS="$firstPD:2379"
+    fi
+    export PD_ADDRESS
+    echo "PD_ADDRESS is empty; derived PD_ADDRESS=$PD_ADDRESS from PD_POD_FQDN_LIST"
+    return 0
+  fi
+
+  echo "PD_ADDRESS is required but empty; set PD_ADDRESS or PD_POD_FQDN_LIST" >&2
+  return 1
+}
+
 # Save backup status info file for syncing progress.
 # timeFormat: %Y-%m-%dT%H:%M:%SZ
 function DP_save_backup_status_info() {

--- a/addons/tidb/dataprotection/restore.sh
+++ b/addons/tidb/dataprotection/restore.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 setStorageVar
+ensurePDAddress
 
 # shellcheck disable=SC2086
 /br restore full --pd "$PD_ADDRESS" --storage "s3://$BUCKET$DP_BACKUP_BASE_PATH?access-key=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY" --s3.endpoint "$ENDPOINT" $BR_EXTRA_ARGS --with-sys-table

--- a/addons/tidb/scripts-ut-spec/dataprotection_common_spec.sh
+++ b/addons/tidb/scripts-ut-spec/dataprotection_common_spec.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "dataprotection common script tests"
+    Include ../dataprotection/common.sh
+
+    setup() {
+        unset PD_ADDRESS
+        unset PD_POD_FQDN_LIST
+    }
+
+    BeforeEach 'setup'
+
+    Describe "ensurePDAddress"
+        It "keeps an explicit PD_ADDRESS"
+            PD_ADDRESS="tidb-pd.default.svc.cluster.local:2379"
+            PD_POD_FQDN_LIST="tidb-pd-0.tidb-pd-headless.default.svc.cluster.local"
+
+            When call ensurePDAddress
+
+            The status should be success
+            The variable PD_ADDRESS should equal "tidb-pd.default.svc.cluster.local:2379"
+            The stdout should equal ""
+        End
+
+        It "derives PD_ADDRESS from PD_POD_FQDN_LIST"
+            PD_POD_FQDN_LIST="tidb-pd-0.tidb-pd-headless.default.svc.cluster.local,tidb-pd-1.tidb-pd-headless.default.svc.cluster.local"
+
+            When call ensurePDAddress
+
+            The status should be success
+            The variable PD_ADDRESS should equal "tidb-pd-0.tidb-pd-headless.default.svc.cluster.local:2379"
+            The stdout should equal "PD_ADDRESS is empty; derived PD_ADDRESS=tidb-pd-0.tidb-pd-headless.default.svc.cluster.local:2379 from PD_POD_FQDN_LIST"
+        End
+
+        It "keeps an explicit port from PD_POD_FQDN_LIST"
+            PD_POD_FQDN_LIST="tidb-pd-0.tidb-pd-headless.default.svc.cluster.local:2379"
+
+            When call ensurePDAddress
+
+            The status should be success
+            The variable PD_ADDRESS should equal "tidb-pd-0.tidb-pd-headless.default.svc.cluster.local:2379"
+            The stdout should equal "PD_ADDRESS is empty; derived PD_ADDRESS=tidb-pd-0.tidb-pd-headless.default.svc.cluster.local:2379 from PD_POD_FQDN_LIST"
+        End
+
+        It "fails when no PD endpoint source exists"
+            When call ensurePDAddress
+
+            The status should be failure
+            The stderr should equal "PD_ADDRESS is required but empty; set PD_ADDRESS or PD_POD_FQDN_LIST"
+        End
+    End
+End

--- a/addons/tidb/templates/cmpd-pd.yaml
+++ b/addons/tidb/templates/cmpd-pd.yaml
@@ -12,6 +12,23 @@ spec:
   updateStrategy: BestEffortParallel
   minReadySeconds: 30
   vars:
+    - name: CLUSTER_NAMESPACE
+      valueFrom:
+        clusterVarRef:
+          namespace: Required
+    - name: PD_HOST
+      valueFrom:
+        serviceVarRef:
+          compDef: {{ include "tidb.pd7.compDefName" . }}
+          host: Required
+    - name: PD_PORT
+      valueFrom:
+        serviceVarRef:
+          compDef: {{ include "tidb.pd7.compDefName" . }}
+          port:
+            name: client
+    - name: PD_ADDRESS
+      value: "$(PD_HOST).$(CLUSTER_NAMESPACE).svc{{ .Values.clusterDomain }}:$(PD_PORT)"
     - name: PD_LEADER_POD_NAME
       valueFrom:
         componentVarRef:


### PR DESCRIPTION
## Summary
- add PD_ADDRESS to the TiDB PD ComponentDefinition vars so postReady restore jobs that run in PD context inherit a BR PD endpoint
- add ensurePDAddress() in the shared dataprotection script and call it before BR restore
- cover explicit, derived, and missing PD address cases with shellspec

## Runtime trigger
Fresh PR1 T13 rerun reached Wall 3/postReady for the first time after #10447 + vcluster syncer a2311179d. The tidb-pd Restore CR failed because the restore job ran /br restore with --pd "", but its envFrom ConfigMap had PD_LEADER_POD_NAME and PD_POD_FQDN_LIST and no PD_ADDRESS. Canonical evidence packet: /tmp/tidb-evidence-wall3-rerun.tar.gz, SHA256 ac8e69e76c5f8078d1b5156e02bedd0dbc0816fa61d959385b75a0b2ce9fcd14.

## Validation
- bash -n addons/tidb/dataprotection/common.sh addons/tidb/dataprotection/restore.sh addons/tidb/dataprotection/backup.sh addons/tidb/dataprotection/backup-pitr.sh addons/tidb/dataprotection/restore-pitr.sh addons/tidb/scripts/*.sh
- shellspec --load-path ./shellspec --default-path "addons/tidb/scripts-ut-spec" --shell bash (18 examples, 0 failures)
- git diff --check

## Runtime validation plan
After idc4 recovers, Kate should rerun the same PR1 T13 smoke-backup shape with this addon patch. The expected first check is that the tidb-pd restore job has a non-empty PD_ADDRESS and no longer fails with "must provide at least one PD server address". The remaining tikv condition mismatch should be classified separately after this fix.