### PR TITLE
fix(clickhouse): enable session log by default

### DIFF
--- a/addons/clickhouse/configs/00_default_overrides.xml.tpl
+++ b/addons/clickhouse/configs/00_default_overrides.xml.tpl
@@ -155,6 +155,18 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </query_log>
+  <session_log>
+    <database>system</database>
+    <table>session_log</table>
+    <partition_by>event_date</partition_by>
+    <order_by>event_time</order_by>
+    <ttl>event_date + INTERVAL 7 day</ttl>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </session_log>
   <!-- User directories configuration -->
   <!-- see https://github.com/ClickHouse/ClickHouse/issues/78830 -->
   <user_directories replace="replace">

--- a/addons/clickhouse/configs/clickhouse-config-constraint.cue
+++ b/addons/clickhouse/configs/clickhouse-config-constraint.cue
@@ -34,6 +34,7 @@
 	tcp_port_secure:                      _
 	listen_host:                          _
 	query_log:                            _
+	session_log:                          _
 	user_directories:                     _
 
 	// Path to a folder where a ClickHouse server stores user and role configurations created by SQL commands


### PR DESCRIPTION
## What

Backport the ClickHouse `session_log` enablement from main PR #2952 to `release-1.0`.

This adds the default `<session_log>` server config block to ClickHouse and allows `clickhouse.session_log` in the config constraint schema.

## Why

apecloud/apecloud#19084 reports new KubeBlocks-created ClickHouse clusters do not have `system.session_log`, so DMS cannot provide best-effort all/idle session visibility and can only fall back to `system.processes`.

Runtime root cause confirmed on IDC2: the rendered ClickHouse instance config only had `<query_log>` and did not include `<session_log>`. ClickHouse 25.9.7 keeps `session_log` commented out in the image default config, so the table is not created unless the addon enables it.

## IDC2 evidence

Environment:
- KubeBlocks IDC2
- Installed addon before validation: `kb-addon-clickhouse` chart `clickhouse-1.0.3`, appVersion `25.9.7`
- Test namespace: `alal-test`

Baseline reproduction with existing release-1.0 addon:
- Created `ch19084a` with standalone topology, 1 shard / 1 replica.
- Cluster reached `Running`, pod `ch19084a-clickhouse-jqq-0` was `2/2 Running`, restart count `0`.
- Rendered instance ConfigMap `ch19084a-clickhouse-jqq-clickhouse-tpl` contained `<query_log>` but no `<session_log>`.
- SQL evidence:
  - `SELECT name, engine FROM system.tables WHERE database='system' AND name IN ('processes','query_log','session_log')` returned only `processes`.
  - `SELECT * FROM system.session_log LIMIT 1` failed with `Code: 60 ... UNKNOWN_TABLE`.

Regression after applying this branch to IDC2 as `kb-addon-clickhouse` revision 8:
- The cluster-scoped template `kb-system/clickhouse-configuration-tpl` contains `<session_log>`.
- `clickhouse-config-pd` contains `session_log` in the allowed schema.
- Standalone smoke `ch19084b` reached `Running`, pod restart counts were `clickhouse=0`, `kbagent=0`.
- Rendered instance ConfigMap `ch19084b-clickhouse-lw2-clickhouse-tpl` contains:
  - `<session_log>`
  - `<partition_by>event_date</partition_by>`
  - `<order_by>event_time</order_by>`
  - `<ttl>event_date + INTERVAL 7 day</ttl>`
- After one ClickHouse log flush interval, SQL showed:
  - `session_log    MergeTree`
  - `SELECT count() FROM system.session_log` returned `10`
  - `SELECT type, user, interface FROM system.session_log ORDER BY event_time DESC LIMIT 5` returned `LoginSuccess` / `Logout` rows for `admin` over `TCP`.
- Cluster topology smoke `ch19084c` with 1 shard / 1 replica / 1 keeper reached `Running`; pods `ch19084c-ch-keeper-0` and `ch19084c-clickhouse-zwq-0` were both `2/2 Running`, all restart counts `0`.
- `ch19084c-clickhouse-zwq-clickhouse-tpl` also rendered `<session_log>` with the same partition/order/ttl config.
- After one ClickHouse log flush interval, SQL showed `session_log    MergeTree`, `SELECT count() FROM system.session_log` returned `4`, and `SELECT 1` returned `1`.

Cleanup:
- Removed Helm releases `ch19084a`, `ch19084b`, `ch19084c`.
- Confirmed no matching Cluster/Pod/PVC/Component remained in `alal-test`.
- IDC2 `kb-addon-clickhouse` remains at local fixed Helm revision 8 for follow-up validation.

## Local validation

- `helm dependency build --skip-refresh addons/clickhouse`
- `helm dependency build --skip-refresh addons-cluster/clickhouse`
- `helm lint addons/clickhouse`
- `helm lint addons-cluster/clickhouse`
- `cue eval addons/clickhouse/configs/clickhouse-config-constraint.cue`
- `helm template kb-addon-clickhouse addons/clickhouse -n kb-system`
- `helm template ch19084b addons-cluster/clickhouse ... | kubectl apply --dry-run=server -f -`
- `helm template ch19084c addons-cluster/clickhouse ... | kubectl apply --dry-run=server -f -`
- `git diff --check`
