### PR TITLE
Revert "fix(redis): include reconfigure script in redis-cluster scripts template (#2941)"

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -193,10 +193,6 @@ Generate scripts configmap
 redis-account.sh: |-
 {{- $.Files.Get "scripts/redis-account.sh" | nindent 2 }}
 {{- end }}
-{{- if $.Files.Get "scripts/redis-reconfigure-config.sh" }}
-redis-reconfigure-config.sh: |-
-{{- $.Files.Get "scripts/redis-reconfigure-config.sh" | nindent 2 }}
-{{- end }}
 {{- end }}
 
 {{- define "apeDts.reshard.image" -}}


### PR DESCRIPTION
## Summary
- Revert the #2941 auto-pick commit on release-1.1 (`d1690f3f9ab1275fb9f78446239be271808ee043`).
- release-1.1 does not contain `redis-reconfigure-config.sh`, so the auto-picked ConfigMap entry points to a non-existent script.
- Scope is limited to removing the four added lines from `addons/redis/templates/_helpers.tpl`.

## Verification
- `git diff --check origin/release-1.1...HEAD`
- `helm dependency build addons/redis`
- `helm template redis addons/redis >/tmp/redis-release11-revert-2941-render.yaml`
- `! rg -n 'redis-reconfigure-config.sh' /tmp/redis-release11-revert-2941-render.yaml`\n\n## Boundary\n- Rollback only for release-1.1 auto-pick.\n- Does not change main #2941 behavior.