### PR TITLE
chore(mariadb): replace hardcoded cluster.local with CLUSTER_DOMAIN

### DIFF
--- a/addons/mariadb/templates/cmpd-replication-merged.yaml
+++ b/addons/mariadb/templates/cmpd-replication-merged.yaml
@@ -310,7 +310,7 @@ spec:
 
             POD_INDEX="${POD_NAME##*-}"
             SERVICE_ID=$((POD_INDEX + 1))
-            PRIMARY_HOST="${CLUSTER_NAME}-${COMPONENT_NAME}.${CLUSTER_NAMESPACE}.svc.cluster.local"
+            PRIMARY_HOST="${CLUSTER_NAME}-${COMPONENT_NAME}.${CLUSTER_NAMESPACE}.svc.${CLUSTER_DOMAIN:-cluster.local}"
             SOCK="/run/mysqld/mysqld.sock"
             MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
             # alpha.64 v1 (Jack 09:35 RED root cause + 10:01 v2 design ack):

--- a/addons/mariadb/templates/cmpd-semisync.yaml
+++ b/addons/mariadb/templates/cmpd-semisync.yaml
@@ -202,7 +202,7 @@ spec:
 
             POD_INDEX="${POD_NAME##*-}"
             SERVICE_ID=$((POD_INDEX + 1))
-            PRIMARY_HOST="${CLUSTER_NAME}-${COMPONENT_NAME}.${CLUSTER_NAMESPACE}.svc.cluster.local"
+            PRIMARY_HOST="${CLUSTER_NAME}-${COMPONENT_NAME}.${CLUSTER_NAMESPACE}.svc.${CLUSTER_DOMAIN:-cluster.local}"
             SOCK="/run/mysqld/mysqld.sock"
             MARIADB_INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
             # alpha.64 v1 (Jack 09:35 RED root cause + 10:01 v2 design ack):


### PR DESCRIPTION
## Summary
- Replace hardcoded `svc.cluster.local` with `svc.${CLUSTER_DOMAIN:-cluster.local}` in merged and semisync CMPDs
- The CLUSTER_DOMAIN env var was already defined but not used for PRIMARY_HOST construction
- Fixes connectivity in Kubernetes clusters using custom cluster domains

## Test plan
- [ ] Create replication cluster in default cluster domain — verify no regression
- [ ] Verify CLUSTER_DOMAIN env var is properly sourced