### PR TITLE
fix(redis): include reconfigure script in redis-cluster scripts template

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -193,6 +193,10 @@ Generate scripts configmap
 redis-account.sh: |-
 {{- $.Files.Get "scripts/redis-account.sh" | nindent 2 }}
 {{- end }}
+{{- if $.Files.Get "scripts/redis-reconfigure-config.sh" }}
+redis-reconfigure-config.sh: |-
+{{- $.Files.Get "scripts/redis-reconfigure-config.sh" | nindent 2 }}
+{{- end }}
 {{- end }}
 
 {{- define "redis.config.reconfigureAction" -}}


### PR DESCRIPTION
Problem
- `redis-cluster-7` ComponentDefinition uses `/scripts/redis-reconfigure-config.sh` as its reconfigure action command.
- The `redis-cluster-scripts-template` ConfigMap only included files under `redis-cluster-scripts/**` and optionally `scripts/redis-account.sh`, so the reconfigure script was not mounted into Redis Cluster data pods.
- Result: Reconfiguring parameters on a Redis Cluster failed because the action could not find the script (/scripts/redis-reconfigure-config.sh: not found).

Fix
Add `scripts/redis-reconfigure-config.sh` to the `redis-cluster.extend.scripts` helper so it is rendered into the cluster scripts ConfigMap.

Runtime evidence
- Vcluster: `redis-tls-fresh-idc4-vc` (cleaned and upgraded to addon main HEAD `5a5a2c11`).
- Before the ConfigMap patch: T05 reconfigure OpsRequest stuck in `Reconfiguring`; data pods did not contain `/scripts/redis-reconfigure-config.sh`.
- After the ConfigMap patch + pod restart: reconfigure OpsRequest `rds-tls-cluster-userprovided-reconf-shard-60647-8406` Succeed.
- Patch B (restart-primary switchover, PR #501) PASS 56/0/0 on the same clean vcluster.