### PR TITLE
fix(falkordb): align cluster reconfigure action container

### DIFF
--- a/addons/falkordb/templates/_helpers.tpl
+++ b/addons/falkordb/templates/_helpers.tpl
@@ -147,12 +147,17 @@ Generate scripts configmap
 falkordb-account.sh: |-
 {{- $.Files.Get "scripts/falkordb-account.sh" | nindent 2 }}
 {{- end }}
+{{- if $.Files.Get "scripts/reload-parameter.sh" }}
+reload-parameter.sh: |-
+{{- $.Files.Get "scripts/reload-parameter.sh" | nindent 2 }}
+{{- end }}
 {{- end }}
 
 {{- define "falkordb.config.reconfigureAction" -}}
+{{- $container := .container | default "falkordb" -}}
 reconfigure:
   exec:
-    container: falkordb
+    container: {{ $container }}
     targetPodSelector: All
     command:
       - /bin/sh

--- a/addons/falkordb/templates/cmpd-falkordb-cluster.yaml
+++ b/addons/falkordb/templates/cmpd-falkordb-cluster.yaml
@@ -83,7 +83,7 @@ spec:
       namespace: {{ $.Release.Namespace }}
       volumeName: falkordb-cluster-config
       externalManaged: true
-      {{- include "falkordb.config.reconfigureAction" $ | nindent 6 }}
+      {{- include "falkordb.config.reconfigureAction" (dict "container" "falkordb-cluster") | nindent 6 }}
   scripts:
     - name: falkordb-cluster-scripts
       template: {{ include "falkordbCluster.scriptsTemplate" $ }}


### PR DESCRIPTION
## Summary
- make the FalkorDB config reconfigure action helper take an explicit action container with `falkordb` as default
- keep replication reconfigure on the default `falkordb`
- use `falkordb-cluster` for cluster topology and include `reload-parameter.sh` in the cluster scripts ConfigMap so the reconfigure action can run from that execution face

## Validation
- `git diff --check`
- `helm dependency build`
- `helm template falkordb . >/tmp/falkordb-rendered-v2.yaml`
- `helm lint .`

## Evidence boundary
This is a static/rendered chart fix for the PR #452 S01 kb-agent build failure. Runtime validation still needs Ann to install this branch/head and rerun smoke-cluster S01 on KB main local-sideload env.