### PR TITLE
fix(clickhouse): enable session log by default

### DIFF
--- a/addons/clickhouse/configs/00_default_overrides.xml.tpl
+++ b/addons/clickhouse/configs/00_default_overrides.xml.tpl
@@ -155,6 +155,18 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </query_log>
+  <session_log>
+    <database>system</database>
+    <table>session_log</table>
+    <partition_by>event_date</partition_by>
+    <order_by>event_time</order_by>
+    <ttl>event_date + INTERVAL 7 day</ttl>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </session_log>
   <!-- User directories configuration -->
   <!-- see https://github.com/ClickHouse/ClickHouse/issues/78830 -->
   <user_directories replace="replace">

--- a/addons/clickhouse/configs/clickhouse-config-constraint.cue
+++ b/addons/clickhouse/configs/clickhouse-config-constraint.cue
@@ -34,6 +34,7 @@
 	tcp_port_secure:                      _
 	listen_host:                          _
 	query_log:                            _
+	session_log:                          _
 	user_directories:                     _
 
 	// Path to a folder where a ClickHouse server stores user and role configurations created by SQL commands


### PR DESCRIPTION
## Summary

- Enable ClickHouse `session_log` in the default server config template.
- Allow `clickhouse.session_log` in the ClickHouse config CUE schema.
- Keep the log table bounded with the same 7-day TTL and queue limits used by the existing `query_log` block.

## Why

`system.processes` only shows currently running queries. DMS can fallback to it when `system.session_log` is absent, but all/idle session views need ClickHouse to create `system.session_log`.

Fixes apecloud/apecloud#19084.

## Validation

- `helm dependency build addons/clickhouse --skip-refresh`
- `helm template clickhouse addons/clickhouse`
  - rendered `clickhouse-configuration-tpl` contains `<session_log>`
  - rendered CUE schema contains `session_log: _`
- `helm lint addons/clickhouse`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- Runtime config smoke with `clickhouse/clickhouse-server:25.9.7.56`
  - mounted the same `session_log` config block under `config.d`
  - server merged `config.d/session_log.xml`
  - after one flush interval, `system.session_log` existed as `MergeTree`
- Runtime config smoke with `clickhouse/clickhouse-server:22.3.18.37`
  - same result: server accepted the config and `system.session_log` existed as `MergeTree`

## Boundaries

- This changes the default config rendered for new/updated addon templates.
- Existing clusters may still need an explicit reconfigure/restart path before the table appears.
- DMS fallback to `system.processes` is still required when `system.session_log` is absent.
