### PR TITLE
fix(postgresql): align bgwriter_lru_maxpages bound

### DIFF
--- a/addons/postgresql/config/pg12-config-constraint.cue
+++ b/addons/postgresql/config/pg12-config-constraint.cue
@@ -95,7 +95,7 @@
 	bgwriter_flush_after?: int & >=0 & <=256 @storeResource(8KB)
 
 	// Background writer maximum number of LRU pages to flush per round.
-	bgwriter_lru_maxpages?: int & >=0 & <=1000
+	bgwriter_lru_maxpages?: int & >=0 & <=1073741823
 
 	// Multiple of the average buffer usage to free per round.
 	bgwriter_lru_multiplier?: float & >=0 & <=10

--- a/addons/postgresql/config/pg14-config-constraint.cue
+++ b/addons/postgresql/config/pg14-config-constraint.cue
@@ -101,7 +101,7 @@
 	bgwriter_flush_after?: int & >=0 & <=256 @storeResource(8KB)
 
 	// Background writer maximum number of LRU pages to flush per round.
-	bgwriter_lru_maxpages?: int & >=0 & <=1000
+	bgwriter_lru_maxpages?: int & >=0 & <=1073741823
 
 	// Multiple of the average buffer usage to free per round.
 	bgwriter_lru_multiplier?: float & >=0 & <=10

--- a/addons/postgresql/config/pg15-config-constraint.cue
+++ b/addons/postgresql/config/pg15-config-constraint.cue
@@ -101,7 +101,7 @@
 	bgwriter_flush_after?: int & >=0 & <=256 @storeResource(8KB)
 
 	// Background writer maximum number of LRU pages to flush per round.
-	bgwriter_lru_maxpages?: int & >=0 & <=1000
+	bgwriter_lru_maxpages?: int & >=0 & <=1073741823
 
 	// Multiple of the average buffer usage to free per round.
 	bgwriter_lru_multiplier?: float & >=0 & <=10

--- a/addons/postgresql/config/pg16-config-constraint.cue
+++ b/addons/postgresql/config/pg16-config-constraint.cue
@@ -101,7 +101,7 @@
 	bgwriter_flush_after?: int & >=0 & <=256 @storeResource(8KB)
 
 	// Background writer maximum number of LRU pages to flush per round.
-	bgwriter_lru_maxpages?: int & >=0 & <=1000
+	bgwriter_lru_maxpages?: int & >=0 & <=1073741823
 
 	// Multiple of the average buffer usage to free per round.
 	bgwriter_lru_multiplier?: float & >=0 & <=10

--- a/addons/postgresql/config/pg17-config-constraint.cue
+++ b/addons/postgresql/config/pg17-config-constraint.cue
@@ -101,7 +101,7 @@
 	bgwriter_flush_after?: int & >=0 & <=256 @storeResource(8KB)
 
 	// Background writer maximum number of LRU pages to flush per round.
-	bgwriter_lru_maxpages?: int & >=0 & <=1000
+	bgwriter_lru_maxpages?: int & >=0 & <=1073741823
 
 	// Multiple of the average buffer usage to free per round.
 	bgwriter_lru_multiplier?: float & >=0 & <=10

--- a/addons/postgresql/config/pg18-config-constraint.cue
+++ b/addons/postgresql/config/pg18-config-constraint.cue
@@ -101,7 +101,7 @@
 	bgwriter_flush_after?: int & >=0 & <=256 @storeResource(8KB)
 
 	// Background writer maximum number of LRU pages to flush per round.
-	bgwriter_lru_maxpages?: int & >=0 & <=1000
+	bgwriter_lru_maxpages?: int & >=0 & <=1073741823
 
 	// Multiple of the average buffer usage to free per round.
 	bgwriter_lru_multiplier?: float & >=0 & <=10


### PR DESCRIPTION
## What Changed

- Expand PostgreSQL addon CUE validation for `bgwriter_lru_maxpages` from `<=1000` to `<=1073741823` across pg12/pg14/pg15/pg16/pg17/pg18.
- Keep the rendered default value at `1000`.

## Why

This supersedes the previous apiserver-only direction in apecloud/apecloud#18985. The root mismatch is that apiserver metadata already advertised the real PostgreSQL upper bound, while the addon CUE contract rejected values above `1000`, so the API could accept a value that later failed at addon/runtime validation.

Evidence:
- PostgreSQL official docs say `pg_settings` exposes setting `min_val` and `max_val`: <https://www.postgresql.org/docs/current/view-pg-settings.html>
- PostgreSQL 10 release notes: `bgwriter_lru_maxpages` maximum became effectively unlimited: <https://www.postgresql.org/docs/release/10.0/>
- Dev cluster PostgreSQL 18.4 primary reported `min_val=0`, `max_val=1073741823`, empty unit, `context=sighup` for `bgwriter_lru_maxpages`.
- Dev cluster applied `ALTER SYSTEM SET bgwriter_lru_maxpages = '1001'; SELECT pg_reload_conf();` successfully, then reset back to the original `1000` successfully.

## Validation

- `helm dependency build addons/postgresql`
  - Passed; the repo update step printed a transient `context deadline exceeded` for the `kubeblocks` chart repository, but dependency save completed.
- `helm lint addons/postgresql`
- `helm template postgresql addons/postgresql --namespace kb-system` + YAML parse
- Render spot-check: six ParamConfig CUE constraints render with `<=1073741823`, and six template defaults remain `bgwriter_lru_maxpages = '1000'`.
- `git diff --check origin/main...HEAD`
- `git diff --check`

## Boundary

- No full KBE parameter update E2E / OpsRequest run after this addon change yet.
- No `pg13-config-constraint.cue` exists in the addon tree, so the change covers the existing pg12/14/15/16/17/18 constraint files only.
