### PR TITLE
fix(redis): build cross-shard CA bundle for TLS cluster bus trust

### DIFF
--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -565,7 +565,21 @@ build_cross_shard_ca_bundle() {
   fi
   set_xtrace_when_ut_mode_false
   if echo "$addslot_output" | grep -qi "already busy"; then
-    echo "Pre-init slot allocation: exchange=$exchange_slot (already owned, reusing from previous attempt)"
+    local myself_slots
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      myself_slots=$($redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER NODES 2>/dev/null | grep "myself" | awk '{for(i=9;i<=NF;i++) print $i}')
+    else
+      myself_slots=$($redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER NODES 2>/dev/null | grep "myself" | awk '{for(i=9;i<=NF;i++) print $i}')
+    fi
+    set_xtrace_when_ut_mode_false
+    if echo "$myself_slots" | grep -q "^${exchange_slot}$"; then
+      echo "Pre-init slot allocation: exchange=$exchange_slot (already owned by local node, reusing from previous attempt)"
+    else
+      echo "Error: CLUSTER ADDSLOTS $exchange_slot busy but not owned by local node (local slots: $myself_slots)" >&2
+      echo "Retaining CA exchange state (slot/full-coverage=no) for retry"
+      return 1
+    fi
   elif echo "$addslot_output" | grep -qi "err"; then
     echo "Error: CLUSTER ADDSLOTS $exchange_slot failed unexpectedly: $addslot_output" >&2
     echo "Retaining CA exchange state (slot/full-coverage=no) for retry"

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -593,6 +593,7 @@ build_cross_shard_ca_bundle() {
 
     if [ -z "$peer_encoded_ca" ]; then
       echo "Error: timed out waiting for CA from $pod_fqdn" >&2
+      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       return 1
     fi
 
@@ -631,6 +632,7 @@ build_cross_shard_ca_bundle() {
   echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
   if [ $config_set_rc -ne 0 ]; then
     echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
+    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     return 1
   fi
 
@@ -645,6 +647,7 @@ build_cross_shard_ca_bundle() {
   echo "CONFIG GET tls-ca-cert-file readback: $readback"
   if [ "$readback" != "$ca_bundle_path" ]; then
     echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
+    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     return 1
   fi
 
@@ -673,6 +676,7 @@ build_cross_shard_ca_bundle() {
   done
   if [ $distribute_failures -gt 0 ]; then
     echo "Error: failed to distribute CA bundle to $distribute_failures pod(s)" >&2
+    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     return 1
   fi
   echo "Distributed CA bundle to all pods"

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -523,8 +523,7 @@ build_cross_shard_ca_bundle() {
   local tls_mount_path="${TLS_MOUNT_PATH:-/etc/pki/tls}"
   local local_ca="${tls_mount_path}/ca.crt"
   local ca_bundle_path="${DATA_DIR:-/data}/ca-bundle.crt"
-  local ca_exchange_key="__KB_TLS_PEER_CA__"
-  local ca_bundle_key="__KB_TLS_CA_BUNDLE_BASE64__"
+  local ca_exchange_key="{__KB_TLS__}_PEER_CA"
   local service_port="${SERVICE_PORT:-6379}"
 
   if [ ! -f "$local_ca" ]; then
@@ -542,6 +541,18 @@ build_cross_shard_ca_bundle() {
 
   local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
 
+  local exchange_slot
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    exchange_slot=$($redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER KEYSLOT "$ca_exchange_key" 2>/dev/null)
+    $redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER ADDSLOTS "$exchange_slot" > /dev/null 2>&1
+  else
+    exchange_slot=$($redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER KEYSLOT "$ca_exchange_key" 2>/dev/null)
+    $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER ADDSLOTS "$exchange_slot" > /dev/null 2>&1
+  fi
+  set_xtrace_when_ut_mode_false
+  echo "Pre-init slot allocation: exchange=$exchange_slot"
+
   local set_rc
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
@@ -553,6 +564,7 @@ build_cross_shard_ca_bundle() {
   set_xtrace_when_ut_mode_false
   if [ $set_rc -ne 0 ]; then
     echo "Error: failed to publish local CA to $ca_exchange_key (rc=$set_rc)" >&2
+    _flush_pre_init_slots "$service_port"
     return 1
   fi
 
@@ -584,6 +596,14 @@ build_cross_shard_ca_bundle() {
         peer_encoded_ca=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_exchange_key" 2>/dev/null)
       fi
       set_xtrace_when_ut_mode_false
+      if [ -n "$peer_encoded_ca" ]; then
+        local pem_check
+        pem_check=$(echo "$peer_encoded_ca" | base64 -d 2>/dev/null | head -1)
+        if ! echo "$pem_check" | grep -q "BEGIN CERTIFICATE"; then
+          echo "Warning: peer $pod_fqdn returned non-PEM data, retrying..." >&2
+          peer_encoded_ca=""
+        fi
+      fi
       if [ -z "$peer_encoded_ca" ]; then
         echo "Waiting for CA from $pod_fqdn (${attempts}/30)..."
         sleep_when_ut_mode_false 2
@@ -594,6 +614,7 @@ build_cross_shard_ca_bundle() {
     if [ -z "$peer_encoded_ca" ]; then
       echo "Error: timed out waiting for CA from $pod_fqdn" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _flush_pre_init_slots "$service_port"
       return 1
     fi
 
@@ -616,6 +637,7 @@ build_cross_shard_ca_bundle() {
     echo "All shards share the same CA, no bundle needed"
     rm -f "$ca_bundle_path"
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+    _flush_pre_init_slots "$service_port"
     return 0
   fi
 
@@ -633,6 +655,7 @@ build_cross_shard_ca_bundle() {
   if [ $config_set_rc -ne 0 ]; then
     echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+    _flush_pre_init_slots "$service_port"
     return 1
   fi
 
@@ -648,42 +671,55 @@ build_cross_shard_ca_bundle() {
   if [ "$readback" != "$ca_bundle_path" ]; then
     echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+    _flush_pre_init_slots "$service_port"
     return 1
   fi
+
+  _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+  _flush_pre_init_slots "$service_port"
+
+  return 0
+}
+
+distribute_ca_bundle_to_cluster() {
+  [ "${TLS_ENABLED}" != "true" ] && return 0
+
+  local ca_bundle_path="${DATA_DIR:-/data}/ca-bundle.crt"
+  local ca_bundle_key="{__KB_TLS__}_CA_BUNDLE"
+  local service_port="${SERVICE_PORT:-6379}"
+  local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
+
+  [ ! -f "$ca_bundle_path" ] && return 0
 
   local encoded_bundle
   encoded_bundle=$(base64 < "$ca_bundle_path" | tr -d '\n')
-  local distribute_failures=0
-  for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
-    local pod_name=${pod_fqdn%%.*}
-    if [ "$pod_name" = "$CURRENT_POD_NAME" ]; then
-      continue
-    fi
-    local peer_port
-    peer_port=$(get_pod_service_port_by_network_mode "$pod_name")
-    unset_xtrace_when_ut_mode_false
-    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-      $redis_cli -h "$pod_fqdn" -p "$peer_port" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
-    else
-      $redis_cli -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
-    fi
-    local dist_rc=$?
-    set_xtrace_when_ut_mode_false
-    if [ $dist_rc -ne 0 ]; then
-      echo "Error: failed to distribute CA bundle to $pod_fqdn (rc=$dist_rc)" >&2
-      distribute_failures=$((distribute_failures + 1))
-    fi
-  done
-  if [ $distribute_failures -gt 0 ]; then
-    echo "Error: failed to distribute CA bundle to $distribute_failures pod(s)" >&2
-    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+
+  local set_rc
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    $redis_cli -c -h 127.0.0.1 -p "$service_port" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null
+  else
+    $redis_cli -c -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null
+  fi
+  set_rc=$?
+  set_xtrace_when_ut_mode_false
+  if [ $set_rc -ne 0 ]; then
+    echo "Warning: failed to distribute CA bundle key to cluster (rc=$set_rc)" >&2
     return 1
   fi
-  echo "Distributed CA bundle to all pods"
-
-  _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-
+  echo "Distributed CA bundle key to cluster"
   return 0
+}
+
+_flush_pre_init_slots() {
+  local port="$1"
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CLUSTER FLUSHSLOTS > /dev/null 2>&1
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER FLUSHSLOTS > /dev/null 2>&1
+  fi
+  set_xtrace_when_ut_mode_false
 }
 
 _cleanup_ca_exchange_key() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -566,6 +566,25 @@ build_cross_shard_ca_bundle() {
   set_xtrace_when_ut_mode_false
   echo "Pre-init slot allocation: exchange=$exchange_slot"
 
+  local attempt_nonce="${RANDOM}${RANDOM}"
+  local nonce_key="{__KB_TLS__}_NONCE"
+  local nonce_set_rc
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    $redis_cli -h 127.0.0.1 -p "$service_port" SET "$nonce_key" "$attempt_nonce" > /dev/null
+  else
+    $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$nonce_key" "$attempt_nonce" > /dev/null
+  fi
+  nonce_set_rc=$?
+  set_xtrace_when_ut_mode_false
+  if [ $nonce_set_rc -ne 0 ]; then
+    echo "Error: failed to set attempt nonce" >&2
+    _flush_pre_init_slots "$service_port"
+    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+    return 1
+  fi
+  echo "Attempt nonce: $attempt_nonce"
+
   local set_rc
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
@@ -577,6 +596,7 @@ build_cross_shard_ca_bundle() {
   set_xtrace_when_ut_mode_false
   if [ $set_rc -ne 0 ]; then
     echo "Error: failed to publish local CA to $ca_exchange_key (rc=$set_rc)" >&2
+    _cleanup_ca_exchange_key "$nonce_key" "$service_port"
     _flush_pre_init_slots "$service_port"
     _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
@@ -588,6 +608,7 @@ build_cross_shard_ca_bundle() {
   local peer_fqdns=()
   local peer_ports=()
   local peer_names=()
+  local peer_nonces=()
 
   for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
     local pod_name=${pod_fqdn%%.*}
@@ -637,10 +658,29 @@ build_cross_shard_ca_bundle() {
     if [ -z "$peer_encoded_ca" ]; then
       echo "Error: timed out waiting for CA from $pod_fqdn" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       _flush_pre_init_slots "$service_port"
       _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
+
+    local peer_nonce=""
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      peer_nonce=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" GET "$nonce_key" 2>/dev/null)
+    else
+      peer_nonce=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$nonce_key" 2>/dev/null)
+    fi
+    set_xtrace_when_ut_mode_false
+    if [ -z "$peer_nonce" ]; then
+      echo "Error: failed to read nonce from $pod_fqdn" >&2
+      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _cleanup_ca_exchange_key "$nonce_key" "$service_port"
+      _flush_pre_init_slots "$service_port"
+      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+      return 1
+    fi
+    peer_nonces+=("$peer_nonce")
 
     local peer_ca_decoded
     peer_ca_decoded=$(echo "$peer_encoded_ca" | base64 -d)
@@ -675,6 +715,7 @@ build_cross_shard_ca_bundle() {
     if [ $config_set_rc -ne 0 ]; then
       echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       _flush_pre_init_slots "$service_port"
       _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
@@ -692,23 +733,25 @@ build_cross_shard_ca_bundle() {
     if [ "$readback" != "$ca_bundle_path" ]; then
       echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       _flush_pre_init_slots "$service_port"
       _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
   fi
 
-  # ACK barrier: each pod writes an ACK key on every peer's Redis after
-  # collecting all CAs, then waits for peers to write their ACK on this
-  # pod's Redis. No pod flushes its slot until all peers have confirmed,
-  # preventing the fast-cleanup race that caused r4 CLUSTERDOWN.
+  # ACK barrier: nonce-scoped to prevent stale ACKs from previous failed
+  # attempts polluting the current barrier. Each pod's ACK key includes its
+  # own nonce; peers read the nonce during CA exchange and only wait for
+  # ACK keys matching the current attempt's nonce.
   local ack_key_prefix="{__KB_TLS__}_ACK"
-  local my_ack_key="${ack_key_prefix}_${CURRENT_POD_NAME}"
+  local my_ack_key="${ack_key_prefix}_${CURRENT_POD_NAME}_${attempt_nonce}"
 
   for i in "${!peer_fqdns[@]}"; do
     if ! _write_ack_to_peer "${peer_fqdns[$i]}" "${peer_ports[$i]}" "$my_ack_key"; then
       echo "Error: failed to write ACK to ${peer_fqdns[$i]}" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       _flush_pre_init_slots "$service_port"
       _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
@@ -717,14 +760,15 @@ build_cross_shard_ca_bundle() {
   echo "ACK sent to ${#peer_fqdns[@]} peers"
 
   local expected_ack_keys=()
-  for name in "${peer_names[@]}"; do
-    expected_ack_keys+=("${ack_key_prefix}_${name}")
+  for i in "${!peer_names[@]}"; do
+    expected_ack_keys+=("${ack_key_prefix}_${peer_names[$i]}_${peer_nonces[$i]}")
   done
 
   if ! _wait_for_peer_acks "$service_port" "${expected_ack_keys[@]}"; then
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-    for name in "${peer_names[@]}"; do
-      _cleanup_ca_exchange_key "${ack_key_prefix}_${name}" "$service_port"
+    _cleanup_ca_exchange_key "$nonce_key" "$service_port"
+    for i in "${!peer_names[@]}"; do
+      _cleanup_ca_exchange_key "${ack_key_prefix}_${peer_names[$i]}_${peer_nonces[$i]}" "$service_port"
     done
     _flush_pre_init_slots "$service_port"
     _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
@@ -732,8 +776,9 @@ build_cross_shard_ca_bundle() {
   fi
 
   _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-  for name in "${peer_names[@]}"; do
-    _cleanup_ca_exchange_key "${ack_key_prefix}_${name}" "$service_port"
+  _cleanup_ca_exchange_key "$nonce_key" "$service_port"
+  for i in "${!peer_names[@]}"; do
+    _cleanup_ca_exchange_key "${ack_key_prefix}_${peer_names[$i]}_${peer_nonces[$i]}" "$service_port"
   done
   if ! _flush_pre_init_slots "$service_port"; then
     echo "Error: CLUSTER FLUSHSLOTS failed after CA exchange" >&2
@@ -850,7 +895,7 @@ _wait_for_peer_acks() {
   local port="$1"
   shift
   local ack_keys=("$@")
-  local max_attempts=60
+  local max_attempts=30
   local attempt=0
 
   while [ $attempt -lt $max_attempts ]; do

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -515,6 +515,157 @@ check_cluster_initialized() {
   return 1
 }
 
+build_cross_shard_ca_bundle() {
+  if [ "${TLS_ENABLED}" != "true" ]; then
+    return 0
+  fi
+
+  local tls_mount_path="${TLS_MOUNT_PATH:-/etc/pki/tls}"
+  local local_ca="${tls_mount_path}/ca.crt"
+  local ca_bundle_path="/data/ca-bundle.crt"
+  local ca_exchange_key="__TLS_PEER_CA__"
+  local ca_bundle_key="__TLS_CA_BUNDLE_BASE64__"
+  local service_port="${SERVICE_PORT:-6379}"
+
+  if [ ! -f "$local_ca" ]; then
+    return 0
+  fi
+
+  echo "=== Building cross-shard TLS CA bundle ==="
+
+  local encoded_local_ca
+  encoded_local_ca=$(base64 < "$local_ca" | tr -d '\n')
+  local local_fingerprint
+  local_fingerprint=$(sha256sum "$local_ca" | awk '{print $1}')
+  echo "Local CA sha256: $local_fingerprint"
+  echo "Local cert sha256: $(sha256sum "${tls_mount_path}/tls.crt" | awk '{print $1}')"
+
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" SET "$ca_exchange_key" "$encoded_local_ca" > /dev/null
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_exchange_key" "$encoded_local_ca" > /dev/null
+  fi
+  set_xtrace_when_ut_mode_false
+
+  cp "$local_ca" "$ca_bundle_path"
+  local fingerprints="$local_fingerprint"
+  local new_ca_count=0
+
+  for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
+    local pod_name=${pod_fqdn%%.*}
+    if [ "$pod_name" = "$CURRENT_POD_NAME" ]; then
+      continue
+    fi
+    local pod_ordinal
+    pod_ordinal=$(extract_obj_ordinal "$pod_name") || continue
+    if [ "$pod_ordinal" != "0" ]; then
+      continue
+    fi
+
+    local peer_port
+    peer_port=$(get_pod_service_port_by_network_mode "$pod_name")
+
+    local peer_encoded_ca=""
+    local attempts=0
+    while [ -z "$peer_encoded_ca" ] && [ $attempts -lt 30 ]; do
+      unset_xtrace_when_ut_mode_false
+      if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+        peer_encoded_ca=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h "$pod_fqdn" -p "$peer_port" GET "$ca_exchange_key" 2>/dev/null)
+      else
+        peer_encoded_ca=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_exchange_key" 2>/dev/null)
+      fi
+      set_xtrace_when_ut_mode_false
+      if [ -z "$peer_encoded_ca" ]; then
+        echo "Waiting for CA from $pod_fqdn (${attempts}/30)..."
+        sleep_when_ut_mode_false 2
+        attempts=$((attempts + 1))
+      fi
+    done
+
+    if [ -z "$peer_encoded_ca" ]; then
+      echo "Error: timed out waiting for CA from $pod_fqdn" >&2
+      return 1
+    fi
+
+    local peer_ca_decoded
+    peer_ca_decoded=$(echo "$peer_encoded_ca" | base64 -d)
+    local peer_fingerprint
+    peer_fingerprint=$(echo "$peer_ca_decoded" | sha256sum | awk '{print $1}')
+    echo "Peer $pod_fqdn CA sha256: $peer_fingerprint"
+
+    if echo "$fingerprints" | grep -q "$peer_fingerprint"; then
+      echo "Peer $pod_fqdn CA is same, skipping"
+    else
+      echo "$peer_ca_decoded" >> "$ca_bundle_path"
+      fingerprints="${fingerprints} ${peer_fingerprint}"
+      new_ca_count=$((new_ca_count + 1))
+    fi
+  done
+
+  if [ $new_ca_count -eq 0 ]; then
+    echo "All shards share the same CA, no bundle needed"
+    rm -f "$ca_bundle_path"
+    return 0
+  fi
+
+  echo "CA bundle: $((new_ca_count + 1)) unique CAs at $ca_bundle_path"
+
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
+  fi
+  local config_set_rc=$?
+  set_xtrace_when_ut_mode_false
+  echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
+
+  local readback
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    readback=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$service_port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+  else
+    readback=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+  fi
+  set_xtrace_when_ut_mode_false
+  echo "CONFIG GET tls-ca-cert-file readback: $readback"
+  if [ "$readback" != "$ca_bundle_path" ]; then
+    echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
+    return 1
+  fi
+
+  local encoded_bundle
+  encoded_bundle=$(base64 < "$ca_bundle_path" | tr -d '\n')
+  for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
+    local pod_name=${pod_fqdn%%.*}
+    if [ "$pod_name" = "$CURRENT_POD_NAME" ]; then
+      continue
+    fi
+    local peer_port
+    peer_port=$(get_pod_service_port_by_network_mode "$pod_name")
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      redis-cli $REDIS_CLI_TLS_CMD -h "$pod_fqdn" -p "$peer_port" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
+    else
+      redis-cli $REDIS_CLI_TLS_CMD -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
+    fi
+    set_xtrace_when_ut_mode_false
+  done
+  echo "Distributed CA bundle to all pods"
+
+  # Clean up exchange keys
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" DEL "$ca_exchange_key" > /dev/null 2>&1
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$ca_exchange_key" > /dev/null 2>&1
+  fi
+  set_xtrace_when_ut_mode_false
+
+  return 0
+}
+
 build_redis_cluster_create_command() {
   local primary_nodes="$1"
   unset_xtrace_when_ut_mode_false

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -585,6 +585,9 @@ build_cross_shard_ca_bundle() {
   cp "$local_ca" "$ca_bundle_path"
   local fingerprints="$local_fingerprint"
   local new_ca_count=0
+  local peer_fqdns=()
+  local peer_ports=()
+  local peer_names=()
 
   for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
     local pod_name=${pod_fqdn%%.*}
@@ -599,6 +602,9 @@ build_cross_shard_ca_bundle() {
 
     local peer_port
     peer_port=$(get_pod_service_port_by_network_mode "$pod_name")
+    peer_fqdns+=("$pod_fqdn")
+    peer_ports+=("$peer_port")
+    peer_names+=("$pod_name")
 
     local peer_encoded_ca=""
     local attempts=0
@@ -654,63 +660,88 @@ build_cross_shard_ca_bundle() {
   if [ $new_ca_count -eq 0 ]; then
     echo "All shards share the same CA, no bundle needed"
     rm -f "$ca_bundle_path"
-    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-    if ! _flush_pre_init_slots "$service_port"; then
-      echo "Error: CLUSTER FLUSHSLOTS failed after same-CA detection" >&2
+  else
+    echo "CA bundle: $((new_ca_count + 1)) unique CAs at $ca_bundle_path"
+
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      $redis_cli -h 127.0.0.1 -p "$service_port" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
+    else
+      $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
+    fi
+    local config_set_rc=$?
+    set_xtrace_when_ut_mode_false
+    echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
+    if [ $config_set_rc -ne 0 ]; then
+      echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
+      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _flush_pre_init_slots "$service_port"
       _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
-    if ! _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"; then
-      echo "Error: failed to restore cluster-require-full-coverage after same-CA detection" >&2
+
+    local readback
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      readback=$($redis_cli --raw -h 127.0.0.1 -p "$service_port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+    else
+      readback=$($redis_cli --raw -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+    fi
+    set_xtrace_when_ut_mode_false
+    echo "CONFIG GET tls-ca-cert-file readback: $readback"
+    if [ "$readback" != "$ca_bundle_path" ]; then
+      echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
+      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _flush_pre_init_slots "$service_port"
+      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
-    return 0
   fi
 
-  echo "CA bundle: $((new_ca_count + 1)) unique CAs at $ca_bundle_path"
+  # ACK barrier: each pod writes an ACK key on every peer's Redis after
+  # collecting all CAs, then waits for peers to write their ACK on this
+  # pod's Redis. No pod flushes its slot until all peers have confirmed,
+  # preventing the fast-cleanup race that caused r4 CLUSTERDOWN.
+  local ack_key_prefix="{__KB_TLS__}_ACK"
+  local my_ack_key="${ack_key_prefix}_${CURRENT_POD_NAME}"
 
-  unset_xtrace_when_ut_mode_false
-  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    $redis_cli -h 127.0.0.1 -p "$service_port" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
-  else
-    $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
-  fi
-  local config_set_rc=$?
-  set_xtrace_when_ut_mode_false
-  echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
-  if [ $config_set_rc -ne 0 ]; then
-    echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
+  for i in "${!peer_fqdns[@]}"; do
+    if ! _write_ack_to_peer "${peer_fqdns[$i]}" "${peer_ports[$i]}" "$my_ack_key"; then
+      echo "Error: failed to write ACK to ${peer_fqdns[$i]}" >&2
+      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+      _flush_pre_init_slots "$service_port"
+      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+      return 1
+    fi
+  done
+  echo "ACK sent to ${#peer_fqdns[@]} peers"
+
+  local expected_ack_keys=()
+  for name in "${peer_names[@]}"; do
+    expected_ack_keys+=("${ack_key_prefix}_${name}")
+  done
+
+  if ! _wait_for_peer_acks "$service_port" "${expected_ack_keys[@]}"; then
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-    _flush_pre_init_slots "$service_port"
-    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
-    return 1
-  fi
-
-  local readback
-  unset_xtrace_when_ut_mode_false
-  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    readback=$($redis_cli --raw -h 127.0.0.1 -p "$service_port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
-  else
-    readback=$($redis_cli --raw -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
-  fi
-  set_xtrace_when_ut_mode_false
-  echo "CONFIG GET tls-ca-cert-file readback: $readback"
-  if [ "$readback" != "$ca_bundle_path" ]; then
-    echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
-    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+    for name in "${peer_names[@]}"; do
+      _cleanup_ca_exchange_key "${ack_key_prefix}_${name}" "$service_port"
+    done
     _flush_pre_init_slots "$service_port"
     _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
   _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+  for name in "${peer_names[@]}"; do
+    _cleanup_ca_exchange_key "${ack_key_prefix}_${name}" "$service_port"
+  done
   if ! _flush_pre_init_slots "$service_port"; then
-    echo "Error: CLUSTER FLUSHSLOTS failed after CA bundle build" >&2
+    echo "Error: CLUSTER FLUSHSLOTS failed after CA exchange" >&2
     _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
   if ! _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"; then
-    echo "Error: failed to restore cluster-require-full-coverage after CA bundle build" >&2
+    echo "Error: failed to restore cluster-require-full-coverage after CA exchange" >&2
     return 1
   fi
 
@@ -797,6 +828,58 @@ _cleanup_ca_exchange_key() {
     redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$key" > /dev/null 2>&1
   fi
   set_xtrace_when_ut_mode_false
+}
+
+_write_ack_to_peer() {
+  local peer_fqdn="$1"
+  local peer_port="$2"
+  local ack_key="$3"
+  local rc
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h "$peer_fqdn" -p "$peer_port" SET "$ack_key" "1" > /dev/null 2>&1
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h "$peer_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ack_key" "1" > /dev/null 2>&1
+  fi
+  rc=$?
+  set_xtrace_when_ut_mode_false
+  return $rc
+}
+
+_wait_for_peer_acks() {
+  local port="$1"
+  shift
+  local ack_keys=("$@")
+  local max_attempts=60
+  local attempt=0
+
+  while [ $attempt -lt $max_attempts ]; do
+    local all_acked=true
+    for ack_key in "${ack_keys[@]}"; do
+      local val
+      unset_xtrace_when_ut_mode_false
+      if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+        val=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" GET "$ack_key" 2>/dev/null)
+      else
+        val=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ack_key" 2>/dev/null)
+      fi
+      set_xtrace_when_ut_mode_false
+      if [ -z "$val" ]; then
+        all_acked=false
+        break
+      fi
+    done
+    if [ "$all_acked" = "true" ]; then
+      echo "All peer ACKs received"
+      return 0
+    fi
+    echo "Waiting for peer ACKs (${attempt}/${max_attempts})..."
+    sleep_when_ut_mode_false 2
+    attempt=$((attempt + 1))
+  done
+
+  echo "Error: timed out waiting for peer ACKs" >&2
+  return 1
 }
 
 build_redis_cluster_create_command() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -522,9 +522,9 @@ build_cross_shard_ca_bundle() {
 
   local tls_mount_path="${TLS_MOUNT_PATH:-/etc/pki/tls}"
   local local_ca="${tls_mount_path}/ca.crt"
-  local ca_bundle_path="/data/ca-bundle.crt"
-  local ca_exchange_key="__TLS_PEER_CA__"
-  local ca_bundle_key="__TLS_CA_BUNDLE_BASE64__"
+  local ca_bundle_path="${DATA_DIR:-/data}/ca-bundle.crt"
+  local ca_exchange_key="__KB_TLS_PEER_CA__"
+  local ca_bundle_key="__KB_TLS_CA_BUNDLE_BASE64__"
   local service_port="${SERVICE_PORT:-6379}"
 
   if [ ! -f "$local_ca" ]; then
@@ -540,13 +540,21 @@ build_cross_shard_ca_bundle() {
   echo "Local CA sha256: $local_fingerprint"
   echo "Local cert sha256: $(sha256sum "${tls_mount_path}/tls.crt" | awk '{print $1}')"
 
+  local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
+
+  local set_rc
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" SET "$ca_exchange_key" "$encoded_local_ca" > /dev/null
+    $redis_cli -h 127.0.0.1 -p "$service_port" SET "$ca_exchange_key" "$encoded_local_ca" > /dev/null
   else
-    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_exchange_key" "$encoded_local_ca" > /dev/null
+    $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_exchange_key" "$encoded_local_ca" > /dev/null
   fi
+  set_rc=$?
   set_xtrace_when_ut_mode_false
+  if [ $set_rc -ne 0 ]; then
+    echo "Error: failed to publish local CA to $ca_exchange_key (rc=$set_rc)" >&2
+    return 1
+  fi
 
   cp "$local_ca" "$ca_bundle_path"
   local fingerprints="$local_fingerprint"
@@ -571,9 +579,9 @@ build_cross_shard_ca_bundle() {
     while [ -z "$peer_encoded_ca" ] && [ $attempts -lt 30 ]; do
       unset_xtrace_when_ut_mode_false
       if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-        peer_encoded_ca=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h "$pod_fqdn" -p "$peer_port" GET "$ca_exchange_key" 2>/dev/null)
+        peer_encoded_ca=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" GET "$ca_exchange_key" 2>/dev/null)
       else
-        peer_encoded_ca=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_exchange_key" 2>/dev/null)
+        peer_encoded_ca=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_exchange_key" 2>/dev/null)
       fi
       set_xtrace_when_ut_mode_false
       if [ -z "$peer_encoded_ca" ]; then
@@ -606,6 +614,7 @@ build_cross_shard_ca_bundle() {
   if [ $new_ca_count -eq 0 ]; then
     echo "All shards share the same CA, no bundle needed"
     rm -f "$ca_bundle_path"
+    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     return 0
   fi
 
@@ -613,20 +622,24 @@ build_cross_shard_ca_bundle() {
 
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
+    $redis_cli -h 127.0.0.1 -p "$service_port" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
   else
-    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
+    $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle_path" > /dev/null
   fi
   local config_set_rc=$?
   set_xtrace_when_ut_mode_false
   echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
+  if [ $config_set_rc -ne 0 ]; then
+    echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
+    return 1
+  fi
 
   local readback
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    readback=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$service_port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+    readback=$($redis_cli --raw -h 127.0.0.1 -p "$service_port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
   else
-    readback=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+    readback=$($redis_cli --raw -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
   fi
   set_xtrace_when_ut_mode_false
   echo "CONFIG GET tls-ca-cert-file readback: $readback"
@@ -637,6 +650,7 @@ build_cross_shard_ca_bundle() {
 
   local encoded_bundle
   encoded_bundle=$(base64 < "$ca_bundle_path" | tr -d '\n')
+  local distribute_failures=0
   for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
     local pod_name=${pod_fqdn%%.*}
     if [ "$pod_name" = "$CURRENT_POD_NAME" ]; then
@@ -646,24 +660,38 @@ build_cross_shard_ca_bundle() {
     peer_port=$(get_pod_service_port_by_network_mode "$pod_name")
     unset_xtrace_when_ut_mode_false
     if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-      redis-cli $REDIS_CLI_TLS_CMD -h "$pod_fqdn" -p "$peer_port" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
+      $redis_cli -h "$pod_fqdn" -p "$peer_port" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
     else
-      redis-cli $REDIS_CLI_TLS_CMD -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
+      $redis_cli -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" SET "$ca_bundle_key" "$encoded_bundle" > /dev/null 2>&1
     fi
+    local dist_rc=$?
     set_xtrace_when_ut_mode_false
+    if [ $dist_rc -ne 0 ]; then
+      echo "Error: failed to distribute CA bundle to $pod_fqdn (rc=$dist_rc)" >&2
+      distribute_failures=$((distribute_failures + 1))
+    fi
   done
+  if [ $distribute_failures -gt 0 ]; then
+    echo "Error: failed to distribute CA bundle to $distribute_failures pod(s)" >&2
+    return 1
+  fi
   echo "Distributed CA bundle to all pods"
 
-  # Clean up exchange keys
-  unset_xtrace_when_ut_mode_false
-  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" DEL "$ca_exchange_key" > /dev/null 2>&1
-  else
-    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$ca_exchange_key" > /dev/null 2>&1
-  fi
-  set_xtrace_when_ut_mode_false
+  _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
 
   return 0
+}
+
+_cleanup_ca_exchange_key() {
+  local key="$1"
+  local port="$2"
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" DEL "$key" > /dev/null 2>&1
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$key" > /dev/null 2>&1
+  fi
+  set_xtrace_when_ut_mode_false
 }
 
 build_redis_cluster_create_command() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -541,6 +541,16 @@ build_cross_shard_ca_bundle() {
 
   local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
 
+  local saved_full_coverage
+  saved_full_coverage=$(_get_cluster_require_full_coverage "$service_port")
+  saved_full_coverage="${saved_full_coverage:-yes}"
+  echo "Saved cluster-require-full-coverage: $saved_full_coverage"
+
+  if ! _set_cluster_require_full_coverage "$service_port" "no"; then
+    echo "Error: failed to set cluster-require-full-coverage no" >&2
+    return 1
+  fi
+
   local exchange_slot
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
@@ -565,6 +575,7 @@ build_cross_shard_ca_bundle() {
   if [ $set_rc -ne 0 ]; then
     echo "Error: failed to publish local CA to $ca_exchange_key (rc=$set_rc)" >&2
     _flush_pre_init_slots "$service_port"
+    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
@@ -618,6 +629,7 @@ build_cross_shard_ca_bundle() {
       echo "Error: timed out waiting for CA from $pod_fqdn" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       _flush_pre_init_slots "$service_port"
+      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
 
@@ -642,6 +654,11 @@ build_cross_shard_ca_bundle() {
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     if ! _flush_pre_init_slots "$service_port"; then
       echo "Error: CLUSTER FLUSHSLOTS failed after same-CA detection" >&2
+      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+      return 1
+    fi
+    if ! _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"; then
+      echo "Error: failed to restore cluster-require-full-coverage after same-CA detection" >&2
       return 1
     fi
     return 0
@@ -662,6 +679,7 @@ build_cross_shard_ca_bundle() {
     echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     _flush_pre_init_slots "$service_port"
+    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
@@ -678,12 +696,18 @@ build_cross_shard_ca_bundle() {
     echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     _flush_pre_init_slots "$service_port"
+    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
   _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
   if ! _flush_pre_init_slots "$service_port"; then
     echo "Error: CLUSTER FLUSHSLOTS failed after CA bundle build" >&2
+    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+    return 1
+  fi
+  if ! _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"; then
+    echo "Error: failed to restore cluster-require-full-coverage after CA bundle build" >&2
     return 1
   fi
 
@@ -732,6 +756,32 @@ _flush_pre_init_slots() {
   flush_rc=$?
   set_xtrace_when_ut_mode_false
   return $flush_rc
+}
+
+_get_cluster_require_full_coverage() {
+  local port="$1"
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" CONFIG GET cluster-require-full-coverage 2>/dev/null | tail -1
+  else
+    redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET cluster-require-full-coverage 2>/dev/null | tail -1
+  fi
+  set_xtrace_when_ut_mode_false
+}
+
+_set_cluster_require_full_coverage() {
+  local port="$1"
+  local value="$2"
+  local rc
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CONFIG SET cluster-require-full-coverage "$value" > /dev/null 2>&1
+  else
+    redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET cluster-require-full-coverage "$value" > /dev/null 2>&1
+  fi
+  rc=$?
+  set_xtrace_when_ut_mode_false
+  return $rc
 }
 
 _cleanup_ca_exchange_key() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -609,6 +609,7 @@ build_cross_shard_ca_bundle() {
   local peer_ports=()
   local peer_names=()
   local peer_nonces=()
+  local peer_encoded_cas=()
 
   for pod_fqdn in $(echo "$KB_CLUSTER_POD_FQDN_LIST" | tr ',' ' '); do
     local pod_name=${pod_fqdn%%.*}
@@ -626,54 +627,71 @@ build_cross_shard_ca_bundle() {
     peer_fqdns+=("$pod_fqdn")
     peer_ports+=("$peer_port")
     peer_names+=("$pod_name")
+    peer_encoded_cas+=("")
+  done
 
-    local peer_encoded_ca=""
-    local attempts=0
-    while [ -z "$peer_encoded_ca" ] && [ $attempts -lt 90 ]; do
+  local total_peers=${#peer_fqdns[@]}
+  local collected=0
+  local attempts=0
+  while [ $collected -lt $total_peers ] && [ $attempts -lt 90 ]; do
+    for i in "${!peer_fqdns[@]}"; do
+      if [ -n "${peer_encoded_cas[$i]}" ]; then continue; fi
+      local peer_encoded_ca=""
       unset_xtrace_when_ut_mode_false
       if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-        peer_encoded_ca=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" GET "$ca_exchange_key" 2>/dev/null)
+        peer_encoded_ca=$($redis_cli --raw -h "${peer_fqdns[$i]}" -p "${peer_ports[$i]}" GET "$ca_exchange_key" 2>/dev/null)
       else
-        peer_encoded_ca=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_exchange_key" 2>/dev/null)
+        peer_encoded_ca=$($redis_cli --raw -h "${peer_fqdns[$i]}" -p "${peer_ports[$i]}" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_exchange_key" 2>/dev/null)
       fi
       set_xtrace_when_ut_mode_false
       if [ -n "$peer_encoded_ca" ]; then
         local pem_decoded
         pem_decoded=$(echo "$peer_encoded_ca" | base64 -d 2>/dev/null)
         if ! echo "$pem_decoded" | head -1 | grep -q "BEGIN CERTIFICATE"; then
-          echo "Warning: peer $pod_fqdn returned non-PEM data, retrying..." >&2
+          echo "Warning: peer ${peer_fqdns[$i]} returned non-PEM data, retrying..." >&2
           peer_encoded_ca=""
         elif ! echo "$pem_decoded" | openssl x509 -noout 2>/dev/null; then
-          echo "Warning: peer $pod_fqdn returned invalid x509 certificate, retrying..." >&2
+          echo "Warning: peer ${peer_fqdns[$i]} returned invalid x509 certificate, retrying..." >&2
           peer_encoded_ca=""
         fi
       fi
-      if [ -z "$peer_encoded_ca" ]; then
-        echo "Waiting for CA from $pod_fqdn (${attempts}/90)..."
-        sleep_when_ut_mode_false 2
-        attempts=$((attempts + 1))
+      if [ -n "$peer_encoded_ca" ]; then
+        peer_encoded_cas[$i]="$peer_encoded_ca"
+        collected=$((collected + 1))
+        echo "Collected CA from ${peer_fqdns[$i]} ($collected/$total_peers)"
       fi
     done
-
-    if [ -z "$peer_encoded_ca" ]; then
-      echo "Error: timed out waiting for CA from $pod_fqdn" >&2
-      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-      _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-      _flush_pre_init_slots "$service_port"
-      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
-      return 1
+    if [ $collected -lt $total_peers ]; then
+      echo "Waiting for CA from $((total_peers - collected)) peer(s) (${attempts}/90)..."
+      sleep_when_ut_mode_false 2
+      attempts=$((attempts + 1))
     fi
+  done
 
+  if [ $collected -lt $total_peers ]; then
+    for i in "${!peer_fqdns[@]}"; do
+      if [ -z "${peer_encoded_cas[$i]}" ]; then
+        echo "Error: timed out waiting for CA from ${peer_fqdns[$i]}" >&2
+      fi
+    done
+    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
+    _cleanup_ca_exchange_key "$nonce_key" "$service_port"
+    _flush_pre_init_slots "$service_port"
+    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+    return 1
+  fi
+
+  for i in "${!peer_fqdns[@]}"; do
     local peer_nonce=""
     unset_xtrace_when_ut_mode_false
     if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-      peer_nonce=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" GET "$nonce_key" 2>/dev/null)
+      peer_nonce=$($redis_cli --raw -h "${peer_fqdns[$i]}" -p "${peer_ports[$i]}" GET "$nonce_key" 2>/dev/null)
     else
-      peer_nonce=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" -a "$REDIS_DEFAULT_PASSWORD" GET "$nonce_key" 2>/dev/null)
+      peer_nonce=$($redis_cli --raw -h "${peer_fqdns[$i]}" -p "${peer_ports[$i]}" -a "$REDIS_DEFAULT_PASSWORD" GET "$nonce_key" 2>/dev/null)
     fi
     set_xtrace_when_ut_mode_false
     if [ -z "$peer_nonce" ]; then
-      echo "Error: failed to read nonce from $pod_fqdn" >&2
+      echo "Error: failed to read nonce from ${peer_fqdns[$i]}" >&2
       _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       _flush_pre_init_slots "$service_port"
@@ -683,13 +701,13 @@ build_cross_shard_ca_bundle() {
     peer_nonces+=("$peer_nonce")
 
     local peer_ca_decoded
-    peer_ca_decoded=$(echo "$peer_encoded_ca" | base64 -d)
+    peer_ca_decoded=$(echo "${peer_encoded_cas[$i]}" | base64 -d)
     local peer_fingerprint
     peer_fingerprint=$(echo "$peer_ca_decoded" | sha256sum | awk '{print $1}')
-    echo "Peer $pod_fqdn CA sha256: $peer_fingerprint"
+    echo "Peer ${peer_fqdns[$i]} CA sha256: $peer_fingerprint"
 
     if echo "$fingerprints" | grep -q "$peer_fingerprint"; then
-      echo "Peer $pod_fqdn CA is same, skipping"
+      echo "Peer ${peer_fqdns[$i]} CA is same, skipping"
     else
       echo "$peer_ca_decoded" >> "$ca_bundle_path"
       fingerprints="${fingerprints} ${peer_fingerprint}"

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -554,16 +554,25 @@ build_cross_shard_ca_bundle() {
   fi
 
   local exchange_slot
+  local addslot_output
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
     exchange_slot=$($redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER KEYSLOT "$ca_exchange_key" 2>/dev/null)
-    $redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER ADDSLOTS "$exchange_slot" > /dev/null 2>&1
+    addslot_output=$($redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER ADDSLOTS "$exchange_slot" 2>&1)
   else
     exchange_slot=$($redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER KEYSLOT "$ca_exchange_key" 2>/dev/null)
-    $redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER ADDSLOTS "$exchange_slot" > /dev/null 2>&1
+    addslot_output=$($redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER ADDSLOTS "$exchange_slot" 2>&1)
   fi
   set_xtrace_when_ut_mode_false
-  echo "Pre-init slot allocation: exchange=$exchange_slot"
+  if echo "$addslot_output" | grep -qi "already busy"; then
+    echo "Pre-init slot allocation: exchange=$exchange_slot (already owned, reusing from previous attempt)"
+  elif echo "$addslot_output" | grep -qi "err"; then
+    echo "Error: CLUSTER ADDSLOTS $exchange_slot failed unexpectedly: $addslot_output" >&2
+    echo "Retaining CA exchange state (slot/full-coverage=no) for retry"
+    return 1
+  else
+    echo "Pre-init slot allocation: exchange=$exchange_slot (fresh)"
+  fi
 
   local attempt_nonce="${RANDOM}${RANDOM}"
   local nonce_key="{__KB_TLS__}_NONCE"
@@ -578,6 +587,7 @@ build_cross_shard_ca_bundle() {
   set_xtrace_when_ut_mode_false
   if [ $nonce_set_rc -ne 0 ]; then
     echo "Error: failed to set attempt nonce" >&2
+    echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
     return 1
   fi
   echo "Attempt nonce: $attempt_nonce"
@@ -593,6 +603,7 @@ build_cross_shard_ca_bundle() {
   set_xtrace_when_ut_mode_false
   if [ $set_rc -ne 0 ]; then
     echo "Error: failed to publish local CA to $ca_exchange_key (rc=$set_rc)" >&2
+    echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
     _cleanup_ca_exchange_key "$nonce_key" "$service_port"
     return 1
   fi
@@ -669,6 +680,7 @@ build_cross_shard_ca_bundle() {
         echo "Error: timed out waiting for CA from ${peer_fqdns[$i]}" >&2
       fi
     done
+    echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
     _cleanup_ca_exchange_key "$nonce_key" "$service_port"
     return 1
   fi
@@ -684,6 +696,7 @@ build_cross_shard_ca_bundle() {
     set_xtrace_when_ut_mode_false
     if [ -z "$peer_nonce" ]; then
       echo "Error: failed to read nonce from ${peer_fqdns[$i]}" >&2
+      echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       return 1
     fi
@@ -721,6 +734,7 @@ build_cross_shard_ca_bundle() {
     echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
     if [ $config_set_rc -ne 0 ]; then
       echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
+      echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       return 1
     fi
@@ -736,6 +750,7 @@ build_cross_shard_ca_bundle() {
     echo "CONFIG GET tls-ca-cert-file readback: $readback"
     if [ "$readback" != "$ca_bundle_path" ]; then
       echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
+      echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       return 1
     fi
@@ -751,6 +766,7 @@ build_cross_shard_ca_bundle() {
   for i in "${!peer_fqdns[@]}"; do
     if ! _write_ack_to_peer "${peer_fqdns[$i]}" "${peer_ports[$i]}" "$my_ack_key"; then
       echo "Error: failed to write ACK to ${peer_fqdns[$i]}" >&2
+      echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
       return 1
     fi
@@ -763,6 +779,7 @@ build_cross_shard_ca_bundle() {
   done
 
   if ! _wait_for_peer_acks "$service_port" "${expected_ack_keys[@]}"; then
+    echo "Retaining CA exchange state (CA key/slot/full-coverage=no) for retry"
     _cleanup_ca_exchange_key "$nonce_key" "$service_port"
     return 1
   fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -543,7 +543,10 @@ build_cross_shard_ca_bundle() {
 
   local saved_full_coverage
   saved_full_coverage=$(_get_cluster_require_full_coverage "$service_port")
-  saved_full_coverage="${saved_full_coverage:-yes}"
+  if [ "$saved_full_coverage" != "yes" ] && [ "$saved_full_coverage" != "no" ]; then
+    echo "Error: CONFIG GET cluster-require-full-coverage returned unexpected value: '$saved_full_coverage'" >&2
+    return 1
+  fi
   echo "Saved cluster-require-full-coverage: $saved_full_coverage"
 
   if ! _set_cluster_require_full_coverage "$service_port" "no"; then

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -597,10 +597,13 @@ build_cross_shard_ca_bundle() {
       fi
       set_xtrace_when_ut_mode_false
       if [ -n "$peer_encoded_ca" ]; then
-        local pem_check
-        pem_check=$(echo "$peer_encoded_ca" | base64 -d 2>/dev/null | head -1)
-        if ! echo "$pem_check" | grep -q "BEGIN CERTIFICATE"; then
+        local pem_decoded
+        pem_decoded=$(echo "$peer_encoded_ca" | base64 -d 2>/dev/null)
+        if ! echo "$pem_decoded" | head -1 | grep -q "BEGIN CERTIFICATE"; then
           echo "Warning: peer $pod_fqdn returned non-PEM data, retrying..." >&2
+          peer_encoded_ca=""
+        elif ! echo "$pem_decoded" | openssl x509 -noout 2>/dev/null; then
+          echo "Warning: peer $pod_fqdn returned invalid x509 certificate, retrying..." >&2
           peer_encoded_ca=""
         fi
       fi
@@ -637,7 +640,10 @@ build_cross_shard_ca_bundle() {
     echo "All shards share the same CA, no bundle needed"
     rm -f "$ca_bundle_path"
     _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-    _flush_pre_init_slots "$service_port"
+    if ! _flush_pre_init_slots "$service_port"; then
+      echo "Error: CLUSTER FLUSHSLOTS failed after same-CA detection" >&2
+      return 1
+    fi
     return 0
   fi
 
@@ -676,7 +682,10 @@ build_cross_shard_ca_bundle() {
   fi
 
   _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
-  _flush_pre_init_slots "$service_port"
+  if ! _flush_pre_init_slots "$service_port"; then
+    echo "Error: CLUSTER FLUSHSLOTS failed after CA bundle build" >&2
+    return 1
+  fi
 
   return 0
 }
@@ -713,13 +722,16 @@ distribute_ca_bundle_to_cluster() {
 
 _flush_pre_init_slots() {
   local port="$1"
+  local flush_rc
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
     redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CLUSTER FLUSHSLOTS > /dev/null 2>&1
   else
     redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER FLUSHSLOTS > /dev/null 2>&1
   fi
+  flush_rc=$?
   set_xtrace_when_ut_mode_false
+  return $flush_rc
 }
 
 _cleanup_ca_exchange_key() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -541,13 +541,12 @@ build_cross_shard_ca_bundle() {
 
   local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
 
-  local saved_full_coverage
-  saved_full_coverage=$(_get_cluster_require_full_coverage "$service_port")
-  if [ "$saved_full_coverage" != "yes" ] && [ "$saved_full_coverage" != "no" ]; then
-    echo "Error: CONFIG GET cluster-require-full-coverage returned unexpected value: '$saved_full_coverage'" >&2
+  local current_full_coverage
+  current_full_coverage=$(_get_cluster_require_full_coverage "$service_port")
+  if [ "$current_full_coverage" != "yes" ] && [ "$current_full_coverage" != "no" ]; then
+    echo "Error: CONFIG GET cluster-require-full-coverage returned unexpected value: '$current_full_coverage'" >&2
     return 1
   fi
-  echo "Saved cluster-require-full-coverage: $saved_full_coverage"
 
   if ! _set_cluster_require_full_coverage "$service_port" "no"; then
     echo "Error: failed to set cluster-require-full-coverage no" >&2
@@ -579,8 +578,6 @@ build_cross_shard_ca_bundle() {
   set_xtrace_when_ut_mode_false
   if [ $nonce_set_rc -ne 0 ]; then
     echo "Error: failed to set attempt nonce" >&2
-    _flush_pre_init_slots "$service_port"
-    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
   echo "Attempt nonce: $attempt_nonce"
@@ -597,8 +594,6 @@ build_cross_shard_ca_bundle() {
   if [ $set_rc -ne 0 ]; then
     echo "Error: failed to publish local CA to $ca_exchange_key (rc=$set_rc)" >&2
     _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-    _flush_pre_init_slots "$service_port"
-    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
@@ -674,10 +669,7 @@ build_cross_shard_ca_bundle() {
         echo "Error: timed out waiting for CA from ${peer_fqdns[$i]}" >&2
       fi
     done
-    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-    _flush_pre_init_slots "$service_port"
-    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
@@ -692,10 +684,7 @@ build_cross_shard_ca_bundle() {
     set_xtrace_when_ut_mode_false
     if [ -z "$peer_nonce" ]; then
       echo "Error: failed to read nonce from ${peer_fqdns[$i]}" >&2
-      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-      _flush_pre_init_slots "$service_port"
-      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
     peer_nonces+=("$peer_nonce")
@@ -732,10 +721,7 @@ build_cross_shard_ca_bundle() {
     echo "CONFIG SET tls-ca-cert-file rc=$config_set_rc"
     if [ $config_set_rc -ne 0 ]; then
       echo "Error: CONFIG SET tls-ca-cert-file failed" >&2
-      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-      _flush_pre_init_slots "$service_port"
-      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
 
@@ -750,10 +736,7 @@ build_cross_shard_ca_bundle() {
     echo "CONFIG GET tls-ca-cert-file readback: $readback"
     if [ "$readback" != "$ca_bundle_path" ]; then
       echo "Error: tls-ca-cert-file readback mismatch, expected $ca_bundle_path" >&2
-      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-      _flush_pre_init_slots "$service_port"
-      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
   fi
@@ -768,10 +751,7 @@ build_cross_shard_ca_bundle() {
   for i in "${!peer_fqdns[@]}"; do
     if ! _write_ack_to_peer "${peer_fqdns[$i]}" "${peer_ports[$i]}" "$my_ack_key"; then
       echo "Error: failed to write ACK to ${peer_fqdns[$i]}" >&2
-      _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
       _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-      _flush_pre_init_slots "$service_port"
-      _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
       return 1
     fi
   done
@@ -783,13 +763,7 @@ build_cross_shard_ca_bundle() {
   done
 
   if ! _wait_for_peer_acks "$service_port" "${expected_ack_keys[@]}"; then
-    _cleanup_ca_exchange_key "$ca_exchange_key" "$service_port"
     _cleanup_ca_exchange_key "$nonce_key" "$service_port"
-    for i in "${!peer_names[@]}"; do
-      _cleanup_ca_exchange_key "${ack_key_prefix}_${peer_names[$i]}_${peer_nonces[$i]}" "$service_port"
-    done
-    _flush_pre_init_slots "$service_port"
-    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
     return 1
   fi
 
@@ -800,10 +774,10 @@ build_cross_shard_ca_bundle() {
   done
   if ! _flush_pre_init_slots "$service_port"; then
     echo "Error: CLUSTER FLUSHSLOTS failed after CA exchange" >&2
-    _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"
+    _set_cluster_require_full_coverage "$service_port" "yes"
     return 1
   fi
-  if ! _set_cluster_require_full_coverage "$service_port" "$saved_full_coverage"; then
+  if ! _set_cluster_require_full_coverage "$service_port" "yes"; then
     echo "Error: failed to restore cluster-require-full-coverage after CA exchange" >&2
     return 1
   fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -555,6 +555,7 @@ build_cross_shard_ca_bundle() {
 
   local exchange_slot
   local addslot_output
+  local addslot_rc
   unset_xtrace_when_ut_mode_false
   if is_empty "$REDIS_DEFAULT_PASSWORD"; then
     exchange_slot=$($redis_cli -h 127.0.0.1 -p "$service_port" CLUSTER KEYSLOT "$ca_exchange_key" 2>/dev/null)
@@ -563,6 +564,7 @@ build_cross_shard_ca_bundle() {
     exchange_slot=$($redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER KEYSLOT "$ca_exchange_key" 2>/dev/null)
     addslot_output=$($redis_cli -h 127.0.0.1 -p "$service_port" -a "$REDIS_DEFAULT_PASSWORD" CLUSTER ADDSLOTS "$exchange_slot" 2>&1)
   fi
+  addslot_rc=$?
   set_xtrace_when_ut_mode_false
   if echo "$addslot_output" | grep -qi "already busy"; then
     local myself_slots
@@ -580,12 +582,12 @@ build_cross_shard_ca_bundle() {
       echo "Retaining CA exchange state (slot/full-coverage=no) for retry"
       return 1
     fi
-  elif echo "$addslot_output" | grep -qi "err"; then
-    echo "Error: CLUSTER ADDSLOTS $exchange_slot failed unexpectedly: $addslot_output" >&2
+  elif [ $addslot_rc -eq 0 ] && ! echo "$addslot_output" | grep -qi "err"; then
+    echo "Pre-init slot allocation: exchange=$exchange_slot (fresh)"
+  else
+    echo "Error: CLUSTER ADDSLOTS $exchange_slot failed (rc=$addslot_rc, output: $addslot_output)" >&2
     echo "Retaining CA exchange state (slot/full-coverage=no) for retry"
     return 1
-  else
-    echo "Pre-init slot allocation: exchange=$exchange_slot (fresh)"
   fi
 
   local attempt_nonce="${RANDOM}${RANDOM}"

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -629,7 +629,7 @@ build_cross_shard_ca_bundle() {
 
     local peer_encoded_ca=""
     local attempts=0
-    while [ -z "$peer_encoded_ca" ] && [ $attempts -lt 30 ]; do
+    while [ -z "$peer_encoded_ca" ] && [ $attempts -lt 90 ]; do
       unset_xtrace_when_ut_mode_false
       if is_empty "$REDIS_DEFAULT_PASSWORD"; then
         peer_encoded_ca=$($redis_cli --raw -h "$pod_fqdn" -p "$peer_port" GET "$ca_exchange_key" 2>/dev/null)
@@ -649,7 +649,7 @@ build_cross_shard_ca_bundle() {
         fi
       fi
       if [ -z "$peer_encoded_ca" ]; then
-        echo "Waiting for CA from $pod_fqdn (${attempts}/30)..."
+        echo "Waiting for CA from $pod_fqdn (${attempts}/90)..."
         sleep_when_ut_mode_false 2
         attempts=$((attempts + 1))
       fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -1024,6 +1024,13 @@ initialize_or_scale_out_redis_cluster() {
   # TODO: remove random sleep, it's a workaround for the multi components initialization parallelism issue
   sleep_random_second_when_ut_mode_false 10 1
 
+  # Exchange CA certs across shards so cluster bus TLS handshake can succeed.
+  # KubeBlocks creates per-Component CAs; without this, server-to-server
+  # certificate validation fails and gossip messages are never exchanged.
+  if ! build_cross_shard_ca_bundle; then
+    echo "Warning: failed to build cross-shard CA bundle, cluster bus TLS may fail" >&2
+  fi
+
   # if the cluster is not initialized, initialize it
   if ! check_cluster_initialized "$KB_CLUSTER_POD_FQDN_LIST"; then
     echo "Redis Cluster not initialized, initializing..."
@@ -1067,10 +1074,14 @@ if [ $# -eq 1 ]; then
     exit 0
     ;;
   --post-provision)
+    exec > >(tee -a /data/post-provision.log) 2>&1
+    echo "=== post-provision start: $(date -u +%Y-%m-%dT%H:%M:%SZ) pod=$CURRENT_POD_NAME ==="
     if initialize_or_scale_out_redis_cluster; then
       echo "Redis Cluster initialized or scale out shard successfully"
+      echo "=== post-provision end: $(date -u +%Y-%m-%dT%H:%M:%SZ) rc=0 ==="
     else
       echo "Failed to initialize or scale out Redis Cluster shard" >&2
+      echo "=== post-provision end: $(date -u +%Y-%m-%dT%H:%M:%SZ) rc=1 ==="
       exit 1
     fi
     exit 0

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -1037,7 +1037,10 @@ initialize_or_scale_out_redis_cluster() {
     echo "Redis Cluster not initialized, initializing..."
     if initialize_redis_cluster; then
       echo "Redis Cluster initialized successfully"
-      distribute_ca_bundle_to_cluster
+      if ! distribute_ca_bundle_to_cluster; then
+        echo "Error: failed to distribute CA bundle to cluster" >&2
+        return 1
+      fi
     else
       echo "Failed to initialize Redis Cluster" >&2
       return 1

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -1037,6 +1037,7 @@ initialize_or_scale_out_redis_cluster() {
     echo "Redis Cluster not initialized, initializing..."
     if initialize_redis_cluster; then
       echo "Redis Cluster initialized successfully"
+      distribute_ca_bundle_to_cluster
     else
       echo "Failed to initialize Redis Cluster" >&2
       return 1

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -1028,7 +1028,8 @@ initialize_or_scale_out_redis_cluster() {
   # KubeBlocks creates per-Component CAs; without this, server-to-server
   # certificate validation fails and gossip messages are never exchanged.
   if ! build_cross_shard_ca_bundle; then
-    echo "Warning: failed to build cross-shard CA bundle, cluster bus TLS may fail" >&2
+    echo "Error: failed to build cross-shard CA bundle, aborting cluster create" >&2
+    return 1
   fi
 
   # if the cluster is not initialized, initialize it

--- a/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
@@ -789,7 +789,7 @@ apply_cross_shard_ca_bundle_background() {
   [ "${TLS_ENABLED}" != "true" ] && return 0
 
   local ca_bundle="${DATA_DIR:-/data}/ca-bundle.crt"
-  local ca_bundle_key="__KB_TLS_CA_BUNDLE_BASE64__"
+  local ca_bundle_key="{__KB_TLS__}_CA_BUNDLE"
   local port="${SERVICE_PORT:-6379}"
   local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
 
@@ -832,12 +832,19 @@ apply_cross_shard_ca_bundle_background() {
     local encoded
     unset_xtrace_when_ut_mode_false
     if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-      encoded=$($redis_cli --raw -h 127.0.0.1 -p "$port" GET "$ca_bundle_key" 2>/dev/null)
+      encoded=$($redis_cli -c --raw -h 127.0.0.1 -p "$port" GET "$ca_bundle_key" 2>/dev/null)
     else
-      encoded=$($redis_cli --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_bundle_key" 2>/dev/null)
+      encoded=$($redis_cli -c --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_bundle_key" 2>/dev/null)
     fi
     set_xtrace_when_ut_mode_false
 
+    if [ -n "$encoded" ]; then
+      local pem_check
+      pem_check=$(echo "$encoded" | base64 -d 2>/dev/null | head -1)
+      if ! echo "$pem_check" | grep -q "BEGIN CERTIFICATE"; then
+        encoded=""
+      fi
+    fi
     if [ -n "$encoded" ]; then
       echo "$encoded" | base64 -d > "$ca_bundle"
       local config_rc

--- a/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
@@ -839,9 +839,11 @@ apply_cross_shard_ca_bundle_background() {
     set_xtrace_when_ut_mode_false
 
     if [ -n "$encoded" ]; then
-      local pem_check
-      pem_check=$(echo "$encoded" | base64 -d 2>/dev/null | head -1)
-      if ! echo "$pem_check" | grep -q "BEGIN CERTIFICATE"; then
+      local pem_decoded
+      pem_decoded=$(echo "$encoded" | base64 -d 2>/dev/null)
+      if ! echo "$pem_decoded" | head -1 | grep -q "BEGIN CERTIFICATE"; then
+        encoded=""
+      elif ! echo "$pem_decoded" | openssl x509 -noout 2>/dev/null; then
         encoded=""
       fi
     fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
@@ -678,9 +678,10 @@ build_redis_cluster_service_port() {
 build_redis_tls_config() {
   if [ "$TLS_ENABLED" == "true" ]; then
     TLS_MOUNT_PATH=${TLS_MOUNT_PATH:-/etc/pki/tls}
+    local data_dir="${DATA_DIR:-/data}"
     local ca_cert_file="$TLS_MOUNT_PATH/ca.crt"
-    if [ -f "/data/ca-bundle.crt" ]; then
-      ca_cert_file="/data/ca-bundle.crt"
+    if [ -f "$data_dir/ca-bundle.crt" ]; then
+      ca_cert_file="$data_dir/ca-bundle.crt"
     fi
     {
       echo "tls-cert-file $TLS_MOUNT_PATH/tls.crt"
@@ -787,22 +788,41 @@ build_redis_conf() {
 apply_cross_shard_ca_bundle_background() {
   [ "${TLS_ENABLED}" != "true" ] && return 0
 
-  local ca_bundle="/data/ca-bundle.crt"
-  local ca_bundle_key="__TLS_CA_BUNDLE_BASE64__"
+  local ca_bundle="${DATA_DIR:-/data}/ca-bundle.crt"
+  local ca_bundle_key="__KB_TLS_CA_BUNDLE_BASE64__"
   local port="${SERVICE_PORT:-6379}"
+  local redis_cli="redis-cli $REDIS_CLI_TLS_CMD"
 
   if ! check_redis_server_ready_with_retry "127.0.0.1" "$port"; then
     return 1
   fi
 
   if [ -f "$ca_bundle" ]; then
+    local config_rc
     unset_xtrace_when_ut_mode_false
     if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-      redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+      $redis_cli -h 127.0.0.1 -p "$port" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
     else
-      redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+      $redis_cli -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+    fi
+    config_rc=$?
+    set_xtrace_when_ut_mode_false
+    if [ $config_rc -ne 0 ]; then
+      echo "apply_cross_shard_ca_bundle: CONFIG SET failed on existing bundle (rc=$config_rc)" >&2
+      return 1
+    fi
+    local readback
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      readback=$($redis_cli --raw -h 127.0.0.1 -p "$port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+    else
+      readback=$($redis_cli --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
     fi
     set_xtrace_when_ut_mode_false
+    if [ "$readback" != "$ca_bundle" ]; then
+      echo "apply_cross_shard_ca_bundle: readback mismatch, expected $ca_bundle got $readback" >&2
+      return 1
+    fi
     echo "apply_cross_shard_ca_bundle: applied existing CA bundle"
     return 0
   fi
@@ -812,21 +832,44 @@ apply_cross_shard_ca_bundle_background() {
     local encoded
     unset_xtrace_when_ut_mode_false
     if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-      encoded=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" GET "$ca_bundle_key" 2>/dev/null)
+      encoded=$($redis_cli --raw -h 127.0.0.1 -p "$port" GET "$ca_bundle_key" 2>/dev/null)
     else
-      encoded=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_bundle_key" 2>/dev/null)
+      encoded=$($redis_cli --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_bundle_key" 2>/dev/null)
     fi
     set_xtrace_when_ut_mode_false
 
     if [ -n "$encoded" ]; then
       echo "$encoded" | base64 -d > "$ca_bundle"
+      local config_rc
       unset_xtrace_when_ut_mode_false
       if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
-        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" DEL "$ca_bundle_key" > /dev/null 2>&1
+        $redis_cli -h 127.0.0.1 -p "$port" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
       else
-        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
-        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$ca_bundle_key" > /dev/null 2>&1
+        $redis_cli -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+      fi
+      config_rc=$?
+      set_xtrace_when_ut_mode_false
+      if [ $config_rc -ne 0 ]; then
+        echo "apply_cross_shard_ca_bundle: CONFIG SET failed (rc=$config_rc), keeping bundle key for retry" >&2
+        return 1
+      fi
+      local readback
+      unset_xtrace_when_ut_mode_false
+      if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+        readback=$($redis_cli --raw -h 127.0.0.1 -p "$port" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+      else
+        readback=$($redis_cli --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG GET tls-ca-cert-file 2>/dev/null | tail -1)
+      fi
+      set_xtrace_when_ut_mode_false
+      if [ "$readback" != "$ca_bundle" ]; then
+        echo "apply_cross_shard_ca_bundle: readback mismatch, expected $ca_bundle got $readback, keeping bundle key" >&2
+        return 1
+      fi
+      unset_xtrace_when_ut_mode_false
+      if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+        $redis_cli -h 127.0.0.1 -p "$port" DEL "$ca_bundle_key" > /dev/null 2>&1
+      else
+        $redis_cli -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$ca_bundle_key" > /dev/null 2>&1
       fi
       set_xtrace_when_ut_mode_false
       echo "apply_cross_shard_ca_bundle: applied CA bundle from post-provision"

--- a/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-server-start.sh
@@ -678,10 +678,14 @@ build_redis_cluster_service_port() {
 build_redis_tls_config() {
   if [ "$TLS_ENABLED" == "true" ]; then
     TLS_MOUNT_PATH=${TLS_MOUNT_PATH:-/etc/pki/tls}
+    local ca_cert_file="$TLS_MOUNT_PATH/ca.crt"
+    if [ -f "/data/ca-bundle.crt" ]; then
+      ca_cert_file="/data/ca-bundle.crt"
+    fi
     {
       echo "tls-cert-file $TLS_MOUNT_PATH/tls.crt"
       echo "tls-key-file $TLS_MOUNT_PATH/tls.key"
-      echo "tls-ca-cert-file $TLS_MOUNT_PATH/ca.crt"
+      echo "tls-ca-cert-file $ca_cert_file"
       echo "tls-auth-clients no"
       echo "tls-replication yes"
       echo "tls-cluster yes"
@@ -780,6 +784,61 @@ build_redis_conf() {
   build_redis_default_accounts
 }
 
+apply_cross_shard_ca_bundle_background() {
+  [ "${TLS_ENABLED}" != "true" ] && return 0
+
+  local ca_bundle="/data/ca-bundle.crt"
+  local ca_bundle_key="__TLS_CA_BUNDLE_BASE64__"
+  local port="${SERVICE_PORT:-6379}"
+
+  if ! check_redis_server_ready_with_retry "127.0.0.1" "$port"; then
+    return 1
+  fi
+
+  if [ -f "$ca_bundle" ]; then
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+    else
+      redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+    fi
+    set_xtrace_when_ut_mode_false
+    echo "apply_cross_shard_ca_bundle: applied existing CA bundle"
+    return 0
+  fi
+
+  local waited=0
+  while [ $waited -lt 300 ]; do
+    local encoded
+    unset_xtrace_when_ut_mode_false
+    if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+      encoded=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" GET "$ca_bundle_key" 2>/dev/null)
+    else
+      encoded=$(redis-cli $REDIS_CLI_TLS_CMD --raw -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" GET "$ca_bundle_key" 2>/dev/null)
+    fi
+    set_xtrace_when_ut_mode_false
+
+    if [ -n "$encoded" ]; then
+      echo "$encoded" | base64 -d > "$ca_bundle"
+      unset_xtrace_when_ut_mode_false
+      if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" DEL "$ca_bundle_key" > /dev/null 2>&1
+      else
+        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" CONFIG SET tls-ca-cert-file "$ca_bundle" > /dev/null 2>&1
+        redis-cli $REDIS_CLI_TLS_CMD -h 127.0.0.1 -p "$port" -a "$REDIS_DEFAULT_PASSWORD" DEL "$ca_bundle_key" > /dev/null 2>&1
+      fi
+      set_xtrace_when_ut_mode_false
+      echo "apply_cross_shard_ca_bundle: applied CA bundle from post-provision"
+      return 0
+    fi
+
+    sleep 2
+    waited=$((waited + 2))
+  done
+  return 0
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -793,4 +852,5 @@ parse_redis_cluster_shard_announce_addr
 build_redis_conf
 # TODO: move to memberJoin action in the future
 scale_redis_cluster_replica &
+apply_cross_shard_ca_bundle_background &
 start_redis_server

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -589,7 +589,14 @@ Describe "Redis Cluster Common Bash Script Tests"
       After "ca_bundle_cleanup"
 
       It "returns non-zero when SET fails"
-        redis-cli() { return 1; }
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
         extract_obj_ordinal() { echo "0"; }
         get_pod_service_port_by_network_mode() { echo "6379"; }
 
@@ -607,9 +614,13 @@ Describe "Redis Cluster Common Bash Script Tests"
       It "returns non-zero on peer CA timeout and cleans up exchange key"
         redis-cli() {
           case "$*" in
-            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *SET*) return 0 ;;
-            *GET*) echo ""; return 0 ;;
+            *GET*_PEER_CA*) echo ""; return 0 ;;
+            *) return 0 ;;
           esac
         }
         extract_obj_ordinal() { echo "0"; }
@@ -623,6 +634,34 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when peer returns non-PEM data"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "rejects CLUSTERDOWN and times out"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
+            *SET*) return 0 ;;
+            *GET*_PEER_CA*) echo "CLUSTERDOWN Hash slot not served"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The path "./test_data/del_called" should be exist
+        The stderr should include "non-PEM data"
+        The stderr should include "timed out waiting for CA"
+      End
+    End
+
     Context "when CONFIG SET fails"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
@@ -630,10 +669,13 @@ Describe "Redis Cluster Common Bash Script Tests"
       It "returns non-zero on CONFIG SET failure and cleans up exchange key"
         redis-cli() {
           case "$*" in
-            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
-            *SET*__KB_TLS_PEER_CA__*) return 0 ;;
-            *GET*__KB_TLS_PEER_CA__*)
-              echo "RVZJTF9QRUVSX0NB"
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
             *"CONFIG SET"*) return 1 ;;
@@ -658,10 +700,13 @@ Describe "Redis Cluster Common Bash Script Tests"
       It "returns non-zero on readback mismatch and cleans up exchange key"
         redis-cli() {
           case "$*" in
-            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
-            *SET*__KB_TLS_PEER_CA__*) return 0 ;;
-            *GET*__KB_TLS_PEER_CA__*)
-              echo "RVZJTF9QRUVSX0NB"
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
             *"CONFIG SET"*) return 0 ;;
@@ -677,40 +722,6 @@ Describe "Redis Cluster Common Bash Script Tests"
         The output should include "CA bundle:"
         The path "./test_data/del_called" should be exist
         The stderr should include "readback mismatch"
-      End
-    End
-
-    Context "when bundle distribution fails"
-      Before "ca_bundle_setup"
-      After "ca_bundle_cleanup"
-
-      It "returns non-zero when distributing to peer fails and cleans up exchange key"
-        redis-cli() {
-          case "$*" in
-            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
-            *SET*__KB_TLS_PEER_CA__*) return 0 ;;
-            *GET*__KB_TLS_PEER_CA__*)
-              echo "RVZJTF9QRUVSX0NB"
-              return 0
-              ;;
-            *"CONFIG SET"*) return 0 ;;
-            *"CONFIG GET"*)
-              echo "tls-ca-cert-file"
-              echo "./test_data/ca-bundle.crt"
-              return 0
-              ;;
-            *SET*__KB_TLS_CA_BUNDLE_BASE64__*) return 1 ;;
-            *) return 0 ;;
-          esac
-        }
-        extract_obj_ordinal() { echo "0"; }
-        get_pod_service_port_by_network_mode() { echo "6379"; }
-
-        When call build_cross_shard_ca_bundle
-        The status should be failure
-        The output should include "CA bundle:"
-        The path "./test_data/del_called" should be exist
-        The stderr should include "failed to distribute CA bundle"
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -1210,6 +1210,31 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when ADDSLOTS rc is non-zero with unrecognized output"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "fails on non-zero rc even without ERR or already-busy in output"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) echo "Could not connect to Redis"; return 1 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The stderr should include "CLUSTER ADDSLOTS 12345 failed"
+        The stderr should include "rc=1"
+        The output should include "Retaining CA exchange state"
+      End
+    End
+
     Context "when ADDSLOTS returns unexpected error"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
@@ -1229,7 +1254,7 @@ Describe "Redis Cluster Common Bash Script Tests"
 
         When call build_cross_shard_ca_bundle
         The status should be failure
-        The stderr should include "CLUSTER ADDSLOTS 12345 failed unexpectedly"
+        The stderr should include "CLUSTER ADDSLOTS 12345 failed"
         The stderr should include "Invalid or out of range slot"
         The output should include "Retaining CA exchange state"
       End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -1015,5 +1015,45 @@ Describe "Redis Cluster Common Bash Script Tests"
         The stderr should include "failed to read nonce"
       End
     End
+
+    Context "when stale ACK from previous attempt exists but current nonce differs"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "times out because code only queries for current-nonce ACK key"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *GET*_ACK_*peer_nonce_42*) echo ""; return 0 ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The output should include "Waiting for peer ACKs"
+        The stderr should include "timed out waiting for peer ACKs"
+      End
+    End
   End
 End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -790,11 +790,14 @@ Describe "Redis Cluster Common Bash Script Tests"
               return 1
               ;;
             *DEL*_PEER_CA*) return 0 ;;
+            *DEL*_ACK_*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
             *) return 0 ;;
@@ -866,11 +869,14 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) return 0 ;;
+            *DEL*_ACK_*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
             *) return 0 ;;
@@ -884,6 +890,78 @@ Describe "Redis Cluster Common Bash Script Tests"
         The status should be failure
         The output should include "CA bundle:"
         The stderr should include "CLUSTER FLUSHSLOTS failed"
+      End
+    End
+
+    Context "when ACK write to peer fails"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when ACK write fails"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *SET*_ACK_*) return 1 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The stderr should include "failed to write ACK"
+      End
+    End
+
+    Context "when ACK wait times out"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when peer ACKs are not received"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *GET*_ACK_*) echo ""; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The output should include "Waiting for peer ACKs"
+        The stderr should include "timed out waiting for peer ACKs"
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -811,6 +811,48 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when CONFIG GET cluster-require-full-coverage returns empty"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "aborts before setting full-coverage to no"
+        redis-cli() {
+          case "$*" in
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo ""; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Building cross-shard TLS CA bundle"
+        The stderr should include "unexpected value"
+      End
+    End
+
+    Context "when CONFIG GET cluster-require-full-coverage returns unexpected value"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "aborts on non-yes/no value"
+        redis-cli() {
+          case "$*" in
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "maybe"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Building cross-shard TLS CA bundle"
+        The stderr should include "unexpected value"
+      End
+    End
+
     Context "when FLUSHSLOTS fails on success path"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -662,6 +662,38 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when peer returns cert-shaped but invalid x509 data"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "rejects invalid x509 and times out"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
+            *SET*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCm5vdC1hLXJlYWwtY2VydAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+              return 0
+              ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 1; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The path "./test_data/del_called" should be exist
+        The stderr should include "invalid x509 certificate"
+        The stderr should include "timed out waiting for CA"
+      End
+    End
+
     Context "when CONFIG SET fails"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
@@ -682,6 +714,7 @@ Describe "Redis Cluster Common Bash Script Tests"
             *) return 0 ;;
           esac
         }
+        openssl() { return 0; }
         extract_obj_ordinal() { echo "0"; }
         get_pod_service_port_by_network_mode() { echo "6379"; }
 
@@ -714,6 +747,7 @@ Describe "Redis Cluster Common Bash Script Tests"
             *) return 0 ;;
           esac
         }
+        openssl() { return 0; }
         extract_obj_ordinal() { echo "0"; }
         get_pod_service_port_by_network_mode() { echo "6379"; }
 
@@ -722,6 +756,38 @@ Describe "Redis Cluster Common Bash Script Tests"
         The output should include "CA bundle:"
         The path "./test_data/del_called" should be exist
         The stderr should include "readback mismatch"
+      End
+    End
+
+    Context "when FLUSHSLOTS fails on success path"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when FLUSHSLOTS fails after successful bundle build"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 1 ;;
+            *DEL*_PEER_CA*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The stderr should include "CLUSTER FLUSHSLOTS failed"
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -604,9 +604,10 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "returns non-zero on peer CA timeout"
+      It "returns non-zero on peer CA timeout and cleans up exchange key"
         redis-cli() {
           case "$*" in
+            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
             *SET*) return 0 ;;
             *GET*) echo ""; return 0 ;;
           esac
@@ -617,6 +618,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The path "./test_data/del_called" should be exist
         The stderr should include "timed out waiting for CA"
       End
     End
@@ -625,9 +627,10 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "returns non-zero on readback mismatch"
+      It "returns non-zero on readback mismatch and cleans up exchange key"
         redis-cli() {
           case "$*" in
+            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
             *SET*__KB_TLS_PEER_CA__*) return 0 ;;
             *GET*__KB_TLS_PEER_CA__*)
               echo "RVZJTF9QRUVSX0NB"
@@ -644,6 +647,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "CA bundle:"
+        The path "./test_data/del_called" should be exist
         The stderr should include "readback mismatch"
       End
     End
@@ -652,9 +656,10 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "returns non-zero when distributing to peer fails"
+      It "returns non-zero when distributing to peer fails and cleans up exchange key"
         redis-cli() {
           case "$*" in
+            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
             *SET*__KB_TLS_PEER_CA__*) return 0 ;;
             *GET*__KB_TLS_PEER_CA__*)
               echo "RVZJTF9QRUVSX0NB"
@@ -676,6 +681,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "CA bundle:"
+        The path "./test_data/del_called" should be exist
         The stderr should include "failed to distribute CA bundle"
       End
     End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -633,7 +633,7 @@ Describe "Redis Cluster Common Bash Script Tests"
 
         When call build_cross_shard_ca_bundle
         The status should be failure
-        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The output should include "Waiting for CA from"
         The path "./test_data/del_called" should be exist
         The stderr should include "timed out waiting for CA"
       End
@@ -662,7 +662,7 @@ Describe "Redis Cluster Common Bash Script Tests"
 
         When call build_cross_shard_ca_bundle
         The status should be failure
-        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The output should include "Waiting for CA from"
         The path "./test_data/del_called" should be exist
         The stderr should include "non-PEM data"
         The stderr should include "timed out waiting for CA"
@@ -696,7 +696,7 @@ Describe "Redis Cluster Common Bash Script Tests"
 
         When call build_cross_shard_ca_bundle
         The status should be failure
-        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The output should include "Waiting for CA from"
         The path "./test_data/del_called" should be exist
         The stderr should include "invalid x509 certificate"
         The stderr should include "timed out waiting for CA"
@@ -1056,7 +1056,7 @@ Describe "Redis Cluster Common Bash Script Tests"
 
         When call build_cross_shard_ca_bundle
         The status should be success
-        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The output should include "Waiting for CA from"
         The output should include "CA bundle:"
         The output should include "All peer ACKs received"
       End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -623,6 +623,34 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when CONFIG SET fails"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero on CONFIG SET failure and cleans up exchange key"
+        redis-cli() {
+          case "$*" in
+            *DEL*__KB_TLS_PEER_CA__*) touch "./test_data/del_called"; return 0 ;;
+            *SET*__KB_TLS_PEER_CA__*) return 0 ;;
+            *GET*__KB_TLS_PEER_CA__*)
+              echo "RVZJTF9QRUVSX0NB"
+              return 0
+              ;;
+            *"CONFIG SET"*) return 1 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The path "./test_data/del_called" should be exist
+        The stderr should include "CONFIG SET tls-ca-cert-file failed"
+      End
+    End
+
     Context "when CONFIG SET readback mismatches"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -547,4 +547,137 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
   End
+
+  Describe "build_cross_shard_ca_bundle()"
+    ca_bundle_setup() {
+      export TLS_ENABLED="true"
+      export TLS_MOUNT_PATH="./test_tls"
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD=""
+      export REDIS_CLI_TLS_CMD=""
+      export CURRENT_POD_NAME="rds-shard-abc-0"
+      export KB_CLUSTER_POD_FQDN_LIST="rds-shard-abc-0.svc,rds-shard-def-0.svc"
+      export DATA_DIR="./test_data"
+      mkdir -p ./test_tls "$DATA_DIR"
+      echo "-----BEGIN CERTIFICATE-----" > ./test_tls/ca.crt
+      echo "MIIFAKE_LOCAL" >> ./test_tls/ca.crt
+      echo "-----END CERTIFICATE-----" >> ./test_tls/ca.crt
+      echo "-----BEGIN CERTIFICATE-----" > ./test_tls/tls.crt
+      echo "MIIFAKE_CERT" >> ./test_tls/tls.crt
+      echo "-----END CERTIFICATE-----" >> ./test_tls/tls.crt
+    }
+
+    ca_bundle_cleanup() {
+      unset TLS_ENABLED TLS_MOUNT_PATH SERVICE_PORT REDIS_DEFAULT_PASSWORD
+      unset REDIS_CLI_TLS_CMD CURRENT_POD_NAME KB_CLUSTER_POD_FQDN_LIST DATA_DIR
+      rm -rf ./test_tls ./test_data 2>/dev/null
+    }
+
+    Context "when TLS is disabled"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns 0 immediately"
+        TLS_ENABLED="false"
+        When call build_cross_shard_ca_bundle
+        The status should be success
+      End
+    End
+
+    Context "when local CA publish fails"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when SET fails"
+        redis-cli() { return 1; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Building cross-shard TLS CA bundle"
+        The stderr should include "failed to publish local CA"
+      End
+    End
+
+    Context "when peer CA times out"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero on peer CA timeout"
+        redis-cli() {
+          case "$*" in
+            *SET*) return 0 ;;
+            *GET*) echo ""; return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The stderr should include "timed out waiting for CA"
+      End
+    End
+
+    Context "when CONFIG SET readback mismatches"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero on readback mismatch"
+        redis-cli() {
+          case "$*" in
+            *SET*__KB_TLS_PEER_CA__*) return 0 ;;
+            *GET*__KB_TLS_PEER_CA__*)
+              echo "RVZJTF9QRUVSX0NB"
+              return 0
+              ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "/wrong/path"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The stderr should include "readback mismatch"
+      End
+    End
+
+    Context "when bundle distribution fails"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when distributing to peer fails"
+        redis-cli() {
+          case "$*" in
+            *SET*__KB_TLS_PEER_CA__*) return 0 ;;
+            *GET*__KB_TLS_PEER_CA__*)
+              echo "RVZJTF9QRUVSX0NB"
+              return 0
+              ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*)
+              echo "tls-ca-cert-file"
+              echo "./test_data/ca-bundle.crt"
+              return 0
+              ;;
+            *SET*__KB_TLS_CA_BUNDLE_BASE64__*) return 1 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The stderr should include "failed to distribute CA bundle"
+      End
+    End
+  End
 End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -596,6 +596,7 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *) return 1 ;;
           esac
         }
@@ -715,11 +716,14 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
+            *DEL*_NONCE*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
             *"CONFIG SET"*) return 1 ;;
             *) return 0 ;;
           esac
@@ -749,11 +753,14 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
+            *DEL*_NONCE*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "/wrong/path"; return 0 ;;
             *) return 0 ;;
@@ -791,12 +798,15 @@ Describe "Redis Cluster Common Bash Script Tests"
               ;;
             *DEL*_PEER_CA*) return 0 ;;
             *DEL*_ACK_*) return 0 ;;
+            *DEL*_NONCE*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *SET*_ACK_*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
             *GET*_ACK_*) echo "1"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
@@ -870,12 +880,15 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) return 0 ;;
             *DEL*_ACK_*) return 0 ;;
+            *DEL*_NONCE*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *SET*_ACK_*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
             *GET*_ACK_*) echo "1"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
@@ -907,10 +920,12 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
             *SET*_ACK_*) return 1 ;;
@@ -942,10 +957,12 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
             *GET*_PEER_CA*)
               echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
               return 0
               ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
             *"CONFIG SET"*) return 0 ;;
             *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
             *SET*_ACK_*) return 0 ;;
@@ -962,6 +979,40 @@ Describe "Redis Cluster Common Bash Script Tests"
         The output should include "CA bundle:"
         The output should include "Waiting for peer ACKs"
         The stderr should include "timed out waiting for peer ACKs"
+      End
+    End
+
+    Context "when peer nonce read fails"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when peer nonce is empty"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *GET*_NONCE*) echo ""; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Attempt nonce:"
+        The stderr should include "failed to read nonce"
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -1062,6 +1062,98 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when 4-shard cluster with 3 peers all publish CA after attempt 60"
+      ca_bundle_4shard_setup() {
+        export TLS_ENABLED="true"
+        export TLS_MOUNT_PATH="./test_tls"
+        export SERVICE_PORT="6379"
+        export REDIS_DEFAULT_PASSWORD=""
+        export REDIS_CLI_TLS_CMD=""
+        export CURRENT_POD_NAME="rds-shard-abc-0"
+        export KB_CLUSTER_POD_FQDN_LIST="rds-shard-abc-0.svc,rds-shard-def-0.svc,rds-shard-ghi-0.svc,rds-shard-jkl-0.svc"
+        export DATA_DIR="./test_data"
+        mkdir -p ./test_tls "$DATA_DIR"
+        echo "-----BEGIN CERTIFICATE-----" > ./test_tls/ca.crt
+        echo "MIIFAKE_LOCAL" >> ./test_tls/ca.crt
+        echo "-----END CERTIFICATE-----" >> ./test_tls/ca.crt
+        echo "-----BEGIN CERTIFICATE-----" > ./test_tls/tls.crt
+        echo "MIIFAKE_CERT" >> ./test_tls/tls.crt
+        echo "-----END CERTIFICATE-----" >> ./test_tls/tls.crt
+      }
+      ca_bundle_4shard_cleanup() {
+        unset TLS_ENABLED TLS_MOUNT_PATH SERVICE_PORT REDIS_DEFAULT_PASSWORD
+        unset REDIS_CLI_TLS_CMD CURRENT_POD_NAME KB_CLUSTER_POD_FQDN_LIST DATA_DIR
+        rm -rf ./test_tls ./test_data 2>/dev/null
+      }
+
+      Before "ca_bundle_4shard_setup"
+      After "ca_bundle_4shard_cleanup"
+
+      It "succeeds within 90 rounds proving budget does not scale with peer count"
+        echo "0" > "./test_data/ca_get_def"
+        echo "0" > "./test_data/ca_get_ghi"
+        echo "0" > "./test_data/ca_get_jkl"
+        echo "0" > "./test_data/sleep_count"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *def*_PEER_CA*)
+              local cnt; cnt=$(cat "./test_data/ca_get_def")
+              cnt=$((cnt + 1)); echo "$cnt" > "./test_data/ca_get_def"
+              if [ $cnt -le 60 ]; then echo ""; return 0; fi
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX0RFRgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+              return 0
+              ;;
+            *ghi*_PEER_CA*)
+              local cnt; cnt=$(cat "./test_data/ca_get_ghi")
+              cnt=$((cnt + 1)); echo "$cnt" > "./test_data/ca_get_ghi"
+              if [ $cnt -le 60 ]; then echo ""; return 0; fi
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX0dISQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+              return 0
+              ;;
+            *jkl*_PEER_CA*)
+              local cnt; cnt=$(cat "./test_data/ca_get_jkl")
+              cnt=$((cnt + 1)); echo "$cnt" > "./test_data/ca_get_jkl"
+              if [ $cnt -le 60 ]; then echo ""; return 0; fi
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX0pLTAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+              return 0
+              ;;
+            *GET*_PEER_CA*) echo ""; return 0 ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+        sleep_when_ut_mode_false() {
+          local cnt; cnt=$(cat "./test_data/sleep_count")
+          cnt=$((cnt + 1)); echo "$cnt" > "./test_data/sleep_count"
+        }
+
+        When call build_cross_shard_ca_bundle
+        The status should be success
+        The output should include "Collected CA from rds-shard-def-0.svc (1/3)"
+        The output should include "Collected CA from rds-shard-ghi-0.svc (2/3)"
+        The output should include "Collected CA from rds-shard-jkl-0.svc (3/3)"
+        The output should include "Waiting for CA from 3 peer(s)"
+        The output should include "CA bundle: 4 unique CAs"
+        The output should include "All peer ACKs received"
+        The contents of file "./test_data/sleep_count" should equal "60"
+      End
+    End
+
     Context "when stale ACK from previous attempt exists but current nonce differs"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -1145,6 +1145,225 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when ADDSLOTS returns already busy from previous attempt"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "treats already-busy as reuse from previous attempt and continues"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) echo "ERR Slot 12345 is already busy"; return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be success
+        The output should include "already owned, reusing from previous attempt"
+        The output should include "CA bundle:"
+        The output should include "All peer ACKs received"
+      End
+    End
+
+    Context "when ADDSLOTS returns unexpected error"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "fails and logs the unexpected error"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) echo "ERR Invalid or out of range slot"; return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The stderr should include "CLUSTER ADDSLOTS 12345 failed unexpectedly"
+        The stderr should include "Invalid or out of range slot"
+        The output should include "Retaining CA exchange state"
+      End
+    End
+
+    Context "when failure path preserves CA exchange state with retry log"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "logs retaining message and does not delete CA or restore full-coverage on timeout"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*no*) return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*yes*) touch "./test_data/coverage_restored"; return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) touch "./test_data/flushslots_called"; return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/ca_del_called"; return 0 ;;
+            *SET*) return 0 ;;
+            *GET*_PEER_CA*) echo ""; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "Retaining CA exchange state"
+        The stderr should include "timed out waiting for CA"
+        The path "./test_data/ca_del_called" should not be exist
+        The path "./test_data/flushslots_called" should not be exist
+        The path "./test_data/coverage_restored" should not be exist
+      End
+    End
+
+    Context "when success path performs full cleanup"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "deletes CA key, nonce, ACKs, flushes slots, and restores coverage on success"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) touch "./test_data/flushslots_called"; return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*no*) return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*yes*) touch "./test_data/coverage_restored"; return 0 ;;
+            *DEL*_PEER_CA*) touch "./test_data/ca_del_called"; return 0 ;;
+            *DEL*_NONCE*) touch "./test_data/nonce_del_called"; return 0 ;;
+            *DEL*_ACK_*) touch "./test_data/ack_del_called"; return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be success
+        The output should include "CA bundle:"
+        The output should include "All peer ACKs received"
+        The path "./test_data/ca_del_called" should be exist
+        The path "./test_data/nonce_del_called" should be exist
+        The path "./test_data/ack_del_called" should be exist
+        The path "./test_data/flushslots_called" should be exist
+        The path "./test_data/coverage_restored" should be exist
+      End
+    End
+
+    Context "when retry-persistent recovery across two attempts"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "attempt1 fails preserving state, attempt2 succeeds with persisted CA and new nonce"
+        echo "1" > "./test_data/attempt"
+        retry_wrapper() {
+          # Attempt 1: peer CA not available -> timeout -> return 1
+          echo "1" > "./test_data/attempt"
+          build_cross_shard_ca_bundle
+          local rc1=$?
+          echo "attempt1_rc=$rc1"
+
+          # Attempt 2: peer CA available, ADDSLOTS already busy from attempt1
+          echo "2" > "./test_data/attempt"
+          build_cross_shard_ca_bundle
+          local rc2=$?
+          echo "attempt2_rc=$rc2"
+
+          return $rc2
+        }
+
+        redis-cli() {
+          local attempt; attempt=$(cat "./test_data/attempt")
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*)
+              if [ "$attempt" = "2" ]; then
+                echo "ERR Slot 12345 is already busy"
+              fi
+              return 0
+              ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*)
+              echo "cluster-require-full-coverage"
+              if [ "$attempt" = "2" ]; then
+                echo "no"
+              else
+                echo "yes"
+              fi
+              return 0
+              ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *GET*_PEER_CA*)
+              if [ "$attempt" = "1" ]; then
+                echo ""; return 0
+              fi
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call retry_wrapper
+        The status should be success
+        The output should include "attempt1_rc=1"
+        The output should include "attempt2_rc=0"
+        The output should include "Retaining CA exchange state"
+        The output should include "already owned, reusing from previous attempt"
+        The output should include "CA bundle:"
+        The output should include "All peer ACKs received"
+        The stderr should include "timed out waiting for CA"
+      End
+    End
+
     Context "when stale ACK from previous attempt exists but current nonce differs"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -1016,6 +1016,52 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when peer publishes CA after attempt 60 (beyond old 30-attempt limit)"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "succeeds because 90-attempt window covers late-publishing peers"
+        echo "0" > "./test_data/ca_get_count"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *DEL*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *SET*_NONCE*) return 0 ;;
+            *SET*_ACK_*) return 0 ;;
+            *GET*_PEER_CA*)
+              local cnt; cnt=$(cat "./test_data/ca_get_count")
+              cnt=$((cnt + 1))
+              echo "$cnt" > "./test_data/ca_get_count"
+              if [ $cnt -le 60 ]; then
+                echo ""; return 0
+              fi
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *GET*_NONCE*) echo "peer_nonce_42"; return 0 ;;
+            *GET*_ACK_*) echo "1"; return 0 ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be success
+        The output should include "Waiting for CA from rds-shard-def-0.svc"
+        The output should include "CA bundle:"
+        The output should include "All peer ACKs received"
+      End
+    End
+
     Context "when stale ACK from previous attempt exists but current nonce differs"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -1145,15 +1145,16 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
-    Context "when ADDSLOTS returns already busy from previous attempt"
+    Context "when ADDSLOTS returns already busy and slot is owned by local node"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "treats already-busy as reuse from previous attempt and continues"
+      It "verifies local ownership via CLUSTER NODES and continues"
         redis-cli() {
           case "$*" in
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) echo "ERR Slot 12345 is already busy"; return 0 ;;
+            *"CLUSTER NODES"*) echo "abc123 127.0.0.1:6379@16379 myself,master - 0 0 0 connected 12345"; return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
@@ -1178,9 +1179,34 @@ Describe "Redis Cluster Common Bash Script Tests"
 
         When call build_cross_shard_ca_bundle
         The status should be success
-        The output should include "already owned, reusing from previous attempt"
+        The output should include "already owned by local node, reusing from previous attempt"
         The output should include "CA bundle:"
         The output should include "All peer ACKs received"
+      End
+    End
+
+    Context "when ADDSLOTS returns already busy but slot not owned by local node"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "fails because local node does not own the busy slot"
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) echo "ERR Slot 12345 is already busy"; return 0 ;;
+            *"CLUSTER NODES"*) echo "abc123 127.0.0.1:6379@16379 myself,master - 0 0 0 connected 999"; return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The stderr should include "busy but not owned by local node"
+        The output should include "Retaining CA exchange state"
       End
     End
 
@@ -1319,6 +1345,7 @@ Describe "Redis Cluster Common Bash Script Tests"
               fi
               return 0
               ;;
+            *"CLUSTER NODES"*) echo "abc123 127.0.0.1:6379@16379 myself,master - 0 0 0 connected 12345"; return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*)
               echo "cluster-require-full-coverage"
@@ -1357,7 +1384,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         The output should include "attempt1_rc=1"
         The output should include "attempt2_rc=0"
         The output should include "Retaining CA exchange state"
-        The output should include "already owned, reusing from previous attempt"
+        The output should include "already owned by local node, reusing from previous attempt"
         The output should include "CA bundle:"
         The output should include "All peer ACKs received"
         The stderr should include "timed out waiting for CA"

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -594,6 +594,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *) return 1 ;;
           esac
         }
@@ -617,6 +619,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *SET*) return 0 ;;
             *GET*_PEER_CA*) echo ""; return 0 ;;
@@ -644,6 +648,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *SET*) return 0 ;;
             *GET*_PEER_CA*) echo "CLUSTERDOWN Hash slot not served"; return 0 ;;
@@ -672,6 +678,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *SET*) return 0 ;;
             *GET*_PEER_CA*)
@@ -704,6 +712,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
             *GET*_PEER_CA*)
@@ -736,6 +746,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
             *GET*_PEER_CA*)
@@ -759,6 +771,46 @@ Describe "Redis Cluster Common Bash Script Tests"
       End
     End
 
+    Context "when full-coverage restore fails on success path"
+      Before "ca_bundle_setup"
+      After "ca_bundle_cleanup"
+
+      It "returns non-zero when cluster-require-full-coverage restore fails"
+        coverage_restore_call_count=0
+        redis-cli() {
+          case "$*" in
+            *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
+            *"CLUSTER ADDSLOTS"*) return 0 ;;
+            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*no*)
+              return 0
+              ;;
+            *"CONFIG SET"*cluster-require-full-coverage*yes*)
+              return 1
+              ;;
+            *DEL*_PEER_CA*) return 0 ;;
+            *SET*_PEER_CA*) return 0 ;;
+            *GET*_PEER_CA*)
+              echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfRElGRkVSRU5UX1BFRVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+              return 0
+              ;;
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "./test_data/ca-bundle.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+        openssl() { return 0; }
+        extract_obj_ordinal() { echo "0"; }
+        get_pod_service_port_by_network_mode() { echo "6379"; }
+
+        When call build_cross_shard_ca_bundle
+        The status should be failure
+        The output should include "CA bundle:"
+        The stderr should include "failed to restore cluster-require-full-coverage"
+      End
+    End
+
     Context "when FLUSHSLOTS fails on success path"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
@@ -769,6 +821,8 @@ Describe "Redis Cluster Common Bash Script Tests"
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
             *"CLUSTER FLUSHSLOTS"*) return 1 ;;
+            *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
+            *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
             *GET*_PEER_CA*)

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -614,12 +614,11 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "returns non-zero on peer CA timeout and cleans up exchange key"
+      It "returns non-zero on peer CA timeout and preserves CA for retry"
         redis-cli() {
           case "$*" in
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
-            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
@@ -634,7 +633,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "Waiting for CA from"
-        The path "./test_data/del_called" should be exist
+        The path "./test_data/del_called" should not be exist
         The stderr should include "timed out waiting for CA"
       End
     End
@@ -643,12 +642,11 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "rejects CLUSTERDOWN and times out"
+      It "rejects CLUSTERDOWN and times out preserving CA for retry"
         redis-cli() {
           case "$*" in
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
-            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
@@ -663,7 +661,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "Waiting for CA from"
-        The path "./test_data/del_called" should be exist
+        The path "./test_data/del_called" should not be exist
         The stderr should include "non-PEM data"
         The stderr should include "timed out waiting for CA"
       End
@@ -673,12 +671,11 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "rejects invalid x509 and times out"
+      It "rejects invalid x509 and times out preserving CA for retry"
         redis-cli() {
           case "$*" in
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
-            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
             *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
@@ -697,7 +694,7 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "Waiting for CA from"
-        The path "./test_data/del_called" should be exist
+        The path "./test_data/del_called" should not be exist
         The stderr should include "invalid x509 certificate"
         The stderr should include "timed out waiting for CA"
       End
@@ -707,15 +704,13 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "returns non-zero on CONFIG SET failure and cleans up exchange key"
+      It "returns non-zero on CONFIG SET failure preserving CA for retry"
         redis-cli() {
           case "$*" in
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
-            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
-            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *DEL*_NONCE*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
             *SET*_NONCE*) return 0 ;;
@@ -735,7 +730,6 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "CA bundle:"
-        The path "./test_data/del_called" should be exist
         The stderr should include "CONFIG SET tls-ca-cert-file failed"
       End
     End
@@ -744,15 +738,13 @@ Describe "Redis Cluster Common Bash Script Tests"
       Before "ca_bundle_setup"
       After "ca_bundle_cleanup"
 
-      It "returns non-zero on readback mismatch and cleans up exchange key"
+      It "returns non-zero on readback mismatch preserving CA for retry"
         redis-cli() {
           case "$*" in
             *"CLUSTER KEYSLOT"*) echo "12345"; return 0 ;;
             *"CLUSTER ADDSLOTS"*) return 0 ;;
-            *"CLUSTER FLUSHSLOTS"*) return 0 ;;
             *"CONFIG GET"*cluster-require-full-coverage*) echo "cluster-require-full-coverage"; echo "yes"; return 0 ;;
             *"CONFIG SET"*cluster-require-full-coverage*) return 0 ;;
-            *DEL*_PEER_CA*) touch "./test_data/del_called"; return 0 ;;
             *DEL*_NONCE*) return 0 ;;
             *SET*_PEER_CA*) return 0 ;;
             *SET*_NONCE*) return 0 ;;
@@ -773,7 +765,6 @@ Describe "Redis Cluster Common Bash Script Tests"
         When call build_cross_shard_ca_bundle
         The status should be failure
         The output should include "CA bundle:"
-        The path "./test_data/del_called" should be exist
         The stderr should include "readback mismatch"
       End
     End

--- a/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
@@ -971,7 +971,7 @@ Describe "Redis Cluster Server Start Bash Script Tests"
         check_redis_server_ready_with_retry() { return 0; }
         redis-cli() {
           case "$*" in
-            *GET*__KB_TLS_CA_BUNDLE_BASE64__*) echo "RkFLRQ=="; return 0 ;;
+            *GET*_CA_BUNDLE*) echo "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBS0VfQlVORExFCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"; return 0 ;;
             *"CONFIG SET"*) return 1 ;;
             *) return 0 ;;
           esac

--- a/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
@@ -976,6 +976,7 @@ Describe "Redis Cluster Server Start Bash Script Tests"
             *) return 0 ;;
           esac
         }
+        openssl() { return 0; }
 
         When call apply_cross_shard_ca_bundle_background
         The status should be failure

--- a/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_server_start_spec.sh
@@ -900,4 +900,87 @@ Describe "Redis Cluster Server Start Bash Script Tests"
       End
     End
   End
+
+  Describe "apply_cross_shard_ca_bundle_background()"
+    setup_bg() {
+      export TLS_ENABLED="true"
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD=""
+      export REDIS_CLI_TLS_CMD=""
+      export DATA_DIR="./test_data_bg"
+      mkdir -p "$DATA_DIR"
+    }
+
+    un_setup_bg() {
+      unset TLS_ENABLED SERVICE_PORT REDIS_DEFAULT_PASSWORD REDIS_CLI_TLS_CMD DATA_DIR
+      rm -rf ./test_data_bg 2>/dev/null
+    }
+
+    Context "when TLS is disabled"
+      Before "setup_bg"
+      After "un_setup_bg"
+
+      It "returns 0 immediately"
+        TLS_ENABLED="false"
+        When call apply_cross_shard_ca_bundle_background
+        The status should be success
+      End
+    End
+
+    Context "when existing bundle CONFIG SET fails"
+      Before "setup_bg"
+      After "un_setup_bg"
+
+      It "returns non-zero on CONFIG SET failure"
+        echo "FAKE_BUNDLE" > ./test_data_bg/ca-bundle.crt
+        check_redis_server_ready_with_retry() { return 0; }
+        redis-cli() { return 1; }
+
+        When call apply_cross_shard_ca_bundle_background
+        The status should be failure
+        The stderr should include "CONFIG SET failed on existing bundle"
+      End
+    End
+
+    Context "when existing bundle readback mismatches"
+      Before "setup_bg"
+      After "un_setup_bg"
+
+      It "returns non-zero on readback mismatch"
+        echo "FAKE_BUNDLE" > ./test_data_bg/ca-bundle.crt
+        check_redis_server_ready_with_retry() { return 0; }
+        redis-cli() {
+          case "$*" in
+            *"CONFIG SET"*) return 0 ;;
+            *"CONFIG GET"*) echo "tls-ca-cert-file"; echo "/wrong/path.crt"; return 0 ;;
+            *) return 0 ;;
+          esac
+        }
+
+        When call apply_cross_shard_ca_bundle_background
+        The status should be failure
+        The stderr should include "readback mismatch"
+      End
+    End
+
+    Context "when bundle key CONFIG SET fails"
+      Before "setup_bg"
+      After "un_setup_bg"
+
+      It "keeps bundle key for retry and returns non-zero"
+        check_redis_server_ready_with_retry() { return 0; }
+        redis-cli() {
+          case "$*" in
+            *GET*__KB_TLS_CA_BUNDLE_BASE64__*) echo "RkFLRQ=="; return 0 ;;
+            *"CONFIG SET"*) return 1 ;;
+            *) return 0 ;;
+          esac
+        }
+
+        When call apply_cross_shard_ca_bundle_background
+        The status should be failure
+        The stderr should include "keeping bundle key for retry"
+      End
+    End
+  End
 End

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -475,6 +475,8 @@ spec:
           - /bin/bash
           - -c
           - /scripts/{{ $redisClusterManageScripts }} --post-provision  > /tmp/post-provision.log 2>&1
+        targetPodSelector: Ordinal
+        matchingKey: "0"
         ## all lifecycle actions share the same env
         env:
           - name: CURRENT_POD_NAME


### PR DESCRIPTION
## Problem

KubeBlocks creates per-Component (per-shard) self-signed CAs for Redis Cluster TLS. Each shard gets a different CA fingerprint. The cluster bus (port 16379) performs server-to-server TLS handshake using `tls-ca-cert-file` for certificate validation. Since each shard's CA cannot validate another shard's certificate, the handshake fails:

```
Verify error: self-signed certificate in certificate chain
SSL routines:tls_post_process_server_certificate:certificate verify failed
Verify return code: 19 (self-signed certificate in certificate chain)
```

Gossip messages are never exchanged (`cluster_stats_messages_sent:0`) and the cluster never forms, despite all 6 pods being Running.

Evidence: three shards with three completely different CA sha256 fingerprints + cross-shard cluster bus TLS handshake failure (verify code 19).

## Fix

Addon-level CA bundle workaround:

1. **Post-provision CA exchange** (`redis-cluster-common.sh`): Each shard-0 pod publishes its CA via Redis key `__TLS_PEER_CA__` (using `--insecure` client connection). The first pod to complete collection concatenates all unique CAs into `/data/ca-bundle.crt`, CONFIG SET `tls-ca-cert-file` to reload TLS context, readback verification via CONFIG GET, distributes encoded bundle to ALL pods via `__TLS_CA_BUNDLE_BASE64__`, cleans up exchange keys.

2. **Secondary pod handling** (`redis-cluster-server-start.sh`): Background process waits for `__TLS_CA_BUNDLE_BASE64__` Redis key, writes to `/data/ca-bundle.crt`, CONFIG SET, then DEL key.

3. **Restart handling** (`redis-cluster-server-start.sh`): `build_redis_tls_config()` checks for existing `/data/ca-bundle.crt` on startup and uses it instead of per-shard CA.

4. **Post-provision log** (`redis-cluster-manage.sh`): `exec > >(tee -a /data/post-provision.log) 2>&1` with timestamps and exit codes.

## Boundary

- This PR fixes only cross-shard CA trust (the confirmed root cause)
- SAN/FQDN/cluster-announce-hostname is a separate layer, needs Phase 1 probe evidence
- Concurrent initialization race is a known secondary issue, separate PR
- No private keys are exchanged — only CA public certificates
- Exchange keys are cleaned up after use