### PR TITLE
chore(oceanbase-ce): harden restore postReady diagnostics

### DIFF
--- a/addons/oceanbase-ce/dataprotection/restore.sh
+++ b/addons/oceanbase-ce/dataprotection/restore.sh
@@ -43,13 +43,12 @@ function restoreTenant() {
   local sql=${2:?missing restore sql}
   local time=0
   while true; do
-    if [[ "$tenant_name" == ${TENANT_NAME} ]]; then
+    if [[ "$tenant_name" == "${TENANT_NAME:-}" ]]; then
       echo "INFO: drop init tenant ${tenant_name}"
       ${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; DROP TENANT IF EXISTS ${TENANT_NAME} FORCE;"
     fi
     echo "INFO: $sql"
-    `${mysql_cmd} "${sql}"`
-    if [[ $? -eq 0 ]]  ; then
+    if ${mysql_cmd} "${sql}"; then
       break
     fi
     if [[ $time -ge 2 ]]; then
@@ -76,6 +75,92 @@ function waitForPrimaryClusterRestore() {
       break
     fi
     sleep 10
+  done
+}
+
+function normalizeSQLValue() {
+  local value=${1}
+  if [[ "${value}" == "NULL" ]]; then
+    echo ""
+    return
+  fi
+  echo "${value}"
+}
+
+function getTenantStatusRole() {
+  local tenant_name=${1:?missing tenant_name}
+  ${mysql_cmd} "SELECT COALESCE(status,''), COALESCE(tenant_role,'') FROM oceanbase.DBA_OB_TENANTS WHERE tenant_name='${tenant_name}' AND tenant_type='USER';" 2>/dev/null | awk 'NF {print; exit}'
+}
+
+function getRestoreProgressCount() {
+  ${mysql_cmd} "SELECT count(*) FROM oceanbase.CDB_OB_RESTORE_PROGRESS;" 2>/dev/null | awk -F '\t' 'NF {print; exit}'
+}
+
+function getLatestRestoreHistoryStatus() {
+  local tenant_name=${1:?missing tenant_name}
+  ${mysql_cmd} "SELECT STATUS FROM oceanbase.CDB_OB_RESTORE_HISTORY WHERE RESTORE_TENANT_NAME='${tenant_name}';" 2>/dev/null | awk 'NF {status=$0} END {print status}'
+}
+
+function printRestoreDiagnostics() {
+  local tenant_name=${1:?missing tenant_name}
+  echo "INFO: restore diagnostics for tenant ${tenant_name}: DBA_OB_TENANTS"
+  ${mysql_cmd} "SELECT tenant_id,tenant_name,status,tenant_role FROM oceanbase.DBA_OB_TENANTS WHERE tenant_name='${tenant_name}' AND tenant_type='USER';" 2>&1 || true
+  echo "INFO: restore diagnostics for tenant ${tenant_name}: CDB_OB_RESTORE_PROGRESS"
+  ${mysql_cmd} "SELECT * FROM oceanbase.CDB_OB_RESTORE_PROGRESS;" 2>&1 || true
+  echo "INFO: restore diagnostics for tenant ${tenant_name}: CDB_OB_RESTORE_HISTORY"
+  ${mysql_cmd} "SELECT TENANT_ID,RESTORE_TENANT_NAME,STATUS,COMMENT FROM oceanbase.CDB_OB_RESTORE_HISTORY WHERE RESTORE_TENANT_NAME='${tenant_name}';" 2>&1 || true
+}
+
+function waitForExistingTenantRestore() {
+  local tenant_name=${1:?missing tenant_name}
+  local timeout=${RESTORE_TENANT_WAIT_TIMEOUT_SECONDS:-300}
+  local interval=${RESTORE_TENANT_WAIT_INTERVAL_SECONDS:-10}
+  local waitTime=0
+  local tenant_state tenant_status tenant_role progress_count history_status
+
+  while true; do
+    tenant_state=$(getTenantStatusRole "${tenant_name}")
+    tenant_status=""
+    tenant_role=""
+    if [[ -n "${tenant_state}" ]]; then
+      IFS=$'\t' read -r tenant_status tenant_role <<< "${tenant_state}"
+      IFS=$OlD_IFS
+      tenant_status=$(normalizeSQLValue "${tenant_status}")
+      tenant_role=$(normalizeSQLValue "${tenant_role}")
+    else
+      echo "ERROR: tenant ${tenant_name} disappeared while waiting for restore convergence"
+      printRestoreDiagnostics "${tenant_name}"
+      return 1
+    fi
+    progress_count=$(getRestoreProgressCount)
+    history_status=$(getLatestRestoreHistoryStatus "${tenant_name}")
+    echo "INFO: tenant ${tenant_name} restore wait: status='${tenant_status:-NULL}', role='${tenant_role:-NULL}', restore_progress_count='${progress_count:-unknown}', latest_restore_history_status='${history_status:-none}', wait=${waitTime}s/${timeout}s"
+
+    if [[ "${tenant_role}" == "PRIMARY" ]] || [[ "${tenant_role}" == "STANDBY" ]]; then
+      echo "INFO: tenant ${tenant_name} restore already converged with role ${tenant_role}"
+      return 0
+    fi
+
+    if [[ "${history_status}" == *"FAIL"* ]]; then
+      echo "ERROR: tenant ${tenant_name} restore history reports failure"
+      printRestoreDiagnostics "${tenant_name}"
+      return 1
+    fi
+
+    if [[ -n "${tenant_status}" ]] && [[ "${tenant_status}" != "RESTORE" ]] && [[ "${tenant_role}" != "RESTORE" ]]; then
+      echo "ERROR: tenant ${tenant_name} exists with unexpected status '${tenant_status}' and role '${tenant_role:-NULL}'"
+      printRestoreDiagnostics "${tenant_name}"
+      return 1
+    fi
+
+    if [[ ${waitTime} -ge ${timeout} ]]; then
+      echo "ERROR: tenant ${tenant_name} did not leave RESTORE state within ${timeout}s"
+      printRestoreDiagnostics "${tenant_name}"
+      return 1
+    fi
+
+    sleep "${interval}"
+    waitTime=$((waitTime+interval))
   done
 }
 
@@ -174,8 +259,14 @@ for i in $(seq 0 ${index}); do
   archivePath=$(json_array_get "$i" archivePath "$extras")
   uri="$(getDestURL data "${tenant_name}"),$(getDestURL restoreFromArchive "${tenant_name}" "${tenant_id}" "${archivePath}")"
   restoreFragment=$(getRestoreFragment "${tenant_name}" "${minRestoreSCN}")
-  existing_role=$(${mysql_cmd} "SELECT tenant_role FROM oceanbase.DBA_OB_TENANTS WHERE tenant_name='${tenant_name}' AND tenant_type='USER';" 2>/dev/null | awk 'NF {print; exit}')
-  if [[ -n "$existing_role" ]]; then
+  tenant_state=$(getTenantStatusRole "${tenant_name}")
+  existing_status=""
+  existing_role=""
+  if [[ -n "${tenant_state}" ]]; then
+    IFS=$'\t' read -r existing_status existing_role <<< "${tenant_state}"
+    IFS=$OlD_IFS
+    existing_status=$(normalizeSQLValue "${existing_status}")
+    existing_role=$(normalizeSQLValue "${existing_role}")
     case "$existing_role" in
       PRIMARY)
         echo "INFO: tenant ${tenant_name} already PRIMARY, skipping RESTORE"
@@ -185,10 +276,17 @@ for i in $(seq 0 ${index}); do
         ;;
       RESTORE)
         echo "INFO: tenant ${tenant_name} in RESTORE state, skipping RESTORE command"
+        waitForExistingTenantRestore "${tenant_name}" || exit 1
         ;;
       *)
-        echo "ERROR: tenant ${tenant_name} exists with unexpected role '${existing_role}'"
-        exit 1
+        if [[ "${existing_status}" == "RESTORE" ]] && [[ -z "${existing_role}" ]]; then
+          echo "INFO: tenant ${tenant_name} already exists in RESTORE status with empty role, waiting for restore convergence"
+          waitForExistingTenantRestore "${tenant_name}" || exit 1
+        else
+          echo "ERROR: tenant ${tenant_name} exists with unexpected status '${existing_status:-NULL}' and role '${existing_role:-NULL}'"
+          printRestoreDiagnostics "${tenant_name}"
+          exit 1
+        fi
         ;;
     esac
     continue
@@ -196,6 +294,7 @@ for i in $(seq 0 ${index}); do
   echo "INFO: start to restore tenant ${tenant_name} until ${restoreFragment}"
   restoreTenant "${tenant_name}" "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM RESTORE ${tenant_name} FROM '${uri}' UNTIL ${restoreFragment} WITH 'pool_list=${poolList}'"
   if [ $? -eq 1 ]; then
+    printRestoreDiagnostics "${tenant_name}"
     exit 1
   fi
   echo "INFO: restoring tenant ${tenant_name}"


### PR DESCRIPTION
## Problem

OBCE soak S1 i11 exposed a restore postReady retry gap: after `ALTER SYSTEM RESTORE` returned `OB_REPLICA_NUM_NOT_ENOUGH(-4672)`, the tenant remained in `status=RESTORE` with `tenant_role=NULL`. A retry then queried only `tenant_role` and failed as `unexpected role 'NULL'`, which hid the more useful restore state.

This PR does not claim to fix the primary 4672 restore root cause. Current candidates are still being investigated separately: OB CE 4.3.5 single-replica restore behavior, missing `locality` restore option, or resource pool/unit allocation state.

## Changes

- Query existing tenants by both `status` and `tenant_role`.
- Treat `status=RESTORE` with empty/NULL role as restore-in-progress/stuck, not as an unknown role.
- Add bounded wait for existing restore tenants with progress logging.
- On restore history failure, timeout, disappeared tenant, unexpected state, or `ALTER SYSTEM RESTORE` failure, print diagnostics from:
  - `DBA_OB_TENANTS`
  - `CDB_OB_RESTORE_PROGRESS`
  - `CDB_OB_RESTORE_HISTORY`
- Replace the restore command backtick execution with direct mysql exit-code checking.

## Verification

- `bash -n addons/oceanbase-ce/dataprotection/restore.sh`
- `helm template obce addons/oceanbase-ce >/tmp/obce-actionset-render.yaml`
- `git diff --check`

Not run: `make scripts-test` because this machine does not have `shellspec`; the Makefile attempted `sudo` install and failed due non-interactive password requirement.

## Boundary

This is L4 retry/idempotence/diagnostic hardening only. Runtime validation still needs an approved vcluster restore run.
