### PR TITLE
chore(valkey): protect data-path parameters as immutable

### DIFF
--- a/addons/valkey/templates/paramsdef.yaml
+++ b/addons/valkey/templates/paramsdef.yaml
@@ -14,13 +14,17 @@ spec:
   fileName: valkey.conf
   fileFormatConfig:
     format: redis
+  immutableParameters:
+    - dir
+    - dbfilename
+    - appendfilename
+    - appenddirname
   staticParameters:
     - bind
     - port
     - tls-port
     - daemonize
     - databases
-    - dir
     - logfile
     - aclfile
     - tcp-backlog


### PR DESCRIPTION
## Summary

- Add `immutableParameters` section to Valkey ParametersDefinition with `dir`, `dbfilename`, `appendfilename`, `appenddirname`
- Move `dir` from `staticParameters` to `immutableParameters`

These 4 parameters control where Valkey stores its data files. If changed via reconfigure OpsRequest, Valkey would restart and look for data in the wrong location, causing silent data loss. Marking them as `immutableParameters` makes KB reject such changes upfront.

Found during deep review (task #338, review criterion: addon-api 1.2 08-parameters-and-config.md contract).

## Verification

- helm template renders correctly for both valkey8-pd and valkey9-pd
- immutableParameters section appears in both PD objects
- staticParameters retains all other entries unchanged
- No changes to dynamicParameters or CUE schema
