### PR TITLE
chore(mariadb): add semisync plugin loading for 10.6 compatibility

### DIFF
--- a/addons/mariadb/config/mariadb-semisync.tpl
+++ b/addons/mariadb/config/mariadb-semisync.tpl
@@ -6,7 +6,10 @@ log_slave_updates = ON
 gtid_strict_mode = OFF
 skip_slave_start = 1
 
-# Semi-sync is built-in to MariaDB 11.4 (no plugin .so files needed).
+# Semi-sync plugins: required for MariaDB 10.6; harmless no-op on 11.4+ where semi-sync is built-in.
+plugin_load_add = semisync_master.so
+plugin_load_add = semisync_slave.so
+
 # Enable both master and slave sides; MariaDB uses the appropriate one based on role.
 rpl_semi_sync_master_enabled = ON
 rpl_semi_sync_slave_enabled = ON


### PR DESCRIPTION
## Summary
- Add `plugin_load_add = semisync_master.so` and `plugin_load_add = semisync_slave.so` to semisync config template
- MariaDB 10.6 requires explicit plugin loading for semisync (it is NOT built-in)
- The replication config template already had these lines; the semisync template assumed 11.4+ built-in
- These are harmless no-ops on 11.4+ where semisync is built-in

## Test plan
- [x] Create semisync cluster with MariaDB 10.6.15 — verify semisync plugins loaded and functional
- [ ] Create semisync cluster with MariaDB 11.4.x — verify no regression (covered by existing N=20 acceptance on 11.4)

## 10.6 semisync provision evidence

Environment: idc3 vcluster, MariaDB 10.6.15 (ACR mirror with semisync plugin .so files)

Results:
- 2-node semisync cluster `mdb-ss-28349` reached Running
- Pod image confirmed: `apecloud/mariadb:10.6.15`
- Primary: `Rpl_semi_sync_master_status=ON`, `rpl_semi_sync_master_enabled=ON`
- Secondary: `Rpl_semi_sync_slave_status=ON`, `rpl_semi_sync_slave_enabled=ON`
- Write-readback: primary INSERT propagated to secondary successfully
- Evidence SHA: `c83267b3b11de0056bc903260cbcab6ef064a6f7c3c06f6bc2bed220fce79751`

11.4 regression boundary: semisync on 11.4 validated by N=20 consecutive clean passes (a113-a132, 262P/0F/10S per round) — plugin_load_add is a harmless no-op on 11.4+ where semisync is built-in.