### PR TITLE
chore(mariadb): propagate all SET GLOBAL errors in reloader

### DIFF
--- a/addons/mariadb/reloader/update-parameter.sh
+++ b/addons/mariadb/reloader/update-parameter.sh
@@ -37,12 +37,8 @@ else
 fi
 
 if [[ ${status} -ne 0 ]]; then
-    if grep -q "ERROR 1045 (28000)" <<<"${output}"; then
-        echo "Failed to set parameter ${param_name} to value ${param_value}: ${output}" >&2
-        exit 1
-    fi
-    echo "Skipping parameter ${param_name}=${param_value}: ${output}" >&2
-    exit 0
+    echo "Failed to set parameter ${param_name} to value ${param_value}: ${output}" >&2
+    exit 1
 fi
 
 echo "Set parameter ${param_name} to value ${param_value}"


### PR DESCRIPTION
## Summary
- Fix update-parameter.sh to exit 1 on any SET GLOBAL failure, not just ERROR 1045
- Previously, non-auth errors (out-of-range values, read-only variables, etc.) were silently swallowed with exit 0, causing reconfigure OpsRequest to falsely report success

## Test plan
- [ ] Reconfigure with invalid parameter value — verify OpsRequest fails (not Succeed)
- [ ] Reconfigure with valid parameter value — verify OpsRequest succeeds