### PR TITLE
chore: keep cmpd configmaps for etcd and milvus

### DIFF
--- a/addons/etcd/templates/_helpers.tpl
+++ b/addons/etcd/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Common annotations
 */}}
 {{- define "etcd.annotations" -}}
-{{- /*{{ include "kblib.helm.resourcePolicy" . }}*/ -}}
+{{ include "kblib.helm.resourcePolicy" . }}
 {{ include "etcd.apiVersion" . }}
 {{- end }}
 

--- a/addons/milvus/templates/configuration-template.yaml
+++ b/addons/milvus/templates/configuration-template.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+  {{- include "milvus.annotations" . | nindent 4 }}
 data:
   user.yaml: |-
     {{- .Files.Get "configs/standalone-user.yaml" | nindent 4 }}
@@ -16,6 +18,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+  {{- include "milvus.annotations" . | nindent 4 }}
 data:
   user.yaml: |-
     {{- .Files.Get "configs/cluster-user.yaml" | nindent 4 }}
@@ -27,6 +31,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+  {{- include "milvus.annotations" . | nindent 4 }}
 data:
   {{- range $path, $_ :=  $.Files.Glob "scripts/**" }}
   {{ $path | base }}: |-


### PR DESCRIPTION
This PR keeps versioned CMPD ConfigMaps during Helm uninstall/upgrade by restoring the Etcd resource policy annotation helper and wiring Milvus configuration ConfigMaps to the existing annotations helper. 