### PR TITLE
chore(mariadb): replace mutating write probe with read-only SHOW GRANTS

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -2049,8 +2049,8 @@ case "$*" in
     echo "GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO 'root'@'127.0.0.1'"
     exit 0
     ;;
-  *"-uroot"*"INSERT"*)
-    echo "ERROR 1044 (42000): Access denied for user 'root'@'127.0.0.1' to database 'kubeblocks'"
+  *"-uroot"*"SHOW GRANTS"*)
+    echo "ERROR 1044 (42000): Access denied for user 'root'@'127.0.0.1' to database 'mysql'"
     exit 1
     ;;
 esac
@@ -2135,7 +2135,8 @@ case "$*" in
     echo "GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO 'root'@'127.0.0.1'"
     exit 0
     ;;
-  *"-uroot"*"INSERT"*)
+  *"-uroot"*"SHOW GRANTS"*)
+    echo "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO 'root'@'127.0.0.1'"
     exit 0
     ;;
 esac
@@ -2405,17 +2406,17 @@ EOF
       It "alpha.63 v1: 127.0.0.1 with multi-line SQL stderr containing 1044 → __PROBE_ERRNO=1044 correctly extracted (alpha.62 RED root cause closed)"
         cat > "${MARIADB_CLIENT_BIN}" <<'EOF'
 #!/bin/sh
-# Simulate alpha.62 RED scenario: mariadb client INSERT returns multi-line SQL stderr containing 1044.
+# Simulate alpha.62 RED scenario: mariadb client SHOW GRANTS returns multi-line SQL stderr containing 1044.
 case "$*" in
   *"-ukb_internal_root"*"SHOW GRANTS"*)
     echo "GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO 'root'@'127.0.0.1'"
     echo "GRANT PROXY ON ''@'%' TO 'root'@'127.0.0.1' WITH GRANT OPTION"
     exit 0
     ;;
-  *"-uroot"*"INSERT"*)
+  *"-uroot"*"SHOW GRANTS"*)
     cat <<MULTILINE
-ERROR 1044 (42000) at line 3: Access denied for user 'root'@'127.0.0.1'
-to database 'kubeblocks'
+ERROR 1044 (42000): Access denied for user 'root'@'127.0.0.1'
+to database 'mysql'
 MULTILINE
     exit 1
     ;;

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -2072,6 +2072,29 @@ EOF
         The output should include "reason_hash=sha256"
       End
 
+      It "alpha.127 v2: 127.0.0.1 SHOW GRANTS rc=0 with no write grants is accepted as read-only fenced"
+        cat > "${MARIADB_CLIENT_BIN}" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *"-ukb_internal_root"*"SHOW GRANTS"*)
+    echo "GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO 'root'@'127.0.0.1'"
+    exit 0
+    ;;
+  *"-uroot"*"SHOW GRANTS"*)
+    echo "GRANT SELECT, PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, REPLICATION MASTER ADMIN ON *.* TO 'root'@'127.0.0.1'"
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+        chmod +x "${MARIADB_CLIENT_BIN}"
+        When call _verify_host_is_fenced "127.0.0.1"
+        The status should be success
+        The output should include "write_probe_rc=0"
+        The output should include "write_probe_errno=1290"
+        The output should include "reason=ok_by_local_probe:1290"
+      End
+
       It "alpha.62 v1: localhost host → grants-only path (no socket probe), reason=ok_by_grants_only:localhost_socket_not_attempted"
         cat > "${MARIADB_CLIENT_BIN}" <<'EOF'
 #!/bin/sh

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -685,7 +685,12 @@ _verify_host_is_fenced() {
       esac
       write_rc="${__PROBE_RC}"
       write_errno="${__PROBE_ERRNO}"
-      case "${write_rc}" in
+      case "${write_errno}" in
+        1044|1290|1142)
+          reason="ok_by_local_probe:${write_errno}"
+          log_switchover_info "remote_root_fence_verify host=${host} verified_host=${host} probe_host=${probe_host} grants_query_rc=0 ${grants_sha_field} grants_bypass=none grants_ignored_count=${__GRANTS_IGNORED_COUNT} write_probe_attempted=true write_probe_rc=${write_rc} write_probe_errno=${write_errno} reason=${reason}"
+          return 0
+          ;;
         0)
           reason="writable_unexpected"
           log_switchover_error "remote_root_fence_verify host=${host} verified_host=${host} probe_host=${probe_host} grants_query_rc=0 ${grants_sha_field} grants_bypass=none grants_ignored_count=${__GRANTS_IGNORED_COUNT} write_probe_attempted=true write_probe_rc=${write_rc} write_probe_errno=${write_errno} reason=${reason}"
@@ -695,21 +700,12 @@ _verify_host_is_fenced() {
           return 1
           ;;
         *)
-          case "${write_errno}" in
-            1044|1290|1142)
-              reason="ok_by_local_probe:${write_errno}"
-              log_switchover_info "remote_root_fence_verify host=${host} verified_host=${host} probe_host=${probe_host} grants_query_rc=0 ${grants_sha_field} grants_bypass=none grants_ignored_count=${__GRANTS_IGNORED_COUNT} write_probe_attempted=true write_probe_rc=${write_rc} write_probe_errno=${write_errno} reason=${reason}"
-              return 0
-              ;;
-            *)
-              reason="probe_account_mismatch"
-              log_switchover_error "remote_root_fence_verify host=${host} verified_host=${host} probe_host=${probe_host} grants_query_rc=0 ${grants_sha_field} grants_bypass=none grants_ignored_count=${__GRANTS_IGNORED_COUNT} write_probe_attempted=true write_probe_rc=${write_rc} write_probe_errno=${write_errno} reason=${reason}"
-              log_switchover_error "remote_root_fence_verify host=${host} probe_dump_begin"
-              log_switchover_error "${__PROBE_OUT}"
-              log_switchover_error "remote_root_fence_verify host=${host} probe_dump_end"
-              return 1
-              ;;
-          esac
+          reason="probe_account_mismatch"
+          log_switchover_error "remote_root_fence_verify host=${host} verified_host=${host} probe_host=${probe_host} grants_query_rc=0 ${grants_sha_field} grants_bypass=none grants_ignored_count=${__GRANTS_IGNORED_COUNT} write_probe_attempted=true write_probe_rc=${write_rc} write_probe_errno=${write_errno} reason=${reason}"
+          log_switchover_error "remote_root_fence_verify host=${host} probe_dump_begin"
+          log_switchover_error "${__PROBE_OUT}"
+          log_switchover_error "remote_root_fence_verify host=${host} probe_dump_end"
+          return 1
           ;;
       esac
       ;;

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -489,28 +489,27 @@ _local_root_write_probe_127() {
   # one of the 5 valid values (1044/1290/1142/0/other) — fail-closed
   # `probe_result_malformed` / `probe_result_malformed_errno` otherwise
   # (Jack 05:24 instrumentation 1).
+  #
+  # alpha.127+ fix: replaced mutating INSERT/DELETE probe with read-only
+  # SHOW GRANTS check to eliminate orphan GTID writes on the demoted primary.
+  # Mirrors the pattern used by verify_post_dcs_local_root_write_fenced().
   __PROBE_OUT=$("${MARIADB_CLIENT_BIN}" "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" \
     --connect-timeout="${MARIADB_CONNECT_TIMEOUT_SECONDS}" \
-    -P3306 -h127.0.0.1 -N -s -e "
-      CREATE DATABASE IF NOT EXISTS kubeblocks;
-      CREATE TABLE IF NOT EXISTS ${SWITCHOVER_REMOTE_ROOT_PROBE_TABLE}(probe_id VARCHAR(128) PRIMARY KEY, check_ts BIGINT);
-      INSERT INTO ${SWITCHOVER_REMOTE_ROOT_PROBE_TABLE}(probe_id, check_ts)
-        VALUES ('switchover_local_root_probe', UNIX_TIMESTAMP());
-      DELETE FROM ${SWITCHOVER_REMOTE_ROOT_PROBE_TABLE} WHERE probe_id='switchover_local_root_probe';
-    " 2>&1)
+    -P3306 -h127.0.0.1 -N -s -e "SHOW GRANTS FOR '${MARIADB_ROOT_USER}'@'127.0.0.1';" 2>&1)
   __PROBE_RC=$?
-  case "${__PROBE_OUT}" in
-    *1044*) __PROBE_ERRNO=1044 ;;
-    *1290*) __PROBE_ERRNO=1290 ;;
-    *1142*) __PROBE_ERRNO=1142 ;;  # Permission for table itself; accepted as fenced
-    *)
-      if [ "${__PROBE_RC}" -eq 0 ]; then
-        __PROBE_ERRNO=0
-      else
-        __PROBE_ERRNO=other
-      fi
-      ;;
-  esac
+  if [ "${__PROBE_RC}" -ne 0 ]; then
+    case "${__PROBE_OUT}" in
+      *1044*) __PROBE_ERRNO=1044 ;;
+      *1141*) __PROBE_ERRNO=1044 ;;
+      *) __PROBE_ERRNO=other ;;
+    esac
+    return
+  fi
+  if echo "${__PROBE_OUT}" | grep -qiE 'ALL PRIVILEGES|INSERT|UPDATE|DELETE|CREATE'; then
+    __PROBE_ERRNO=0
+  else
+    __PROBE_ERRNO=1290
+  fi
 }
 
 _filter_grants_keep_unmatched() {


### PR DESCRIPTION
## Summary
- Replace INSERT/DELETE write probe in switchover with read-only SHOW GRANTS check
- The old probe created orphan GTIDs on the demoted primary via binlog events
- The remote candidate path was already fixed (alpha.127), but the local 127.0.0.1 path was missed
- New probe checks privilege state via SHOW GRANTS — no binlog side effects

## Test plan
- [ ] Switchover with async replication — verify no orphan GTID events
- [ ] Switchover with semisync replication — verify clean GTID state
- [ ] Verify fence detection still works (fenced account correctly identified)