### PR TITLE
chore(falkordb): adapt cluster lifecycle env vars

### DIFF
--- a/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
+++ b/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
@@ -45,6 +45,53 @@ init_environment(){
   if [[ -z "${ALL_SHARDS_ADVERTISED_BUS_PORT}" ]]; then
     ALL_SHARDS_ADVERTISED_BUS_PORT="${ALL_SHARDS_LB_ADVERTISED_BUS_PORT}"
   fi
+
+  local all_shards_pods
+  local all_shards_pod_fqdns
+  local all_shards_components
+  all_shards_pods=$(get_all_shards_pods 2>/dev/null || true)
+  all_shards_pod_fqdns=$(get_all_shards_pod_fqdns 2>/dev/null || true)
+  all_shards_components=$(get_all_shards_components 2>/dev/null || true)
+
+  if [[ -z "${KB_CLUSTER_POD_NAME_LIST}" && -n "$all_shards_pods" ]]; then
+    KB_CLUSTER_POD_NAME_LIST="$all_shards_pods"
+  fi
+  # The legacy "*_IP_LIST" values are used as redis-cli -h endpoints in
+  # the default network path. KB main exposes declared pod FQDN lists here.
+  if [[ -z "${KB_CLUSTER_POD_IP_LIST}" && -n "$all_shards_pod_fqdns" ]]; then
+    KB_CLUSTER_POD_IP_LIST="$all_shards_pod_fqdns"
+  fi
+  if [[ -z "${KB_CLUSTER_POD_HOST_IP_LIST}" && -n "${KB_CLUSTER_POD_IP_LIST}" ]]; then
+    KB_CLUSTER_POD_HOST_IP_LIST="${KB_CLUSTER_POD_IP_LIST}"
+  fi
+  if [[ -z "${KB_CLUSTER_COMPONENT_POD_NAME_LIST}" && -n "${CURRENT_SHARD_POD_NAME_LIST}" ]]; then
+    KB_CLUSTER_COMPONENT_POD_NAME_LIST="${CURRENT_SHARD_POD_NAME_LIST}"
+  fi
+  if [[ -z "${KB_CLUSTER_COMPONENT_POD_IP_LIST}" && -n "${CURRENT_SHARD_POD_FQDN_LIST}" ]]; then
+    KB_CLUSTER_COMPONENT_POD_IP_LIST="${CURRENT_SHARD_POD_FQDN_LIST}"
+  fi
+  if [[ -z "${KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST}" && -n "${KB_CLUSTER_COMPONENT_POD_IP_LIST}" ]]; then
+    KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="${KB_CLUSTER_COMPONENT_POD_IP_LIST}"
+  fi
+  if [[ -z "${KB_CLUSTER_COMPONENT_LIST}" && -n "$all_shards_components" ]]; then
+    KB_CLUSTER_COMPONENT_LIST="$all_shards_components"
+  fi
+  if [[ -z "${KB_CLUSTER_COMPONENT_UNDELETED_LIST}" && -n "${KB_CLUSTER_COMPONENT_LIST}" ]]; then
+    KB_CLUSTER_COMPONENT_UNDELETED_LIST="${KB_CLUSTER_COMPONENT_LIST}"
+  fi
+  if [[ -z "${KB_CLUSTER_COMPONENT_DELETING_LIST+x}" ]]; then
+    KB_CLUSTER_COMPONENT_DELETING_LIST=""
+  fi
+
+  export KB_CLUSTER_POD_NAME_LIST
+  export KB_CLUSTER_POD_IP_LIST
+  export KB_CLUSTER_POD_HOST_IP_LIST
+  export KB_CLUSTER_COMPONENT_POD_NAME_LIST
+  export KB_CLUSTER_COMPONENT_POD_IP_LIST
+  export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+  export KB_CLUSTER_COMPONENT_LIST
+  export KB_CLUSTER_COMPONENT_UNDELETED_LIST
+  export KB_CLUSTER_COMPONENT_DELETING_LIST
 }
 
 load_redis_cluster_common_utils() {
@@ -1059,8 +1106,8 @@ ${__SOURCED__:+false} : || return 0
 
 # main
 if [ $# -eq 1 ]; then
-  init_environment
   load_redis_cluster_common_utils
+  init_environment
   case $1 in
   --help)
     echo "Usage: $0 [options]"

--- a/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
@@ -31,6 +31,79 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
   }
   AfterAll 'cleanup'
 
+  Describe "init_environment()"
+    Context "when KB main provides declared shard variables without legacy KB_CLUSTER lists"
+      init_environment_and_print_vars() {
+        init_environment
+        echo "KB_CLUSTER_POD_NAME_LIST=$KB_CLUSTER_POD_NAME_LIST"
+        echo "KB_CLUSTER_POD_IP_LIST=$KB_CLUSTER_POD_IP_LIST"
+        echo "KB_CLUSTER_COMPONENT_POD_NAME_LIST=$KB_CLUSTER_COMPONENT_POD_NAME_LIST"
+        echo "KB_CLUSTER_COMPONENT_POD_IP_LIST=$KB_CLUSTER_COMPONENT_POD_IP_LIST"
+        echo "KB_CLUSTER_COMPONENT_LIST=$KB_CLUSTER_COMPONENT_LIST"
+        echo "KB_CLUSTER_COMPONENT_UNDELETED_LIST=$KB_CLUSTER_COMPONENT_UNDELETED_LIST"
+      }
+
+      setup() {
+        unset KB_CLUSTER_POD_NAME_LIST
+        unset KB_CLUSTER_POD_IP_LIST
+        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset KB_CLUSTER_COMPONENT_POD_IP_LIST
+        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+        unset KB_CLUSTER_COMPONENT_LIST
+        unset KB_CLUSTER_COMPONENT_DELETING_LIST
+        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-fgt:shard-fgt,shard-2qk:shard-2qk,shard-r7s:shard-r7s"
+        export ALL_SHARDS_POD_NAME_LIST=""
+        export ALL_SHARDS_POD_NAME_LIST_SHARD_FGT="fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1"
+        export ALL_SHARDS_POD_NAME_LIST_SHARD_2QK="fdb-cl-debug-shard-2qk-0,fdb-cl-debug-shard-2qk-1"
+        export ALL_SHARDS_POD_NAME_LIST_SHARD_R7S="fdb-cl-debug-shard-r7s-0,fdb-cl-debug-shard-r7s-1"
+        export ALL_SHARDS_POD_FQDN_LIST=""
+        export ALL_SHARDS_POD_FQDN_LIST_SHARD_FGT="fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local"
+        export ALL_SHARDS_POD_FQDN_LIST_SHARD_2QK="fdb-cl-debug-shard-2qk-0.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-2qk-1.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local"
+        export ALL_SHARDS_POD_FQDN_LIST_SHARD_R7S="fdb-cl-debug-shard-r7s-0.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-1.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST="fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1"
+        export CURRENT_SHARD_POD_FQDN_LIST="fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset ALL_SHARDS_COMPONENT_SHORT_NAMES
+        unset ALL_SHARDS_POD_NAME_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_SHARD_FGT
+        unset ALL_SHARDS_POD_NAME_LIST_SHARD_2QK
+        unset ALL_SHARDS_POD_NAME_LIST_SHARD_R7S
+        unset ALL_SHARDS_POD_FQDN_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_SHARD_FGT
+        unset ALL_SHARDS_POD_FQDN_LIST_SHARD_2QK
+        unset ALL_SHARDS_POD_FQDN_LIST_SHARD_R7S
+        unset CURRENT_SHARD_POD_NAME_LIST
+        unset CURRENT_SHARD_POD_FQDN_LIST
+        unset KB_CLUSTER_POD_NAME_LIST
+        unset KB_CLUSTER_POD_IP_LIST
+        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset KB_CLUSTER_COMPONENT_POD_IP_LIST
+        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+        unset KB_CLUSTER_COMPONENT_LIST
+        unset KB_CLUSTER_COMPONENT_DELETING_LIST
+        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+      }
+      After "un_setup"
+
+      It "synthesizes legacy KB_CLUSTER variables from declared shard variables"
+        When call init_environment_and_print_vars
+        The status should be success
+        The output should include "KB_CLUSTER_POD_NAME_LIST=fdb-cl-debug-shard-2qk-0,fdb-cl-debug-shard-2qk-1,fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1,fdb-cl-debug-shard-r7s-0,fdb-cl-debug-shard-r7s-1"
+        The output should include "KB_CLUSTER_POD_IP_LIST=fdb-cl-debug-shard-2qk-0.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-2qk-1.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-0.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-1.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local"
+        The output should include "KB_CLUSTER_COMPONENT_POD_NAME_LIST=fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1"
+        The output should include "KB_CLUSTER_COMPONENT_POD_IP_LIST=fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local"
+        The output should include "KB_CLUSTER_COMPONENT_LIST=shard-fgt,shard-2qk,shard-r7s"
+        The output should include "KB_CLUSTER_COMPONENT_UNDELETED_LIST=shard-fgt,shard-2qk,shard-r7s"
+      End
+    End
+  End
+
   Describe "init_other_components_and_pods_info()"
     It "initializes other components and pods info correctly"
       export KB_CLUSTER_COMPONENT_LIST="component1,component2,component3"


### PR DESCRIPTION
## What
- Synthesize legacy `KB_CLUSTER_*` lifecycle inputs from the CmpD-declared `CURRENT_SHARD_*` vars and suffixed `ALL_SHARDS_*` vars before cluster postProvision runs.
- Keep existing legacy envs when present, so older controller/action paths are not overwritten.
- Add ShellSpec coverage for the KB main env shape observed in runtime: empty base `ALL_SHARDS_POD_*` vars plus suffixed per-shard vars.

## Why
Ann's PR #452 S01 runtime rerun on KB main closed the previous `only one exec container` blocker but exposed a new first blocker: `falkordb-cluster-manage.sh --post-provision` failed before cluster initialization because it still required old `KB_CLUSTER_POD_IP_LIST` / `KB_CLUSTER_POD_NAME_LIST` vars. The current CmpD declares `CURRENT_SHARD_POD_*` and per-shard `ALL_SHARDS_POD_*` vars instead.

## Verification
- `bash -n addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh`
- `bash -n addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh`
- Docker Bash 5 sourced-function check: `init_environment` synthesizes the old variables from the captured KB main env shape.
- Docker Bash 5 function-level check: after synthesis, `initialize_or_scale_out_redis_cluster` no longer fails the missing `KB_CLUSTER_POD_*` gate with the captured env shape.

Runtime cluster formation still needs Ann's S01 rerun on the patched addon head.
