### PR TITLE
fix(redis): set sharding definition in cluster manifests

### DIFF
--- a/addons-cluster/redis/templates/_helpers.tpl
+++ b/addons-cluster/redis/templates/_helpers.tpl
@@ -17,11 +17,11 @@ Define redis cluster shardingSpec with ComponentDefinition.
 */}}
 {{- define "redis-cluster.shardingSpec" }}
 - name: shard
+  shardingDef: redis-cluster
   shards: {{ .Values.redisCluster.shardCount }}
   template:
     name: redis
     {{- include "redis-cluster.tls" . | indent 4 }}
-    componentDef: redis-cluster
     replicas: {{ .Values.replicas }}
     {{- if .Values.podAntiAffinityEnabled }}
     {{- include "redis-cluster.shardingSchedulingPolicy" . | indent 2 }}

--- a/examples/redis/cluster-sharding.yaml
+++ b/examples/redis/cluster-sharding.yaml
@@ -9,13 +9,13 @@ spec:
   shardings:
     # Represents the common parent part of all shard names. This identifier is included as part of the Service DNS name and must comply with IANA service naming rules. It is used to generate the names of underlying Components following the pattern `$(shardingSpec.name)-$(ShardID)`. ShardID is a random string that is appended to the Name to generate unique identifiers for each shard. For example, if the sharding specification name is "my-shard" and the ShardID is "abc", the resulting component name would be "my-shard-abc". Note that the name defined in component template(`shardingSpec.template.name`) will be disregarded when generating the component names of the shards. The `shardingSpec.name` field takes precedence.
   - name: shard
+    shardingDef: redis-cluster
     # Specifies the desired number of shards. Users can declare the desired number of shards through this field. KubeBlocks dynamically creates and deletes Components based on the difference between the desired and actual number of shards. KubeBlocks provides lifecycle management for sharding, including: - Executing the postProvision Action defined in the ComponentDefinition when the number of shards increases. This allows for custom actions to be performed after a new shard is provisioned. - Executing the preTerminate Action defined in the ComponentDefinition when the number of shards decreases. This enables custom cleanup or data migration tasks to be executed before a shard is terminated. Resources and data associated with the corresponding Component will also be deleted.
     # The number of shards should be no less than 3
     shards: 3
     # The template for generating Components for shards, where each shard consists of one Component. This field is of type ClusterComponentSpec, which encapsulates all the required details and definitions for creating and managing the Components. KubeBlocks uses this template to generate a set of identical Components or shards. All the generated Components will have the same specifications and definitions as specified in the `template` field. This allows for the creation of multiple Components with consistent configurations, enabling sharding and distribution of workloads across Components.
     template:
       name: redis
-      componentDef: redis-cluster-7
       disableExporter: true
       replicas: 2
       resources:


### PR DESCRIPTION
## Summary
- set shardingDef: redis-cluster in the Redis sharding example
- render shardingDef: redis-cluster from the Redis cluster Helm chart

## Why
Redis cluster creation can stay in Creating when the sharding spec does not explicitly bind the Redis ShardingDefinition. The Redis addon already defines the cluster topology with shardingDef: redis-cluster, so the example and cluster chart should render the same binding.