### PR TITLE
fix(valkey): fail closed on uncertain HA operations

### DIFF
--- a/addons/valkey/dataprotection/post-restore-sentinel.sh
+++ b/addons/valkey/dataprotection/post-restore-sentinel.sh
@@ -19,9 +19,8 @@
 #   sentinel comp: <cluster>-valkey-sentinel  (standard topology name)
 #
 # Current BackupPolicyTemplate env schema cannot inject cross-component
-# Sentinel credentials. Re-registration uses an explicit Sentinel target list
-# when supplied; otherwise it uses the DNS-published endpoints of the Sentinel
-# headless service and requires at least the chart's minimum Sentinel count.
+# Sentinel credentials. The chart currently supports exactly 3 Sentinel
+# replicas, so the DNS fallback has an independent expected count.
 
 set -e
 set -o pipefail
@@ -158,7 +157,8 @@ fi
 # ── register primary with each Sentinel pod ──────────────────────────────────
 # SENTINEL_POD_FQDN_LIST is the authoritative target set when supplied.
 # Otherwise, the Sentinel headless service DNS endpoints are the runtime target
-# set available to this DataProtection job. Restore must not report success
+# set available to this DataProtection job, and the expected count comes from
+# the chart's fixed Sentinel replicas contract. Restore must not report success
 # after configuring only a guessed or partial subset of Sentinel pods.
 sentinel_fqdn_list=()
 expected_sentinel_count=""
@@ -175,16 +175,16 @@ if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
   fi
   echo "INFO: using SENTINEL_POD_FQDN_LIST (${expected_sentinel_count} entries) as target set."
 else
+  expected_sentinel_count=$(positive_int_or_default "${POST_RESTORE_SENTINEL_EXPECTED_COUNT:-3}" 3)
   while read -r sentinel_ip _; do
     [ -n "${sentinel_ip}" ] && sentinel_fqdn_list+=("${sentinel_ip}")
   done < <(getent hosts "${sentinel_headless}" 2>/dev/null | awk '!seen[$1]++ { print $1 }')
-  expected_sentinel_count="${#sentinel_fqdn_list[@]}"
-  min_sentinel_count=$(positive_int_or_default "${POST_RESTORE_SENTINEL_MIN_COUNT:-3}" 3)
-  if [ "${expected_sentinel_count}" -lt "${min_sentinel_count}" ]; then
-    echo "ERROR: discovered ${expected_sentinel_count}/${min_sentinel_count} minimum Sentinel endpoint(s) from ${sentinel_headless}; refusing partial post-restore registration." >&2
+  discovered_sentinel_count="${#sentinel_fqdn_list[@]}"
+  if [ "${discovered_sentinel_count}" -ne "${expected_sentinel_count}" ]; then
+    echo "ERROR: discovered ${discovered_sentinel_count}/${expected_sentinel_count} expected Sentinel endpoint(s) from ${sentinel_headless}; refusing partial post-restore registration." >&2
     exit 1
   fi
-  echo "INFO: using ${expected_sentinel_count} DNS-discovered Sentinel endpoint(s) from ${sentinel_headless} as target set."
+  echo "INFO: using ${discovered_sentinel_count}/${expected_sentinel_count} DNS-discovered Sentinel endpoint(s) from ${sentinel_headless} as target set."
 fi
 
 reachable_sentinel_fqdn_list=()

--- a/addons/valkey/dataprotection/post-restore-sentinel.sh
+++ b/addons/valkey/dataprotection/post-restore-sentinel.sh
@@ -19,9 +19,9 @@
 #   sentinel comp: <cluster>-valkey-sentinel  (standard topology name)
 #
 # Current BackupPolicyTemplate env schema cannot inject cross-component
-# Sentinel credentials. Re-registration fails closed when no Sentinel can be
-# configured; passworded Sentinel requires SENTINEL_PASSWORD from a future
-# explicit contract.
+# Sentinel credentials. Re-registration uses an explicit Sentinel target list
+# when supplied; otherwise it uses the DNS-published endpoints of the Sentinel
+# headless service and requires at least the chart's minimum Sentinel count.
 
 set -e
 set -o pipefail
@@ -156,24 +156,36 @@ if [ -z "${primary_fqdn}" ]; then
 fi
 
 # ── register primary with each Sentinel pod ──────────────────────────────────
-# SENTINEL_POD_FQDN_LIST is the authoritative target set. Restore must not
-# report success after configuring only a guessed subset of Sentinel pods.
+# SENTINEL_POD_FQDN_LIST is the authoritative target set when supplied.
+# Otherwise, the Sentinel headless service DNS endpoints are the runtime target
+# set available to this DataProtection job. Restore must not report success
+# after configuring only a guessed or partial subset of Sentinel pods.
 sentinel_fqdn_list=()
-if [ -z "${SENTINEL_POD_FQDN_LIST:-}" ]; then
-  echo "ERROR: SENTINEL_POD_FQDN_LIST is not set; cannot prove all Sentinel pods are reconfigured after restore." >&2
-  exit 1
+expected_sentinel_count=""
+if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
+  sentinel_fqdn_list_raw=()
+  IFS=',' read -ra sentinel_fqdn_list_raw <<< "${SENTINEL_POD_FQDN_LIST}"
+  for sentinel_fqdn in "${sentinel_fqdn_list_raw[@]}"; do
+    [ -n "${sentinel_fqdn}" ] && sentinel_fqdn_list+=("${sentinel_fqdn}")
+  done
+  expected_sentinel_count="${#sentinel_fqdn_list[@]}"
+  if [ "${expected_sentinel_count}" -eq 0 ]; then
+    echo "ERROR: SENTINEL_POD_FQDN_LIST is set but empty after parsing." >&2
+    exit 1
+  fi
+  echo "INFO: using SENTINEL_POD_FQDN_LIST (${expected_sentinel_count} entries) as target set."
+else
+  while read -r sentinel_ip _; do
+    [ -n "${sentinel_ip}" ] && sentinel_fqdn_list+=("${sentinel_ip}")
+  done < <(getent hosts "${sentinel_headless}" 2>/dev/null | awk '!seen[$1]++ { print $1 }')
+  expected_sentinel_count="${#sentinel_fqdn_list[@]}"
+  min_sentinel_count=$(positive_int_or_default "${POST_RESTORE_SENTINEL_MIN_COUNT:-3}" 3)
+  if [ "${expected_sentinel_count}" -lt "${min_sentinel_count}" ]; then
+    echo "ERROR: discovered ${expected_sentinel_count}/${min_sentinel_count} minimum Sentinel endpoint(s) from ${sentinel_headless}; refusing partial post-restore registration." >&2
+    exit 1
+  fi
+  echo "INFO: using ${expected_sentinel_count} DNS-discovered Sentinel endpoint(s) from ${sentinel_headless} as target set."
 fi
-sentinel_fqdn_list_raw=()
-IFS=',' read -ra sentinel_fqdn_list_raw <<< "${SENTINEL_POD_FQDN_LIST}"
-for sentinel_fqdn in "${sentinel_fqdn_list_raw[@]}"; do
-  [ -n "${sentinel_fqdn}" ] && sentinel_fqdn_list+=("${sentinel_fqdn}")
-done
-expected_sentinel_count="${#sentinel_fqdn_list[@]}"
-if [ "${expected_sentinel_count}" -eq 0 ]; then
-  echo "ERROR: SENTINEL_POD_FQDN_LIST is set but empty after parsing." >&2
-  exit 1
-fi
-echo "INFO: using SENTINEL_POD_FQDN_LIST (${expected_sentinel_count} entries) as target set."
 
 reachable_sentinel_fqdn_list=()
 failed_sentinel_count=0

--- a/addons/valkey/dataprotection/post-restore-sentinel.sh
+++ b/addons/valkey/dataprotection/post-restore-sentinel.sh
@@ -156,39 +156,24 @@ if [ -z "${primary_fqdn}" ]; then
 fi
 
 # ── register primary with each Sentinel pod ──────────────────────────────────
-# When SENTINEL_POD_FQDN_LIST is provided, use it as the authoritative target
-# set and require every listed Sentinel to be configured (fail-closed).
-# Otherwise, fall back to ordinal scanning with SENTINEL_REPLICA_COUNT or a
-# bounded scan limit.
+# SENTINEL_POD_FQDN_LIST is the authoritative target set. Restore must not
+# report success after configuring only a guessed subset of Sentinel pods.
 sentinel_fqdn_list=()
-if [ -n "${SENTINEL_POD_FQDN_LIST:-}" ]; then
-  sentinel_fqdn_list_raw=()
-  IFS=',' read -ra sentinel_fqdn_list_raw <<< "${SENTINEL_POD_FQDN_LIST}"
-  for sentinel_fqdn in "${sentinel_fqdn_list_raw[@]}"; do
-    [ -n "${sentinel_fqdn}" ] && sentinel_fqdn_list+=("${sentinel_fqdn}")
-  done
-  expected_sentinel_count="${#sentinel_fqdn_list[@]}"
-  if [ "${expected_sentinel_count}" -eq 0 ]; then
-    echo "ERROR: SENTINEL_POD_FQDN_LIST is set but empty after parsing." >&2
-    exit 1
-  fi
-  echo "INFO: using SENTINEL_POD_FQDN_LIST (${expected_sentinel_count} entries) as target set."
-else
-  default_sentinel_scan_limit="${POST_RESTORE_SENTINEL_SCAN_LIMIT:-9}"
-  default_sentinel_scan_limit=$(positive_int_or_default "${default_sentinel_scan_limit}" 9)
-  expected_sentinel_count="${SENTINEL_REPLICA_COUNT:-}"
-  if [ -n "${expected_sentinel_count}" ]; then
-    sentinel_replica_count=$(positive_int_or_default "${expected_sentinel_count}" "${default_sentinel_scan_limit}")
-    expected_sentinel_count="${sentinel_replica_count}"
-  else
-    sentinel_replica_count="${default_sentinel_scan_limit}"
-  fi
-  ordinal=0
-  while [ "${ordinal}" -lt "${sentinel_replica_count}" ]; do
-    sentinel_fqdn_list+=("${sentinel_comp}-${ordinal}.${sentinel_headless}")
-    ordinal=$((ordinal + 1))
-  done
+if [ -z "${SENTINEL_POD_FQDN_LIST:-}" ]; then
+  echo "ERROR: SENTINEL_POD_FQDN_LIST is not set; cannot prove all Sentinel pods are reconfigured after restore." >&2
+  exit 1
 fi
+sentinel_fqdn_list_raw=()
+IFS=',' read -ra sentinel_fqdn_list_raw <<< "${SENTINEL_POD_FQDN_LIST}"
+for sentinel_fqdn in "${sentinel_fqdn_list_raw[@]}"; do
+  [ -n "${sentinel_fqdn}" ] && sentinel_fqdn_list+=("${sentinel_fqdn}")
+done
+expected_sentinel_count="${#sentinel_fqdn_list[@]}"
+if [ "${expected_sentinel_count}" -eq 0 ]; then
+  echo "ERROR: SENTINEL_POD_FQDN_LIST is set but empty after parsing." >&2
+  exit 1
+fi
+echo "INFO: using SENTINEL_POD_FQDN_LIST (${expected_sentinel_count} entries) as target set."
 
 reachable_sentinel_fqdn_list=()
 failed_sentinel_count=0
@@ -232,10 +217,6 @@ else
   sentinel_count="${#reachable_sentinel_fqdn_list[@]}"
 fi
 sentinel_monitor_quorum=$(( sentinel_count / 2 + 1 ))
-if [ -z "${expected_sentinel_count}" ] && [ "${sentinel_monitor_quorum}" -lt 2 ]; then
-  echo "WARNING: partial probe found ${sentinel_count} Sentinel(s); flooring quorum at 2 for safety." >&2
-  sentinel_monitor_quorum=2
-fi
 echo "INFO: using Sentinel monitor quorum ${sentinel_monitor_quorum}/${sentinel_count}."
 
 configured_sentinel_count=0

--- a/addons/valkey/scripts-ut-spec/post_restore_sentinel_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/post_restore_sentinel_contract_spec.sh
@@ -67,10 +67,16 @@ Describe "Valkey post-restore Sentinel contract"
     The stdout should include "getent hosts"
   End
 
-  It "requires at least the chart-minimum Sentinel endpoints from DNS fallback"
-    When call grep -F "POST_RESTORE_SENTINEL_MIN_COUNT:-3" "${script_file}"
+  It "requires the chart-expected Sentinel endpoint count from DNS fallback"
+    When call grep -F "POST_RESTORE_SENTINEL_EXPECTED_COUNT:-3" "${script_file}"
     The status should be success
-    The stdout should include "POST_RESTORE_SENTINEL_MIN_COUNT:-3"
+    The stdout should include "POST_RESTORE_SENTINEL_EXPECTED_COUNT:-3"
+  End
+
+  It "rejects DNS fallback when discovered count differs from expected count"
+    When call grep -F 'discovered_sentinel_count}" -ne "${expected_sentinel_count}' "${script_file}"
+    The status should be success
+    The stdout should include "expected_sentinel_count"
   End
 
   It "parses SENTINEL_POD_FQDN_LIST into an array with IFS comma split"

--- a/addons/valkey/scripts-ut-spec/post_restore_sentinel_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/post_restore_sentinel_contract_spec.sh
@@ -61,10 +61,16 @@ Describe "Valkey post-restore Sentinel contract"
     The stdout should include "SENTINEL_POD_FQDN_LIST"
   End
 
-  It "fails closed when SENTINEL_POD_FQDN_LIST is missing"
-    When call grep -F "SENTINEL_POD_FQDN_LIST is not set" "${script_file}"
+  It "discovers Sentinel targets from headless service DNS when explicit list is missing"
+    When call grep -F 'getent hosts "${sentinel_headless}"' "${script_file}"
     The status should be success
-    The stdout should include "SENTINEL_POD_FQDN_LIST is not set"
+    The stdout should include "getent hosts"
+  End
+
+  It "requires at least the chart-minimum Sentinel endpoints from DNS fallback"
+    When call grep -F "POST_RESTORE_SENTINEL_MIN_COUNT:-3" "${script_file}"
+    The status should be success
+    The stdout should include "POST_RESTORE_SENTINEL_MIN_COUNT:-3"
   End
 
   It "parses SENTINEL_POD_FQDN_LIST into an array with IFS comma split"

--- a/addons/valkey/scripts-ut-spec/post_restore_sentinel_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/post_restore_sentinel_contract_spec.sh
@@ -61,6 +61,12 @@ Describe "Valkey post-restore Sentinel contract"
     The stdout should include "SENTINEL_POD_FQDN_LIST"
   End
 
+  It "fails closed when SENTINEL_POD_FQDN_LIST is missing"
+    When call grep -F "SENTINEL_POD_FQDN_LIST is not set" "${script_file}"
+    The status should be success
+    The stdout should include "SENTINEL_POD_FQDN_LIST is not set"
+  End
+
   It "parses SENTINEL_POD_FQDN_LIST into an array with IFS comma split"
     When call grep -E "IFS=',' read -ra sentinel_fqdn_list" "${script_file}"
     The status should be success
@@ -77,6 +83,11 @@ Describe "Valkey post-restore Sentinel contract"
     When call grep -E 'configured.*expected.*Sentinel pods' "${script_file}"
     The status should be success
     The stdout should include "expected Sentinel pods"
+  End
+
+  It "does not use ordinal scan fallback for unknown Sentinel targets"
+    When call grep -E "POST_RESTORE_SENTINEL_SCAN_LIMIT|sentinel_replica_count|partial probe found" "${script_file}"
+    The status should be failure
   End
 
   It "does not reference restore-sentinel-acl.sh (dead code removed)"

--- a/addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh
@@ -12,10 +12,10 @@ Describe "Valkey replicasLimit contract"
     The stdout should not include "maxReplicas"
   End
 
-  It "keeps Sentinel lower bound but does not declare an unproven max"
+  It "keeps Sentinel fixed at the validated three-replica contract"
     When call bash -c "grep -A3 'replicasLimit:' '${sentinel_cmpd}'"
     The status should be success
     The stdout should include "minReplicas: 3"
-    The stdout should not include "maxReplicas"
+    The stdout should include "maxReplicas: 3"
   End
 End

--- a/addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Valkey replicasLimit contract"
+  data_cmpd="../templates/cmpd.yaml"
+  sentinel_cmpd="../templates/cmpd-valkey-sentinel.yaml"
+
+  It "keeps data component lower bound but does not declare an unproven max"
+    When call bash -c "grep -A3 'replicasLimit:' '${data_cmpd}'"
+    The status should be success
+    The stdout should include "minReplicas: 1"
+    The stdout should not include "maxReplicas"
+  End
+
+  It "keeps Sentinel lower bound but does not declare an unproven max"
+    When call bash -c "grep -A3 'replicasLimit:' '${sentinel_cmpd}'"
+    The status should be success
+    The stdout should include "minReplicas: 3"
+    The stdout should not include "maxReplicas"
+  End
+End

--- a/addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh
@@ -5,11 +5,11 @@ Describe "Valkey replicasLimit contract"
   data_cmpd="../templates/cmpd.yaml"
   sentinel_cmpd="../templates/cmpd-valkey-sentinel.yaml"
 
-  It "keeps data component lower bound but does not declare an unproven max"
-    When call bash -c "grep -A3 'replicasLimit:' '${data_cmpd}'"
+  It "keeps data component within the tested scale contract"
+    When call bash -c "grep -A6 'replicasLimit:' '${data_cmpd}'"
     The status should be success
     The stdout should include "minReplicas: 1"
-    The stdout should not include "maxReplicas"
+    The stdout should include "maxReplicas: 4"
   End
 
   It "keeps Sentinel fixed at the validated three-replica contract"

--- a/addons/valkey/scripts-ut-spec/sentinel_monitor_quorum_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/sentinel_monitor_quorum_contract_spec.sh
@@ -28,10 +28,9 @@ Describe "Valkey Sentinel monitor quorum contract"
     The stdout should include '[ -n "${sentinel_fqdn}" ]'
   End
 
-  It "floors quorum at 2 when expected count is unknown in post-restore fallback"
+  It "does not compute quorum from an unknown post-restore Sentinel subset"
     When call grep -F 'sentinel_monitor_quorum}" -lt 2' "${post_restore_script}"
-    The status should be success
-    The stdout should include "-lt 2"
+    The status should be failure
   End
 
   It "uses the computed quorum in each SENTINEL monitor path"

--- a/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
@@ -113,12 +113,13 @@ Describe "Valkey Member-Leave Bash Script Tests"
       }
       After "teardown"
 
-      It "exits early with 'nothing to do'"
-        # Simulate the main guard that checks for Sentinel
-        check_no_sentinel() {
-          is_empty "${SENTINEL_COMPONENT_NAME}" || is_empty "${SENTINEL_POD_FQDN_LIST}"
+      It "uses the no-Sentinel fail-closed safety check instead of a success-only early exit"
+        member_leave_script="../scripts/valkey-member-leave.sh"
+        no_sentinel_guard_contract() {
+          ! grep -F "No Sentinel component — nothing to do on member leave." "${member_leave_script}" >/dev/null &&
+            grep -F "no_sentinel_safety_check" "${member_leave_script}" >/dev/null
         }
-        When call check_no_sentinel
+        When call no_sentinel_guard_contract
         The status should be success
       End
     End
@@ -227,6 +228,22 @@ Describe "Valkey Member-Leave Bash Script Tests"
       When call grep -E "never call SENTINEL RESET|SENTINEL RESET is intentionally NOT called|never called on member leave" "${member_leave_script}"
       The status should be success
       The stdout should not eq ""
+    End
+  End
+
+  Describe "master memberLeave fail-closed contract"
+    member_leave_script="../scripts/valkey-member-leave.sh"
+
+    It "treats a rejected SENTINEL FAILOVER as an error, not a warning-only success"
+      When call grep -F "ERROR: SENTINEL FAILOVER rejected" "${member_leave_script}"
+      The status should be success
+      The stdout should include "ERROR: SENTINEL FAILOVER rejected"
+    End
+
+    It "refuses memberLeave success when no new master is confirmed"
+      When call grep -F "refusing memberLeave success while the leaving pod is still master" "${member_leave_script}"
+      The status should be success
+      The stdout should include "refusing memberLeave success"
     End
   End
 

--- a/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_member_leave_spec.sh
@@ -245,6 +245,23 @@ Describe "Valkey Member-Leave Bash Script Tests"
       The status should be success
       The stdout should include "refusing memberLeave success"
     End
+
+    It "treats empty Sentinel master answers as unknown instead of already-safe"
+      export master_name="mycluster-valkey"
+      export KB_LEAVE_MEMBER_POD_NAME="valkey-0"
+      leaving_ip=""
+      s_cli=(valkey-cli)
+      valkey-cli() { printf "(nil)\n"; }
+      When call sentinel_master_state
+      The status should be success
+      The stdout should eq "unknown"
+    End
+
+    It "has an explicit error for unknown Sentinel master while local role is master"
+      When call grep -F "Sentinel returned no concrete master" "${member_leave_script}"
+      The status should be success
+      The stdout should include "Sentinel returned no concrete master"
+    End
   End
 
   Describe "no_sentinel_safety_check()"

--- a/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
@@ -289,5 +289,52 @@ Describe "Valkey Start Bash Script Tests"
         The contents of file "${CONF_RUNTIME}" should include "replicaof valkey-0.valkey-headless.default.svc.cluster.local 6379"
       End
     End
+
+    Context "when Sentinel topology has no trusted master"
+      setup() {
+        : > "${CONF_RUNTIME}"
+        valkey_start_data_dir=$(mktemp -d "${TMPDIR:-/tmp}/valkey-start-data.XXXXXX")
+        export DATA_DIR="${valkey_start_data_dir}"
+        export SENTINEL_COMPONENT_NAME="valkey-sentinel"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.sentinel-headless.default.svc.cluster.local"
+        export CURRENT_POD_NAME="valkey-0"
+        export VALKEY_POD_NAME_LIST="valkey-0,valkey-1"
+        export VALKEY_POD_FQDN_LIST="valkey-0.valkey-headless.default.svc.cluster.local,valkey-1.valkey-headless.default.svc.cluster.local"
+        export SERVICE_PORT="6379"
+        export VALKEY_COMPONENT_NAME="mycluster-valkey"
+      }
+      Before "setup"
+
+      teardown() {
+        rm -rf "${valkey_start_data_dir:-}"
+        unset DATA_DIR
+        unset SENTINEL_COMPONENT_NAME
+        unset SENTINEL_POD_FQDN_LIST
+        unset CURRENT_POD_NAME
+        unset VALKEY_POD_NAME_LIST
+        unset VALKEY_POD_FQDN_LIST
+        unset SERVICE_PORT
+        unset VALKEY_COMPONENT_NAME
+      }
+      After "teardown"
+
+      It "allows lexicographic bootstrap only for a fresh data directory"
+        query_sentinel_quorum_for_master() { echo ""; }
+        scan_pods_for_master() { echo ""; }
+        verify_pod_role() { echo ""; }
+        When call build_replicaof_config
+        The status should be success
+        The stderr should include "electing bootstrap primary"
+      End
+
+      It "fails closed instead of guessing when data already exists"
+        touch "${DATA_DIR}/dump.rdb"
+        query_sentinel_quorum_for_master() { echo ""; }
+        scan_pods_for_master() { echo ""; }
+        When call build_replicaof_config
+        The status should be failure
+        The stderr should include "refusing lexicographic primary guess"
+      End
+    End
   End
 End

--- a/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
@@ -327,16 +327,34 @@ Describe "Valkey Start Bash Script Tests"
         The stderr should include "electing bootstrap primary"
       End
 
-      It "fails closed instead of guessing when data already exists"
+      It "allows lexicographic election for full-cluster restart when data already exists"
         touch "${DATA_DIR}/dump.rdb"
         query_sentinel_quorum_for_master() { echo ""; }
         scan_pods_for_master() { echo ""; }
+        verify_pod_role() { echo ""; }
         When call build_replicaof_config
-        The status should be failure
-        The stderr should include "refusing lexicographic primary guess"
+        The status should be success
+        The stderr should include "treating as full-cluster restart"
+        The stderr should include "electing bootstrap primary"
       End
 
       It "fails closed when any peer is already a slave even if this pod data dir is fresh"
+        query_sentinel_quorum_for_master() { echo ""; }
+        scan_pods_for_master() { echo ""; }
+        verify_pod_role() {
+          case "$1" in
+            valkey-1.*) echo "slave" ;;
+            *) echo "" ;;
+          esac
+        }
+        When call build_replicaof_config
+        The status should be failure
+        The stderr should include "reports role:slave"
+        The stderr should include "refusing lexicographic primary guess"
+      End
+
+      It "fails closed when any peer is already a slave even if this pod data dir has existing data"
+        touch "${DATA_DIR}/dump.rdb"
         query_sentinel_quorum_for_master() { echo ""; }
         scan_pods_for_master() { echo ""; }
         verify_pod_role() {

--- a/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_start_spec.sh
@@ -335,6 +335,21 @@ Describe "Valkey Start Bash Script Tests"
         The status should be failure
         The stderr should include "refusing lexicographic primary guess"
       End
+
+      It "fails closed when any peer is already a slave even if this pod data dir is fresh"
+        query_sentinel_quorum_for_master() { echo ""; }
+        scan_pods_for_master() { echo ""; }
+        verify_pod_role() {
+          case "$1" in
+            valkey-1.*) echo "slave" ;;
+            *) echo "" ;;
+          esac
+        }
+        When call build_replicaof_config
+        The status should be failure
+        The stderr should include "reports role:slave"
+        The stderr should include "refusing lexicographic primary guess"
+      End
     End
   End
 End

--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -571,7 +571,7 @@ Describe "Valkey Switchover Bash Script Tests"
       It "restores all replica priorities to 100 and returns failure without calling execute_sentinel_failover"
         get_role() { echo "slave"; }
         set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
-        wait_sentinel_sees_priority() { return 1; }
+        wait_sentinel_sees_priority_bias() { return 1; }
         execute_sentinel_failover() { echo "SHOULD_NOT_BE_CALLED"; }
         When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
         The status should be failure
@@ -586,7 +586,7 @@ Describe "Valkey Switchover Bash Script Tests"
         export VALKEY_POD_FQDN_LIST="valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local"
         get_role() { echo "slave"; }
         set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
-        wait_sentinel_sees_priority() { return 1; }
+        wait_sentinel_sees_priority_bias() { return 1; }
         execute_sentinel_failover() { echo "SHOULD_NOT_BE_CALLED"; }
         When call switchover_with_sentinel "valkey-3.headless.default.svc.cluster.local"
         The status should be failure
@@ -597,17 +597,33 @@ Describe "Valkey Switchover Bash Script Tests"
     End
 
     Context "when candidate role is unknown (get_role returns empty — transient network issue)"
-      It "logs a warning and proceeds to call Sentinel (does not abort)"
+      It "fails closed and does not call Sentinel"
         get_role() { echo ""; }
-        set_replica_priority() { return 0; }
-        wait_sentinel_sees_priority() { return 0; }
-        execute_sentinel_failover() { echo "OK"; return 0; }
-        wait_for_new_master() { return 0; }
+        execute_sentinel_failover() { echo "SHOULD_NOT_BE_CALLED"; return 0; }
         When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
-        The status should be success
-        The stdout should include "Biasing"
-        The stderr should include "WARNING"
-        The stderr should include "after retries — proceeding without role pre-check"
+        The status should be failure
+        The stderr should include "ERROR"
+        The stderr should include "could not determine role"
+        The stdout should not include "SHOULD_NOT_BE_CALLED"
+      End
+    End
+
+    Context "when priority normalization fails before targeted FAILOVER"
+      It "restores priorities and does not call Sentinel"
+        get_role() { echo "slave"; }
+        set_replica_priority() {
+          echo "SET_PRIO:${1}:${2}"
+          [ "${1%%.*}" = "valkey-2" ] && return 1
+          return 0
+        }
+        execute_sentinel_failover() { echo "SHOULD_NOT_BE_CALLED"; return 0; }
+        export VALKEY_POD_FQDN_LIST="valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local,valkey-2.headless.default.svc.cluster.local"
+        When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
+        The status should be failure
+        The stdout should include "SET_PRIO:valkey-2.headless.default.svc.cluster.local:100"
+        The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:100"
+        The stdout should not include "SHOULD_NOT_BE_CALLED"
+        The stderr should include "failed to normalize priority"
       End
     End
 
@@ -615,7 +631,7 @@ Describe "Valkey Switchover Bash Script Tests"
       It "proceeds to call Sentinel without warnings"
         get_role() { echo "slave"; }
         set_replica_priority() { return 0; }
-        wait_sentinel_sees_priority() { return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
         execute_sentinel_failover() { echo "OK"; return 0; }
         wait_for_new_master() { return 0; }
         When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
@@ -637,7 +653,7 @@ Describe "Valkey Switchover Bash Script Tests"
           [ "${calls}" -ge 2 ] && echo "slave" || echo ""
         }
         set_replica_priority() { return 0; }
-        wait_sentinel_sees_priority() { return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
         execute_sentinel_failover() { echo "OK"; return 0; }
         wait_for_new_master() { return 0; }
         When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
@@ -673,7 +689,7 @@ Describe "Valkey Switchover Bash Script Tests"
           echo "SET_PRIO:${1}:${2}"
           return 0
         }
-        wait_sentinel_sees_priority() { return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
         execute_sentinel_failover() { echo "OK"; return 0; }
         wait_for_new_master() {
           wfnm_done=1
@@ -806,6 +822,46 @@ Describe "Valkey Switchover Bash Script Tests"
         When call wait_sentinel_sees_priority "valkey-1.headless.default.svc.cluster.local" "1"
         The status should be failure
         The stderr should include "ERROR"
+      End
+    End
+  End
+
+  Describe "wait_sentinel_sees_priority_bias()"
+    setup() {
+      export VALKEY_COMPONENT_NAME="mycluster-valkey"
+      export SENTINEL_POD_FQDN_LIST="sentinel-0.headless.default.svc.cluster.local"
+      export SENTINEL_SERVICE_PORT="26379"
+      export KB_SWITCHOVER_CURRENT_FQDN="valkey-0.headless.default.svc.cluster.local"
+    }
+    Before "setup"
+
+    teardown() {
+      unset VALKEY_COMPONENT_NAME
+      unset SENTINEL_POD_FQDN_LIST
+      unset SENTINEL_SERVICE_PORT
+      unset KB_SWITCHOVER_CURRENT_FQDN
+    }
+    After "teardown"
+
+    Context "when candidate is priority 1 and other replica is priority 100"
+      It "returns success"
+        valkey-cli() {
+          printf 'name\nvalkey-1.headless.default.svc.cluster.local:6379\nslave-priority\n1\nname\nvalkey-2.headless.default.svc.cluster.local:6379\nslave-priority\n100\n'
+        }
+        When call wait_sentinel_sees_priority_bias "valkey-1.headless.default.svc.cluster.local" "valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local,valkey-2.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "targeted bias"
+      End
+    End
+
+    Context "when another replica still has priority 1"
+      It "returns failure before FAILOVER can be issued"
+        valkey-cli() {
+          printf 'name\nvalkey-1.headless.default.svc.cluster.local:6379\nslave-priority\n1\nname\nvalkey-2.headless.default.svc.cluster.local:6379\nslave-priority\n1\n'
+        }
+        When call wait_sentinel_sees_priority_bias "valkey-1.headless.default.svc.cluster.local" "valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local,valkey-2.headless.default.svc.cluster.local"
+        The status should be failure
+        The stderr should include "full targeted priority bias"
       End
     End
   End
@@ -999,7 +1055,7 @@ Describe "Valkey Switchover Bash Script Tests"
           echo "SET_PRIO:${1}:${2}"
           return 0
         }
-        wait_sentinel_sees_priority() { return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
         execute_sentinel_failover() { echo "OK"; return 0; }
         wait_for_new_master() {
           wfnm_done=1
@@ -1019,7 +1075,7 @@ Describe "Valkey Switchover Bash Script Tests"
       It "restores all replica priorities to 100 and returns failure"
         get_role() { echo "slave"; }
         set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
-        wait_sentinel_sees_priority() { return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
         execute_sentinel_failover() { return 1; }
         wait_for_new_master() { echo "SHOULD_NOT_BE_CALLED"; return 0; }
         When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
@@ -1044,7 +1100,7 @@ Describe "Valkey Switchover Bash Script Tests"
           echo "SET_PRIO:${1}:${2}"
           return 0
         }
-        wait_sentinel_sees_priority() { return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
         execute_sentinel_failover() { echo "OK"; return 0; }
         wait_for_new_master() {
           wfnm_done=1

--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -304,10 +304,10 @@ Describe "Valkey Switchover Bash Script Tests"
     End
 
     Context "when a replica fails to repoint"
-      It "logs a WARNING but still returns success (non-fatal)"
+      It "logs a WARNING and returns failure"
         call_func_with_retry() { return 1; }
         When call repoint_replicas "valkey-1.headless.default.svc.cluster.local"
-        The status should be success
+        The status should be failure
         The stdout should include "Repointing"
         The stderr should include "WARNING"
         The stderr should include "failed to repoint"
@@ -1113,6 +1113,21 @@ Describe "Valkey Switchover Bash Script Tests"
         The status should be failure
         The stderr should include "no new primary confirmed"
       End
+    End
+  End
+
+  Describe "no-Sentinel switchover contract"
+    switchover_script="../scripts/switchover.sh"
+
+    It "fails closed instead of using manual best-effort promotion"
+      When call grep -F "switchover is unsupported without Sentinel" "${switchover_script}"
+      The status should be success
+      The stdout should include "unsupported without Sentinel"
+    End
+
+    It "does not leave manual confirmation failures as best-effort success"
+      When call grep -F "wait_until_master \"${target_fqdn}\" 10 || true" "${switchover_script}"
+      The status should be failure
     End
   End
 End

--- a/addons/valkey/scripts-ut-spec/valkey_sync_acl_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_sync_acl_spec.sh
@@ -56,7 +56,7 @@ Describe "Valkey Sync-ACL Bash Script Tests"
       End
     End
 
-    Context "when no pod reports role:master (fallback to lexicographic heuristic)"
+    Context "when no pod reports role:master"
       setup() {
         export VALKEY_POD_NAME_LIST="valkey-2,valkey-0,valkey-1"
         export VALKEY_POD_FQDN_LIST="valkey-2.headless.default.svc.cluster.local,valkey-0.headless.default.svc.cluster.local,valkey-1.headless.default.svc.cluster.local"
@@ -69,14 +69,14 @@ Describe "Valkey Sync-ACL Bash Script Tests"
       }
       After "teardown"
 
-      It "falls back to lexicographic minimum pod (valkey-0)"
+      It "fails closed instead of guessing a lexicographic ACL source"
         valkey-cli() {
           printf "role:slave\r\n"
         }
         When call find_primary_fqdn
-        The status should be success
-        The stdout should eq "valkey-0.headless.default.svc.cluster.local"
-        The stderr should include "no pod reported role:master"
+        The status should be failure
+        The stdout should eq ""
+        The stderr should include "refusing to guess"
       End
     End
   End

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -186,6 +186,20 @@ set_replica_priority() {
   call_func_with_retry 3 3 _do_set_replica_priority "${fqdn}" "${prio}"
 }
 
+sentinel_observed_replica_priority() {
+  local sentinel_fqdn="${1}" replica_fqdn="${2}"
+  local replica_host="${replica_fqdn%%.*}"
+  sentinel_cli_for "${sentinel_fqdn}"
+  "${_sentinel_cli[@]}" SENTINEL REPLICAS "${VALKEY_COMPONENT_NAME}" 2>/dev/null \
+    | tr -d '"' \
+    | sed 's/.*) //' \
+    | awk -v cand="${replica_host}." '
+        prev == "name" { in_cand = (index($0, cand) > 0) }
+        in_cand && prev == "slave-priority" { print; exit }
+        { prev = $0 }
+      '
+}
+
 execute_sentinel_failover() {
   local master_name="${VALKEY_COMPONENT_NAME}"
   IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
@@ -226,21 +240,7 @@ wait_sentinel_sees_priority() {
     local confirmed=0 total=${#sentinel_fqdns[@]}
     for s_fqdn in "${sentinel_fqdns[@]}"; do
       local prio
-      sentinel_cli_for "${s_fqdn}"
-      # Parse SENTINEL REPLICAS output:
-      #   tr -d '"'       — strip valkey-cli string quotes
-      #   sed 's/.*) //'  — strip leading array-index prefixes like "  3) "
-      #   awk             — find the replica matching candidate_host, extract slave-priority
-      #                     Uses index()+literal "." suffix (e.g. "valkey-1.")
-      #                     to avoid "valkey-1" substring-matching "valkey-10".
-      prio=$("${_sentinel_cli[@]}" SENTINEL REPLICAS "${VALKEY_COMPONENT_NAME}" 2>/dev/null \
-        | tr -d '"' \
-        | sed 's/.*) //' \
-        | awk -v cand="${candidate_host}." '
-            prev == "name" { in_cand = (index($0, cand) > 0) }
-            in_cand && prev == "slave-priority" { print; exit }
-            { prev = $0 }
-          ') || true
+      prio=$(sentinel_observed_replica_priority "${s_fqdn}" "${candidate_host}.") || true
       if [ "${prio}" = "${expected_prio}" ]; then
         confirmed=$((confirmed + 1))
       fi
@@ -255,6 +255,42 @@ wait_sentinel_sees_priority() {
   # after 30s, issuing SENTINEL FAILOVER now risks promoting the wrong replica.
   # Returning 1 causes the targeted switchover to fail fast so the caller can retry.
   echo "ERROR: Sentinel did not reflect priority=${expected_prio} for ${candidate_fqdn} within 30s — aborting targeted switchover" >&2
+  return 1
+}
+
+wait_sentinel_sees_priority_bias() {
+  local candidate_fqdn="${1}" all_fqdns_csv="${2}"
+  local candidate_pod="${candidate_fqdn%%.*}"
+  local current_pod="${KB_SWITCHOVER_CURRENT_FQDN%%.*}"
+  local deadline=$((SECONDS + 30))
+
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    IFS=',' read -ra sentinel_fqdns <<< "${SENTINEL_POD_FQDN_LIST}"
+    IFS=',' read -ra all_fqdns <<< "${all_fqdns_csv}"
+    local total=0 confirmed=0
+    for s_fqdn in "${sentinel_fqdns[@]}"; do
+      for fqdn in "${all_fqdns[@]}"; do
+        local pod expected_prio observed_prio
+        pod="${fqdn%%.*}"
+        # The current master is not listed in SENTINEL REPLICAS before failover.
+        [ "${pod}" = "${current_pod}" ] && continue
+        expected_prio="100"
+        [ "${pod}" = "${candidate_pod}" ] && expected_prio="1"
+        total=$((total + 1))
+        observed_prio=$(sentinel_observed_replica_priority "${s_fqdn}" "${fqdn}") || true
+        if [ "${observed_prio}" = "${expected_prio}" ]; then
+          confirmed=$((confirmed + 1))
+        fi
+      done
+    done
+    if [ "${total}" -gt 0 ] && [ "${confirmed}" -eq "${total}" ]; then
+      echo "All Sentinel replica priority caches confirmed targeted bias for ${candidate_fqdn}."
+      return 0
+    fi
+    sleep_when_ut_mode_false 1
+  done
+
+  echo "ERROR: Sentinel did not confirm full targeted priority bias for ${candidate_fqdn} within 30s — aborting targeted switchover" >&2
   return 1
 }
 
@@ -318,32 +354,40 @@ switchover_with_sentinel() {
       echo "ERROR: candidate ${candidate_fqdn} has role='${candidate_role}', expected 'slave' — aborting switchover" >&2
       return 1
     elif is_empty "${candidate_role}"; then
-      echo "WARNING: could not determine role of ${candidate_fqdn} after retries — proceeding without role pre-check" >&2
+      echo "ERROR: could not determine role of ${candidate_fqdn} after retries — aborting targeted switchover" >&2
+      return 1
     fi
 
     echo "Biasing Sentinel toward candidate ${candidate_fqdn}..."
-    # Set candidate priority to 1 (best), all others to 100 (lowest).
-    # If priority cannot be set (e.g. transient TLS connection failure), log a
-    # warning and continue without bias — Sentinel will still elect a new primary.
     IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
+    priority_failed=0
     for fqdn in "${all_fqdns[@]}"; do
       # Append "." so "valkey-1." is not a substring of "valkey-11.headless..." (substring false positive).
       if contains "${fqdn}" "${candidate_fqdn%%.*}."; then
         if ! set_replica_priority "${fqdn}" 1; then
-          echo "WARNING: failed to set priority on candidate ${fqdn} — proceeding without priority bias" >&2
-          # Do not abort: let Sentinel proceed and pick whichever candidate it prefers.
+          echo "ERROR: failed to set priority on candidate ${fqdn} — aborting targeted switchover" >&2
+          priority_failed=1
         fi
       else
-        set_replica_priority "${fqdn}" 100 || true
+        if ! set_replica_priority "${fqdn}" 100; then
+          echo "ERROR: failed to normalize priority on ${fqdn} — aborting targeted switchover" >&2
+          priority_failed=1
+        fi
       fi
     done
+    if [ "${priority_failed}" -ne 0 ]; then
+      for fqdn in "${all_fqdns[@]}"; do
+        set_replica_priority "${fqdn}" 100 || true
+      done
+      return 1
+    fi
 
-    # Wait for Sentinel's replica-info cache to reflect the new priority before
+    # Wait for Sentinel's replica-info cache to reflect the full priority bias before
     # issuing FAILOVER.  Sentinel refreshes its replica cache every ~10 seconds;
-    # without this wait, FAILOVER may be issued while the cache still shows the
-    # old priority=100, causing Sentinel to pick the wrong replica.
-    echo "Waiting for Sentinel to reflect priority bias on ${candidate_fqdn}..."
-    if ! wait_sentinel_sees_priority "${candidate_fqdn}" "1"; then
+    # without this wait, FAILOVER may be issued while another replica still has
+    # stale priority=1, causing Sentinel to pick the wrong replica.
+    echo "Waiting for Sentinel to reflect full priority bias on ${candidate_fqdn}..."
+    if ! wait_sentinel_sees_priority_bias "${candidate_fqdn}" "$(IFS=','; echo "${all_fqdns[*]}")"; then
       # Sentinel did not reflect the priority in time — restore before aborting
       # so the bias is never left in place after a failed switchover attempt.
       IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -14,10 +14,9 @@
 #   its own conf.  If a specific candidate is requested we first set its
 #   replica-priority to 1 (highest) so Sentinel picks it.
 #
-# When Sentinel is absent (standalone replication):
-#   Manual approach:
-#     1. REPLICAOF NO ONE on the target.
-#     2. REPLICAOF <new-primary> on all other pods.
+# When Sentinel is absent:
+#   Fail closed. Valkey standalone/no-Sentinel topology has no HA coordinator
+#   that can prove the new primary and replica routing converged.
 
 # shellcheck disable=SC2034
 ut_mode="false"
@@ -101,13 +100,17 @@ repoint_one() {
 
 repoint_replicas() {
   local new_primary_fqdn="${1}"
+  local failures=0
   IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
   for fqdn in "${pod_fqdns[@]}"; do
     [ "${fqdn}" = "${new_primary_fqdn}" ] && continue   # skip the new primary itself
     echo "Repointing ${fqdn} → ${new_primary_fqdn}..."
-    call_func_with_retry 3 3 repoint_one "${fqdn}" "${new_primary_fqdn}" "${port}" || \
+    call_func_with_retry 3 3 repoint_one "${fqdn}" "${new_primary_fqdn}" "${port}" || {
       echo "WARNING: failed to repoint ${fqdn} to ${new_primary_fqdn} — it may remain pointing at the old primary" >&2
+      failures=$((failures + 1))
+    }
   done
+  [ "${failures}" -eq 0 ]
 }
 
 pick_any_secondary() {
@@ -394,12 +397,6 @@ ${__SOURCED__:+false} : || return 0
 # ── main ────────────────────────────────────────────────────────────────────
 load_common_library
 
-# Nothing to do for single-replica clusters
-if [ "${COMPONENT_REPLICAS}" -lt 2 ]; then
-  echo "Only one replica — nothing to switch over."
-  exit 0
-fi
-
 # Only act when KubeBlocks asks us to transfer the primary role
 if [ "${KB_SWITCHOVER_ROLE}" != "primary" ]; then
   echo "switchover not for primary role (got '${KB_SWITCHOVER_ROLE}') — exiting."
@@ -414,22 +411,6 @@ if ! is_empty "${SENTINEL_COMPONENT_NAME}" && ! is_empty "${SENTINEL_POD_FQDN_LI
   exit 0
 fi
 
-# ── Manual path (no Sentinel) ──
-target_fqdn="${KB_SWITCHOVER_CANDIDATE_FQDN}"
-if is_empty "${target_fqdn}"; then
-  target_fqdn=$(pick_any_secondary)
-  if is_empty "${target_fqdn}"; then
-    echo "ERROR: no available secondary found" >&2
-    exit 1
-  fi
-fi
-
-echo "Manual switchover: ${KB_SWITCHOVER_CURRENT_FQDN} → ${target_fqdn}"
-
-promote_replica "${target_fqdn}"
-# wait_until_master is best-effort: repoint_replicas must always run even on
-# timeout to avoid leaving replicas pointed at the old (demoted) primary.
-wait_until_master "${target_fqdn}" 10 || true
-repoint_replicas "${target_fqdn}"
-
-echo "Manual switchover complete. New primary: ${target_fqdn}"
+# ── No-Sentinel path ──
+echo "ERROR: switchover is unsupported without Sentinel; refusing manual best-effort promotion." >&2
+exit 1

--- a/addons/valkey/scripts/sync-acl.sh
+++ b/addons/valkey/scripts/sync-acl.sh
@@ -43,7 +43,7 @@ build_cli() {
   fi
 }
 
-# Find the current primary by polling each pod's role
+# Find the current primary by polling each pod's role.
 find_primary_fqdn() {
   IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
   for fqdn in "${pod_fqdns[@]}"; do
@@ -56,14 +56,8 @@ find_primary_fqdn() {
       return 0
     fi
   done
-  # No pod confirmed as master (e.g. cluster initialising or mid-failover).
-  # Fall back to lexicographic heuristic only on fresh clusters; warn so operators
-  # know the ACL sync may use a replica as source if a failover is in progress.
-  local primary_pod primary_fqdn
-  primary_pod=$(min_lexicographical_order_pod "${VALKEY_POD_NAME_LIST}")
-  primary_fqdn=$(get_target_pod_fqdn_from_pod_fqdn_vars "${VALKEY_POD_FQDN_LIST}" "${primary_pod}")
-  echo "WARNING: no pod reported role:master — falling back to lexicographic heuristic (${primary_fqdn}); ACL sync may use stale data if a failover is in progress" >&2
-  echo "${primary_fqdn}"
+  echo "ERROR: no pod reported role:master — refusing to guess an ACL source." >&2
+  return 1
 }
 
 # Copy all non-default ACL rules from source to target
@@ -144,10 +138,10 @@ if is_empty "${KB_JOIN_MEMBER_POD_FQDN}"; then
   exit 0
 fi
 
-primary_fqdn=$(find_primary_fqdn)
+primary_fqdn=$(find_primary_fqdn) || exit 1
 if is_empty "${primary_fqdn}"; then
-  echo "WARNING: could not determine primary — skipping ACL sync." >&2
-  exit 0
+  echo "ERROR: could not determine primary — refusing to skip ACL sync." >&2
+  exit 1
 fi
 
 # Don't sync from/to the same pod.

--- a/addons/valkey/scripts/valkey-member-leave.sh
+++ b/addons/valkey/scripts/valkey-member-leave.sh
@@ -73,6 +73,26 @@ no_sentinel_safety_check() {
   return 1
 }
 
+sentinel_master_state() {
+  # Prints one of:
+  #   leaving   - Sentinel still reports the leaving pod as master
+  #   different - Sentinel reports another concrete master
+  #   unknown   - Sentinel has no concrete master answer
+  local sm
+  sm=$("${s_cli[@]}" SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null \
+         | head -n1 | tr -d '\r\n') || true
+  if is_empty "${sm}" || [ "${sm}" = "(nil)" ]; then
+    echo "unknown"
+    return 0
+  fi
+  if contains "${sm}" "${KB_LEAVE_MEMBER_POD_NAME}." || \
+     { ! is_empty "${leaving_ip}" && [ "${sm}" = "${leaving_ip}" ]; }; then
+    echo "leaving"
+    return 0
+  fi
+  echo "different"
+}
+
 # This is magic for shellspec ut framework, do not modify!
 ${__SOURCED__:+false} : || return 0
 
@@ -139,21 +159,6 @@ s_cli=("${_sentinel_cli_cmd[@]}")
 # Resolve the leaving pod's IP once for all comparisons below.
 leaving_ip=$(getent hosts "${leaving_fqdn}" 2>/dev/null | awk '{print $1}' | head -n1) || true
 
-_sentinel_master_is_leaving() {
-  # Returns 0 (true) when the chosen sentinel reports the leaving pod as master.
-  local sm
-  sm=$("${s_cli[@]}" SENTINEL get-master-addr-by-name "${master_name}" 2>/dev/null \
-         | head -n1 | tr -d '\r\n') || true
-  if is_empty "${sm}" || [ "${sm}" = "(nil)" ]; then
-    return 1   # sentinel doesn't know — treat as "not leaving"
-  fi
-  if contains "${sm}" "${KB_LEAVE_MEMBER_POD_NAME}." || \
-     { ! is_empty "${leaving_ip}" && [ "${sm}" = "${leaving_ip}" ]; }; then
-    return 0   # still points at the leaving pod
-  fi
-  return 1
-}
-
 # Policy: never call SENTINEL RESET on member leave.
 #
 # SENTINEL RESET tells a sentinel to drop its known-replica AND known-sentinel
@@ -211,7 +216,8 @@ if [ "${leaving_role}" = "master" ]; then
   # KubeBlocks calls switchover before memberLeave; if the chosen sentinel
   # already reports a different master the failover is done — skip FAILOVER
   # (sentinel auto-cleans when the pod actually goes away).
-  if _sentinel_master_is_leaving; then
+  sentinel_state=$(sentinel_master_state)
+  if [ "${sentinel_state}" = "leaving" ]; then
     echo "Leaving pod is the primary per sentinel — triggering SENTINEL FAILOVER first..."
     # valkey-cli exits 0 even for protocol errors; capture output and log it.
     failover_out=$("${s_cli[@]}" SENTINEL FAILOVER "${master_name}" 2>&1) || true
@@ -243,8 +249,11 @@ if [ "${leaving_role}" = "master" ]; then
       echo "ERROR: failover still in progress after 30s — refusing memberLeave success while the leaving pod is still master." >&2
       exit 1
     fi
-  else
+  elif [ "${sentinel_state}" = "different" ]; then
     echo "Sentinel already reports a different master — skipping SENTINEL FAILOVER. Sentinel will self-clean when the pod is deleted by KubeBlocks."
+  else
+    echo "ERROR: Sentinel returned no concrete master for ${master_name}; refusing memberLeave success while leaving pod is locally master." >&2
+    exit 1
   fi
 fi
 

--- a/addons/valkey/scripts/valkey-member-leave.sh
+++ b/addons/valkey/scripts/valkey-member-leave.sh
@@ -13,7 +13,8 @@
 #   - If the leaving pod is the current primary: trigger SENTINEL FAILOVER
 #     first so Sentinel promotes a new primary before this pod goes away.
 #
-# When Sentinel is absent (standalone): nothing to do.
+# When Sentinel is absent: fail closed unless the leaving pod is confirmed to
+# be a replica. A primary leave without Sentinel cannot be made safe here.
 #
 # Note: SENTINEL RESET is intentionally NOT called from this script. See the
 # detailed comment above the master-leave block for rationale.
@@ -79,8 +80,16 @@ ${__SOURCED__:+false} : || return 0
 load_common_library
 
 if is_empty "${SENTINEL_COMPONENT_NAME}" || is_empty "${SENTINEL_POD_FQDN_LIST}"; then
-  echo "No Sentinel component — nothing to do on member leave."
-  exit 0
+  if is_empty "${KB_LEAVE_MEMBER_POD_FQDN}"; then
+    echo "ERROR: no Sentinel component and KB_LEAVE_MEMBER_POD_FQDN is not set — cannot prove memberLeave is safe." >&2
+    exit 1
+  fi
+  build_data_cli "${KB_LEAVE_MEMBER_POD_FQDN}"
+  leaving_role=$("${_data_cli_cmd[@]}" INFO replication 2>/dev/null \
+                   | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
+  echo "Leaving pod: ${KB_LEAVE_MEMBER_POD_FQDN}, role: ${leaving_role:-unknown}"
+  no_sentinel_safety_check "${leaving_role}"
+  exit $?
 fi
 
 if is_empty "${KB_LEAVE_MEMBER_POD_FQDN}"; then
@@ -209,7 +218,8 @@ if [ "${leaving_role}" = "master" ]; then
     echo "SENTINEL FAILOVER response: ${failover_out}"
     case "${failover_out}" in
       *"ERR"*|*"error"*|*"BUSY"*)
-        echo "WARNING: SENTINEL FAILOVER rejected — ${failover_out}" >&2 ;;
+        echo "ERROR: SENTINEL FAILOVER rejected — ${failover_out}" >&2
+        exit 1 ;;
     esac
     # Wait up to 30 s for a new primary to emerge
     failover_done=false
@@ -230,7 +240,8 @@ if [ "${leaving_role}" = "master" ]; then
       fi
     done
     if [ "${failover_done}" = "false" ]; then
-      echo "WARNING: failover still in progress after 30s — KubeBlocks pod removal will proceed; sentinel will reach consistency via natural pod-down detection." >&2
+      echo "ERROR: failover still in progress after 30s — refusing memberLeave success while the leaving pod is still master." >&2
+      exit 1
     fi
   else
     echo "Sentinel already reports a different master — skipping SENTINEL FAILOVER. Sentinel will self-clean when the pod is deleted by KubeBlocks."

--- a/addons/valkey/scripts/valkey-start.sh
+++ b/addons/valkey/scripts/valkey-start.sh
@@ -192,20 +192,20 @@ build_replicaof_config() {
       if ! is_empty "${primary_fqdn}"; then
         : # already logged above
       else
-        # Step A-3: no peer is a master yet. Only a fresh component bootstrap
-        # may use lexicographic order. If this pod has existing data, or any
-        # peer already reports role:slave, this is not a pure first bootstrap;
-        # guessing a primary while Sentinel cannot prove one can create a
-        # second master after restart/restore.
-        if ! is_fresh_bootstrap_data_dir; then
-          echo "ERROR: Sentinel topology has no trusted master and ${DATA_DIR:-/data} contains existing data — refusing lexicographic primary guess." >&2
-          return 1
-        fi
+        # Step A-3: no peer is a master yet. Fresh component bootstrap and
+        # clean full-component restart both need one pod to seed the topology
+        # by lexicographic order. Existing data alone is not unsafe: Stop/Start
+        # preserves PVC data while every data pod is down. The unsafe signal is
+        # observing an already-running slave while Sentinel cannot prove the
+        # master; guessing then can create a second master after restart/restore.
         local known_slave_fqdn
         known_slave_fqdn=$(find_known_slave_pod) || true
         if ! is_empty "${known_slave_fqdn}"; then
           echo "ERROR: Sentinel topology has no trusted master but ${known_slave_fqdn} reports role:slave — refusing lexicographic primary guess." >&2
           return 1
+        fi
+        if ! is_fresh_bootstrap_data_dir; then
+          echo "INFO: Sentinel topology has no trusted master and ${DATA_DIR:-/data} contains existing data, but no running peer role was observed — treating as full-cluster restart." >&2
         fi
         # Elect the lowest-ordinal pod as the bootstrap primary, then verify it
         # is actually reporting role:master.

--- a/addons/valkey/scripts/valkey-start.sh
+++ b/addons/valkey/scripts/valkey-start.sh
@@ -192,12 +192,19 @@ build_replicaof_config() {
       if ! is_empty "${primary_fqdn}"; then
         : # already logged above
       else
-        # Step A-3: no peer is a master yet. Only a fresh data directory may
-        # bootstrap by lexicographic order. If this pod has existing data,
+        # Step A-3: no peer is a master yet. Only a fresh component bootstrap
+        # may use lexicographic order. If this pod has existing data, or any
+        # peer already reports role:slave, this is not a pure first bootstrap;
         # guessing a primary while Sentinel cannot prove one can create a
         # second master after restart/restore.
         if ! is_fresh_bootstrap_data_dir; then
           echo "ERROR: Sentinel topology has no trusted master and ${DATA_DIR:-/data} contains existing data — refusing lexicographic primary guess." >&2
+          return 1
+        fi
+        local known_slave_fqdn
+        known_slave_fqdn=$(find_known_slave_pod) || true
+        if ! is_empty "${known_slave_fqdn}"; then
+          echo "ERROR: Sentinel topology has no trusted master but ${known_slave_fqdn} reports role:slave — refusing lexicographic primary guess." >&2
           return 1
         fi
         # Elect the lowest-ordinal pod as the bootstrap primary, then verify it
@@ -389,6 +396,20 @@ scan_pods_for_master() {
     role=$(timeout 3 "${cli_base[@]}" -h "${pod_fqdn}" info replication 2>/dev/null \
       | grep "^role:" | tr -d '\r\n' | cut -d: -f2) || true
     if [ "${role}" = "master" ]; then
+      echo "${pod_fqdn}"
+      return 0
+    fi
+  done
+  return 0
+}
+
+find_known_slave_pod() {
+  IFS=',' read -ra pod_fqdns <<< "${VALKEY_POD_FQDN_LIST}"
+  for pod_fqdn in "${pod_fqdns[@]}"; do
+    contains "${pod_fqdn}" "${CURRENT_POD_NAME}." && continue
+    local role
+    role=$(verify_pod_role "${pod_fqdn}") || true
+    if [ "${role}" = "slave" ]; then
       echo "${pod_fqdn}"
       return 0
     fi

--- a/addons/valkey/scripts/valkey-start.sh
+++ b/addons/valkey/scripts/valkey-start.sh
@@ -192,8 +192,16 @@ build_replicaof_config() {
       if ! is_empty "${primary_fqdn}"; then
         : # already logged above
       else
-        # Step A-3: no peer is a master yet.  Elect the lowest-ordinal pod as
-        # the bootstrap primary, then verify it is actually reporting role:master.
+        # Step A-3: no peer is a master yet. Only a fresh data directory may
+        # bootstrap by lexicographic order. If this pod has existing data,
+        # guessing a primary while Sentinel cannot prove one can create a
+        # second master after restart/restore.
+        if ! is_fresh_bootstrap_data_dir; then
+          echo "ERROR: Sentinel topology has no trusted master and ${DATA_DIR:-/data} contains existing data — refusing lexicographic primary guess." >&2
+          return 1
+        fi
+        # Elect the lowest-ordinal pod as the bootstrap primary, then verify it
+        # is actually reporting role:master.
         # During rolling restarts the lexicographic pod may itself be a slave
         # (sentinel already failed over to a different pod); connecting to it
         # would create a cascading topology that sentinel will not auto-correct.
@@ -259,6 +267,15 @@ build_replicaof_config() {
   fi
 
   echo "replicaof ${primary_fqdn} ${primary_port}" >> "${CONF_RUNTIME}"
+}
+
+is_fresh_bootstrap_data_dir() {
+  local dir="${DATA_DIR:-/data}"
+  [ ! -e "${dir}/dump.rdb" ] || return 1
+  [ ! -e "${dir}/appendonly.aof" ] || return 1
+  [ ! -d "${dir}/appendonlydir" ] || return 1
+  [ ! -e "${dir}/nodes.conf" ] || return 1
+  return 0
 }
 
 # query_sentinel_quorum_for_master — query ALL sentinel pods and return the

--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -38,6 +38,7 @@ spec:
 
   replicasLimit:
     minReplicas: 3
+    maxReplicas: 3
 
   # Sentinel state is persisted in the data volume so the conf survives restarts.
   volumes:

--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -38,7 +38,6 @@ spec:
 
   replicasLimit:
     minReplicas: 3
-    maxReplicas: 16384
 
   # Sentinel state is persisted in the data volume so the conf survives restarts.
   volumes:

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -41,6 +41,9 @@ spec:
 
   replicasLimit:
     minReplicas: 1
+    # Current tested scale contract: default 3 data pods with one-pod
+    # horizontal scale-out to 4, then scale-in back to 3.
+    maxReplicas: 4
 
   # ── TLS ────────────────────────────────────────────────────────────────
   tls:

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -41,7 +41,6 @@ spec:
 
   replicasLimit:
     minReplicas: 1
-    maxReplicas: 16384
 
   # ── TLS ────────────────────────────────────────────────────────────────
   tls:
@@ -452,8 +451,9 @@ spec:
           - /scripts/account-provision.sh
         targetPodSelector: All
 
-    # switchover: when Sentinel is present, delegates to SENTINEL FAILOVER.
-    # When absent (standalone), performs a direct REPLICAOF NO ONE.
+    # switchover: supported only when Sentinel is present. Without Sentinel
+    # there is no authoritative HA coordinator, so the action fails closed
+    # instead of attempting a manual best-effort promotion.
     # timeoutSeconds: -1 disables the kbagent-layer exec timeout so that the
     # Sentinel priority-cache polling (up to 30s) and the wait_for_new_master
     # confirmation (up to 300s) are not cut short.


### PR DESCRIPTION
Fixes #2969

## Summary
- Replace the unvalidated data component `maxReplicas: 16384` with the current tested scale contract (`minReplicas: 1`, `maxReplicas: 4`); fix Sentinel to the validated three-replica contract (`minReplicas: 3`, `maxReplicas: 3`) until broader Sentinel scaling is validated.
- Fail closed when HA state cannot be proven: no-Sentinel switchover, ACL source selection without a confirmed primary, master memberLeave without confirmed failover, Sentinel topology startup with a known slave peer and no trusted master, and restore Sentinel monitor registration without a complete target set.
- Preserve the legitimate full-cluster Stop->Start path: when Sentinel has no trusted master, pod scan finds no running master, and no peer reports `role:slave`, a pod with persisted data may seed the restart by lexicographic order instead of crash-looping.
- Close reviewer/runtime-found gaps: restore postReady now uses explicit Sentinel targets or exactly three DNS-discovered headless endpoints; memberLeave treats empty Sentinel master answers as unknown; targeted switchover proves the full priority bias before `SENTINEL FAILOVER`; startup distinguishes full-cluster restart from unsafe partial-state guessing.
- Add ShellSpec contract coverage for the fail-closed paths, the Stop->Start restart regression, and the narrowed replicasLimit contracts.

## Local validation
- `bash -n addons/valkey/scripts/*.sh addons/valkey/dataprotection/*.sh`
- `git diff --check`
- `helm lint addons/valkey`
- `helm template valkey addons/valkey --namespace kb-system`
- `shellspec --load-path shellspec --shell /opt/homebrew/bin/bash addons/valkey/scripts-ut-spec/valkey_start_spec.sh` -> 17 examples, 0 failures
- `shellspec --load-path shellspec --shell /opt/homebrew/bin/bash addons/valkey/scripts-ut-spec/replicas_limit_contract_spec.sh` -> 2 examples, 0 failures
- `shellspec --load-path shellspec --shell /opt/homebrew/bin/bash addons/valkey/scripts-ut-spec/*_spec.sh` -> 312 examples, 0 failures

## Runtime validation
- Earlier round 1 on head `60d4554aea83c846366a26cd75e8a2308045ef57` stopped at smoke-lifecycle T05 Start. Evidence log: `artifacts/10round-pr2962/round-1.log`, sha256 `fbbcc52f648bbc3de06303c733566f84dd6a88447c7337345af4dd7b5c1c0e1e`. This round is first-red evidence only and is not counted.
- Current head `1315857f1b3ce8832f41cd6ae73188a0a90e5c63` contains the Stop->Start fix and has static/ShellSpec validation above.
- Focused Sentinel validation with the updated negative replicasLimit tests passed: `82/0/0`, direct rc=0, log `artifacts/10round-pr2962/focused-sentinel-23b3779.log`, sha256 `fe58e3658a6d84de6789f217fd21eccbb7aa66f1bac3ab6b918d8033e438e441`. It verified Sentinel 3->4 and 3->2 OpsRequests are rejected by the fixed `minReplicas=3/maxReplicas=3` contract, while 3 Sentinels still monitor the master and `ckquorum` remains OK.
- Fresh full-suite round 1 on current head completed all 16 suites with direct rc=1 because of one environment-classified NodePort failure. Log: `artifacts/10round-pr2962/round-1-fresh-full.log`, 1869 lines, sha256 `b0e330841866c2e8a99bd60107c1d0abcfb4480cc68df319a98aa078607633c1`. Summary: `793 PASS / 1 FAIL / 4 SKIP`; cleanup confirmed namespace `valkey-10r-r1` NotFound.
- Fresh full-suite round 2 on current head completed all 16 suites with direct rc=1 because the same environment-classified NodePort path failed again. Log: `artifacts/10round-pr2962/round-2.log`, 1884 lines, sha256 `8d86d650b0016fdea4ec49daf40caa27a004e7bcff143afc5c5242ffb495bbf1`. Summary: `805 PASS / 1 FAIL / 0 SKIP`; cleanup confirmed namespace `valkey-10r-r2` NotFound.
- Product result boundary for both fresh full-suite rounds: `product_fail=0 candidate`, not a zero-fail full-suite PASS. The single FAIL in both rounds is `r05-nodeport` R05b: NodePort returned empty from the pod network, matching the known vcluster overlay CNI / node InternalIP reachability limitation also seen in the r9d baseline.
- Round 2 improved rebuild coverage versus round 1: rebuild completed `23/0/0` with 0 SKIP, while round 1 had 4 SKIP from the pod self-heal timing window.
- Runtime milestones observed on current head across fresh rounds: T05 Stop->Start PASS; TLS suite PASS and runner survived the previous TLS-cleanup risk point; Sentinel suite PASS with PR #539 negative fixed-replica contract tests; ACL, rebuild, and switchover-regression passed in round 2; all fail-closed/lifecycle/HA contract paths exercised in these rounds had no product regression.
- Pinned package for fresh validation: addon PR #2962 head `1315857f1b3ce8832f41cd6ae73188a0a90e5c63`, chart sha256 `53ed17a50c1eeafaaae49ccaf3855db95a954ff7ba6c94f0409a176febb1af42`, helm rev 14; tests PR #539 head `23b3779252189e7ecbd361a7ec123627fd38ad39` for round 1 and `kubeblocks-tests/main@f49b99b` for round 2, with `sentinel.sh` sha256 `259423d6e8b126c79329254bd9d878ab13a2a46173f28910a73aa62ac5e21981`.
