### PR TITLE
chore: Add keep policy to Milvus config maps

### DIFF
--- a/addons/milvus/templates/configuration-template.yaml
+++ b/addons/milvus/templates/configuration-template.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+  {{- include "milvus.annotations" . | nindent 4 }}
 data:
   user.yaml: |-
     {{- .Files.Get "configs/standalone-user.yaml" | nindent 4 }}
@@ -16,6 +18,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+  {{- include "milvus.annotations" . | nindent 4 }}
 data:
   user.yaml: |-
     {{- .Files.Get "configs/cluster-user.yaml" | nindent 4 }}
@@ -27,6 +31,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+  {{- include "milvus.annotations" . | nindent 4 }}
 data:
   {{- range $path, $_ :=  $.Files.Glob "scripts/**" }}
   {{ $path | base }}: |-


### PR DESCRIPTION
Summary: Add Milvus config and scripts ConfigMaps to the existing chart annotations helper so versioned ConfigMaps rendered from CMPD references keep helm.sh/resource-policy=keep.