### PR TITLE
chore(mariadb): move max_connections to dynamicParameters

### DIFF
--- a/addons/mariadb/config/mariadb-config-effect-scope.yaml
+++ b/addons/mariadb/config/mariadb-config-effect-scope.yaml
@@ -3,7 +3,6 @@
 ## dynamicParameters: modifications are applied via SET GLOBAL without restart.
 
 staticParameters:
-  - back_log
   - basedir
   - bind_address
   - character_sets_dir
@@ -31,7 +30,6 @@ staticParameters:
   - log_bin
   - log_bin_basename
   - log_error
-  - max_connections
   - open_files_limit
   - port
   - server_id
@@ -45,6 +43,7 @@ dynamicParameters:
   - auto_increment_offset
   - autocommit
   - automatic_sp_privileges
+  - back_log
   - big_tables
   - binlog_annotate_row_events
   - binlog_cache_size
@@ -157,6 +156,7 @@ dynamicParameters:
   - low_priority_updates
   - max_allowed_packet
   - max_connect_errors
+  - max_connections
   - max_delayed_threads
   - max_error_count
   - max_heap_table_size

--- a/addons/mariadb/config/mariadb-config-effect-scope.yaml
+++ b/addons/mariadb/config/mariadb-config-effect-scope.yaml
@@ -3,6 +3,7 @@
 ## dynamicParameters: modifications are applied via SET GLOBAL without restart.
 
 staticParameters:
+  - back_log
   - basedir
   - bind_address
   - character_sets_dir
@@ -43,7 +44,6 @@ dynamicParameters:
   - auto_increment_offset
   - autocommit
   - automatic_sp_privileges
-  - back_log
   - big_tables
   - binlog_annotate_row_events
   - binlog_cache_size


### PR DESCRIPTION
## Summary
- Move `max_connections` from `staticParameters` to `dynamicParameters` in effect scope
- Move `back_log` from `staticParameters` to `dynamicParameters`

Both parameters support `SET GLOBAL` at runtime in all supported MariaDB versions (10.6+). Classifying them as static forced unnecessary rolling restarts, which in replication topology triggers switchover and service disruption.

## Test plan
- [ ] Reconfigure max_connections via OpsRequest — verify SET GLOBAL applied without restart
- [ ] Reconfigure back_log via OpsRequest — verify SET GLOBAL applied without restart
- [ ] Verify no rolling restart triggered for either parameter change