### PR TITLE
chore(mariadb): remove read_only toggle in switchover health check repair

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -666,9 +666,9 @@ EOF
       The status should be success
       The output should include "detected repairable kubeblocks health check replication error"
       The contents of file "${TEST_DIR}/calls" should include "best_effort=STOP SLAVE SQL_THREAD;"
-      The contents of file "${TEST_DIR}/calls" should include "set_read_only=OFF"
       The contents of file "${TEST_DIR}/calls" should include "CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check"
-      The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
+      The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
+      The contents of file "${TEST_DIR}/calls" should not include "set_read_only=ON"
       The contents of file "${TEST_DIR}/calls" should include "best_effort=START SLAVE SQL_THREAD;"
       The contents of file "${TEST_DIR}/slave-status-count" should eq "2"
     End

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1647,40 +1647,14 @@ clear_local_kb_health_check_table() {
 
 repair_kb_health_check_replication_error() {
   local slave_status="$1"
-  local old_read_only
   if ! slave_status_has_kb_health_check_repairable_error "${slave_status}"; then
     return 1
   fi
   log_switchover_info "Switchover old-primary follow repair: detected repairable kubeblocks health check replication error"
   run_local_sql_best_effort "STOP SLAVE SQL_THREAD;"
-  old_read_only=$(query_value "127.0.0.1" "SELECT @@global.read_only;")
-  case "${old_read_only}" in
-    0)
-      ;;
-    *)
-      if ! set_local_read_only "OFF"; then
-        log_switchover_error "Switchover old-primary follow repair: failed to temporarily open local read_only for health check repair"
-        return 1
-      fi
-      ;;
-  esac
   if ! clear_local_kb_health_check_table "prepared-local-kb-health-check-after-switchover-replication-error"; then
-    case "${old_read_only}" in
-      0) ;;
-      *) set_local_read_only "ON" || true ;;
-    esac
     return 1
   fi
-  case "${old_read_only}" in
-    0)
-      ;;
-    *)
-      if ! set_local_read_only "ON"; then
-        log_switchover_error "Switchover old-primary follow repair: failed to restore local read_only after health check repair"
-        return 1
-      fi
-      ;;
-  esac
   run_local_sql_best_effort "START SLAVE SQL_THREAD;"
   return 0
 }


### PR DESCRIPTION
## Summary
- Remove temporary `read_only=OFF` toggle in `repair_kb_health_check_replication_error()`
- The toggle created a write window on the demoted primary, violating the fence invariant
- The toggle was unnecessary because `clear_local_kb_health_check_table()` already uses `kb_internal_root` which has `READ_ONLY ADMIN` privilege and can write with read_only=ON

## Test plan
- [ ] Switchover followed by Stop/Start — verify health check repair works without read_only toggle
- [ ] Verify demoted primary maintains read_only=ON throughout repair