### PR TITLE
chore(falkordb): sharding lifecycle actions

### DIFF
--- a/addons-cluster/falkordb/templates/_helpers.tpl
+++ b/addons-cluster/falkordb/templates/_helpers.tpl
@@ -17,11 +17,11 @@ Define falkordb cluster shardingSpec with ComponentDefinition.
 */}}
 {{- define "falkordb-cluster.shardingSpec" }}
 - name: shard
+  shardingDef: falkordb-cluster
   shards: {{ .Values.falkordbCluster.shardCount }}
   template:
     name: falkordb
     {{- include "redis-cluster.tls" . | indent 4 }}
-    componentDef: falkordb-cluster
     replicas: {{ .Values.replicas }}
     {{- if .Values.podAntiAffinityEnabled }}
     {{- include "falkordb-cluster.shardingSchedulingPolicy" . | indent 2 }}

--- a/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-common.sh
+++ b/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-common.sh
@@ -35,9 +35,8 @@ sleep_random_second_when_ut_mode_false() {
   fi
 }
 
-# usage: parse_host_ip_from_built_in_envs <pod_name>
-# $KB_CLUSTER_COMPONENT_POD_NAME_LIST and $KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST are built-in envs in KubeBlocks postProvision lifecycle action.
-# TODO: the built-in envs will be removed in the future.
+# usage: parse_host_ip_from_built_in_envs <pod_name> <pod_name_list> <pod_host_ip_list>
+# Kept for scripts that pass an explicit pod-name/IP mapping.
 parse_host_ip_from_built_in_envs() {
   local given_pod_name="$1"
   local all_pod_name_list="$2"
@@ -454,24 +453,17 @@ check_slots_covered() {
 
 # check if the cluster has been initialized
 check_cluster_initialized() {
-  local cluster_pod_ip_list="$1"
-  local cluster_pod_name_list="$2"
-  if is_empty "$cluster_pod_ip_list" || is_empty "$cluster_pod_name_list"; then
-    echo "Error: Required environment variable cluster_pod_ip_list or cluster_pod_name_list is not set." >&2
+  local cluster_pod_fqdn_list="$1"
+  if is_empty "$cluster_pod_fqdn_list"; then
+    echo "Error: Required environment variable cluster_pod_fqdn_list is not set." >&2
     return 1
   fi
 
-  local pod_ip
   local service_port
-  for pod_name in $(echo "$cluster_pod_name_list" | tr ',' ' '); do
-    pod_ip=$(parse_host_ip_from_built_in_envs "$pod_name" "$cluster_pod_name_list" "$cluster_pod_ip_list")
-    if is_empty "$pod_ip"; then
-      echo "Failed to get the host ip of the pod $pod_name in check_cluster_initialized"
-      continue
-    fi
-
+  for pod_fqdn in $(echo "$cluster_pod_fqdn_list" | tr ',' ' '); do
+    pod_name=${pod_fqdn%%.*}
     service_port=$(get_pod_service_port_by_network_mode "${pod_name}")
-    cluster_info=$(get_cluster_info_with_retry "$pod_ip" "$service_port")
+    cluster_info=$(get_cluster_info_with_retry "$pod_fqdn" "$service_port")
     status=$?
     if [ $status -ne 0 ]; then
       echo "Failed to get cluster info in check_cluster_initialized" >&2
@@ -485,6 +477,36 @@ check_cluster_initialized() {
   done
   echo "FalkorDB Cluster not initialized" >&2
   return 1
+}
+
+redis_config_get() {
+  local host=$1
+  local port=$2
+  local password=$3
+  local command=$4
+
+  local output
+  unset_xtrace_when_ut_mode_false
+  if ! is_empty "$password"; then
+    output=$(redis-cli $REDIS_CLI_TLS_CMD -h "$host" -p "$port" -a "$password" $command)
+  else
+    output=$(redis-cli $REDIS_CLI_TLS_CMD -h "$host" -p "$port" $command)
+  fi
+  local status=$?
+  set_xtrace_when_ut_mode_false
+
+  if [[ $status -ne 0 ]]; then
+    echo "Command failed with status $status." >&2
+    return 1
+  fi
+
+  if [[ -z "$output" ]]; then
+    echo "Command returned no output." >&2
+    return 1
+  fi
+
+  echo "$output"
+  return 0
 }
 
 build_redis_cluster_create_command() {

--- a/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
+++ b/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
@@ -31,6 +31,7 @@ declare -gA initialize_pod_name_to_advertise_host_port_map
 # declare the global variables for scale out redis cluster shard
 declare -gA scale_out_shard_default_primary_node
 declare -gA scale_out_shard_default_other_nodes
+network_mode="default"
 
 init_environment(){
   if [[ -z "${CURRENT_SHARD_ADVERTISED_PORT}" ]]; then
@@ -46,148 +47,28 @@ init_environment(){
     ALL_SHARDS_ADVERTISED_BUS_PORT="${ALL_SHARDS_LB_ADVERTISED_BUS_PORT}"
   fi
 
-  local all_shards_pods
-  local all_shards_pod_fqdns
-  local all_shards_components
-  all_shards_pods=$(get_all_shards_pods 2>/dev/null || true)
-  all_shards_pod_fqdns=$(get_all_shards_pod_fqdns 2>/dev/null || true)
-  all_shards_components=$(get_all_shards_components 2>/dev/null || true)
-
-  if [[ -z "${KB_CLUSTER_POD_NAME_LIST}" && -n "$all_shards_pods" ]]; then
-    KB_CLUSTER_POD_NAME_LIST="$all_shards_pods"
-  fi
-  # The legacy "*_IP_LIST" values are used as redis-cli -h endpoints in
-  # the default network path. KB main exposes declared pod FQDN lists here.
-  if [[ -z "${KB_CLUSTER_POD_IP_LIST}" && -n "$all_shards_pod_fqdns" ]]; then
-    KB_CLUSTER_POD_IP_LIST="$all_shards_pod_fqdns"
-  fi
-  if [[ -z "${KB_CLUSTER_POD_HOST_IP_LIST}" && -n "${KB_CLUSTER_POD_IP_LIST}" ]]; then
-    KB_CLUSTER_POD_HOST_IP_LIST="${KB_CLUSTER_POD_IP_LIST}"
-  fi
-  if [[ -z "${KB_CLUSTER_COMPONENT_POD_NAME_LIST}" && -n "${CURRENT_SHARD_POD_NAME_LIST}" ]]; then
-    KB_CLUSTER_COMPONENT_POD_NAME_LIST="${CURRENT_SHARD_POD_NAME_LIST}"
-  fi
-  if [[ -z "${KB_CLUSTER_COMPONENT_POD_IP_LIST}" && -n "${CURRENT_SHARD_POD_FQDN_LIST}" ]]; then
-    KB_CLUSTER_COMPONENT_POD_IP_LIST="${CURRENT_SHARD_POD_FQDN_LIST}"
-  fi
-  if [[ -z "${KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST}" && -n "${KB_CLUSTER_COMPONENT_POD_IP_LIST}" ]]; then
-    KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="${KB_CLUSTER_COMPONENT_POD_IP_LIST}"
-  fi
-  if [[ -z "${KB_CLUSTER_COMPONENT_LIST}" && -n "$all_shards_components" ]]; then
-    KB_CLUSTER_COMPONENT_LIST="$all_shards_components"
-  fi
-  if [[ -z "${KB_CLUSTER_COMPONENT_UNDELETED_LIST}" && -n "${KB_CLUSTER_COMPONENT_LIST}" ]]; then
-    KB_CLUSTER_COMPONENT_UNDELETED_LIST="${KB_CLUSTER_COMPONENT_LIST}"
-  fi
-  if [[ -z "${KB_CLUSTER_COMPONENT_DELETING_LIST+x}" ]]; then
-    KB_CLUSTER_COMPONENT_DELETING_LIST=""
+  if [[ -n "$ALL_SHARDS_ADVERTISED_PORT" ]]; then
+    network_mode="advertised_svc"
+  elif [[ -n "$REDIS_CLUSTER_ALL_SHARDS_HOST_NETWORK_PORT" ]]; then
+    network_mode="host_network"
   fi
 
-  export KB_CLUSTER_POD_NAME_LIST
-  export KB_CLUSTER_POD_IP_LIST
-  export KB_CLUSTER_POD_HOST_IP_LIST
-  export KB_CLUSTER_COMPONENT_POD_NAME_LIST
-  export KB_CLUSTER_COMPONENT_POD_IP_LIST
-  export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-  export KB_CLUSTER_COMPONENT_LIST
-  export KB_CLUSTER_COMPONENT_UNDELETED_LIST
-  export KB_CLUSTER_COMPONENT_DELETING_LIST
-}
+  ALL_SHARDS_POD_NAME_LIST_COMBINED=$(get_all_shards_pods 2>/dev/null || true)
+  ALL_SHARDS_POD_FQDN_LIST_COMBINED=$(get_all_shards_pod_fqdns 2>/dev/null || true)
+  ALL_SHARDS_COMPONENT_LIST=$(get_all_shards_components 2>/dev/null || true)
+  ALL_SHARDS_UNDELETED_COMPONENT_LIST="${ALL_SHARDS_UNDELETED_COMPONENT_LIST:-$ALL_SHARDS_COMPONENT_LIST}"
+  ALL_SHARDS_DELETING_COMPONENT_LIST="${ALL_SHARDS_DELETING_COMPONENT_LIST:-}"
+  CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="${CURRENT_SHARD_POD_NAME_LIST:-}"
+  CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="${CURRENT_SHARD_POD_FQDN_LIST:-}"
 
-component_list_contains_exact() {
-  local component_list="$1"
-  local component="$2"
-
-  if [[ -z "$component_list" || -z "$component" ]]; then
-    return 1
-  fi
-
-  IFS=',' read -ra components <<< "$component_list"
-  for item in "${components[@]}"; do
-    if [[ "$item" == "$component" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-component_matches_remove_shard_name() {
-  local remove_shard_name="$1"
-  local component_name="$2"
-  local component_short_name="$3"
-
-  if [[ -z "$remove_shard_name" || -z "$component_name" ]]; then
-    return 1
-  fi
-  if [[ "$remove_shard_name" == "$component_name" ]]; then
-    return 0
-  fi
-  if [[ -n "$component_short_name" && "$remove_shard_name" == "$component_short_name" ]]; then
-    return 0
-  fi
-  if [[ "$component_name" == *-"$remove_shard_name" ]]; then
-    return 0
-  fi
-  return 1
-}
-
-component_list_without_exact() {
-  local component_list="$1"
-  local component="$2"
-  local result=""
-
-  if [[ -z "$component_list" || -z "$component" ]]; then
-    return 0
-  fi
-
-  IFS=',' read -ra components <<< "$component_list"
-  for item in "${components[@]}"; do
-    if [[ -z "$item" || "$item" == "$component" ]]; then
-      continue
-    fi
-    if [[ -z "$result" ]]; then
-      result="$item"
-    else
-      result="$result,$item"
-    fi
-  done
-  echo "$result"
-}
-
-detect_scale_in_context() {
-  if ! is_empty "$KB_CLUSTER_COMPONENT_IS_SCALING_IN"; then
-    return 0
-  fi
-
-  if component_matches_remove_shard_name "$KB_REMOVE_SHARD_NAME" "$CURRENT_SHARD_COMPONENT_NAME" "$CURRENT_SHARD_COMPONENT_SHORT_NAME"; then
-    KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
-    export KB_CLUSTER_COMPONENT_IS_SCALING_IN
-    if is_empty "$KB_CLUSTER_COMPONENT_DELETING_LIST"; then
-      KB_CLUSTER_COMPONENT_DELETING_LIST="$CURRENT_SHARD_COMPONENT_NAME"
-      export KB_CLUSTER_COMPONENT_DELETING_LIST
-    fi
-    if is_empty "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"; then
-      KB_CLUSTER_COMPONENT_UNDELETED_LIST=$(component_list_without_exact "$KB_CLUSTER_COMPONENT_LIST" "$CURRENT_SHARD_COMPONENT_NAME")
-      export KB_CLUSTER_COMPONENT_UNDELETED_LIST
-    fi
-    echo "Detected scale-in context from KB_REMOVE_SHARD_NAME"
-    return 0
-  fi
-
-  if ! component_list_contains_exact "$KB_CLUSTER_COMPONENT_DELETING_LIST" "$CURRENT_SHARD_COMPONENT_NAME"; then
-    return 1
-  fi
-  if component_list_contains_exact "$KB_CLUSTER_COMPONENT_UNDELETED_LIST" "$CURRENT_SHARD_COMPONENT_NAME"; then
-    return 1
-  fi
-  if is_empty "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"; then
-    return 1
-  fi
-
-  KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
-  export KB_CLUSTER_COMPONENT_IS_SCALING_IN
-  echo "Detected scale-in context from KB_CLUSTER_COMPONENT_DELETING_LIST/UNDELETED_LIST"
-  return 0
+  export ALL_SHARDS_POD_NAME_LIST_COMBINED
+  export ALL_SHARDS_POD_FQDN_LIST_COMBINED
+  export ALL_SHARDS_COMPONENT_LIST
+  export ALL_SHARDS_UNDELETED_COMPONENT_LIST
+  export ALL_SHARDS_DELETING_COMPONENT_LIST
+  export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+  export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+  export network_mode
 }
 
 load_redis_cluster_common_utils() {
@@ -215,16 +96,14 @@ check_initialize_nodes_ready() {
 # initialize the other component and pods info
 init_other_components_and_pods_info() {
   local current_component="$1"
-  local all_pod_ip_list="$2"
-  local all_pod_name_list="$3"
-  local all_component_list="$4"
-  local all_deleting_component_list="$5"
-  local all_undeleted_component_list="$6"
+  local all_pod_fqdn_list="$2"
+  local all_component_list="$3"
+  local all_deleting_component_list="$4"
+  local all_undeleted_component_list="$5"
 
   other_components=()
   other_deleting_components=()
   other_undeleted_components=()
-  other_undeleted_component_pod_ips=()
   other_undeleted_component_pod_names=()
   other_undeleted_component_nodes=()
   echo "init other components and pods info, current component: $current_component"
@@ -255,38 +134,32 @@ init_other_components_and_pods_info() {
   done
 
   # filter out the pods of the given component
-  IFS=',' read -ra pod_ips <<< "$all_pod_ip_list"
-  IFS=',' read -ra pod_names <<< "$all_pod_name_list"
-  for index in "${!pod_ips[@]}"; do
-    if echo "${pod_names[$index]}" | grep "$current_component-"; then
-      echo "skip the pod ${pod_names[$index]} as it belongs the component $current_component"
+  for pod_fqdn in $(echo "$all_pod_fqdn_list" | tr ',' '\n'); do
+    pod_name=${pod_fqdn%%.*}
+    if echo "$pod_name" | grep "$current_component-"; then
+      echo "skip the pod $pod_name as it belongs the component $current_component"
       continue
     fi
 
     # skip the pod belongs to the deleting component
     for deleting_comp in "${deleting_components[@]}"; do
-      if echo "${pod_names[$index]}" | grep "$deleting_comp-"; then
-        echo "skip the pod ${pod_names[$index]} as it belongs the deleting component $deleting_comp"
+      if echo "$pod_name" | grep "$deleting_comp-"; then
+        echo "skip the pod $pod_name as it belongs the deleting component $deleting_comp"
         continue 2
       fi
     done
 
-    other_undeleted_component_pod_ips+=("${pod_ips[$index]}")
-    other_undeleted_component_pod_names+=("${pod_names[$index]}")
+    other_undeleted_component_pod_names+=("$pod_name")
 
     local service_port
-    service_port=$(get_pod_service_port_by_network_mode "${pod_names[$index]}")
+    service_port=$(get_pod_service_port_by_network_mode "$pod_name")
 
-    # TODO: resolve the pod fqdn from the Vars
-    pod_name_prefix=$(extract_pod_name_prefix "${pod_names[$index]}")
-    pod_fqdn="${pod_names[$index]}.$pod_name_prefix-headless.$CLUSTER_NAMESPACE.svc.$CLUSTER_DOMAIN"
     other_undeleted_component_nodes+=("$pod_fqdn:$service_port")
   done
 
   echo "other_components: ${other_components[*]}"
   echo "other_deleting_components: ${other_deleting_components[*]}"
   echo "other_undeleted_components: ${other_undeleted_components[*]}"
-  echo "other_undeleted_component_pod_ips: ${other_undeleted_component_pod_ips[*]}"
   echo "other_undeleted_component_pod_names: ${other_undeleted_component_pod_names[*]}"
   echo "other_undeleted_component_nodes: ${other_undeleted_component_nodes[*]}"
 }
@@ -450,8 +323,12 @@ get_current_comp_nodes_for_scale_in() {
 
 # init the current shard component default primary and secondary nodes for scale out shard.
 # TODO: if advertised address is enable and instanceTemplate is specified, the pod service could not be parsed from the pod ordinal.
-# TODO: remove the dependency of the built-in envs like KB_CLUSTER_COMPONENT_XXXX
 init_current_comp_default_nodes_for_scale_out() {
+  if is_empty "$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE" || is_empty "$CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE"; then
+    echo "Error: Required environment variable CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE and CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE are not set when initializing current shard default nodes" >&2
+    return 1
+  fi
+
   # categorize the scale out node map
   categorize_scale_out_node_map() {
     local pod_name="$1"
@@ -467,8 +344,21 @@ init_current_comp_default_nodes_for_scale_out() {
 
   # handle the advertised service network mode (currently only support NodePort service type
   handle_advertised_svc_network_mode() {
-    local pod_name="$1"
+    local pod_fqdn="$1"
     local pod_name_ordinal="$2"
+    local pod_name=${pod_fqdn%%.*}
+
+    local pod_host_ip
+    local pod_service_port
+    pod_service_port=$(get_pod_service_port_by_network_mode "$pod_name") || {
+      echo "Failed to get service port for pod: $pod_name" >&2
+      return 1
+    }
+    pod_host_ip=$(redis_config_get "$pod_fqdn" "$pod_service_port" "$REDIS_DEFAULT_PASSWORD" "config get cluster-announce-ip" | sed -n '2p')
+    if is_empty "$pod_host_ip"; then
+      echo "Failed to get host ip of pod $pod_name" >&2
+      return 1
+    fi
 
     local old_ifs="$IFS"
     IFS=','
@@ -485,14 +375,11 @@ init_current_comp_default_nodes_for_scale_out() {
       advertised_svc_ordinal=$(extract_obj_ordinal "$advertised_svc")
 
       if [ "$pod_name_ordinal" == "$advertised_svc_ordinal" ]; then
-        local pod_host_ip
         lb_host=$(extract_lb_host_by_svc_name "${advertised_svc}")
         if ! is_empty "$lb_host"; then
             echo "Found load balancer host for svcName '$advertised_svc', value is '$lb_host'."
             pod_host_ip="$lb_host"
             advertised_port="6379"
-        else
-            pod_host_ip=$(parse_host_ip_from_built_in_envs "$pod_name" "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" "$KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST")
         fi
         status=$?
         if is_empty "$pod_host_ip" || [ $status -ne 0 ]; then
@@ -515,11 +402,17 @@ init_current_comp_default_nodes_for_scale_out() {
 
   # handle the host network mode
   handle_host_network_mode() {
-    local pod_name="$1"
+    local pod_fqdn="$1"
     local pod_name_ordinal="$2"
+    local pod_name=${pod_fqdn%%.*}
 
     local pod_host_ip
-    pod_host_ip=$(parse_host_ip_from_built_in_envs "$pod_name" "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" "$KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST")
+    local pod_service_port
+    pod_service_port=$(get_pod_service_port_by_network_mode "$pod_name") || {
+      echo "Failed to get service port for pod: $pod_name" >&2
+      return 1
+    }
+    pod_host_ip=$(redis_config_get "$pod_fqdn" "$pod_service_port" "$REDIS_DEFAULT_PASSWORD" "config get cluster-announce-ip" | sed -n '2p')
     if is_empty "$pod_host_ip"; then
       echo "Failed to get host ip of pod $pod_name in host network mode" >&2
       return 1
@@ -531,15 +424,14 @@ init_current_comp_default_nodes_for_scale_out() {
 
   # handle the default network mode
   handle_default_network_mode() {
-    local pod_name="$1"
+    local pod_fqdn="$1"
     local pod_name_ordinal="$2"
+    local pod_name=${pod_fqdn%%.*}
 
-    local pod_fqdn
     local port="$SERVICE_PORT"
 
-    pod_fqdn=$(get_target_pod_fqdn_from_pod_fqdn_vars "$CURRENT_SHARD_POD_FQDN_LIST" "$pod_name")
     if is_empty "$pod_fqdn"; then
-      echo "Error: Failed to get pod $pod_name fqdn from list: $CURRENT_SHARD_POD_FQDN_LIST" >&2
+      echo "Error: Failed to get pod $pod_name fqdn from current shard pod FQDN list" >&2
       return 1
     fi
 
@@ -549,18 +441,18 @@ init_current_comp_default_nodes_for_scale_out() {
 
   process_pod_by_network_mode() {
     local network_mode="$1"
-    local pod_name="$2"
+    local pod_fqdn="$2"
     local pod_name_ordinal="$3"
 
     case "$network_mode" in
       "advertised_svc")
-        handle_advertised_svc_network_mode "$pod_name" "$pod_name_ordinal"
+        handle_advertised_svc_network_mode "$pod_fqdn" "$pod_name_ordinal"
         ;;
       "host_network")
-        handle_host_network_mode "$pod_name" "$pod_name_ordinal"
+        handle_host_network_mode "$pod_fqdn" "$pod_name_ordinal"
         ;;
       *)
-        handle_default_network_mode "$pod_name" "$pod_name_ordinal"
+        handle_default_network_mode "$pod_fqdn" "$pod_name_ordinal"
         ;;
     esac
     return $?
@@ -568,7 +460,7 @@ init_current_comp_default_nodes_for_scale_out() {
 
   local min_lexicographical_pod_name
   local min_lexicographical_pod_ordinal
-  min_lexicographical_pod_name=$(min_lexicographical_order_pod "$KB_CLUSTER_COMPONENT_POD_NAME_LIST")
+  min_lexicographical_pod_name=$(min_lexicographical_order_pod "$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE")
   min_lexicographical_pod_ordinal=$(extract_obj_ordinal "$min_lexicographical_pod_name")
   if is_empty "$min_lexicographical_pod_ordinal"; then
     echo "Failed to get the ordinal of the min lexicographical pod $min_lexicographical_pod_name in init_current_comp_default_nodes_for_scale_out" >&2
@@ -583,10 +475,12 @@ init_current_comp_default_nodes_for_scale_out() {
     network_mode="host_network"
   fi
 
-  for pod_name in $(echo "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" | tr ',' ' '); do
+  for pod_fqdn in $(echo "$CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE" | tr ',' ' '); do
+    local pod_name
     local pod_name_ordinal
+    pod_name=${pod_fqdn%%.*}
     pod_name_ordinal=$(extract_obj_ordinal "$pod_name")
-    process_pod_by_network_mode "$network_mode" "$pod_name" "$pod_name_ordinal" || return 1
+    process_pod_by_network_mode "$network_mode" "$pod_fqdn" "$pod_name_ordinal" || return 1
   done
   return 0
 }
@@ -594,6 +488,11 @@ init_current_comp_default_nodes_for_scale_out() {
 # initialize the redis cluster primary and secondary nodes, use the min lexicographical pod of each shard as the primary nodes by default.
 gen_initialize_redis_cluster_node() {
   local is_primary=$1
+
+  if is_empty "$ALL_SHARDS_POD_NAME_LIST_COMBINED" || is_empty "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"; then
+    echo "Error: Required environment variable ALL_SHARDS_POD_NAME_LIST_COMBINED and ALL_SHARDS_POD_FQDN_LIST_COMBINED are not set when generating redis cluster nodes" >&2
+    return 1
+  fi
 
   categorize_node_maps() {
     local pod_name="$1"
@@ -626,15 +525,25 @@ gen_initialize_redis_cluster_node() {
 
   # Initialize node with advertised service configuration
   initialize_advertised_svc_node() {
-    local pod_name="$1"
+    local pod_fqdn="$1"
     local pod_name_ordinal="$2"
     local is_primary="$3"
+    local pod_name=${pod_fqdn%%.*}
 
     local pod_host_ip
-    pod_host_ip=$(parse_host_ip_from_built_in_envs "$pod_name" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_POD_HOST_IP_LIST") || {
+    local pod_service_port
+    pod_service_port=$(get_pod_service_port_by_network_mode "$pod_name") || {
+      echo "Failed to get service port for pod: $pod_name" >&2
+      return 1
+    }
+    pod_host_ip=$(redis_config_get "$pod_fqdn" "$pod_service_port" "$REDIS_DEFAULT_PASSWORD" "config get cluster-announce-ip" | sed -n '2p') || {
       echo "Failed to get host IP for pod: $pod_name" >&2
       return 1
     }
+    if is_empty "$pod_host_ip"; then
+      echo "Failed to get host IP for pod: $pod_name" >&2
+      return 1
+    fi
 
     ## the value format of ALL_SHARDS_ADVERTISED_PORT is "shard-98x@falkordb-shard-98x-falkordb-advertised-0:32024,falkordb-shard-98x-falkordb-advertised-1:31318.shard-cq7@falkordb-shard-cq7-falkordb-advertised-0:31828,falkordb-shard-cq7-falkordb-advertised-1:32000"
     local old_ifs="$IFS"
@@ -691,20 +600,24 @@ gen_initialize_redis_cluster_node() {
 
   # Initialize node with host network configuration
   initialize_host_network_node() {
-    local pod_name="$1"
+    local pod_fqdn="$1"
     local is_primary="$2"
+    local pod_name=${pod_fqdn%%.*}
 
     local pod_host_ip
-    pod_host_ip=$(parse_host_ip_from_built_in_envs "$pod_name" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_POD_HOST_IP_LIST") || {
-      echo "Failed to get host IP for pod: $pod_name" >&2
-      return 1
-    }
-
     local service_port
     service_port=$(get_pod_service_port_by_network_mode "${pod_name}") || {
       echo "Failed to get service port for pod: $pod_name" >&2
       return 1
     }
+    pod_host_ip=$(redis_config_get "$pod_fqdn" "$service_port" "$REDIS_DEFAULT_PASSWORD" "config get cluster-announce-ip" | sed -n '2p') || {
+      echo "Failed to get host IP for pod: $pod_name" >&2
+      return 1
+    }
+    if is_empty "$pod_host_ip"; then
+      echo "Failed to get host IP for pod: $pod_name" >&2
+      return 1
+    fi
 
     categorize_node_maps "$pod_name" "$pod_host_ip" "$service_port" "$is_primary"
     return 0
@@ -712,8 +625,9 @@ gen_initialize_redis_cluster_node() {
 
   # Initialize node with default network configuration
   initialize_default_network_node() {
-    local pod_name="$1"
+    local pod_fqdn="$1"
     local is_primary="$2"
+    local pod_name=${pod_fqdn%%.*}
 
     local service_port
     service_port=$(get_pod_service_port_by_network_mode "${pod_name}") || {
@@ -721,25 +635,8 @@ gen_initialize_redis_cluster_node() {
       return 1
     }
 
-    local all_shard_pod_fqdns
-    all_shard_pod_fqdns=$(get_all_shards_pod_fqdns) || {
-      echo "Failed to get all shard pod FQDNs" >&2
-      return 1
-    }
-
-    if is_empty "$all_shard_pod_fqdns"; then
-      echo "Failed to get all shard pod FQDNs" >&2
-      return 1
-    fi
-
-    local pod_fqdn
-    pod_fqdn=$(get_target_pod_fqdn_from_pod_fqdn_vars "$all_shard_pod_fqdns" "$pod_name") || {
-      echo "Failed to get FQDN for pod: $pod_name" >&2
-      return 1
-    }
-
     if is_empty "$pod_fqdn"; then
-      echo "Failed to get pod $pod_name fqdn from list: $all_shard_pod_fqdns" >&2
+      echo "Failed to get pod $pod_name fqdn from list: $ALL_SHARDS_POD_FQDN_LIST_COMBINED" >&2
       return 1
     fi
 
@@ -758,7 +655,7 @@ gen_initialize_redis_cluster_node() {
   # get and validate the min lexicographical pod name and ordinal
   local min_lexicographical_pod_name
   local min_lexicographical_pod_ordinal
-  min_lexicographical_pod_name=$(min_lexicographical_order_pod "$KB_CLUSTER_POD_NAME_LIST")
+  min_lexicographical_pod_name=$(min_lexicographical_order_pod "$ALL_SHARDS_POD_NAME_LIST_COMBINED")
   min_lexicographical_pod_ordinal=$(extract_obj_ordinal "$min_lexicographical_pod_name")
   if is_empty "$min_lexicographical_pod_ordinal"; then
     echo "Failed to get the ordinal of the min lexicographical pod $min_lexicographical_pod_name in gen_initialize_redis_cluster_node" >&2
@@ -766,8 +663,10 @@ gen_initialize_redis_cluster_node() {
   fi
 
   local pod_name
-  for pod_name in $(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' ' '); do
+  local pod_fqdn
+  for pod_fqdn in $(echo "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" | tr ',' ' '); do
     local pod_name_ordinal
+    pod_name=${pod_fqdn%%.*}
     pod_name_ordinal=$(extract_obj_ordinal "$pod_name") || continue
 
     # skip pods based on primary/secondary role
@@ -777,13 +676,13 @@ gen_initialize_redis_cluster_node() {
     # initialize pod based on network mode
     case "$network_mode" in
       "advertised_svc")
-        initialize_advertised_svc_node "$pod_name" "$pod_name_ordinal" "$is_primary" || return 1
+        initialize_advertised_svc_node "$pod_fqdn" "$pod_name_ordinal" "$is_primary" || return 1
         ;;
       "host_network")
-        initialize_host_network_node "$pod_name" "$is_primary" || return 1
+        initialize_host_network_node "$pod_fqdn" "$is_primary" || return 1
         ;;
       "default")
-        initialize_default_network_node "$pod_name" "$is_primary" || return 1
+        initialize_default_network_node "$pod_fqdn" "$is_primary" || return 1
         ;;
     esac
   done
@@ -799,8 +698,8 @@ gen_initialize_redis_cluster_secondary_nodes() {
 }
 
 initialize_redis_cluster() {
-  if is_empty "$KB_CLUSTER_POD_NAME_LIST" || is_empty "$KB_CLUSTER_POD_HOST_IP_LIST"; then
-    echo "Error: Required environment variable KB_CLUSTER_POD_NAME_LIST and KB_CLUSTER_POD_HOST_IP_LIST are not set when initializing redis cluster" >&2
+  if is_empty "$ALL_SHARDS_POD_NAME_LIST_COMBINED" || is_empty "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"; then
+    echo "Error: Required environment variable ALL_SHARDS_POD_NAME_LIST_COMBINED and ALL_SHARDS_POD_FQDN_LIST_COMBINED are not set when initializing redis cluster" >&2
     return 1
   fi
 
@@ -942,12 +841,12 @@ check_current_shard_other_nodes_are_joined() {
 }
 
 scale_out_redis_cluster_shard() {
-  if is_empty "$CURRENT_SHARD_COMPONENT_SHORT_NAME" || is_empty "$KB_CLUSTER_POD_NAME_LIST" || is_empty "$KB_CLUSTER_POD_HOST_IP_LIST" || is_empty "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" || is_empty "$KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST"; then
-    echo "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, KB_CLUSTER_POD_NAME_LIST, KB_CLUSTER_POD_HOST_IP_LIST, KB_CLUSTER_COMPONENT_POD_NAME_LIST and KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST are not set when scale out redis cluster shard" >&2
+  if is_empty "$CURRENT_SHARD_COMPONENT_SHORT_NAME" || is_empty "$ALL_SHARDS_POD_NAME_LIST_COMBINED" || is_empty "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" || is_empty "$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE" || is_empty "$CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE"; then
+    echo "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, ALL_SHARDS_POD_NAME_LIST_COMBINED, ALL_SHARDS_POD_FQDN_LIST_COMBINED, CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE and CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE are not set when scale out redis cluster shard" >&2
     return 1
   fi
 
-  init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$KB_CLUSTER_POD_IP_LIST" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_COMPONENT_LIST" "$KB_CLUSTER_COMPONENT_DELETING_LIST" "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"
+  init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" "$ALL_SHARDS_COMPONENT_LIST" "$ALL_SHARDS_DELETING_COMPONENT_LIST" "$ALL_SHARDS_UNDELETED_COMPONENT_LIST"
   if init_current_comp_default_nodes_for_scale_out; then
     echo "FalkorDB cluster scale out shard default primary and secondary nodes successfully"
   else
@@ -1022,8 +921,8 @@ scale_out_redis_cluster_shard() {
   local shard_count
   local slots_per_shard
   total_slots=16384
-  current_comp_pod_count=$(echo "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
-  all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
+  current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
+  all_comp_pod_count=$(echo "$ALL_SHARDS_POD_NAME_LIST_COMBINED" | tr ',' '\n' | grep -c ".*")
   shard_count=$((all_comp_pod_count / current_comp_pod_count))
   slots_per_shard=$((total_slots / shard_count))
   if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$slots_per_shard"; then
@@ -1047,21 +946,17 @@ sync_acl_for_redis_cluster_shard() {
   is_ok=false
   acl_list=""
   # 1. get acl list from other pods
-  for pod_name in $(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' ' '); do
-    pod_ip=$(parse_host_ip_from_built_in_envs "$pod_name" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_POD_IP_LIST")
-    if is_empty "$pod_ip"; then
-      echo "Failed to get the host ip of the pod $pod_name"
-      continue
-    fi
-
-    cluster_info=$(get_cluster_info_with_retry "$pod_ip" "$SERVICE_PORT")
+  for pod_fqdn in $(echo "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" | tr ',' ' '); do
+    pod_name=${pod_fqdn%%.*}
+    pod_service_port=$(get_pod_service_port_by_network_mode "$pod_name")
+    cluster_info=$(get_cluster_info_with_retry "$pod_fqdn" "$pod_service_port")
     status=$?
     if [ $status -ne 0 ]; then
       continue
     fi
     cluster_state=$(echo "$cluster_info" | awk -F: '/cluster_state/{print $2}' | tr -d '[:space:]')
     if is_empty "$cluster_state" || equals "$cluster_state" "ok"; then
-       acl_list=$($redis_base_cmd -h "$pod_ip" ACL LIST)
+       acl_list=$($redis_base_cmd -h "$pod_fqdn" -p "$pod_service_port" ACL LIST)
        is_ok=true
        break
     fi
@@ -1101,30 +996,21 @@ sync_acl_for_redis_cluster_shard() {
 }
 
 scale_in_redis_cluster_shard() {
-  if ! detect_scale_in_context; then
-    echo "The KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set and current component is not exclusively in KB_CLUSTER_COMPONENT_DELETING_LIST, skip scaling in"
-    return 0
-  fi
-
-  if is_empty "$CURRENT_SHARD_COMPONENT_SHORT_NAME" || is_empty "$KB_CLUSTER_POD_NAME_LIST" || is_empty "$KB_CLUSTER_POD_HOST_IP_LIST" || is_empty "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" || is_empty "$KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST"; then
-    echo "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, KB_CLUSTER_POD_NAME_LIST, KB_CLUSTER_POD_HOST_IP_LIST, KB_CLUSTER_COMPONENT_POD_NAME_LIST and KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST are not set when scale in redis cluster shard" >&2
+  if is_empty "$CURRENT_SHARD_COMPONENT_SHORT_NAME" || is_empty "$ALL_SHARDS_POD_NAME_LIST_COMBINED" || is_empty "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" || is_empty "$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE" || is_empty "$CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE"; then
+    echo "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, ALL_SHARDS_POD_NAME_LIST_COMBINED, ALL_SHARDS_POD_FQDN_LIST_COMBINED, CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE and CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE are not set when scale in redis cluster shard" >&2
     return 1
   fi
 
   # init information for the other components and pods
-  init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$KB_CLUSTER_POD_IP_LIST" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_COMPONENT_LIST" "$KB_CLUSTER_COMPONENT_DELETING_LIST" "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"
+  init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" "$ALL_SHARDS_COMPONENT_LIST" "$ALL_SHARDS_DELETING_COMPONENT_LIST" "$ALL_SHARDS_UNDELETED_COMPONENT_LIST"
   available_node=$(find_exist_available_node)
-  if is_empty "$available_node"; then
-    echo "No stable available FalkorDB Cluster node found before scaling in shard" >&2
-    return 1
-  fi
   available_node_fqdn=$(echo "$available_node" | awk -F ':' '{print $1}')
   available_node_port=$(echo "$available_node" | awk -F ':' '{print $2}')
   get_current_comp_nodes_for_scale_in "$available_node_fqdn" "$available_node_port"
 
   # Check if the number of shards in the cluster is less than 3 after scaling down.
   current_comp_pod_count=0
-  for pod_name in $(echo "$KB_CLUSTER_COMPONENT_POD_NAME_LIST" | tr ',' ' '); do
+  for pod_name in $(echo "$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE" | tr ',' ' '); do
     if [[ "$pod_name" == "$CURRENT_SHARD_COMPONENT_NAME"* ]]; then
       current_comp_pod_count=$((current_comp_pod_count + 1))
     fi
@@ -1169,13 +1055,13 @@ initialize_or_scale_out_redis_cluster() {
   # TODO: remove random sleep, it's a workaround for the multi components initialization parallelism issue
   sleep_random_second_when_ut_mode_false 10 1
 
-  if is_empty "$KB_CLUSTER_POD_IP_LIST" || is_empty "$KB_CLUSTER_POD_NAME_LIST"; then
-    echo "Error: Required environment variable KB_CLUSTER_POD_IP_LIST and KB_CLUSTER_POD_NAME_LIST and SERVICE_PORT is not set." >&2
+  if is_empty "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" || is_empty "$ALL_SHARDS_POD_NAME_LIST_COMBINED"; then
+    echo "Error: Required environment variable ALL_SHARDS_POD_FQDN_LIST_COMBINED and ALL_SHARDS_POD_NAME_LIST_COMBINED and SERVICE_PORT is not set." >&2
     return 1
   fi
 
   # if the cluster is not initialized, initialize it
-  if ! check_cluster_initialized "$KB_CLUSTER_POD_IP_LIST" "$KB_CLUSTER_POD_NAME_LIST"; then
+  if ! check_cluster_initialized "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"; then
     echo "FalkorDB Cluster not initialized, initializing..."
     if initialize_redis_cluster; then
       echo "FalkorDB Cluster initialized successfully"

--- a/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
+++ b/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
@@ -33,6 +33,66 @@ declare -gA scale_out_shard_default_primary_node
 declare -gA scale_out_shard_default_other_nodes
 network_mode="default"
 
+component_list_contains_exact() {
+  local component_list="$1"
+  local component="$2"
+
+  if [[ -z "$component_list" || -z "$component" ]]; then
+    return 1
+  fi
+
+  IFS=',' read -ra components <<< "$component_list"
+  for item in "${components[@]}"; do
+    if [[ "$item" == "$component" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+component_matches_remove_shard_name() {
+  local remove_shard_name="$1"
+  local component_name="$2"
+  local component_short_name="$3"
+
+  if [[ -z "$remove_shard_name" || -z "$component_name" ]]; then
+    return 1
+  fi
+  if [[ "$remove_shard_name" == "$component_name" ]]; then
+    return 0
+  fi
+  if [[ -n "$component_short_name" && "$remove_shard_name" == "$component_short_name" ]]; then
+    return 0
+  fi
+  if [[ "$component_name" == *-"$remove_shard_name" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+component_list_without_exact() {
+  local component_list="$1"
+  local component="$2"
+  local result=""
+
+  if [[ -z "$component_list" || -z "$component" ]]; then
+    return 0
+  fi
+
+  IFS=',' read -ra components <<< "$component_list"
+  for item in "${components[@]}"; do
+    if [[ -z "$item" || "$item" == "$component" ]]; then
+      continue
+    fi
+    if [[ -z "$result" ]]; then
+      result="$item"
+    else
+      result="$result,$item"
+    fi
+  done
+  echo "$result"
+}
+
 init_environment(){
   if [[ -z "${CURRENT_SHARD_ADVERTISED_PORT}" ]]; then
     CURRENT_SHARD_ADVERTISED_PORT="${CURRENT_SHARD_LB_ADVERTISED_PORT}"
@@ -60,6 +120,14 @@ init_environment(){
   ALL_SHARDS_DELETING_COMPONENT_LIST="${ALL_SHARDS_DELETING_COMPONENT_LIST:-}"
   CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="${CURRENT_SHARD_POD_NAME_LIST:-}"
   CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="${CURRENT_SHARD_POD_FQDN_LIST:-}"
+
+  if component_matches_remove_shard_name "${KB_REMOVE_SHARD_NAME:-}" "${CURRENT_SHARD_COMPONENT_NAME:-}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME:-}"; then
+    ALL_SHARDS_DELETING_COMPONENT_LIST="${ALL_SHARDS_DELETING_COMPONENT_LIST:-$CURRENT_SHARD_COMPONENT_SHORT_NAME}"
+    if component_list_contains_exact "$ALL_SHARDS_UNDELETED_COMPONENT_LIST" "$CURRENT_SHARD_COMPONENT_SHORT_NAME"; then
+      ALL_SHARDS_UNDELETED_COMPONENT_LIST=$(component_list_without_exact "$ALL_SHARDS_UNDELETED_COMPONENT_LIST" "$CURRENT_SHARD_COMPONENT_SHORT_NAME")
+    fi
+    echo "Detected shardRemove context from KB_REMOVE_SHARD_NAME"
+  fi
 
   export ALL_SHARDS_POD_NAME_LIST_COMBINED
   export ALL_SHARDS_POD_FQDN_LIST_COMBINED

--- a/addons/falkordb/scripts-ut-spec/falkordb_cluster_common_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/falkordb_cluster_common_spec.sh
@@ -204,19 +204,19 @@ Describe "FalkorDB Cluster Common Bash Script Tests"
       }
 
       setup() {
-        export KB_CLUSTER_POD_IP_LIST="172.0.0.1,172.0.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.0.0.1,172.0.0.2"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
 
       It "returns 0 when cluster is initialized"
-        When call check_cluster_initialized "$KB_CLUSTER_POD_IP_LIST" "$SERVICE_PORT"
+        When call check_cluster_initialized "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"
         The status should be success
         The output should include "FalkorDB Cluster already initialized"
       End
@@ -229,41 +229,41 @@ Describe "FalkorDB Cluster Common Bash Script Tests"
       }
 
       setup() {
-        export KB_CLUSTER_POD_IP_LIST="172.0.0.1,172.0.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.0.0.1,172.0.0.2"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
 
       It "returns 1 when cluster is not initialized"
-        When call check_cluster_initialized "$KB_CLUSTER_POD_IP_LIST" "$SERVICE_PORT"
+        When call check_cluster_initialized "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"
         The status should be failure
         The stderr should include "FalkorDB Cluster not initialized"
       End
     End
 
-    Context "returns 1 when cluster_node_list or cluster_pod_name_list is empty"
+    Context "returns 1 when cluster_pod_fqdn_list is empty"
       setup() {
-        export KB_CLUSTER_POD_IP_LIST=""
-        export KB_CLUSTER_POD_NAME_LIST=""
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED=""
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED=""
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
       }
       After "un_setup"
 
-      It "returns 1 when cluster_node_list or cluster_pod_name_list is empty"
-        When run check_cluster_initialized "$KB_CLUSTER_POD_IP_LIST" "$KB_CLUSTER_POD_NAME_LIST"
+      It "returns 1 when cluster_pod_fqdn_list is empty"
+        When run check_cluster_initialized "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"
         The status should be failure
-        The stderr should include "Error: Required environment variable cluster_pod_ip_list or cluster_pod_name_list is not set."
+        The stderr should include "Error: Required environment variable cluster_pod_fqdn_list is not set."
       End
     End
   End

--- a/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
@@ -117,6 +117,49 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
         The output should include "ALL_SHARDS_UNDELETED_COMPONENT_LIST=shard-fgt,shard-2qk,shard-r7s"
       End
     End
+
+    Context "when shardRemove identifies the deleted shard"
+      init_environment_and_print_shard_remove_vars() {
+        init_environment
+        echo "ALL_SHARDS_COMPONENT_LIST=$ALL_SHARDS_COMPONENT_LIST"
+        echo "ALL_SHARDS_DELETING_COMPONENT_LIST=$ALL_SHARDS_DELETING_COMPONENT_LIST"
+        echo "ALL_SHARDS_UNDELETED_COMPONENT_LIST=$ALL_SHARDS_UNDELETED_COMPONENT_LIST"
+      }
+
+      setup() {
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
+        export KB_REMOVE_SHARD_NAME="98x"
+        export CURRENT_SHARD_COMPONENT_NAME="falkordb-sharding-shard-98x"
+        export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
+        export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-98x:shard-98x,shard-7hy:shard-7hy,shard-jwl:shard-jwl,shard-kpl:shard-kpl"
+        export CURRENT_SHARD_POD_NAME_LIST="falkordb-sharding-shard-98x-0,falkordb-sharding-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST="falkordb-sharding-shard-98x-0.falkordb-sharding-shard-98x-headless.default.svc.cluster.local,falkordb-sharding-shard-98x-1.falkordb-sharding-shard-98x-headless.default.svc.cluster.local"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset KB_REMOVE_SHARD_NAME
+        unset CURRENT_SHARD_COMPONENT_NAME
+        unset CURRENT_SHARD_COMPONENT_SHORT_NAME
+        unset ALL_SHARDS_COMPONENT_SHORT_NAMES
+        unset CURRENT_SHARD_POD_NAME_LIST
+        unset CURRENT_SHARD_POD_FQDN_LIST
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
+      }
+      After "un_setup"
+
+      It "derives deleting and undeleted component lists from KB_REMOVE_SHARD_NAME"
+        When call init_environment_and_print_shard_remove_vars
+        The status should be success
+        The output should include "ALL_SHARDS_COMPONENT_LIST=shard-98x,shard-7hy,shard-jwl,shard-kpl"
+        The output should include "ALL_SHARDS_DELETING_COMPONENT_LIST=shard-98x"
+        The output should include "ALL_SHARDS_UNDELETED_COMPONENT_LIST=shard-7hy,shard-jwl,shard-kpl"
+      End
+    End
   End
 
   Describe "init_other_components_and_pods_info()"

--- a/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
@@ -26,33 +26,48 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
   }
   BeforeAll "init"
 
+  redis_config_get() {
+    echo "cluster-announce-ip"
+    case "$1" in
+      *sxj-0*) echo "10.42.0.1" ;;
+      *sxj-1*) echo "10.42.0.2" ;;
+      *98x-0*) echo "10.42.0.1" ;;
+      *98x-1*) echo "10.42.0.2" ;;
+      *7hy-0*) echo "10.42.0.3" ;;
+      *7hy-1*) echo "10.42.0.4" ;;
+      *jwl-0*) echo "10.42.0.5" ;;
+      *jwl-1*) echo "10.42.0.6" ;;
+      *) echo "$1" ;;
+    esac
+  }
+
   cleanup() {
     rm -f $common_library_file;
   }
   AfterAll 'cleanup'
 
   Describe "init_environment()"
-    Context "when KB main provides declared shard variables without legacy KB_CLUSTER lists"
+    Context "when KB main provides declared shard variables"
       init_environment_and_print_vars() {
         init_environment
-        echo "KB_CLUSTER_POD_NAME_LIST=$KB_CLUSTER_POD_NAME_LIST"
-        echo "KB_CLUSTER_POD_IP_LIST=$KB_CLUSTER_POD_IP_LIST"
-        echo "KB_CLUSTER_COMPONENT_POD_NAME_LIST=$KB_CLUSTER_COMPONENT_POD_NAME_LIST"
-        echo "KB_CLUSTER_COMPONENT_POD_IP_LIST=$KB_CLUSTER_COMPONENT_POD_IP_LIST"
-        echo "KB_CLUSTER_COMPONENT_LIST=$KB_CLUSTER_COMPONENT_LIST"
-        echo "KB_CLUSTER_COMPONENT_UNDELETED_LIST=$KB_CLUSTER_COMPONENT_UNDELETED_LIST"
+        echo "ALL_SHARDS_POD_NAME_LIST_COMBINED=$ALL_SHARDS_POD_NAME_LIST_COMBINED"
+        echo "ALL_SHARDS_POD_FQDN_LIST_COMBINED=$ALL_SHARDS_POD_FQDN_LIST_COMBINED"
+        echo "CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE=$CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE"
+        echo "CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE=$CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE"
+        echo "ALL_SHARDS_COMPONENT_LIST=$ALL_SHARDS_COMPONENT_LIST"
+        echo "ALL_SHARDS_UNDELETED_COMPONENT_LIST=$ALL_SHARDS_UNDELETED_COMPONENT_LIST"
       }
 
       setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
         export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-fgt:shard-fgt,shard-2qk:shard-2qk,shard-r7s:shard-r7s"
         export ALL_SHARDS_POD_NAME_LIST=""
         export ALL_SHARDS_POD_NAME_LIST_SHARD_FGT="fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1"
@@ -79,48 +94,46 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
         unset ALL_SHARDS_POD_FQDN_LIST_SHARD_R7S
         unset CURRENT_SHARD_POD_NAME_LIST
         unset CURRENT_SHARD_POD_FQDN_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
-      It "synthesizes legacy KB_CLUSTER variables from declared shard variables"
+      It "initializes addon-owned topology variables from declared shard variables"
         When call init_environment_and_print_vars
         The status should be success
-        The output should include "KB_CLUSTER_POD_NAME_LIST=fdb-cl-debug-shard-2qk-0,fdb-cl-debug-shard-2qk-1,fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1,fdb-cl-debug-shard-r7s-0,fdb-cl-debug-shard-r7s-1"
-        The output should include "KB_CLUSTER_POD_IP_LIST=fdb-cl-debug-shard-2qk-0.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-2qk-1.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-0.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-1.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local"
-        The output should include "KB_CLUSTER_COMPONENT_POD_NAME_LIST=fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1"
-        The output should include "KB_CLUSTER_COMPONENT_POD_IP_LIST=fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local"
-        The output should include "KB_CLUSTER_COMPONENT_LIST=shard-fgt,shard-2qk,shard-r7s"
-        The output should include "KB_CLUSTER_COMPONENT_UNDELETED_LIST=shard-fgt,shard-2qk,shard-r7s"
+        The output should include "ALL_SHARDS_POD_NAME_LIST_COMBINED=fdb-cl-debug-shard-2qk-0,fdb-cl-debug-shard-2qk-1,fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1,fdb-cl-debug-shard-r7s-0,fdb-cl-debug-shard-r7s-1"
+        The output should include "ALL_SHARDS_POD_FQDN_LIST_COMBINED=fdb-cl-debug-shard-2qk-0.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-2qk-1.fdb-cl-debug-shard-2qk-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-0.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local,fdb-cl-debug-shard-r7s-1.fdb-cl-debug-shard-r7s-headless.default.svc.cluster.local"
+        The output should include "CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE=fdb-cl-debug-shard-fgt-0,fdb-cl-debug-shard-fgt-1"
+        The output should include "CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE=fdb-cl-debug-shard-fgt-0.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local,fdb-cl-debug-shard-fgt-1.fdb-cl-debug-shard-fgt-headless.default.svc.cluster.local"
+        The output should include "ALL_SHARDS_COMPONENT_LIST=shard-fgt,shard-2qk,shard-r7s"
+        The output should include "ALL_SHARDS_UNDELETED_COMPONENT_LIST=shard-fgt,shard-2qk,shard-r7s"
       End
     End
   End
 
   Describe "init_other_components_and_pods_info()"
     It "initializes other components and pods info correctly"
-      export KB_CLUSTER_COMPONENT_LIST="component1,component2,component3"
-      export KB_CLUSTER_COMPONENT_DELETING_LIST="component2"
-      export KB_CLUSTER_COMPONENT_UNDELETED_LIST="component1,component3"
-      export KB_CLUSTER_POD_IP_LIST="10.0.0.1,10.0.0.2,10.0.0.3,10.0.0.4"
-      export KB_CLUSTER_POD_NAME_LIST="component1-0,component2-0,component3-0,component3-1"
+      export ALL_SHARDS_COMPONENT_LIST="component1,component2,component3"
+      export ALL_SHARDS_DELETING_COMPONENT_LIST="component2"
+      export ALL_SHARDS_UNDELETED_COMPONENT_LIST="component1,component3"
+      export ALL_SHARDS_POD_FQDN_LIST_COMBINED="component1-0.component1-headless.kb-system.svc.cluster.local,component2-0.component2-headless.kb-system.svc.cluster.local,component3-0.component3-headless.kb-system.svc.cluster.local,component3-1.component3-headless.kb-system.svc.cluster.local"
       export CLUSTER_NAMESPACE="kb-system"
       export CLUSTER_DOMAIN="cluster.local"
       export SERVICE_PORT="6379"
 
-      When call init_other_components_and_pods_info "component1" "$KB_CLUSTER_POD_IP_LIST" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_COMPONENT_LIST" "$KB_CLUSTER_COMPONENT_DELETING_LIST" "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"
+      When call init_other_components_and_pods_info "component1" "$ALL_SHARDS_POD_FQDN_LIST_COMBINED" "$ALL_SHARDS_COMPONENT_LIST" "$ALL_SHARDS_DELETING_COMPONENT_LIST" "$ALL_SHARDS_UNDELETED_COMPONENT_LIST"
       The status should be success
       The output should include "other_components: component2 component3"
       The output should include "other_deleting_components: component2"
       The output should include "other_undeleted_components: component3"
-      The output should include "other_undeleted_component_pod_ips: 10.0.0.3 10.0.0.4"
       The output should include "other_undeleted_component_pod_names: component3-0 component3-1"
       The output should include "other_undeleted_component_nodes: component3-0.component3-headless.kb-system.svc.cluster.local:6379 component3-1.component3-headless.kb-system.svc.cluster.local:6379"
     End
@@ -157,18 +170,18 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
   End
 
   Describe "parse_host_ip_from_built_in_envs()"
-    It "parses host IP from built-in environment variables"
-      export KB_CLUSTER_POD_NAME_LIST="pod1,pod2,pod3"
-      export KB_CLUSTER_POD_HOST_IP_LIST="10.0.0.1,10.0.0.2,10.0.0.3"
-      When call parse_host_ip_from_built_in_envs "pod2" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_POD_HOST_IP_LIST"
+    It "parses host IP from an explicit pod mapping"
+      export ALL_SHARDS_POD_NAME_LIST_COMBINED="pod1,pod2,pod3"
+      export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.0.0.1,10.0.0.2,10.0.0.3"
+      When call parse_host_ip_from_built_in_envs "pod2" "$ALL_SHARDS_POD_NAME_LIST_COMBINED" "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"
       The status should be success
       The output should eq "10.0.0.2"
     End
 
     It "exits with error when pod name not found"
-      export KB_CLUSTER_POD_NAME_LIST="pod1,pod2,pod3"
-      export KB_CLUSTER_POD_HOST_IP_LIST="10.0.0.1,10.0.0.2,10.0.0.3"
-      When call parse_host_ip_from_built_in_envs "pod4" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_POD_HOST_IP_LIST"
+      export ALL_SHARDS_POD_NAME_LIST_COMBINED="pod1,pod2,pod3"
+      export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.0.0.1,10.0.0.2,10.0.0.3"
+      When call parse_host_ip_from_built_in_envs "pod4" "$ALL_SHARDS_POD_NAME_LIST_COMBINED" "$ALL_SHARDS_POD_FQDN_LIST_COMBINED"
       The status should be failure
       The stderr should include "the given pod name pod4 not found"
     End
@@ -294,13 +307,15 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       setup() {
         declare -gA scale_out_shard_default_primary_node
         declare -gA scale_out_shard_default_other_nodes
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
         export CURRENT_SHARD_ADVERTISED_PORT="falkordb-shard-sxj-0:31000,falkordb-shard-sxj-1:31001"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
         unset CURRENT_SHARD_ADVERTISED_PORT
       }
       After "un_setup"
@@ -336,15 +351,15 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       setup() {
         declare -gA scale_out_shard_default_primary_node
         declare -gA scale_out_shard_default_other_nodes
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
-        export CURRENT_SHARD_POD_FQDN_LIST="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset CURRENT_SHARD_POD_FQDN_LIST
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -367,12 +382,14 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
       }
       After "un_setup"
 
@@ -399,18 +416,21 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
         esac
       }
 
-      parse_host_ip_from_built_in_envs() {
-        return 1
+      redis_config_get() {
+        echo "cluster-announce-ip"
+        echo ""
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
         export CURRENT_SHARD_ADVERTISED_PORT="falkordb-shard-sxj-0:31000,falkordb-shard-sxj-1:31001"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
         unset CURRENT_SHARD_ADVERTISED_PORT
       }
       After "un_setup"
@@ -450,13 +470,15 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
         export CURRENT_SHARD_ADVERTISED_PORT="falkordb-shard-sxj-0:31000"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
         unset CURRENT_SHARD_ADVERTISED_PORT
       }
       After "un_setup"
@@ -489,15 +511,15 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
-        export CURRENT_SHARD_POD_FQDN_LIST="falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-sxj-0,falkordb-shard-sxj-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE=""
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset CURRENT_SHARD_POD_FQDN_LIST
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -505,7 +527,7 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       It "exits with error when failed to get pod fqdn"
         When run init_current_comp_default_nodes_for_scale_out
         The status should be failure
-        The stderr should include "Error: Failed to get pod falkordb-shard-sxj-0 fqdn from list: falkordb-shard-sxj-0.falkordb-shard-sxj-headless.default.svc.cluster.local,falkordb-shard-sxj-1.falkordb-shard-sxj-headless.default.svc.cluster.local"
+        The stderr should include "Error: Required environment variable CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE and CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE are not set when initializing current shard default nodes"
       End
     End
   End
@@ -513,8 +535,8 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
   Describe "gen_initialize_redis_cluster_node()"
     Context "when is_primary is true and using advertised ports"
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
         export ALL_SHARDS_ADVERTISED_PORT="shard-98x@falkordb-shard-98x-redis-advertised-0:32024,falkordb-shard-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:32025,falkordb-shard-7hy-redis-advertised-1:31319.shard-jwl@falkordb-shard-jwl-redis-advertised-0:32026,falkordb-shard-jwl-redis-advertised-1:31320"
         declare -gA initialize_redis_cluster_primary_nodes
         declare -gA initialize_redis_cluster_secondary_nodes
@@ -523,8 +545,8 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset ALL_SHARDS_ADVERTISED_PORT
       }
       After "un_setup"
@@ -546,8 +568,8 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
 
     Context "when is_primary is false and using advertised ports"
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
         export ALL_SHARDS_ADVERTISED_PORT="shard-98x@falkordb-shard-98x-redis-advertised-0:32024,falkordb-shard-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:32025,falkordb-shard-7hy-redis-advertised-1:31319.shard-jwl@falkordb-shard-jwl-redis-advertised-0:32026,falkordb-shard-jwl-redis-advertised-1:31320"
         declare -gA initialize_redis_cluster_primary_nodes
         declare -gA initialize_redis_cluster_secondary_nodes
@@ -556,8 +578,8 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset ALL_SHARDS_ADVERTISED_PORT
       }
       After "un_setup"
@@ -578,12 +600,9 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
     End
 
     Context "when is_primary is true and not using advertised ports"
-      get_all_shards_pod_fqdns() {
-        echo "falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
-      }
-
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
         export SERVICE_PORT="6379"
         declare -gA initialize_redis_cluster_primary_nodes
         declare -gA initialize_redis_cluster_secondary_nodes
@@ -592,7 +611,8 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -613,12 +633,9 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
     End
 
     Context "when is_primary is false and not using advertised ports"
-      get_all_shards_pod_fqdns() {
-        echo "falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
-      }
-
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
         export SERVICE_PORT="6379"
         declare -gA initialize_redis_cluster_primary_nodes
         declare -gA initialize_redis_cluster_secondary_nodes
@@ -627,7 +644,8 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -653,12 +671,14 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
       }
       After "un_setup"
 
@@ -670,22 +690,22 @@ Describe "FalkorDB Cluster Manage Bash Script Tests"
     End
 
     Context "when failed to get host ip of pod"
-      parse_host_ip_from_built_in_envs() {
+      redis_config_get() {
+        echo "cluster-announce-ip"
         echo ""
-        return 1
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.namespace.svc.cluster.local,falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
         export ALL_SHARDS_ADVERTISED_PORT="shard-98x@falkordb-shard-98x-redis-advertised-0:32024,redis-shar
 d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:32025,falkordb-shard-7hy-redis-advertised-1:31319.shard-jwl@falkordb-shard-jwl-redis-advertised-0:32026,falkordb-shard-jwl-redis-advertised-1:31320"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset ALL_SHARDS_ADVERTISED_PORT
       }
       After "un_setup"
@@ -698,18 +718,16 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
     End
 
     Context "when failed to get all shard pod fqdns"
-      get_all_shards_pod_fqdns() {
-        echo ""
-      }
-
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED=""
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -717,37 +735,10 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       It "returns error when failed to get all shard pod fqdns"
         When call gen_initialize_redis_cluster_node "true"
         The status should be failure
-        The error should include "Failed to get all shard pod FQDNs"
+        The error should include "Error: Required environment variable ALL_SHARDS_POD_NAME_LIST_COMBINED and ALL_SHARDS_POD_FQDN_LIST_COMBINED are not set when generating redis cluster nodes"
       End
     End
 
-    Context "when failed to get target pod fqdn"
-      get_all_shards_pod_fqdns() {
-        echo "falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-98x-2.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
-      }
-
-      get_target_pod_fqdn_from_pod_fqdn_vars() {
-        echo ""
-      }
-
-      setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export SERVICE_PORT="6379"
-      }
-      Before "setup"
-
-      un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset SERVICE_PORT
-      }
-      After "un_setup"
-
-      It "returns error when failed to get target pod fqdn"
-        When call gen_initialize_redis_cluster_node "true"
-        The status should be failure
-        The stderr should include "Failed to get pod falkordb-shard-98x-0 fqdn from list: falkordb-shard-98x-1.namespace.svc.cluster.local,falkordb-shard-98x-2.namespace.svc.cluster.local,falkordb-shard-7hy-0.namespace.svc.cluster.local,falkordb-shard-7hy-1.namespace.svc.cluster.local,falkordb-shard-jwl-0.namespace.svc.cluster.local,falkordb-shard-jwl-1.namespace.svc.cluster.local"
-      End
-    End
   End
 
   Describe "gen_initialize_redis_cluster_primary_node()"
@@ -771,23 +762,23 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
   End
 
   Describe "initialize_redis_cluster()"
-    Context "when KB_CLUSTER_POD_NAME_LIST or KB_CLUSTER_POD_HOST_IP_LIST is empty"
+    Context "when ALL_SHARDS_POD_NAME_LIST_COMBINED or ALL_SHARDS_POD_FQDN_LIST_COMBINED is empty"
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST=""
-        export KB_CLUSTER_POD_HOST_IP_LIST=""
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED=""
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED=""
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
       }
       After "un_setup"
 
-      It "exits with error when KB_CLUSTER_POD_NAME_LIST or KB_CLUSTER_POD_HOST_IP_LIST is empty"
+      It "exits with error when ALL_SHARDS_POD_NAME_LIST_COMBINED or ALL_SHARDS_POD_FQDN_LIST_COMBINED is empty"
         When run initialize_redis_cluster
         The status should be failure
-        The stderr should include "Error: Required environment variable KB_CLUSTER_POD_NAME_LIST and KB_CLUSTER_POD_HOST_IP_LIST are not set when initializing redis cluster"
+        The stderr should include "Error: Required environment variable ALL_SHARDS_POD_NAME_LIST_COMBINED and ALL_SHARDS_POD_FQDN_LIST_COMBINED are not set when initializing redis cluster"
       End
     End
 
@@ -797,14 +788,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
       }
       After "un_setup"
 
@@ -832,14 +823,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
       }
       After "un_setup"
 
@@ -871,15 +862,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -917,15 +908,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -963,15 +954,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1021,15 +1012,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1079,15 +1070,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1105,26 +1096,26 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
     Context "when required environment variables are not set"
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME=""
-        export KB_CLUSTER_POD_NAME_LIST=""
-        export KB_CLUSTER_POD_HOST_IP_LIST=""
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST=""
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST=""
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED=""
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED=""
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE=""
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE=""
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
       }
       After "un_setup"
 
       It "returns error when required environment variables are not set"
         When call scale_out_redis_cluster_shard
         The status should be failure
-        The error should include "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, KB_CLUSTER_POD_NAME_LIST, KB_CLUSTER_POD_HOST_IP_LIST, KB_CLUSTER_COMPONENT_POD_NAME_LIST and KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST are not set when scale out redis cluster shard"
+        The error should include "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, ALL_SHARDS_POD_NAME_LIST_COMBINED, ALL_SHARDS_POD_FQDN_LIST_COMBINED, CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE and CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE are not set when scale out redis cluster shard"
       End
     End
 
@@ -1135,27 +1126,26 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x"
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
@@ -1175,27 +1165,27 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x"
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
@@ -1227,28 +1217,28 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1280,28 +1270,28 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1338,28 +1328,28 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1402,28 +1392,28 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
         unset SERVICE_PORT
       }
       After "un_setup"
@@ -1471,14 +1461,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       setup() {
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy"
         export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
         export SERVICE_PORT="6379"
       }
@@ -1486,14 +1476,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
 
       un_setup() {
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
         unset CURRENT_SHARD_COMPONENT_NAME
         unset SERVICE_PORT
       }
@@ -1509,186 +1499,30 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
   End
 
   Describe "scale_in_redis_cluster_shard()"
-    Context "when no scale-in signal is set"
-      setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
-        export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy"
-      }
-      Before "setup"
-
-      un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
-        unset CURRENT_SHARD_COMPONENT_NAME
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
-      }
-      After "un_setup"
-
-      It "returns 0 and skips scale-in cleanup"
-        When call scale_in_redis_cluster_shard
-        The status should be success
-        The output should include "The KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set and current component is not exclusively in KB_CLUSTER_COMPONENT_DELETING_LIST, skip scaling in"
-      End
-    End
-
-    Context "when legacy KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set but deleting lists identify scale-in target"
-      find_exist_available_node() {
-        echo "falkordb-shard-7hy-0.namespace.svc.cluster.local:6379"
-      }
-
-      get_current_comp_nodes_for_scale_in() {
-        current_comp_primary_node=("falkordb-shard-98x-0.namespace.svc.cluster.local:6379")
-        current_comp_other_nodes=("falkordb-shard-98x-1.namespace.svc.cluster.local:6379")
-      }
-
-      get_cluster_id() {
-        echo "cluster_id_123"
-      }
-
-      scale_in_shard_rebalance_to_zero() {
-        return 0
-      }
-
-      scale_in_shard_del_node() {
-        return 0
-      }
-
-      setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
-        export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST="falkordb-shard-98x"
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
-        export SERVICE_PORT="6379"
-      }
-      Before "setup"
-
-      un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
-        unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset CURRENT_SHARD_COMPONENT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
-        unset SERVICE_PORT
-      }
-      After "un_setup"
-
-      It "runs scale-in cleanup without the legacy scaling-in flag"
-        When call scale_in_redis_cluster_shard
-        The status should be success
-        The output should include "Detected scale-in context from KB_CLUSTER_COMPONENT_DELETING_LIST/UNDELETED_LIST"
-        The output should include "FalkorDB cluster scale in shard rebalance to zero successfully"
-        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-0.namespace.svc.cluster.local:6379 successfully"
-        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-1.namespace.svc.cluster.local:6379 successfully"
-      End
-    End
-
-    Context "when shardRemove action identifies the removed shard"
-      find_exist_available_node() {
-        echo "falkordb-shard-7hy-0.namespace.svc.cluster.local:6379"
-      }
-
-      get_current_comp_nodes_for_scale_in() {
-        current_comp_primary_node=("falkordb-shard-98x-0.namespace.svc.cluster.local:6379")
-        current_comp_other_nodes=("falkordb-shard-98x-1.namespace.svc.cluster.local:6379")
-      }
-
-      get_cluster_id() {
-        echo "cluster_id_123"
-      }
-
-      scale_in_shard_rebalance_to_zero() {
-        return 0
-      }
-
-      scale_in_shard_del_node() {
-        return 0
-      }
-
-      setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
-        export KB_REMOVE_SHARD_NAME="98x"
-        export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
-        export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST=""
-        export SERVICE_PORT="6379"
-      }
-      Before "setup"
-
-      un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
-        unset KB_REMOVE_SHARD_NAME
-        unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset CURRENT_SHARD_COMPONENT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
-        unset SERVICE_PORT
-      }
-      After "un_setup"
-
-      It "runs scale-in cleanup and derives deleting lists from KB_REMOVE_SHARD_NAME"
-        When call scale_in_redis_cluster_shard
-        The status should be success
-        The output should include "Detected scale-in context from KB_REMOVE_SHARD_NAME"
-        The output should include "FalkorDB cluster scale in shard rebalance to zero successfully"
-        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-0.namespace.svc.cluster.local:6379 successfully"
-        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-1.namespace.svc.cluster.local:6379 successfully"
-      End
-    End
-
     Context "when required environment variables are not set"
       setup() {
-        export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME=""
-        export KB_CLUSTER_POD_NAME_LIST=""
-        export KB_CLUSTER_POD_HOST_IP_LIST=""
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST=""
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST=""
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED=""
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED=""
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE=""
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE=""
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
       }
       After "un_setup"
 
       It "returns 1 when required environment variables are not set"
         When call scale_in_redis_cluster_shard
         The status should be failure
-        The error should include "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, KB_CLUSTER_POD_NAME_LIST, KB_CLUSTER_POD_HOST_IP_LIST, KB_CLUSTER_COMPONENT_POD_NAME_LIST and KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST are not set when scale in redis cluster shard"
+        The error should include "Error: Required environment variable CURRENT_SHARD_COMPONENT_SHORT_NAME, ALL_SHARDS_POD_NAME_LIST_COMBINED, ALL_SHARDS_POD_FQDN_LIST_COMBINED, CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE and CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE are not set when scale in redis cluster shard"
       End
     End
 
@@ -1703,17 +1537,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-7hy-0.falkordb-shard-7hy-headless.kb-system.svc.cluster.local,falkordb-shard-7hy-1.falkordb-shard-7hy-headless.kb-system.svc.cluster.local,falkordb-shard-jwl-0.falkordb-shard-jwl-headless.kb-system.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl"
         export CLUSTER_NAMESPACE="kb-system"
         export CLUSTER_DOMAIN="cluster.local"
         export SERVICE_PORT="6379"
@@ -1721,16 +1553,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
@@ -1765,32 +1596,29 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-7hy-0.falkordb-shard-7hy-headless.kb-system.svc.cluster.local,falkordb-shard-7hy-1.falkordb-shard-7hy-headless.kb-system.svc.cluster.local,falkordb-shard-jwl-0.falkordb-shard-jwl-headless.kb-system.svc.cluster.local,falkordb-shard-jwl-1.falkordb-shard-jwl-headless.kb-system.svc.cluster.local,falkordb-shard-kpl-0.falkordb-shard-kpl-headless.kb-system.svc.cluster.local,falkordb-shard-kpl-1.falkordb-shard-kpl-headless.kb-system.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
@@ -1822,17 +1650,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-7hy-0.falkordb-shard-7hy-headless.kb-system.svc.cluster.local,falkordb-shard-7hy-1.falkordb-shard-7hy-headless.kb-system.svc.cluster.local,falkordb-shard-jwl-0.falkordb-shard-jwl-headless.kb-system.svc.cluster.local,falkordb-shard-jwl-1.falkordb-shard-jwl-headless.kb-system.svc.cluster.local,falkordb-shard-kpl-0.falkordb-shard-kpl-headless.kb-system.svc.cluster.local,falkordb-shard-kpl-1.falkordb-shard-kpl-headless.kb-system.svc.cluster.local"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="falkordb-shard-98x-0.falkordb-shard-98x-headless.kb-system.svc.cluster.local,falkordb-shard-98x-1.falkordb-shard-98x-headless.kb-system.svc.cluster.local"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
         export CLUSTER_NAMESPACE="kb-system"
         export CLUSTER_DOMAIN="cluster.local"
         export SERVICE_PORT="6379"
@@ -1840,16 +1666,15 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
@@ -1884,32 +1709,30 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
-        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
-        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
-        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
-        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
-        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
-        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
+        export CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE="10.42.0.1,10.42.0.2"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
+        export ALL_SHARDS_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export ALL_SHARDS_DELETING_COMPONENT_LIST=""
+        export ALL_SHARDS_UNDELETED_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
         export SERVICE_PORT="6379"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
-        unset KB_CLUSTER_POD_NAME_LIST
-        unset KB_CLUSTER_POD_HOST_IP_LIST
-        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
-        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_COMPONENT_LIST
-        unset KB_CLUSTER_COMPONENT_DELETING_LIST
-        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset CURRENT_SHARD_POD_NAME_LIST_EFFECTIVE
+        unset CURRENT_SHARD_POD_FQDN_LIST_EFFECTIVE
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_COMPONENT_LIST
+        unset ALL_SHARDS_DELETING_COMPONENT_LIST
+        unset ALL_SHARDS_UNDELETED_COMPONENT_LIST
       }
       After "un_setup"
 
@@ -1925,21 +1748,21 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
   Describe "initialize_or_scale_out_redis_cluster()"
     Context "when required environment variables are not set"
       setup() {
-        export KB_CLUSTER_POD_IP_LIST=""
-        export KB_CLUSTER_POD_NAME_LIST=""
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED=""
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED=""
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
       }
       After "un_setup"
 
       It "exits with status 1 when required environment variables are not set"
         When run initialize_or_scale_out_redis_cluster
         The status should be failure
-        The stderr should include "Error: Required environment variable KB_CLUSTER_POD_IP_LIST and KB_CLUSTER_POD_NAME_LIST and SERVICE_PORT is not set."
+        The stderr should include "Error: Required environment variable ALL_SHARDS_POD_FQDN_LIST_COMBINED and ALL_SHARDS_POD_NAME_LIST_COMBINED and SERVICE_PORT is not set."
       End
     End
 
@@ -1953,14 +1776,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
       }
       After "un_setup"
 
@@ -1986,14 +1809,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
       }
       After "un_setup"
 
@@ -2015,14 +1838,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
       }
       After "un_setup"
 
@@ -2044,14 +1867,14 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       }
 
       setup() {
-        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
-        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
+        export ALL_SHARDS_POD_FQDN_LIST_COMBINED="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6"
+        export ALL_SHARDS_POD_NAME_LIST_COMBINED="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1"
       }
       Before "setup"
 
       un_setup() {
-        unset KB_CLUSTER_POD_IP_LIST
-        unset KB_CLUSTER_POD_NAME_LIST
+        unset ALL_SHARDS_POD_FQDN_LIST_COMBINED
+        unset ALL_SHARDS_POD_NAME_LIST_COMBINED
       }
       After "un_setup"
 

--- a/addons/falkordb/templates/cmpd-falkordb-cluster.yaml
+++ b/addons/falkordb/templates/cmpd-falkordb-cluster.yaml
@@ -466,15 +466,6 @@ spec:
       preCondition: RuntimeReady
       retryPolicy:
         maxRetries: 10
-    preTerminate:
-      exec:
-        container: falkordb-cluster
-        command:
-          - /bin/bash
-          - -c
-          - /scripts/{{ $falkordbClusterManageScripts }} --pre-terminate > /tmp/pre-terminate.log 2>&1
-      retryPolicy:
-        maxRetries: 10
     memberLeave:
       exec:
         container: falkordb-cluster

--- a/addons/falkordb/templates/cmpv-falkordb-cluster.yaml
+++ b/addons/falkordb/templates/cmpv-falkordb-cluster.yaml
@@ -28,6 +28,7 @@ spec:
       accountProvision: {{ $falkordbRepository }}:{{ .imageTag }}
       switchover: {{ $falkordbRepository }}:{{ .imageTag }}
       preTerminate: {{ $falkordbRepository }}:{{ .imageTag }}
+      shardRemove: {{ $falkordbRepository }}:{{ .imageTag }}
       memberLeave: {{ $falkordbRepository }}:{{ .imageTag }}
       memberJoin: {{ $falkordbRepository }}:{{ .imageTag }}
       metrics: {{ include "metrics.repository" $ }}:{{ $.Values.metrics.image.tag }}

--- a/addons/falkordb/templates/cmpv-falkordb-cluster.yaml
+++ b/addons/falkordb/templates/cmpv-falkordb-cluster.yaml
@@ -27,8 +27,6 @@ spec:
       postProvision: {{ $falkordbRepository }}:{{ .imageTag }}
       accountProvision: {{ $falkordbRepository }}:{{ .imageTag }}
       switchover: {{ $falkordbRepository }}:{{ .imageTag }}
-      preTerminate: {{ $falkordbRepository }}:{{ .imageTag }}
-      shardRemove: {{ $falkordbRepository }}:{{ .imageTag }}
       memberLeave: {{ $falkordbRepository }}:{{ .imageTag }}
       memberJoin: {{ $falkordbRepository }}:{{ .imageTag }}
       metrics: {{ include "metrics.repository" $ }}:{{ $.Values.metrics.image.tag }}

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -21,6 +21,7 @@ spec:
     shardRemove:
       timeoutSeconds: 600
       exec:
+        image: {{ include "falkordb4.image" . }}
         container: falkordb-cluster
         command:
           - /bin/bash

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -14,6 +14,9 @@ spec:
     maxShards: 64
   provisionStrategy: Parallel
   updateStrategy: Parallel
+  systemAccounts:
+    - name: default
+      shared: true
   lifecycleActions:
     shardRemove:
       timeoutSeconds: 600
@@ -22,6 +25,7 @@ spec:
         command:
           - /bin/bash
           - -c
-          - /scripts/falkordb-cluster-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
+          - |
+            /scripts/falkordb-cluster-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
       retryPolicy:
         maxRetries: 10

--- a/examples/falkordb/README.md
+++ b/examples/falkordb/README.md
@@ -721,12 +721,14 @@ You may change the number of shards and replicas in the yaml file.
 apiVersion: apps.kubeblocks.io/v1
 kind: Cluster
 spec:
+  clusterDef: falkordb
+  topology: cluster
   shardings:
   - name: shard
+    shardingDef: falkordb-cluster
     shards: 3  # set the desired number of shards.
     template:
       name: falkordb
-      componentDef: falkordb-cluster-4
       replicas: 2 # set the desired number of replicas for each shard.
       serviceVersion: 4.12.5
       # Component-level services override services defined in
@@ -755,12 +757,14 @@ Similarly to add or remove shards, you can update the `shardings` field in the `
 apiVersion: apps.kubeblocks.io/v1
 kind: Cluster
 spec:
+  clusterDef: falkordb
+  topology: cluster
   shardings:
   - name: shard
+    shardingDef: falkordb-cluster
     shards: 3 # increase or decrease the number of shards.
     template:
       name: falkordb
-      componentDef: falkordb-cluster-4
       replicas: 2 # set the desired number of replicas for each shard.
       serviceVersion: 4.12.5
       stop: false # set to `true` to stop all components

--- a/examples/falkordb/cluster-sharding.yaml
+++ b/examples/falkordb/cluster-sharding.yaml
@@ -5,26 +5,28 @@ metadata:
   namespace: demo
 spec:
   terminationPolicy: Delete
+  clusterDef: falkordb
+  topology: cluster
   # Specifies a list of ShardingSpec objects that configure the sharding topology for components of a Cluster. Each ShardingSpec corresponds to a group of components organized into shards, with each shard containing multiple replicas. Components within a shard are based on a common ClusterComponentSpec template, ensuring that all components in a shard have identical configurations as per the template. This field supports dynamic scaling by facilitating the addition or removal of shards based on the specified number in each ShardingSpec. Note: `shardingSpecs` and `componentSpecs` cannot both be empty; at least one must be defined to configure a cluster. ShardingSpec defines how KubeBlocks manage dynamic provisioned shards. A typical design pattern for distributed databases is to distribute data across multiple shards, with each shard consisting of multiple replicas. Therefore, KubeBlocks supports representing a shard with a Component and dynamically instantiating Components using a template when shards are added. When shards are removed, the corresponding Components are also deleted.
   shardings:
     # Represents the common parent part of all shard names. This identifier is included as part of the Service DNS name and must comply with IANA service naming rules. It is used to generate the names of underlying Components following the pattern `$(shardingSpec.name)-$(ShardID)`. ShardID is a random string that is appended to the Name to generate unique identifiers for each shard. For example, if the sharding specification name is "my-shard" and the ShardID is "abc", the resulting component name would be "my-shard-abc". Note that the name defined in component template(`shardingSpec.template.name`) will be disregarded when generating the component names of the shards. The `shardingSpec.name` field takes precedence.
   - name: shard
-    # Specifies the desired number of shards. Users can declare the desired number of shards through this field. KubeBlocks dynamically creates and deletes Components based on the difference between the desired and actual number of shards. KubeBlocks provides lifecycle management for sharding, including: - Executing the postProvision Action defined in the ComponentDefinition when the number of shards increases. This allows for custom actions to be performed after a new shard is provisioned. - Executing the preTerminate Action defined in the ComponentDefinition when the number of shards decreases. This enables custom cleanup or data migration tasks to be executed before a shard is terminated. Resources and data associated with the corresponding Component will also be deleted.
+    shardingDef: falkordb-cluster
+    # Specifies the desired number of shards. Users can declare the desired number of shards through this field. KubeBlocks dynamically creates and deletes Components based on the difference between the desired and actual number of shards. KubeBlocks provides lifecycle management for sharding, including: - Executing the postProvision Action defined in the ComponentDefinition when the number of shards increases. This allows for custom actions to be performed after a new shard is provisioned. - Executing the shardRemove Action defined in the ShardingDefinition when the number of shards decreases. This enables custom cleanup or data migration tasks to be executed before a shard is terminated. Resources and data associated with the corresponding Component will also be deleted.
     # The number of shards should be no less than 3
     shards: 3
     # The template for generating Components for shards, where each shard consists of one Component. This field is of type ClusterComponentSpec, which encapsulates all the required details and definitions for creating and managing the Components. KubeBlocks uses this template to generate a set of identical Components or shards. All the generated Components will have the same specifications and definitions as specified in the `template` field. This allows for the creation of multiple Components with consistent configurations, enabling sharding and distribution of workloads across Components.
     template:
       name: falkordb
-      componentDef: falkordb-cluster-4
       disableExporter: true
       replicas: 2
       resources:
         limits:
           cpu: '1'
-          memory: 1.1Gi
+          memory: 1Gi
         requests:
           cpu: '1'
-          memory: 1.1Gi
+          memory: 1Gi
       # Specifies the version of the Component service. This field is used to determine the version of the service that is created for the Component. \
       # The serviceVersion is used to determine the version of the falkordb Sharding Cluster kernel. If the serviceVersion is not specified, the default value is the ServiceVersion defined in ComponentDefinition.
       serviceVersion: 4.12.5


### PR DESCRIPTION
- fix: https://github.com/apecloud/kubeblocks-addons/issues/2861


- update shardingdefinition lifecycle with shardRemove
- remove perTerminate from Cluster ComponentDefinitions
- update addons-clusters/falkordb, creating clusters with shardingdef reference
- update falkordb examples
- update shellspec test