### PR TITLE
Revert "chore(redis): enable switchover result check for without-candidate path"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,6 +70,9 @@ addons-cluster/oceanbase-ce/ @Powerfooi @shanshanying @leon-ape @apecloud/kb-rev
 addons/opensearch/ @leon-ape @apecloud/kb-reviewers @apecloud/kb-addon-reviewers
 addons-cluster/opensearch/ @leon-ape @apecloud/kb-reviewers @apecloud/kb-addon-reviewers
 
+addons/openviking/ @OpenViking_Contributors @leon-ape @apecloud/kb-reviewers @apecloud/kb-addon-reviewers
+addons-cluster/openviking/ @OpenViking_Contributors @leon-ape @apecloud/kb-reviewers @apecloud/kb-addon-reviewers
+
 addons/orchestrator/ @leon-ape @apecloud/kb-reviewers @apecloud/kb-addon-reviewers
 addons-cluster/orchestrator/ @leon-ape @apecloud/kb-reviewers @apecloud/kb-addon-reviewers
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ KubeBlocks add-ons.
 | neon | neon-broker-1.0.0<br>neon-compute-1.0.0<br>neon-pageserver-1.0.0<br>neon-safekeeper-1.0.0 | Neon is a serverless open-source alternative to AWS Aurora Postgres. It separates storage and compute and substitutes the PostgreSQL storage layer by redistributing data across a cluster of nodes. | ApeCloud |
 | oceanbase-ce | oceanbase-ce-4.2.1<br>oceanbase-ce-4.2.5<br>oceanbase-ce-4.3.5 | OceanBase has served over 400 customers across the globe and has been supporting all mission critical systems in Alipay. | Powerfooi shanshanying |
 | opensearch | opensearch-2.7.0<br>opensearch-dashboard-2.7.0 | Open source distributed and RESTful search engine. | ApeCloud |
+| openviking | openviking-0.3.12 | OpenViking is an open-source RAG and semantic search engine that serves as a Context Database MCP (Model Context Protocol) server. | OpenViking Contributors |
 | orchestrator | orchestrator-3.2.6 | Orchestrator is a MySQL high availability and replication management tool, runs as a service and provides command line access, HTTP API and Web interface. | ApeCloud |
 | orioledb | orioledb-16.4.0 | OrioleDB is a new storage engine for PostgreSQL, bringing a modern approach to database capacity, capabilities and performance to the world's most-loved database platform. | ApeCloud |
 | polardbx | polardbx-cdc-2.3.0<br>polardbx-cn-2.3.0<br>polardbx-dn-2.3.0<br>polardbx-gms-2.3.0 | PolarDB-X is a cloud native distributed SQL Database designed for high concurrency, massive storage, complex querying scenarios. | ApeCloud Vettal Wu |

--- a/addons/redis/scripts-ut-spec/redis_switchover_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_switchover_spec.sh
@@ -412,16 +412,6 @@ master_host:redis-master"
         The stdout should equal ""
       End
 
-      It "should fail when result check fails"
-        check_redis_kernel_status() {
-          echo "redis1"
-        }
-        execute_sentinel_failover() { return 0; }
-        check_switchover_result() { return 1; }
-        When call switchover_without_candidate
-        The status should be failure
-      End
-
     End
 
     Context "check_switchover_result()"

--- a/addons/redis/scripts/redis-switchover.sh
+++ b/addons/redis/scripts/redis-switchover.sh
@@ -356,7 +356,9 @@ switchover_without_candidate() {
   # do switchover
   execute_sentinel_failover "$CUSTOM_SENTINEL_MASTER_NAME" || return 1
 
-  check_switchover_result "" "$initial_master" || return 1
+  # check switchover result using initial_master
+  # if no candidate specified, skip check
+  # check_switchover_result "" "$initial_master" || return 1
 }
 
 # This is magic for shellspec ut framework.


### PR DESCRIPTION
Reverts apecloud/kubeblocks-addons#2895.

When restarting Redis components, the system invokes a switchover without specifying a candidate. A failure in this switchover will block the restart, so avoid testing the switchover without a candidate in isolation.