### PR TITLE
fix(falkordb): use redis dts type for rebalance

### DIFF
--- a/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
+++ b/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
@@ -111,8 +111,66 @@ component_list_contains_exact() {
   return 1
 }
 
+component_matches_remove_shard_name() {
+  local remove_shard_name="$1"
+  local component_name="$2"
+  local component_short_name="$3"
+
+  if [[ -z "$remove_shard_name" || -z "$component_name" ]]; then
+    return 1
+  fi
+  if [[ "$remove_shard_name" == "$component_name" ]]; then
+    return 0
+  fi
+  if [[ -n "$component_short_name" && "$remove_shard_name" == "$component_short_name" ]]; then
+    return 0
+  fi
+  if [[ "$component_name" == *-"$remove_shard_name" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+component_list_without_exact() {
+  local component_list="$1"
+  local component="$2"
+  local result=""
+
+  if [[ -z "$component_list" || -z "$component" ]]; then
+    return 0
+  fi
+
+  IFS=',' read -ra components <<< "$component_list"
+  for item in "${components[@]}"; do
+    if [[ -z "$item" || "$item" == "$component" ]]; then
+      continue
+    fi
+    if [[ -z "$result" ]]; then
+      result="$item"
+    else
+      result="$result,$item"
+    fi
+  done
+  echo "$result"
+}
+
 detect_scale_in_context() {
   if ! is_empty "$KB_CLUSTER_COMPONENT_IS_SCALING_IN"; then
+    return 0
+  fi
+
+  if component_matches_remove_shard_name "$KB_REMOVE_SHARD_NAME" "$CURRENT_SHARD_COMPONENT_NAME" "$CURRENT_SHARD_COMPONENT_SHORT_NAME"; then
+    KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
+    export KB_CLUSTER_COMPONENT_IS_SCALING_IN
+    if is_empty "$KB_CLUSTER_COMPONENT_DELETING_LIST"; then
+      KB_CLUSTER_COMPONENT_DELETING_LIST="$CURRENT_SHARD_COMPONENT_NAME"
+      export KB_CLUSTER_COMPONENT_DELETING_LIST
+    fi
+    if is_empty "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"; then
+      KB_CLUSTER_COMPONENT_UNDELETED_LIST=$(component_list_without_exact "$KB_CLUSTER_COMPONENT_LIST" "$CURRENT_SHARD_COMPONENT_NAME")
+      export KB_CLUSTER_COMPONENT_UNDELETED_LIST
+    fi
+    echo "Detected scale-in context from KB_REMOVE_SHARD_NAME"
     return 0
   fi
 

--- a/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
+++ b/addons/falkordb/falkordb-cluster-scripts/falkordb-cluster-manage.sh
@@ -94,6 +94,44 @@ init_environment(){
   export KB_CLUSTER_COMPONENT_DELETING_LIST
 }
 
+component_list_contains_exact() {
+  local component_list="$1"
+  local component="$2"
+
+  if [[ -z "$component_list" || -z "$component" ]]; then
+    return 1
+  fi
+
+  IFS=',' read -ra components <<< "$component_list"
+  for item in "${components[@]}"; do
+    if [[ "$item" == "$component" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+detect_scale_in_context() {
+  if ! is_empty "$KB_CLUSTER_COMPONENT_IS_SCALING_IN"; then
+    return 0
+  fi
+
+  if ! component_list_contains_exact "$KB_CLUSTER_COMPONENT_DELETING_LIST" "$CURRENT_SHARD_COMPONENT_NAME"; then
+    return 1
+  fi
+  if component_list_contains_exact "$KB_CLUSTER_COMPONENT_UNDELETED_LIST" "$CURRENT_SHARD_COMPONENT_NAME"; then
+    return 1
+  fi
+  if is_empty "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"; then
+    return 1
+  fi
+
+  KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"
+  export KB_CLUSTER_COMPONENT_IS_SCALING_IN
+  echo "Detected scale-in context from KB_CLUSTER_COMPONENT_DELETING_LIST/UNDELETED_LIST"
+  return 0
+}
+
 load_redis_cluster_common_utils() {
   # the common.sh and falkordb-cluster-common.sh scripts are defined in the falkordb-cluster-scripts-template configmap
   # and are mounted to the same path which defined in the cmpd.spec.scripts
@@ -1005,9 +1043,8 @@ sync_acl_for_redis_cluster_shard() {
 }
 
 scale_in_redis_cluster_shard() {
-  # check KB_CLUSTER_COMPONENT_IS_SCALING_IN env
-  if is_empty "$KB_CLUSTER_COMPONENT_IS_SCALING_IN"; then
-    echo "The KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set, skip scaling in"
+  if ! detect_scale_in_context; then
+    echo "The KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set and current component is not exclusively in KB_CLUSTER_COMPONENT_DELETING_LIST, skip scaling in"
     return 0
   fi
 
@@ -1019,6 +1056,10 @@ scale_in_redis_cluster_shard() {
   # init information for the other components and pods
   init_other_components_and_pods_info "$CURRENT_SHARD_COMPONENT_SHORT_NAME" "$KB_CLUSTER_POD_IP_LIST" "$KB_CLUSTER_POD_NAME_LIST" "$KB_CLUSTER_COMPONENT_LIST" "$KB_CLUSTER_COMPONENT_DELETING_LIST" "$KB_CLUSTER_COMPONENT_UNDELETED_LIST"
   available_node=$(find_exist_available_node)
+  if is_empty "$available_node"; then
+    echo "No stable available FalkorDB Cluster node found before scaling in shard" >&2
+    return 1
+  fi
   available_node_fqdn=$(echo "$available_node" | awk -F ':' '{print $1}')
   available_node_port=$(echo "$available_node" | awk -F ':' '{print $2}')
   get_current_comp_nodes_for_scale_in "$available_node_fqdn" "$available_node_port"

--- a/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
@@ -1509,21 +1509,91 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
   End
 
   Describe "scale_in_redis_cluster_shard()"
-    Context "when KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set"
+    Context "when no scale-in signal is set"
       setup() {
-        export KB_CLUSTER_COMPONENT_IS_SCALING_IN=""
+        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
+        export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
+        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
+        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-98x,falkordb-shard-7hy"
       }
       Before "setup"
 
       un_setup() {
         unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
+        unset CURRENT_SHARD_COMPONENT_NAME
+        unset KB_CLUSTER_COMPONENT_DELETING_LIST
+        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
       }
       After "un_setup"
 
-      It "returns 0 when KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set"
+      It "returns 0 and skips scale-in cleanup"
         When call scale_in_redis_cluster_shard
         The status should be success
-        The output should include "The KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set, skip scaling in"
+        The output should include "The KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set and current component is not exclusively in KB_CLUSTER_COMPONENT_DELETING_LIST, skip scaling in"
+      End
+    End
+
+    Context "when legacy KB_CLUSTER_COMPONENT_IS_SCALING_IN env is not set but deleting lists identify scale-in target"
+      find_exist_available_node() {
+        echo "falkordb-shard-7hy-0.namespace.svc.cluster.local:6379"
+      }
+
+      get_current_comp_nodes_for_scale_in() {
+        current_comp_primary_node=("falkordb-shard-98x-0.namespace.svc.cluster.local:6379")
+        current_comp_other_nodes=("falkordb-shard-98x-1.namespace.svc.cluster.local:6379")
+      }
+
+      get_cluster_id() {
+        echo "cluster_id_123"
+      }
+
+      scale_in_shard_rebalance_to_zero() {
+        return 0
+      }
+
+      scale_in_shard_del_node() {
+        return 0
+      }
+
+      setup() {
+        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
+        export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
+        export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
+        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
+        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
+        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
+        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
+        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export KB_CLUSTER_COMPONENT_DELETING_LIST="falkordb-shard-98x"
+        export KB_CLUSTER_COMPONENT_UNDELETED_LIST="falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export SERVICE_PORT="6379"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
+        unset CURRENT_SHARD_COMPONENT_SHORT_NAME
+        unset CURRENT_SHARD_COMPONENT_NAME
+        unset KB_CLUSTER_POD_NAME_LIST
+        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+        unset KB_CLUSTER_POD_IP_LIST
+        unset KB_CLUSTER_COMPONENT_LIST
+        unset KB_CLUSTER_COMPONENT_DELETING_LIST
+        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset SERVICE_PORT
+      }
+      After "un_setup"
+
+      It "runs scale-in cleanup without the legacy scaling-in flag"
+        When call scale_in_redis_cluster_shard
+        The status should be success
+        The output should include "Detected scale-in context from KB_CLUSTER_COMPONENT_DELETING_LIST/UNDELETED_LIST"
+        The output should include "FalkorDB cluster scale in shard rebalance to zero successfully"
+        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-0.namespace.svc.cluster.local:6379 successfully"
+        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-1.namespace.svc.cluster.local:6379 successfully"
       End
     End
 

--- a/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/falkordb_cluster_manage_spec.sh
@@ -1597,6 +1597,72 @@ d-98x-redis-advertised-1:31318.shard-7hy@falkordb-shard-7hy-redis-advertised-0:3
       End
     End
 
+    Context "when shardRemove action identifies the removed shard"
+      find_exist_available_node() {
+        echo "falkordb-shard-7hy-0.namespace.svc.cluster.local:6379"
+      }
+
+      get_current_comp_nodes_for_scale_in() {
+        current_comp_primary_node=("falkordb-shard-98x-0.namespace.svc.cluster.local:6379")
+        current_comp_other_nodes=("falkordb-shard-98x-1.namespace.svc.cluster.local:6379")
+      }
+
+      get_cluster_id() {
+        echo "cluster_id_123"
+      }
+
+      scale_in_shard_rebalance_to_zero() {
+        return 0
+      }
+
+      scale_in_shard_del_node() {
+        return 0
+      }
+
+      setup() {
+        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
+        export KB_REMOVE_SHARD_NAME="98x"
+        export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
+        export CURRENT_SHARD_COMPONENT_NAME="falkordb-shard-98x"
+        export KB_CLUSTER_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1,falkordb-shard-7hy-0,falkordb-shard-7hy-1,falkordb-shard-jwl-0,falkordb-shard-jwl-1,falkordb-shard-kpl-0,falkordb-shard-kpl-1"
+        export KB_CLUSTER_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2,10.42.0.3,10.42.0.4,10.42.0.5,10.42.0.6,10.42.0.7,10.42.0.8"
+        export KB_CLUSTER_COMPONENT_POD_NAME_LIST="falkordb-shard-98x-0,falkordb-shard-98x-1"
+        export KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST="10.42.0.1,10.42.0.2"
+        export KB_CLUSTER_POD_IP_LIST="172.42.0.1,172.42.0.2,172.42.0.3,172.42.0.4,172.42.0.5,172.42.0.6,172.42.0.7,172.42.0.8"
+        export KB_CLUSTER_COMPONENT_LIST="falkordb-shard-98x,falkordb-shard-7hy,falkordb-shard-jwl,falkordb-shard-kpl"
+        export KB_CLUSTER_COMPONENT_DELETING_LIST=""
+        export KB_CLUSTER_COMPONENT_UNDELETED_LIST=""
+        export SERVICE_PORT="6379"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset KB_CLUSTER_COMPONENT_IS_SCALING_IN
+        unset KB_REMOVE_SHARD_NAME
+        unset CURRENT_SHARD_COMPONENT_SHORT_NAME
+        unset CURRENT_SHARD_COMPONENT_NAME
+        unset KB_CLUSTER_POD_NAME_LIST
+        unset KB_CLUSTER_POD_HOST_IP_LIST
+        unset KB_CLUSTER_COMPONENT_POD_NAME_LIST
+        unset KB_CLUSTER_COMPONENT_POD_HOST_IP_LIST
+        unset KB_CLUSTER_POD_IP_LIST
+        unset KB_CLUSTER_COMPONENT_LIST
+        unset KB_CLUSTER_COMPONENT_DELETING_LIST
+        unset KB_CLUSTER_COMPONENT_UNDELETED_LIST
+        unset SERVICE_PORT
+      }
+      After "un_setup"
+
+      It "runs scale-in cleanup and derives deleting lists from KB_REMOVE_SHARD_NAME"
+        When call scale_in_redis_cluster_shard
+        The status should be success
+        The output should include "Detected scale-in context from KB_REMOVE_SHARD_NAME"
+        The output should include "FalkorDB cluster scale in shard rebalance to zero successfully"
+        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-0.namespace.svc.cluster.local:6379 successfully"
+        The output should include "FalkorDB cluster scale in shard delete node falkordb-shard-98x-1.namespace.svc.cluster.local:6379 successfully"
+      End
+    End
+
     Context "when required environment variables are not set"
       setup() {
         export KB_CLUSTER_COMPONENT_IS_SCALING_IN="true"

--- a/addons/falkordb/templates/opsdefinition-rebalance.yaml
+++ b/addons/falkordb/templates/opsdefinition-rebalance.yaml
@@ -49,7 +49,7 @@ spec:
                 echo ${REDIS_URL}
                 cat <<EOF > /tmp/reshard.ini
                 [extractor]
-                db_type=falkordb
+                db_type=redis
                 extract_type=reshard
                 url=${REDIS_URL}
                 [sinker]

--- a/addons/falkordb/templates/opsdefinition-rebalance.yaml
+++ b/addons/falkordb/templates/opsdefinition-rebalance.yaml
@@ -45,7 +45,7 @@ spec:
             args:
               - |
                 POD_FQDN=$CURRENT_POD_NAME.$CURRENT_SHARD_COMPONENT_NAME-headless.$CLUSTER_NAMESPACE.svc.$CLUSTER_DOMAIN
-                REDIS_URL="falkordb://${REDIS_DEFAULT_USER}:${REDIS_DEFAULT_PASSWORD}@${POD_FQDN}"
+                REDIS_URL="redis://${REDIS_DEFAULT_USER}:${REDIS_DEFAULT_PASSWORD}@${POD_FQDN}"
                 echo ${REDIS_URL}
                 cat <<EOF > /tmp/reshard.ini
                 [extractor]

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -14,3 +14,14 @@ spec:
     maxShards: 64
   provisionStrategy: Parallel
   updateStrategy: Parallel
+  lifecycleActions:
+    shardRemove:
+      timeoutSeconds: 600
+      exec:
+        container: falkordb-cluster
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/falkordb-cluster-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
+      retryPolicy:
+        maxRetries: 10


### PR DESCRIPTION
## Summary
- change FalkorDB rebalance OpsDefinition ape-dts config from db_type=falkordb to db_type=redis
- keep the ape-dts image and container structure unchanged for minimal R05 validation delta

## Evidence
- PR526 retained R05 evidence: componentName shard is valid; Custom Ops created Job b3b5a11e-fdb-rsh-retained-1--rebalance-0; images pulled; falkordb-rebalance failed inside ape-dts parsing db_type=falkordb
- failure log: config [extractor].db_type=falkordb can not be parsed as dt_common::config::config_enums::DbType
- Redis rebalance OpsDefinition and FalkorDB restore already use db_type=redis with ape-dts

## Validation
- git diff --check
- helm template falkordb ./addons/falkordb --set clusterVersionOverride=4.12.5 | rg -n "name: falkordb-cluster-rebalance|db_type=|falkordb-rebalance|ape-dts" -C 3
- helm lint ./addons/falkordb --set clusterVersionOverride=4.12.5

## Runtime follow-up
- Ask Ann to rerun retained R05 only first on PR526 environment with this addon patch; if R05 passes, restart a fresh full reshard run from R01.