### PR TITLE
chore(mariadb): remove eval injection in Galera accountProvision

### DIFF
--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -98,9 +98,7 @@ spec:
           - -c
           - |
             set -ex
-            ALL_DB='*.*'
-            eval statement=\"${KB_ACCOUNT_STATEMENT}\"
-            mariadb -u${MARIADB_ROOT_USER} -p${MARIADB_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement}"
+            mariadb -u${MARIADB_ROOT_USER} -p${MARIADB_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${KB_ACCOUNT_STATEMENT}"
     roleProbe:
       periodSeconds: {{ .Values.roleProbe.periodSeconds }}
       timeoutSeconds: 5

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -94,11 +94,19 @@ spec:
       exec:
         container: mariadb
         command:
-          - /bin/sh
+          - /bin/bash
           - -c
           - |
             set -ex
-            mariadb -u${MARIADB_ROOT_USER} -p${MARIADB_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${KB_ACCOUNT_STATEMENT}"
+            ALL_DB='*.*'
+            p_name='${KB_ACCOUNT_NAME}'
+            p_pass='${KB_ACCOUNT_PASSWORD}'
+            p_alldb='${ALL_DB}'
+            stmt=${KB_ACCOUNT_STATEMENT}
+            stmt=${stmt//$p_name/$KB_ACCOUNT_NAME}
+            stmt=${stmt//$p_pass/$KB_ACCOUNT_PASSWORD}
+            stmt=${stmt//$p_alldb/$ALL_DB}
+            mariadb -u"${MARIADB_ROOT_USER}" -p"${MARIADB_ROOT_PASSWORD}" -P3306 -h127.0.0.1 -e "${stmt}"
     roleProbe:
       periodSeconds: {{ .Values.roleProbe.periodSeconds }}
       timeoutSeconds: 5

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -94,19 +94,24 @@ spec:
       exec:
         container: mariadb
         command:
-          - /bin/bash
+          - /bin/sh
           - -c
           - |
-            set -ex
+            set -e
             ALL_DB='*.*'
-            p_name='${KB_ACCOUNT_NAME}'
-            p_pass='${KB_ACCOUNT_PASSWORD}'
-            p_alldb='${ALL_DB}'
-            stmt=${KB_ACCOUNT_STATEMENT}
-            stmt=${stmt//$p_name/$KB_ACCOUNT_NAME}
-            stmt=${stmt//$p_pass/$KB_ACCOUNT_PASSWORD}
-            stmt=${stmt//$p_alldb/$ALL_DB}
-            mariadb -u"${MARIADB_ROOT_USER}" -p"${MARIADB_ROOT_PASSWORD}" -P3306 -h127.0.0.1 -e "${stmt}"
+            escape_sed_replacement() {
+              printf '%s' "$1" | sed 's/[|\/&]/\\&/g'
+            }
+            account_name="$(escape_sed_replacement "${KB_ACCOUNT_NAME}")"
+            account_password="$(escape_sed_replacement "${KB_ACCOUNT_PASSWORD}")"
+            all_db="$(escape_sed_replacement "${ALL_DB}")"
+            statement="$(
+              printf '%s' "${KB_ACCOUNT_STATEMENT}" | sed \
+                -e "s"'|\${KB_ACCOUNT_NAME}|'"${account_name}"'|g' \
+                -e "s"'|\${KB_ACCOUNT_PASSWORD}|'"${account_password}"'|g' \
+                -e "s"'|\${ALL_DB}|'"${all_db}"'|g'
+            )"
+            mariadb -u"${MARIADB_ROOT_USER}" -p"${MARIADB_ROOT_PASSWORD}" -P3306 -h127.0.0.1 -e "${statement}"
     roleProbe:
       periodSeconds: {{ .Values.roleProbe.periodSeconds }}
       timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- Remove `eval` in Galera CMPD accountProvision that performed shell expansion on KB_ACCOUNT_STATEMENT
- Shell metacharacters in account passwords could be executed as commands
- Replace with bash parameter expansion to safely substitute `${KB_ACCOUNT_NAME}`, `${KB_ACCOUNT_PASSWORD}`, and `${ALL_DB}` placeholders in KB_ACCOUNT_STATEMENT without eval

## Test plan
- [x] CI shellspec tests pass
- [ ] Create Galera cluster — verify system accounts provisioned correctly
- [ ] Verify account with special characters in password works