### PR TITLE
chore: add exporter port to network port list

### DIFF
--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -356,3 +356,6 @@ spec:
         ports:
           - mongodb
           - ha
+      - container: exporter
+        ports:
+          - exporter


### PR DESCRIPTION
- fix https://github.com/apecloud/kubeblocks-addons/issues/2916