### PR TITLE
test(qdrant): cover lifecycle backup restore

### DIFF
--- a/addons/qdrant/scripts-ut-spec/qdrant_backup_restore_spec.sh
+++ b/addons/qdrant/scripts-ut-spec/qdrant_backup_restore_spec.sh
@@ -1,0 +1,323 @@
+# shellcheck shell=bash
+
+Describe "Qdrant backup and restore scripts"
+  setup() {
+    export QDRANT_TEST_DIR="${SHELLSPEC_TMPBASE}/qdrant-${SHELLSPEC_WORKER_ID:-0}"
+    mkdir -p "$QDRANT_TEST_DIR"
+    export QDRANT_CURL_LOG="${QDRANT_TEST_DIR}/curl.log"
+    export QDRANT_EXPECT_API_KEY="test-key"
+    export QDRANT__SERVICE__API_KEY="test-key"
+    export QDRANT_COMMON_FILE="../scripts/qdrant-common.sh"
+    export DP_DATASAFED_BIN_PATH="/mock-datasafed"
+    export DP_BACKUP_BASE_PATH="${QDRANT_TEST_DIR}/backup"
+    export DP_BACKUP_INFO_FILE="${QDRANT_TEST_DIR}/backup-info.json"
+    export DP_DB_HOST="qdrant-cluster-qdrant"
+    export DATA_DIR="${QDRANT_TEST_DIR}/data"
+    export QDRANT_CONFIG_FILE="${QDRANT_TEST_DIR}/config.yaml"
+    mkdir -p "${DATA_DIR}/_dp_snapshots"
+    : > "$QDRANT_CURL_LOG"
+    cat > "$QDRANT_CONFIG_FILE" <<EOF
+service:
+  api_key: config-key
+EOF
+  }
+
+  cleanup() {
+    rm -rf "$QDRANT_TEST_DIR"
+    unset QDRANT_EXPECT_API_KEY
+    unset QDRANT__SERVICE__API_KEY
+    unset QDRANT_COMMON_FILE
+    unset TLS_ENABLED
+  }
+
+  BeforeEach "setup"
+  AfterEach "cleanup"
+
+  Mock curl
+    printf "%s\n" "$*" >> "$QDRANT_CURL_LOG"
+    if [ -n "${QDRANT_EXPECT_API_KEY:-}" ]; then
+      case " $* " in
+        *" -H api-key: ${QDRANT_EXPECT_API_KEY} "*|*" -H api-key:${QDRANT_EXPECT_API_KEY} "*) ;;
+        *)
+          echo "missing api key"
+          exit 22
+          ;;
+      esac
+    fi
+
+    case "$*" in
+      *"/collections/"*"/snapshots/upload"*)
+        echo '{"status":"ok"}'
+        ;;
+      *"-XPOST"*"/snapshots"*)
+        echo '{"status":"ok","result":{"name":"collection-a.snapshot"}}'
+        ;;
+      *"/collections/collection-a/snapshots/collection-a.snapshot"*)
+        echo "snapshot-bytes"
+        ;;
+      *"/collections"*)
+        echo '{"result":{"collections":[{"name":"collection-a"}]}}'
+        ;;
+      *)
+        echo '{"status":"ok"}'
+        ;;
+    esac
+  End
+
+  Mock jq
+    query=""
+    for arg in "$@"; do
+      case "$arg" in
+        .*) query="$arg" ;;
+      esac
+    done
+    input=$(cat)
+    case "$query" in
+      ".result.collections[].name"|".result.collections[].name // empty")
+        echo "collection-a"
+        ;;
+      ".status"|".status // empty")
+        echo "ok"
+        ;;
+      ".result.name"|".result.name // empty")
+        echo "collection-a.snapshot"
+        ;;
+      *)
+        echo "$input"
+        ;;
+    esac
+  End
+
+  Mock datasafed
+    case "$1" in
+      stat)
+        echo "TotalSize 1024"
+        ;;
+      push)
+        cat >/dev/null
+        echo "pushed $3"
+        ;;
+      list)
+        echo "collection-a.snapshot"
+        ;;
+      pull)
+        echo "snapshot-bytes" > "$3"
+        ;;
+    esac
+  End
+
+  It "passes the qdrant API key header to every backup API call"
+    When run source ../scripts/qdrant-backup.sh
+    The status should be success
+    The stdout should include "INFO: snapshot collection collection-a successfully."
+    The contents of file "$QDRANT_CURL_LOG" should include "-H api-key: test-key"
+    The contents of file "$DP_BACKUP_INFO_FILE" should include "totalSize"
+  End
+
+  It "passes the qdrant API key header to restore snapshot upload"
+    When run source ../scripts/qdrant-restore.sh
+    The status should be success
+    The stdout should include "restore collection collection-a successfully"
+    The contents of file "$QDRANT_CURL_LOG" should include "-H api-key: test-key"
+    The contents of file "$QDRANT_CURL_LOG" should include "/snapshots/upload?priority=snapshot"
+  End
+
+  It "uses service api key from qdrant config when env is unset"
+    unset QDRANT__SERVICE__API_KEY
+    export QDRANT_EXPECT_API_KEY="config-key"
+
+    When run source ../scripts/qdrant-backup.sh
+    The status should be success
+    The stdout should include "INFO: snapshot collection collection-a successfully."
+    The contents of file "$QDRANT_CURL_LOG" should include "-H api-key: config-key"
+  End
+
+  It "prefers qdrant API key env over config"
+    export QDRANT_EXPECT_API_KEY="test-key"
+
+    When run source ../scripts/qdrant-backup.sh
+    The status should be success
+    The stdout should include "INFO: snapshot collection collection-a successfully."
+    The contents of file "$QDRANT_CURL_LOG" should include "-H api-key: test-key"
+  End
+
+  It "renders qdrant probes from scripts mounted by configmap"
+    When run sh -c "grep -q '/qdrant/scripts/liveness-probe.sh' ../templates/cmpd.yaml && grep -q '/qdrant/scripts/readiness-probe.sh' ../templates/cmpd.yaml && grep -q '/qdrant/scripts/startup-probe.sh' ../templates/cmpd.yaml"
+    The status should be success
+  End
+
+  It "keeps qdrant probe script bodies out of the component pod spec"
+    When run sh -c "sed -n '/containers:/,/dnsPolicy:/p' ../templates/cmpd.yaml | grep -E -c 'qdrant_curl|consensus_status|QDRANT_CURL_BIN|/qdrant/tools/curl' || true"
+    The status should be success
+    The output should eq 0
+  End
+
+  It "packages qdrant probe scripts in the scripts configmap"
+    When run sh -c "grep -q 'liveness-probe.sh' ../templates/script-template.yaml && grep -q 'readiness-probe.sh' ../templates/script-template.yaml && grep -q 'startup-probe.sh' ../templates/script-template.yaml"
+    The status should be success
+  End
+
+  It "exposes service api key as a qdrant config variable"
+    When run grep -c 'service_api_key' ../configs/config.yaml.tpl
+    The status should be success
+    The output should eq 2
+  End
+
+  It "exposes telemetry disabled as a qdrant config variable with telemetry disabled by default"
+    When run sh -c "grep -q 'hasKey . \"telemetry_disabled\"' ../configs/config.yaml.tpl && grep -q 'telemetry_disabled: true' ../configs/config.yaml.tpl"
+    The status should be success
+  End
+
+  It "does not hardcode qdrant telemetry disabled through container env"
+    When run sh -c "grep -E -c 'QDRANT__TELEMETRY_DISABLED' ../templates/cmpd.yaml || true"
+    The status should be success
+    The output should eq 0
+  End
+
+  It "loads qdrant config from the standalone configs file"
+    When run grep -c 'configs/config.yaml.tpl' ../templates/config-template.yaml
+    The status should be success
+    The output should eq 1
+  End
+
+  It "mounts the qdrant config into backup and restore actions"
+    When run grep -c 'mountPath: /qdrant/config' ../templates/backuppolicytemplate.yaml
+    The status should be success
+    The output should eq 1
+  End
+
+  It "declares only qdrant config as backup target volume"
+    When run grep -c -- '- qdrant-config' ../templates/backuppolicytemplate.yaml
+    The status should be success
+    The output should eq 1
+  End
+
+  It "does not mount the qdrant data volume for API-based backup and restore"
+    When run sh -c "grep -E -c '^[[:space:]]*- data$|mountPath: \\{\\{ .Values.dataMountPath \\}\\}' ../templates/backuppolicytemplate.yaml || true"
+    The status should be success
+    The output should eq 0
+  End
+
+  It "uses a local temporary directory for restore snapshots"
+    When run grep -c 'SNAPSHOT_DIR="${TMPDIR:-/tmp}/qdrant-snapshots"' ../scripts/qdrant-restore.sh
+    The status should be success
+    The output should eq 1
+  End
+
+  It "uses backup policy target volume mounts for qdrant config"
+    When run sh -c "grep -q 'targetVolumes:' ../templates/backuppolicytemplate.yaml && grep -q 'volumeMounts:' ../templates/backuppolicytemplate.yaml && grep -q 'mountPath: /qdrant/config' ../templates/backuppolicytemplate.yaml"
+    The status should be success
+  End
+
+  It "keeps target-node scheduling so qdrant target volume mounts are projected"
+    When run grep -c 'runOnTargetPodNode: true' ../templates/actionset-datafile.yaml
+    The status should be success
+    The output should eq 2
+  End
+
+  It "renders qdrant TLS settings in the main config template"
+    When run sh -c "grep -c 'enable_tls: true' ../configs/config.yaml.tpl"
+    The status should be success
+    The output should eq 2
+  End
+
+  It "renders qdrant TLS certificate paths in the main config template"
+    When run sh -c "grep -q 'cert: {{ .TLS_MOUNT_PATH }}/tls.crt' ../configs/config.yaml.tpl && grep -q 'key: {{ .TLS_MOUNT_PATH }}/tls.key' ../configs/config.yaml.tpl && grep -q 'ca_cert: {{ .TLS_MOUNT_PATH }}/ca.crt' ../configs/config.yaml.tpl"
+    The status should be success
+  End
+
+  It "does not generate a separate qdrant TLS config at startup"
+    When run sh -c "grep -E -c '/tmp/tls.yaml|TLS_CONFIG_ARG' ../scripts/qdrant-setup.sh || true"
+    The status should be success
+    The output should eq 0
+  End
+
+  It "keeps the qdrant e2e configurable for TLS and API-key modes"
+    When run sh -c "grep -q 'QDRANT_TLS_ENABLED' ../../../examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh && grep -q 'API_KEY_ENABLED' ../../../examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh && grep -q 'RUN_LIFECYCLE_CHECK' ../../../examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh"
+    The status should be success
+  End
+
+  It "covers qdrant TLS/API-key on and off combinations in e2e"
+    When run sh -c "grep -q 'tls-off-api-key-off' ../../../examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh && grep -q 'tls-off-api-key-on' ../../../examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh && grep -q 'tls-on-api-key-off' ../../../examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh && grep -q 'tls-on-api-key-on' ../../../examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh"
+    The status should be success
+  End
+
+  It "removes leaving qdrant peers through the current live peer without bypassing qdrant shard safety"
+    When run sh -c "grep -q 'current_peer_uri=' ../scripts/qdrant-member-leave.sh && grep -q '/cluster/peer/' ../scripts/qdrant-member-leave.sh && ! grep -q 'force=true' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
+  It "serializes concurrent qdrant member leave actions"
+    When run grep -c 'flock -n -x 9' ../scripts/qdrant-member-leave.sh
+    The status should be success
+    The output should eq 1
+  End
+
+  It "does not skip different qdrant members during concurrent member leave actions"
+    When run sh -c "grep -q 'qdrant-leave-member-.*KB_LEAVE_MEMBER_POD_NAME' ../scripts/qdrant-member-leave.sh && ! grep -q 'qdrant-leave-member-lock' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
+  It "does not report duplicate qdrant member leave success while the peer still exists"
+    When run sh -c "grep -q 'is_leaving_peer_removed' ../scripts/qdrant-member-leave.sh && grep -q 'retry member leave later' ../scripts/qdrant-member-leave.sh && grep -q 'exit 1' ../scripts/qdrant-member-leave.sh && ! grep -q 'skip duplicate request' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
+  It "does not block qdrant member leave on shard movement"
+    When run sh -c "grep -E -c 'while true|sleep [0-9]|move_shards|local_shards' ../scripts/qdrant-member-leave.sh || true"
+    The status should be success
+    The output should eq 0
+  End
+
+  It "makes qdrant member leave retry-safe when the leaving pod is already gone"
+    When run sh -c "grep -q 'leave_peer_id=.*current_cluster_info' ../scripts/qdrant-member-leave.sh && ! grep -q 'qdrant_curl -s \\${leave_peer_uri}/cluster' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
+  It "injects the current pod name into qdrant member leave actions"
+    When run sh -c "sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'name: CURRENT_POD_NAME' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'fieldPath: metadata.name'"
+    The status should be success
+  End
+
+  It "falls back to HOSTNAME when qdrant member leave action env omits the current pod name"
+    When run grep -c 'CURRENT_POD_NAME="${CURRENT_POD_NAME:-${HOSTNAME:-}}"' ../scripts/qdrant-member-leave.sh
+    The status should be success
+    The output should eq 1
+  End
+
+  It "bounds and retries the qdrant member leave lifecycle action"
+    When run sh -c "sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'timeoutSeconds: 30' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'maxRetries: 3' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'retryInterval: 5'"
+    The status should be success
+  End
+
+  It "validates qdrant peer count during lifecycle e2e"
+    When run grep -c 'wait_for_qdrant_peer_count' ../../../examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh
+    The status should be success
+    The output should eq 3
+  End
+
+  It "covers qdrant member leave shard-safety in live e2e"
+    When run sh -c "test -f ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'wait_for_leaving_peer_with_shards' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'assert_scale_in_not_succeed' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q -- '--wait=false' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh"
+    The status should be success
+  End
+
+  It "supports the latest qdrant patch release for every minor after 1.10"
+    When run sh -c "grep -q '\"1.11.5\"' ../values.yaml && grep -q '\"1.12.6\"' ../values.yaml && grep -q '\"1.13.6\"' ../values.yaml && grep -q '\"1.14.1\"' ../values.yaml && grep -q '\"1.15.5\"' ../values.yaml && grep -q '\"1.16.3\"' ../values.yaml && grep -q '\"1.17.1\"' ../values.yaml && grep -q '\"1.18.2\"' ../values.yaml"
+    The status should be success
+  End
+
+  It "does not keep superseded qdrant patch releases after 1.10"
+    When run sh -c "! grep -q '\"1.13.4\"' ../values.yaml && ! grep -q '\"1.15.4\"' ../values.yaml"
+    The status should be success
+  End
+
+  It "provides qdrant TLS and API-key cluster examples"
+    When run sh -c "test -f ../../../examples/qdrant/cluster-with-api-key.yaml && test -f ../../../examples/qdrant/cluster-with-tls.yaml && test -f ../../../examples/qdrant/cluster-with-tls-and-api-key.yaml"
+    The status should be success
+  End
+
+  It "documents qdrant TLS and API-key examples"
+    When run sh -c "grep -q 'cluster-with-api-key.yaml' ../../../examples/qdrant/README.md && grep -q 'cluster-with-tls.yaml' ../../../examples/qdrant/README.md && grep -q 'cluster-with-tls-and-api-key.yaml' ../../../examples/qdrant/README.md"
+    The status should be success
+  End
+End

--- a/addons/qdrant/scripts-ut-spec/qdrant_backup_restore_spec.sh
+++ b/addons/qdrant/scripts-ut-spec/qdrant_backup_restore_spec.sh
@@ -247,6 +247,17 @@ EOF
     The status should be success
   End
 
+  It "uses the packaged curl binary for qdrant member leave actions"
+    When run grep -c 'QDRANT_CURL_BIN="${QDRANT_CURL_BIN:-/qdrant/tools/curl}"' ../scripts/qdrant-member-leave.sh
+    The status should be success
+    The output should eq 1
+  End
+
+  It "uses a non-leaving qdrant peer as the member leave API endpoint"
+    When run sh -c "grep -q 'select_qdrant_api_peer_fqdn' ../scripts/qdrant-member-leave.sh && grep -q 'KB_LEAVE_MEMBER_POD_NAME' ../scripts/qdrant-member-leave.sh && grep -q 'current_peer_uri=.*api_peer_fqdn' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
   It "serializes concurrent qdrant member leave actions"
     When run grep -c 'flock -n -x 9' ../scripts/qdrant-member-leave.sh
     The status should be success
@@ -263,10 +274,24 @@ EOF
     The status should be success
   End
 
-  It "does not block qdrant member leave on shard movement"
-    When run sh -c "grep -E -c 'while true|sleep [0-9]|move_shards|local_shards' ../scripts/qdrant-member-leave.sh || true"
+  It "drains qdrant shards before removing the leaving peer"
+    When run sh -c "grep -q 'drain_peer_shards' ../scripts/qdrant-member-leave.sh && grep -q 'move_shard' ../scripts/qdrant-member-leave.sh && grep -q 'drop_replica' ../scripts/qdrant-member-leave.sh && grep -q 'wait_for_peer_drain' ../scripts/qdrant-member-leave.sh && sed -n '/remove_peer()/,/^}/p' ../scripts/qdrant-member-leave.sh | awk '/drain_peer_shards/{drain=NR} /-XDELETE/{remove=NR} END{exit !(drain && remove && drain < remove)}'"
     The status should be success
-    The output should eq 0
+  End
+
+  It "moves qdrant shards only to desired peers when pod variables are available"
+    When run sh -c "grep -q 'desired_peer' ../scripts/qdrant-member-leave.sh && grep -q 'map(select(desired_peer(.value.uri)))' ../scripts/qdrant-member-leave.sh && grep -Fq '. as \$pod | \$uri | contains(\"://\" + \$pod + \".\")' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
+  It "prefers lower-ordinal qdrant peers as shard drain targets"
+    When run sh -c "grep -q 'def pod_ordinal' ../scripts/qdrant-member-leave.sh && grep -q 'ordinal: pod_ordinal(.value.uri)' ../scripts/qdrant-member-leave.sh && grep -q 'sort_by(if .preferred then 0 else 1 end, .ordinal' ../scripts/qdrant-member-leave.sh"
+    The status should be success
+  End
+
+  It "counts local qdrant shards on the leaving peer before remove"
+    When run sh -c "grep -Fq '(if ((' ../scripts/qdrant-member-leave.sh && grep -Fq 'else empty end),' ../scripts/qdrant-member-leave.sh && grep -Fq 'remote_shards[]?' ../scripts/qdrant-member-leave.sh"
+    The status should be success
   End
 
   It "makes qdrant member leave retry-safe when the leaving pod is already gone"
@@ -285,8 +310,8 @@ EOF
     The output should eq 1
   End
 
-  It "bounds and retries the qdrant member leave lifecycle action"
-    When run sh -c "sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'timeoutSeconds: 30' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'maxRetries: 3' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'retryInterval: 5'"
+  It "bounds and retries qdrant member leave long enough for shard migration"
+    When run sh -c "sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'timeoutSeconds: 60' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'maxRetries: 120' && sed -n '/memberLeave:/,/logConfigs:/p' ../templates/cmpd.yaml | grep -q 'retryInterval: 5'"
     The status should be success
   End
 
@@ -296,8 +321,8 @@ EOF
     The output should eq 3
   End
 
-  It "covers qdrant member leave shard-safety in live e2e"
-    When run sh -c "test -f ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'wait_for_leaving_peer_with_shards' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'assert_scale_in_not_succeed' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q -- '--wait=false' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh"
+  It "covers qdrant member leave shard-drain success and data consistency in live e2e"
+    When run sh -c "test -f ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'wait_for_leaving_peer_with_shards' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'wait_for_scale_in_succeed' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q 'assert_points_consistent' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && ! grep -q 'assert_scale_in_not_succeed' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh && grep -q -- '--wait=false' ../../../examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh"
     The status should be success
   End
 

--- a/examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh
+++ b/examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-demo}"
+CLUSTER_NAME="${CLUSTER_NAME:-qdrant-api-key-e2e}"
+RESTORE_CLUSTER_NAME="${RESTORE_CLUSTER_NAME:-qdrant-api-key-e2e-restore}"
+BACKUP_NAME="${BACKUP_NAME:-${CLUSTER_NAME}-backup}"
+API_KEY="${QDRANT_API_KEY:-qdrant-e2e-key}"
+API_KEY_ENABLED="${API_KEY_ENABLED:-true}"
+QDRANT_TLS_ENABLED="${QDRANT_TLS_ENABLED:-false}"
+RUN_LIFECYCLE_CHECK="${RUN_LIFECYCLE_CHECK:-true}"
+CHECK_QDRANT_PEER_COUNT="${CHECK_QDRANT_PEER_COUNT:-false}"
+SERVICE_VERSION="${SERVICE_VERSION:-1.10.0}"
+STORAGE_CLASS_NAME="${STORAGE_CLASS_NAME:-}"
+STORAGE_SIZE="${STORAGE_SIZE:-20Gi}"
+BACKUP_TARGET_SETTLE_SECONDS="${BACKUP_TARGET_SETTLE_SECONDS:-20}"
+LIFECYCLE_TIMEOUT_SECONDS="${LIFECYCLE_TIMEOUT_SECONDS:-300}"
+QDRANT_COLLECTION="${QDRANT_COLLECTION:-api-key-backup-e2e}"
+QDRANT_POINT_ID="${QDRANT_POINT_ID:-1}"
+QDRANT_POINT_SOURCE="${QDRANT_POINT_SOURCE:-api-key-backup-e2e}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-900}"
+SKIP_CLEANUP="${SKIP_CLEANUP:-false}"
+
+TMP_DIR="$(mktemp -d)"
+QDRANT_SCHEME="http"
+if [ "$QDRANT_TLS_ENABLED" = "true" ]; then
+  QDRANT_SCHEME="https"
+fi
+
+cleanup() {
+  if [ "$SKIP_CLEANUP" = "true" ]; then
+    echo "INFO: SKIP_CLEANUP=true, leaving resources in namespace ${NAMESPACE}"
+    echo "INFO: temporary manifests are in ${TMP_DIR}"
+    return
+  fi
+  kubectl -n "$NAMESPACE" delete opsrequest "${CLUSTER_NAME}-scale-out-3" --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl -n "$NAMESPACE" delete opsrequest "${CLUSTER_NAME}-scale-in-1" --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl -n "$NAMESPACE" delete cluster "$RESTORE_CLUSTER_NAME" --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl -n "$NAMESPACE" delete backup "$BACKUP_NAME" --ignore-not-found=true >/dev/null 2>&1 || true
+  kubectl -n "$NAMESPACE" delete cluster "$CLUSTER_NAME" --ignore-not-found=true >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+
+  case "$value" in
+    true|false) ;;
+    *)
+      echo "ERROR: ${name} must be true or false, got: ${value}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+now_seconds() {
+  date +%s
+}
+
+deadline_after() {
+  echo $(( $(now_seconds) + "$1" ))
+}
+
+wait_for_jsonpath() {
+  local resource="$1"
+  local jsonpath="$2"
+  local expected="$3"
+  local deadline
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    value="$(kubectl -n "$NAMESPACE" get "$resource" -o "jsonpath=${jsonpath}" 2>/dev/null || true)"
+    if [ "$value" = "$expected" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for ${resource} ${jsonpath}=${expected}" >&2
+  kubectl -n "$NAMESPACE" get "$resource" -oyaml >&2 || true
+  return 1
+}
+
+wait_for_cluster_generation_running() {
+  local cluster="$1"
+  local generation="$2"
+  local deadline
+  local observed_generation
+  local phase
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    observed_generation="$(kubectl -n "$NAMESPACE" get "cluster/${cluster}" -o "jsonpath={.status.observedGeneration}" 2>/dev/null || true)"
+    phase="$(kubectl -n "$NAMESPACE" get "cluster/${cluster}" -o "jsonpath={.status.phase}" 2>/dev/null || true)"
+    if [ "$observed_generation" = "$generation" ] && [ "$phase" = "Running" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for cluster/${cluster} generation ${generation} to become Running" >&2
+  kubectl -n "$NAMESPACE" get "cluster/${cluster}" -oyaml >&2 || true
+  return 1
+}
+
+wait_for_opsrequest_succeed() {
+  local ops_name="$1"
+  local deadline
+  local phase
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    phase="$(kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -o "jsonpath={.status.phase}" 2>/dev/null || true)"
+    if [ "$phase" = "Succeed" ]; then
+      return 0
+    fi
+    if [ "$phase" = "Failed" ] || [ "$phase" = "Cancelled" ]; then
+      echo "ERROR: opsrequest/${ops_name} ended with phase ${phase}" >&2
+      kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -oyaml >&2 || true
+      return 1
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for opsrequest/${ops_name} to Succeed" >&2
+  kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -oyaml >&2 || true
+  return 1
+}
+
+scale_cluster_replicas() {
+  local cluster="$1"
+  local replicas="$2"
+  local direction="$3"
+  local changes="$4"
+  local ops_suffix
+  local ops_name
+  local generation
+
+  case "$direction" in
+    scaleOut) ops_suffix="scale-out" ;;
+    scaleIn) ops_suffix="scale-in" ;;
+    *)
+      echo "ERROR: unsupported scale direction: ${direction}" >&2
+      return 1
+      ;;
+  esac
+  ops_name="${cluster}-${ops_suffix}-${replicas}"
+
+  cat > "${TMP_DIR}/${ops_name}.yaml" <<EOF
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ${ops_name}
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${cluster}
+  type: HorizontalScaling
+  horizontalScaling:
+    - componentName: qdrant
+      ${direction}:
+        replicaChanges: ${changes}
+EOF
+
+  kubectl apply -f "${TMP_DIR}/${ops_name}.yaml"
+  wait_for_opsrequest_succeed "$ops_name"
+  generation="$(kubectl -n "$NAMESPACE" get "cluster/${cluster}" -o "jsonpath={.metadata.generation}")"
+  wait_for_cluster_generation_running "$cluster" "$generation"
+}
+
+wait_for_qdrant_ready_pod_count() {
+  local cluster="$1"
+  local expected_count="$2"
+  local deadline
+  local ready_count
+  local pod_names
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    ready_count="$(kubectl -n "$NAMESPACE" get pod \
+      -l "app.kubernetes.io/instance=${cluster},apps.kubeblocks.io/component-name=qdrant" \
+      -o json | jq -r '
+        [
+          .items[]
+          | select(.metadata.deletionTimestamp == null)
+          | select(any(.status.conditions[]?; .type == "Ready" and .status == "True"))
+        ]
+        | length
+      ')"
+    if [ "$ready_count" = "$expected_count" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  pod_names="$(kubectl -n "$NAMESPACE" get pod \
+    -l "app.kubernetes.io/instance=${cluster},apps.kubeblocks.io/component-name=qdrant" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.metadata.deletionTimestamp}{"\n"}{end}' 2>/dev/null || true)"
+  echo "ERROR: timed out waiting for ${expected_count} ready qdrant pod(s) in cluster ${cluster}" >&2
+  echo "$pod_names" >&2
+  return 1
+}
+
+wait_for_qdrant_peer_count() {
+  local cluster="$1"
+  local expected_count="$2"
+  local deadline
+  local response
+  local peer_count
+
+  deadline="$(deadline_after "$LIFECYCLE_TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    response="$(qdrant_curl "$cluster" "${QDRANT_SCHEME}://localhost:6333/cluster" 2>/dev/null || true)"
+    peer_count="$(echo "$response" | jq -r '.result.peers | length' 2>/dev/null || true)"
+    if [ "$peer_count" = "$expected_count" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for ${expected_count} qdrant peer(s) in cluster ${cluster}" >&2
+  qdrant_curl "$cluster" "${QDRANT_SCHEME}://localhost:6333/cluster" >&2 || true
+  return 1
+}
+
+qdrant_pod() {
+  kubectl -n "$NAMESPACE" get pod \
+    -l "app.kubernetes.io/instance=$1,apps.kubeblocks.io/component-name=qdrant" \
+    -o jsonpath='{.items[0].metadata.name}'
+}
+
+qdrant_curl() {
+  local cluster="$1"
+  shift
+  local pod
+  local curl_args=(-sS -f)
+
+  if [ "$QDRANT_TLS_ENABLED" = "true" ]; then
+    curl_args+=(-k)
+  fi
+  if [ "$API_KEY_ENABLED" = "true" ]; then
+    curl_args+=(-H "api-key: ${API_KEY}")
+  fi
+
+  pod="$(qdrant_pod "$cluster")"
+  kubectl -n "$NAMESPACE" exec "$pod" -- /qdrant/tools/curl "${curl_args[@]}" "$@"
+}
+
+wait_for_qdrant_collection() {
+  local cluster="$1"
+  local deadline
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    if qdrant_curl "$cluster" "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for qdrant collection ${QDRANT_COLLECTION} in cluster ${cluster}" >&2
+  return 1
+}
+
+retrieve_qdrant_point() {
+  local cluster="$1"
+
+  qdrant_curl "$cluster" -X POST "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}/points" \
+    -H "Content-Type: application/json" \
+    -d "{\"ids\":[${QDRANT_POINT_ID}],\"with_payload\":true,\"with_vector\":true}"
+}
+
+run_lifecycle_check() {
+  echo "INFO: scaling ${CLUSTER_NAME} from 1 to 3 replicas"
+  scale_cluster_replicas "$CLUSTER_NAME" 3 scaleOut 2
+  wait_for_qdrant_ready_pod_count "$CLUSTER_NAME" 3
+  if [ "$CHECK_QDRANT_PEER_COUNT" = "true" ]; then
+    wait_for_qdrant_peer_count "$CLUSTER_NAME" 3
+  fi
+  source_point_response="$(retrieve_qdrant_point "$CLUSTER_NAME")"
+  assert_qdrant_point_shape "$source_point_response"
+
+  echo "INFO: scaling ${CLUSTER_NAME} from 3 to 1 replicas"
+  scale_cluster_replicas "$CLUSTER_NAME" 1 scaleIn 2
+  wait_for_qdrant_ready_pod_count "$CLUSTER_NAME" 1
+  if [ "$CHECK_QDRANT_PEER_COUNT" = "true" ]; then
+    wait_for_qdrant_peer_count "$CLUSTER_NAME" 1
+  fi
+  source_point_response="$(retrieve_qdrant_point "$CLUSTER_NAME")"
+  assert_qdrant_point_shape "$source_point_response"
+}
+
+assert_qdrant_point_shape() {
+  local response="$1"
+
+  if ! echo "$response" | jq -e \
+    --arg source "$QDRANT_POINT_SOURCE" \
+    --argjson point_id "$QDRANT_POINT_ID" \
+    '
+      def absdiff(a; b): ((a - b) | if . < 0 then -. else . end);
+      .status == "ok"
+      and (.result | length) == 1
+      and .result[0].id == $point_id
+      and .result[0].payload.source == $source
+      and (.result[0].vector | length) == 4
+      and (.result[0].vector[] | type == "number")
+    ' >/dev/null; then
+    echo "ERROR: qdrant point does not match expected shape" >&2
+    echo "$response" >&2
+    return 1
+  fi
+}
+
+assert_qdrant_points_equal() {
+  local source_response="$1"
+  local restored_response="$2"
+
+  if ! jq -n -e \
+    --argjson source "$source_response" \
+    --argjson restored "$restored_response" \
+    '
+      def absdiff(a; b): ((a - b) | if . < 0 then -. else . end);
+      ($source.result[0]) as $s
+      | ($restored.result[0]) as $r
+      | $s.id == $r.id
+      and $s.payload == $r.payload
+      and ($s.vector | length) == ($r.vector | length)
+      and all(range(0; ($s.vector | length)); absdiff($s.vector[.]; $r.vector[.]) < 0.00001)
+    ' >/dev/null; then
+    echo "ERROR: restored qdrant point differs from source point" >&2
+    echo "source:   ${source_response}" >&2
+    echo "restored: ${restored_response}" >&2
+    return 1
+  fi
+}
+
+write_cluster_manifest() {
+  local name="$1"
+  local file="$2"
+  local restore_annotation="${3:-}"
+
+  {
+    echo "apiVersion: apps.kubeblocks.io/v1"
+    echo "kind: Cluster"
+    echo "metadata:"
+    echo "  name: ${name}"
+    echo "  namespace: ${NAMESPACE}"
+    if [ -n "$restore_annotation" ]; then
+      echo "  annotations:"
+      echo "    kubeblocks.io/restore-from-backup: '${restore_annotation}'"
+    fi
+    echo "spec:"
+    echo "  terminationPolicy: Delete"
+    echo "  clusterDef: qdrant"
+    echo "  topology: cluster"
+    echo "  componentSpecs:"
+    echo "    - name: qdrant"
+    echo "      serviceVersion: ${SERVICE_VERSION}"
+    echo "      replicas: 1"
+    if [ "$QDRANT_TLS_ENABLED" = "true" ]; then
+      echo "      tls: true"
+      echo "      issuer:"
+      echo "        name: KubeBlocks"
+    fi
+    if [ "$API_KEY_ENABLED" = "true" ]; then
+      echo "      configs:"
+      echo "        - name: qdrant-config-template"
+      echo "          variables:"
+      echo "            service_api_key: ${API_KEY}"
+    fi
+    echo "      resources:"
+    echo "        limits:"
+    echo "          cpu: \"0.5\""
+    echo "          memory: \"0.5Gi\""
+    echo "        requests:"
+    echo "          cpu: \"0.5\""
+    echo "          memory: \"0.5Gi\""
+    echo "      volumeClaimTemplates:"
+    echo "        - name: data"
+    echo "          spec:"
+    if [ -n "$STORAGE_CLASS_NAME" ]; then
+      echo "            storageClassName: ${STORAGE_CLASS_NAME}"
+    else
+      echo "            storageClassName: \"\""
+    fi
+    echo "            accessModes:"
+    echo "              - ReadWriteOnce"
+    echo "            resources:"
+    echo "              requests:"
+    echo "                storage: ${STORAGE_SIZE}"
+  } > "$file"
+}
+
+require_cmd kubectl
+require_cmd jq
+require_bool API_KEY_ENABLED "$API_KEY_ENABLED"
+require_bool QDRANT_TLS_ENABLED "$QDRANT_TLS_ENABLED"
+require_bool RUN_LIFECYCLE_CHECK "$RUN_LIFECYCLE_CHECK"
+require_bool CHECK_QDRANT_PEER_COUNT "$CHECK_QDRANT_PEER_COUNT"
+kubectl create namespace "$NAMESPACE" --dry-run=client -oyaml | kubectl apply -f -
+
+cluster_manifest="${TMP_DIR}/cluster.yaml"
+write_cluster_manifest "$CLUSTER_NAME" "$cluster_manifest"
+kubectl apply -f "$cluster_manifest"
+wait_for_jsonpath "cluster/${CLUSTER_NAME}" "{.status.phase}" "Running"
+
+echo "INFO: creating qdrant collection ${QDRANT_COLLECTION}"
+qdrant_curl "$CLUSTER_NAME" -X PUT "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}" \
+  -H "Content-Type: application/json" \
+  -d '{"vectors":{"size":4,"distance":"Cosine"},"wal_config":{"wal_capacity_mb":1,"wal_segments_ahead":0}}' >/dev/null
+
+qdrant_curl "$CLUSTER_NAME" -X PUT "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}/points?wait=true" \
+  -H "Content-Type: application/json" \
+  -d "{\"points\":[{\"id\":${QDRANT_POINT_ID},\"vector\":[0.1,0.2,0.3,0.4],\"payload\":{\"source\":\"${QDRANT_POINT_SOURCE}\"}}]}" >/dev/null
+
+echo "INFO: verifying source qdrant data before backup"
+source_point_response="$(retrieve_qdrant_point "$CLUSTER_NAME")"
+assert_qdrant_point_shape "$source_point_response"
+if [ "$RUN_LIFECYCLE_CHECK" = "true" ]; then
+  run_lifecycle_check
+fi
+wait_for_qdrant_ready_pod_count "$CLUSTER_NAME" 1
+if [ "$BACKUP_TARGET_SETTLE_SECONDS" -gt 0 ]; then
+  echo "INFO: waiting ${BACKUP_TARGET_SETTLE_SECONDS}s for qdrant backup target to settle after lifecycle changes"
+  sleep "$BACKUP_TARGET_SETTLE_SECONDS"
+fi
+
+cat > "${TMP_DIR}/backup.yaml" <<EOF
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  name: ${BACKUP_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  backupMethod: datafile
+  backupPolicyName: ${CLUSTER_NAME}-qdrant-backup-policy
+  deletionPolicy: Delete
+EOF
+
+kubectl apply -f "${TMP_DIR}/backup.yaml"
+wait_for_jsonpath "backup/${BACKUP_NAME}" "{.status.phase}" "Completed"
+
+restore_manifest="${TMP_DIR}/restore-cluster.yaml"
+restore_from_backup="{\"qdrant\":{\"name\":\"${BACKUP_NAME}\",\"namespace\":\"${NAMESPACE}\",\"volumeRestorePolicy\":\"Parallel\"}}"
+write_cluster_manifest "$RESTORE_CLUSTER_NAME" "$restore_manifest" "$restore_from_backup"
+kubectl apply -f "$restore_manifest"
+wait_for_jsonpath "cluster/${RESTORE_CLUSTER_NAME}" "{.status.phase}" "Running"
+
+echo "INFO: verifying restored collection ${QDRANT_COLLECTION}"
+wait_for_qdrant_collection "$RESTORE_CLUSTER_NAME"
+echo "INFO: verifying restored qdrant point data"
+restored_point_response="$(retrieve_qdrant_point "$RESTORE_CLUSTER_NAME")"
+assert_qdrant_point_shape "$restored_point_response"
+assert_qdrant_points_equal "$source_point_response" "$restored_point_response"
+
+echo "INFO: qdrant backup/restore e2e passed with TLS=${QDRANT_TLS_ENABLED}, API key=${API_KEY_ENABLED}"

--- a/examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh
+++ b/examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh
@@ -3,16 +3,17 @@
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-demo}"
-CLUSTER_NAME="${CLUSTER_NAME:-qdrant-memberleave-shard-safety}"
-API_KEY="${QDRANT_API_KEY:-qdrant-shard-safety-key}"
+CLUSTER_NAME="${CLUSTER_NAME:-qdrant-memberleave-shard-drain}"
+API_KEY="${QDRANT_API_KEY:-qdrant-shard-drain-key}"
 API_KEY_ENABLED="${API_KEY_ENABLED:-true}"
 QDRANT_TLS_ENABLED="${QDRANT_TLS_ENABLED:-false}"
 SERVICE_VERSION="${SERVICE_VERSION:-1.18.2}"
 STORAGE_CLASS_NAME="${STORAGE_CLASS_NAME:-}"
 STORAGE_SIZE="${STORAGE_SIZE:-20Gi}"
-QDRANT_COLLECTION="${QDRANT_COLLECTION:-memberleave-shard-safety}"
+QDRANT_COLLECTION="${QDRANT_COLLECTION:-memberleave-shard-drain}"
+QDRANT_POINT_SOURCE="${QDRANT_POINT_SOURCE:-memberleave-shard-drain}"
+QDRANT_POINT_COUNT="${QDRANT_POINT_COUNT:-18}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-900}"
-SCALE_IN_SAFETY_SECONDS="${SCALE_IN_SAFETY_SECONDS:-120}"
 SKIP_CLEANUP="${SKIP_CLEANUP:-false}"
 
 TMP_DIR="$(mktemp -d)"
@@ -211,6 +212,83 @@ wait_for_leaving_peer_with_shards() {
   return 1
 }
 
+seed_points() {
+  local payload
+
+  payload="$(jq -n \
+    --arg source "$QDRANT_POINT_SOURCE" \
+    --argjson count "$QDRANT_POINT_COUNT" '
+      {
+        points: [
+          range(1; $count + 1) as $id
+          | {
+              id: $id,
+              vector: [($id / 100), 0.2, 0.3, 0.4],
+              payload: {
+                source: $source,
+                seq: $id
+              }
+            }
+        ]
+      }
+    ')"
+
+  qdrant_curl -X PUT "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}/points?wait=true" \
+    -H "Content-Type: application/json" \
+    -d "$payload" >/dev/null
+}
+
+point_count() {
+  qdrant_curl -X POST "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}/points/count" \
+    -H "Content-Type: application/json" \
+    -d '{"exact":true}' \
+    | jq -r '.result.count'
+}
+
+points_digest() {
+  local limit
+
+  limit=$((QDRANT_POINT_COUNT + 5))
+  qdrant_curl -X POST "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}/points/scroll" \
+    -H "Content-Type: application/json" \
+    -d "{\"limit\":${limit},\"with_payload\":true,\"with_vector\":true}" \
+    | jq -c --arg source "$QDRANT_POINT_SOURCE" '
+        [
+          .result.points[]
+          | select(.payload.source == $source)
+          | {
+              id,
+              payload: {
+                source: .payload.source,
+                seq: .payload.seq
+              },
+              vector
+            }
+        ]
+        | sort_by(.id)
+      '
+}
+
+wait_for_point_count() {
+  local expected_count="$1"
+  local deadline
+  local actual_count
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    actual_count="$(point_count 2>/dev/null || true)"
+    if [ "$actual_count" = "$expected_count" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for ${expected_count} qdrant point(s)" >&2
+  point_count >&2 || true
+  return 1
+}
+
 create_scale_in_opsrequest() {
   local ops_name="${CLUSTER_NAME}-scale-in-1"
 
@@ -232,33 +310,53 @@ EOF
   kubectl apply -f "${TMP_DIR}/${ops_name}.yaml"
 }
 
-assert_scale_in_not_succeed() {
+wait_for_scale_in_succeed() {
   local ops_name="${CLUSTER_NAME}-scale-in-1"
   local deadline
   local phase
 
-  deadline="$(deadline_after "$SCALE_IN_SAFETY_SECONDS")"
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
 
   while [ "$(now_seconds)" -lt "$deadline" ]; do
     phase="$(kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -o "jsonpath={.status.phase}" 2>/dev/null || true)"
     case "$phase" in
       Succeed)
-        echo "ERROR: opsrequest/${ops_name} succeeded even though a leaving peer owns shards" >&2
+        return 0
+        ;;
+      Failed|Cancelled|Aborted)
+        echo "ERROR: opsrequest/${ops_name} ended with phase ${phase}" >&2
         kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -oyaml >&2 || true
         collection_cluster_info >&2 || true
         return 1
-        ;;
-      Failed|Cancelled)
-        echo "INFO: opsrequest/${ops_name} ended with phase ${phase}; shard safety was preserved"
-        return 0
         ;;
     esac
     sleep 5
   done
 
-  echo "INFO: opsrequest/${ops_name} did not succeed within ${SCALE_IN_SAFETY_SECONDS}s; shard safety was preserved"
+  echo "ERROR: timed out waiting for opsrequest/${ops_name} to succeed" >&2
   kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -oyaml >&2 || true
-  return 0
+  collection_cluster_info >&2 || true
+  return 1
+}
+
+assert_points_consistent() {
+  local expected_digest="$1"
+  local actual_count
+  local actual_digest
+
+  wait_for_point_count "$QDRANT_POINT_COUNT"
+  actual_count="$(point_count)"
+  actual_digest="$(points_digest)"
+  if [ "$actual_count" != "$QDRANT_POINT_COUNT" ]; then
+    echo "ERROR: expected ${QDRANT_POINT_COUNT} qdrant point(s), got ${actual_count}" >&2
+    return 1
+  fi
+  if [ "$actual_digest" != "$expected_digest" ]; then
+    echo "ERROR: qdrant point digest changed after scale-in" >&2
+    echo "expected: ${expected_digest}" >&2
+    echo "actual:   ${actual_digest}" >&2
+    return 1
+  fi
 }
 
 write_cluster_manifest() {
@@ -331,10 +429,18 @@ qdrant_curl -X PUT "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLE
   -H "Content-Type: application/json" \
   -d '{"vectors":{"size":4,"distance":"Cosine"},"shard_number":6,"replication_factor":1,"write_consistency_factor":1}' >/dev/null
 
+echo "INFO: writing ${QDRANT_POINT_COUNT} qdrant point(s)"
+seed_points
+wait_for_point_count "$QDRANT_POINT_COUNT"
+expected_digest="$(points_digest)"
+
 wait_for_leaving_peer_with_shards
 
-echo "INFO: verifying qdrant scale-in does not succeed while leaving peers own shards"
+echo "INFO: verifying qdrant memberLeave drains shards before removing peers"
 create_scale_in_opsrequest
-assert_scale_in_not_succeed
+wait_for_scale_in_succeed
+wait_for_qdrant_ready_pod_count 1
+wait_for_qdrant_peer_count 1
+assert_points_consistent "$expected_digest"
 
-echo "INFO: qdrant memberLeave shard-safety e2e passed"
+echo "INFO: qdrant memberLeave shard-drain e2e passed"

--- a/examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh
+++ b/examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-demo}"
+CLUSTER_NAME="${CLUSTER_NAME:-qdrant-memberleave-shard-safety}"
+API_KEY="${QDRANT_API_KEY:-qdrant-shard-safety-key}"
+API_KEY_ENABLED="${API_KEY_ENABLED:-true}"
+QDRANT_TLS_ENABLED="${QDRANT_TLS_ENABLED:-false}"
+SERVICE_VERSION="${SERVICE_VERSION:-1.18.2}"
+STORAGE_CLASS_NAME="${STORAGE_CLASS_NAME:-}"
+STORAGE_SIZE="${STORAGE_SIZE:-20Gi}"
+QDRANT_COLLECTION="${QDRANT_COLLECTION:-memberleave-shard-safety}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-900}"
+SCALE_IN_SAFETY_SECONDS="${SCALE_IN_SAFETY_SECONDS:-120}"
+SKIP_CLEANUP="${SKIP_CLEANUP:-false}"
+
+TMP_DIR="$(mktemp -d)"
+QDRANT_SCHEME="http"
+if [ "$QDRANT_TLS_ENABLED" = "true" ]; then
+  QDRANT_SCHEME="https"
+fi
+
+cleanup() {
+  if [ "$SKIP_CLEANUP" = "true" ]; then
+    echo "INFO: SKIP_CLEANUP=true, leaving resources in namespace ${NAMESPACE}"
+    echo "INFO: temporary manifests are in ${TMP_DIR}"
+    return
+  fi
+  kubectl -n "$NAMESPACE" delete opsrequest "${CLUSTER_NAME}-scale-in-1" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$NAMESPACE" delete cluster "$CLUSTER_NAME" --ignore-not-found=true --timeout=300s >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_bool() {
+  local name="$1"
+  local value="$2"
+
+  case "$value" in
+    true|false) ;;
+    *)
+      echo "ERROR: ${name} must be true or false, got: ${value}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+now_seconds() {
+  date +%s
+}
+
+deadline_after() {
+  echo $(( $(now_seconds) + "$1" ))
+}
+
+wait_for_jsonpath() {
+  local resource="$1"
+  local jsonpath="$2"
+  local expected="$3"
+  local deadline
+  local value
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    value="$(kubectl -n "$NAMESPACE" get "$resource" -o "jsonpath=${jsonpath}" 2>/dev/null || true)"
+    if [ "$value" = "$expected" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for ${resource} ${jsonpath}=${expected}" >&2
+  kubectl -n "$NAMESPACE" get "$resource" -oyaml >&2 || true
+  return 1
+}
+
+wait_for_qdrant_ready_pod_count() {
+  local expected_count="$1"
+  local deadline
+  local ready_count
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    ready_count="$(kubectl -n "$NAMESPACE" get pod \
+      -l "app.kubernetes.io/instance=${CLUSTER_NAME},apps.kubeblocks.io/component-name=qdrant" \
+      -o json | jq -r '
+        [
+          .items[]
+          | select(.metadata.deletionTimestamp == null)
+          | select(any(.status.conditions[]?; .type == "Ready" and .status == "True"))
+        ]
+        | length
+      ')"
+    if [ "$ready_count" = "$expected_count" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for ${expected_count} ready qdrant pod(s)" >&2
+  kubectl -n "$NAMESPACE" get pod -l "app.kubernetes.io/instance=${CLUSTER_NAME},apps.kubeblocks.io/component-name=qdrant" -owide >&2 || true
+  return 1
+}
+
+qdrant_pod() {
+  echo "${CLUSTER_NAME}-qdrant-0"
+}
+
+qdrant_curl() {
+  local pod
+  local curl_args=(-sS -f)
+
+  if [ "$QDRANT_TLS_ENABLED" = "true" ]; then
+    curl_args+=(-k)
+  fi
+  if [ "$API_KEY_ENABLED" = "true" ]; then
+    curl_args+=(-H "api-key: ${API_KEY}")
+  fi
+
+  pod="$(qdrant_pod)"
+  kubectl -n "$NAMESPACE" exec "$pod" -- /qdrant/tools/curl "${curl_args[@]}" "$@"
+}
+
+wait_for_qdrant_peer_count() {
+  local expected_count="$1"
+  local deadline
+  local response
+  local peer_count
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    response="$(qdrant_curl "${QDRANT_SCHEME}://localhost:6333/cluster" 2>/dev/null || true)"
+    peer_count="$(echo "$response" | jq -r '.result.peers | length' 2>/dev/null || true)"
+    if [ "$peer_count" = "$expected_count" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for ${expected_count} qdrant peer(s)" >&2
+  qdrant_curl "${QDRANT_SCHEME}://localhost:6333/cluster" >&2 || true
+  return 1
+}
+
+peer_id_for_pod() {
+  local pod_name="$1"
+
+  qdrant_curl "${QDRANT_SCHEME}://localhost:6333/cluster" \
+    | jq -r --arg pod "$pod_name" '
+        .result.peers
+        | to_entries[]
+        | select(.value.uri | contains("://" + $pod + "."))
+        | .key
+      '
+}
+
+collection_cluster_info() {
+  qdrant_curl "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}/cluster"
+}
+
+collection_has_shard_on_peer() {
+  local peer_id="$1"
+  local response="$2"
+
+  echo "$response" | jq -e --arg peer_id "$peer_id" '
+    [
+      .result.local_shards[]? | select((.peer_id? // .peer_id | tostring) == $peer_id)
+    ]
+    +
+    [
+      .result.remote_shards[]? | select((.peer_id | tostring) == $peer_id)
+    ]
+    | length > 0
+  ' >/dev/null
+}
+
+wait_for_leaving_peer_with_shards() {
+  local deadline
+  local response
+  local peer_id
+  local pod_name
+
+  deadline="$(deadline_after "$TIMEOUT_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    response="$(collection_cluster_info 2>/dev/null || true)"
+    for pod_name in "${CLUSTER_NAME}-qdrant-1" "${CLUSTER_NAME}-qdrant-2"; do
+      peer_id="$(peer_id_for_pod "$pod_name" 2>/dev/null || true)"
+      if [ -n "$peer_id" ] && collection_has_shard_on_peer "$peer_id" "$response"; then
+        echo "INFO: ${pod_name} peer ${peer_id} owns collection shards"
+        return 0
+      fi
+    done
+    sleep 5
+  done
+
+  echo "ERROR: timed out waiting for a leaving qdrant peer to own collection shards" >&2
+  collection_cluster_info >&2 || true
+  qdrant_curl "${QDRANT_SCHEME}://localhost:6333/cluster" >&2 || true
+  return 1
+}
+
+create_scale_in_opsrequest() {
+  local ops_name="${CLUSTER_NAME}-scale-in-1"
+
+  cat > "${TMP_DIR}/${ops_name}.yaml" <<EOF
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ${ops_name}
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  type: HorizontalScaling
+  horizontalScaling:
+    - componentName: qdrant
+      scaleIn:
+        replicaChanges: 2
+EOF
+
+  kubectl apply -f "${TMP_DIR}/${ops_name}.yaml"
+}
+
+assert_scale_in_not_succeed() {
+  local ops_name="${CLUSTER_NAME}-scale-in-1"
+  local deadline
+  local phase
+
+  deadline="$(deadline_after "$SCALE_IN_SAFETY_SECONDS")"
+
+  while [ "$(now_seconds)" -lt "$deadline" ]; do
+    phase="$(kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -o "jsonpath={.status.phase}" 2>/dev/null || true)"
+    case "$phase" in
+      Succeed)
+        echo "ERROR: opsrequest/${ops_name} succeeded even though a leaving peer owns shards" >&2
+        kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -oyaml >&2 || true
+        collection_cluster_info >&2 || true
+        return 1
+        ;;
+      Failed|Cancelled)
+        echo "INFO: opsrequest/${ops_name} ended with phase ${phase}; shard safety was preserved"
+        return 0
+        ;;
+    esac
+    sleep 5
+  done
+
+  echo "INFO: opsrequest/${ops_name} did not succeed within ${SCALE_IN_SAFETY_SECONDS}s; shard safety was preserved"
+  kubectl -n "$NAMESPACE" get "opsrequest/${ops_name}" -oyaml >&2 || true
+  return 0
+}
+
+write_cluster_manifest() {
+  local file="$1"
+
+  {
+    echo "apiVersion: apps.kubeblocks.io/v1"
+    echo "kind: Cluster"
+    echo "metadata:"
+    echo "  name: ${CLUSTER_NAME}"
+    echo "  namespace: ${NAMESPACE}"
+    echo "spec:"
+    echo "  terminationPolicy: Delete"
+    echo "  clusterDef: qdrant"
+    echo "  topology: cluster"
+    echo "  componentSpecs:"
+    echo "    - name: qdrant"
+    echo "      serviceVersion: ${SERVICE_VERSION}"
+    echo "      replicas: 3"
+    if [ "$QDRANT_TLS_ENABLED" = "true" ]; then
+      echo "      tls: true"
+      echo "      issuer:"
+      echo "        name: KubeBlocks"
+    fi
+    if [ "$API_KEY_ENABLED" = "true" ]; then
+      echo "      configs:"
+      echo "        - name: qdrant-config-template"
+      echo "          variables:"
+      echo "            service_api_key: ${API_KEY}"
+    fi
+    echo "      resources:"
+    echo "        limits:"
+    echo "          cpu: \"0.5\""
+    echo "          memory: \"0.5Gi\""
+    echo "        requests:"
+    echo "          cpu: \"0.5\""
+    echo "          memory: \"0.5Gi\""
+    echo "      volumeClaimTemplates:"
+    echo "        - name: data"
+    echo "          spec:"
+    if [ -n "$STORAGE_CLASS_NAME" ]; then
+      echo "            storageClassName: ${STORAGE_CLASS_NAME}"
+    else
+      echo "            storageClassName: \"\""
+    fi
+    echo "            accessModes:"
+    echo "              - ReadWriteOnce"
+    echo "            resources:"
+    echo "              requests:"
+    echo "                storage: ${STORAGE_SIZE}"
+  } > "$file"
+}
+
+require_cmd kubectl
+require_cmd jq
+require_bool API_KEY_ENABLED "$API_KEY_ENABLED"
+require_bool QDRANT_TLS_ENABLED "$QDRANT_TLS_ENABLED"
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -oyaml | kubectl apply -f -
+
+cluster_manifest="${TMP_DIR}/cluster.yaml"
+write_cluster_manifest "$cluster_manifest"
+kubectl apply -f "$cluster_manifest"
+wait_for_jsonpath "cluster/${CLUSTER_NAME}" "{.status.phase}" "Running"
+wait_for_qdrant_ready_pod_count 3
+wait_for_qdrant_peer_count 3
+
+echo "INFO: creating sharded qdrant collection ${QDRANT_COLLECTION}"
+qdrant_curl -X PUT "${QDRANT_SCHEME}://localhost:6333/collections/${QDRANT_COLLECTION}" \
+  -H "Content-Type: application/json" \
+  -d '{"vectors":{"size":4,"distance":"Cosine"},"shard_number":6,"replication_factor":1,"write_consistency_factor":1}' >/dev/null
+
+wait_for_leaving_peer_with_shards
+
+echo "INFO: verifying qdrant scale-in does not succeed while leaving peers own shards"
+create_scale_in_opsrequest
+assert_scale_in_not_succeed
+
+echo "INFO: qdrant memberLeave shard-safety e2e passed"

--- a/examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh
+++ b/examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CASE_SCRIPT="${SCRIPT_DIR}/qdrant_api_key_backup_restore_e2e.sh"
+RUN_LIFECYCLE_CHECK="${RUN_LIFECYCLE_CHECK:-true}"
+
+run_case() {
+  local case_name="$1"
+  local tls_enabled="$2"
+  local api_key_enabled="$3"
+  local cluster_name="qdrant-${case_name}"
+
+  echo "INFO: running qdrant e2e case ${case_name} TLS=${tls_enabled} API key=${api_key_enabled}"
+  CLUSTER_NAME="$cluster_name" \
+    RESTORE_CLUSTER_NAME="${cluster_name}-restore" \
+    BACKUP_NAME="${cluster_name}-backup" \
+    QDRANT_COLLECTION="${case_name}-collection" \
+    QDRANT_POINT_SOURCE="${case_name}" \
+    QDRANT_API_KEY="${case_name}-key" \
+    QDRANT_TLS_ENABLED="$tls_enabled" \
+    API_KEY_ENABLED="$api_key_enabled" \
+    RUN_LIFECYCLE_CHECK="$RUN_LIFECYCLE_CHECK" \
+    "$CASE_SCRIPT"
+}
+
+run_case "tls-off-api-key-off" "false" "false"
+run_case "tls-off-api-key-on" "false" "true"
+run_case "tls-on-api-key-off" "true" "false"
+run_case "tls-on-api-key-on" "true" "true"
+
+echo "INFO: qdrant TLS/API-key lifecycle backup/restore e2e matrix passed"


### PR DESCRIPTION
## Summary

- Add ShellSpec coverage for Qdrant API key, TLS, backup/restore, memberLeave drain behavior, examples, version matrix behavior, and backup policy target volume mounting.
- Add a focused e2e script for create -> inject data -> lifecycle scale -> backup -> restore -> compare restored data.
- Add a matrix wrapper for TLS on/off and API key set/unset modes.
- Update the shard memberLeave e2e to verify the functional path: create a sharded collection, write points, scale in from 3 replicas to 1, require OpsRequest success, require Qdrant peer count convergence to 1, and compare point data digest after scale-in.

## Dependency

Depends on #2942.

## Why

The Qdrant changes touch config rendering, backup/restore credentials/TLS handling, lifecycle scale-in behavior, and user-facing examples. This PR keeps the verification assets separate from the implementation PRs so the functional patches remain easier to review.

The previous shard test only proved a fail-safe behavior. The new test covers the required behavior directly: `memberLeave` must drain/migrate shards, remove the peer, allow scale-in to succeed, and preserve Qdrant point data.

The ShellSpec coverage also checks that `memberLeave` uses the packaged curl binary, calls Qdrant through a non-leaving peer, drains before removal, avoids `force=true`, handles local shard counting correctly, prefers stable lower-ordinal drain targets, and does not report duplicate action success while the peer still exists.

## Validation

- `shellspec --load-path ./shellspec --shell bash addons/qdrant/scripts-ut-spec/qdrant_backup_restore_spec.sh` -> 42 examples, 0 failures
- `bash -n addons/qdrant/scripts/qdrant-member-leave.sh examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh`
- `shellcheck --severity=error addons/qdrant/scripts/qdrant-member-leave.sh examples/qdrant/test/qdrant_member_leave_shard_safety_e2e.sh examples/qdrant/test/qdrant_api_key_backup_restore_e2e.sh examples/qdrant/test/qdrant_tls_api_key_matrix_e2e.sh`
- `helm lint addons/qdrant`
- `git diff --check -- addons/qdrant examples/qdrant`
- Local kind shard-drain e2e on `kind-kb-upgrade-103b9`: Qdrant v1.18.2 with TLS=false and API key=true created a 3-replica cluster and sharded collection, wrote 18 points, confirmed a leaving peer owned shards, scaled in 3 -> 1 successfully, waited for Qdrant peer count 1, and verified point count/digest after scale-in. Test resources were cleaned up.
- Local kind backup/restore e2e on `kind-kb-upgrade-103b9`: Qdrant v1.18.2 with TLS=true and API key=true, lifecycle scale-out/scale-in enabled, backup completed, restore cluster became Running, and restored point data matched source data. Test resources were cleaned up.
