### PR TITLE
chore(valkey): report per-backup size instead of total repo size

### DIFF
--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -123,7 +123,7 @@ save_sentinel_acl || \
   echo "WARNING: Sentinel ACL save failed — ACL rules will not be restored after a cluster restore." >&2
 
 echo "INFO: Data archived successfully."
-TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}') || true
+TOTAL_SIZE=$(datasafed stat "${DP_BACKUP_NAME}.tar.zst" | grep TotalSize | awk '{print $2}') || true
 if [ -z "${TOTAL_SIZE}" ]; then
   echo "WARNING: could not parse TotalSize from datasafed stat — reporting 0" >&2
   TOTAL_SIZE=0


### PR DESCRIPTION
## Summary

- `datasafed stat /` reports TotalSize of the entire backup repository, not this specific backup
- When multiple backups exist, totalSize in backup info gets inflated
- Changed to `datasafed stat "${DP_BACKUP_NAME}.tar.zst"` to report the actual archive size

## Impact

Cosmetic metadata only. Does not affect restore or data integrity.

## Test plan

- [ ] Backup with existing repo containing prior backups → verify totalSize reflects only this backup
- [ ] Single backup scenario → verify behavior unchanged

Co-authored-by: Alice <alice@apecloud.com>