### PR TITLE
ci(elasticsearch): add plugin image release workflow

### DIFF
--- a/.github/workflows/release-elasticsearch-plugin-image.yml
+++ b/.github/workflows/release-elasticsearch-plugin-image.yml
@@ -1,0 +1,27 @@
+name: Release Elasticsearch Plugin Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: 'The version of elasticsearch plugin image'
+        required: true
+        default: '0.1.1'
+      BUILDX_PLATFORMS:
+        description: 'buildx platforms'
+        required: false
+        default: 'linux/amd64,linux/arm64'
+
+run-name: release elasticsearch plugin image ${{ inputs.VERSION }}
+
+jobs:
+  release-elasticsearch-plugin-image:
+    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache2.yml@v0.1.96
+    with:
+      IMG: "apecloud/elasticsearch-plugins"
+      VERSION: "${{ inputs.VERSION }}"
+      APECD_REF: "v0.1.96"
+      DOCKERFILE_PATH: "./addons/elasticsearch/plugins/Dockerfile"
+      REMOVE_PREFIX: false
+      BUILDX_PLATFORMS: "${{ inputs.BUILDX_PLATFORMS }}"
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a workflow_dispatch wrapper to publish `apecloud/elasticsearch-plugins:<VERSION>` from `addons/elasticsearch/plugins/Dockerfile`
- reuse `apecloud-cd/.github/workflows/release-image-cache2.yml@v0.1.96` so repo registry secrets handle Docker Hub and Aliyun pushes
- default VERSION to `0.1.1`, the current blocker for ES 8.19.0 support, while keeping the input overrideable

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/release-elasticsearch-plugin-image.yml`

## Boundary
This PR only adds the release mechanism. It does not publish `apecloud/elasticsearch-plugins:0.1.1` by itself. After this lands, someone with workflow/secret permission still needs to dispatch the workflow and verify the official manifests before PR #2835 can bump `plugin.tag` and rerun plugin-covered validation.
