### PR TITLE
Revert "fix(redis): include reconfigure script in redis-cluster scripts template (#2941)"

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -221,10 +221,6 @@ Generate scripts configmap
 redis-account.sh: |-
 {{- $.Files.Get "scripts/redis-account.sh" | nindent 2 }}
 {{- end }}
-{{- if $.Files.Get "scripts/redis-reconfigure-config.sh" }}
-redis-reconfigure-config.sh: |-
-{{- $.Files.Get "scripts/redis-reconfigure-config.sh" | nindent 2 }}
-{{- end }}
 {{- end }}
 
 {{- define "apeDts.reshard.image" -}}


### PR DESCRIPTION
## Summary
- Revert the #2941 auto-pick commit on release-1.0 (`f01b00dd3986c7fa4a6869837666d886e2c82778`).
- release-1.0 does not contain `redis-reconfigure-config.sh`, so the auto-picked ConfigMap entry points to a non-existent script.
- Scope is limited to removing the four added lines from `addons/redis/templates/_helpers.tpl`.

## Verification
- `git diff --check origin/release-1.0...HEAD`
- `helm dependency build addons/redis`
- `helm template redis addons/redis >/tmp/redis-release10-revert-2941-render.yaml`
- `! rg -n 'redis-reconfigure-config.sh' /tmp/redis-release10-revert-2941-render.yaml`\n\n## Boundary\n- Rollback only for release-1.0 auto-pick.\n- Does not change main #2941 behavior.