### PR TITLE
chore(valkey): run sentinel accountProvision on all pods

### DIFF
--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -186,6 +186,7 @@ spec:
       exec:
         container: valkey-sentinel
         command: [sh, -c, /scripts/valkey-sentinel-account-provision.sh]
+        targetPodSelector: All
 
   runtime:
     containers:


### PR DESCRIPTION
## Summary

Sentinel ACL is node-local — each sentinel pod maintains its own `users.acl` independently, unlike data nodes where ACL changes on the primary can be synced to replicas.

Without `targetPodSelector`, KubeBlocks runs `accountProvision` on only one sentinel pod, leaving the other sentinel pods without the new account.

**Fix**: Add `targetPodSelector: All` to the sentinel CMPD `accountProvision` action, so KubeBlocks runs the ACL SETUSER on every sentinel pod.

## Evidence

Runtime test on 3-sentinel cluster (namespace `valkey-b3b4`):
- Manual account provision on sentinel-0: account **found** on sentinel-0, **not found** on sentinel-1 and sentinel-2
- Confirms sentinel ACL is node-local and the script only operates on localhost

## Change

1 file, 1 line: `addons/valkey/templates/cmpd-valkey-sentinel.yaml`

```yaml
accountProvision:
  exec:
    container: valkey-sentinel
    command: [sh, -c, /scripts/valkey-sentinel-account-provision.sh]
    targetPodSelector: All   # <-- added
```

## Addon API reference

`05b-lifecycle-action-fields.md`: `targetPodSelector: All` runs the action on all pods in the component.

Co-authored-by: Alice <alice@apecloud.com>