### PR TITLE
fix(rustfs): make TLS secret readable by runtime user

### DIFF
--- a/addons/rustfs/scripts/startup.sh
+++ b/addons/rustfs/scripts/startup.sh
@@ -4,16 +4,34 @@ replicas_history_file="/rustfs-config/RUSTFS_REPLICAS_HISTORY"
 writable_certs_path="/data/.rustfs/certs"
 
 setup_tls_certs() {
-  if [ "$TLS_ENABLED" = "true" ] && [ -f ${CERTS_PATH}/ca.crt ]; then
+  if [ "${TLS_ENABLED:-}" = "true" ]; then
     echo "Setting up TLS certificates for RustFS..."
 
-    mkdir -p ${writable_certs_path}
+    for cert_file in ca.crt tls.crt tls.key; do
+      if [ ! -r "${CERTS_PATH}/${cert_file}" ]; then
+        echo "TLS certificate source file is missing or unreadable: ${CERTS_PATH}/${cert_file}" >&2
+        exit 1
+      fi
+    done
 
-    cp -L ${CERTS_PATH}/tls.crt ${writable_certs_path}/tls.crt
-    cp -L ${CERTS_PATH}/tls.key ${writable_certs_path}/tls.key
-    cp -L ${CERTS_PATH}/ca.crt ${writable_certs_path}/ca.crt
+    mkdir -p "${writable_certs_path}" || {
+      echo "Failed to create writable TLS certificate directory: ${writable_certs_path}" >&2
+      exit 1
+    }
 
-    chmod 600 ${writable_certs_path}/tls.key
+    cp -L "${CERTS_PATH}/tls.crt" "${writable_certs_path}/rustfs_cert.pem" || exit 1
+    cp -L "${CERTS_PATH}/tls.key" "${writable_certs_path}/rustfs_key.pem" || exit 1
+    cp -L "${CERTS_PATH}/ca.crt" "${writable_certs_path}/ca.crt" || exit 1
+
+    chmod 0644 "${writable_certs_path}/rustfs_cert.pem" "${writable_certs_path}/ca.crt" || exit 1
+    chmod 0600 "${writable_certs_path}/rustfs_key.pem" || exit 1
+
+    for cert_file in rustfs_cert.pem rustfs_key.pem ca.crt; do
+      if [ ! -s "${writable_certs_path}/${cert_file}" ]; then
+        echo "TLS certificate target file is missing or empty: ${writable_certs_path}/${cert_file}" >&2
+        exit 1
+      fi
+    done
 
     export RUSTFS_TLS_PATH=${writable_certs_path}
 

--- a/addons/rustfs/templates/cmpd.yaml
+++ b/addons/rustfs/templates/cmpd.yaml
@@ -108,6 +108,7 @@ spec:
     caFile: ca.crt
     certFile: tls.crt
     keyFile: tls.key
+    defaultMode: 0644
   roles:
     - name: readwrite
       updatePriority: 1


### PR DESCRIPTION
Fixes #2972

## Problem

Jean's RustFS TLS/day2 validation hit addon-side startup failures when TLS was enabled with a user-provided Secret:

```text
cp: cannot open '/etc/rustfs/certs//tls.crt' for reading: Permission denied
[FATAL] TLS is explicitly configured via RUSTFS_TLS_PATH/tls_path='/data/.rustfs/certs' but no server certificates were found
```

There are two addon-side issues:

1. The RustFS container runs as a non-root runtime user, but the KB-mounted TLS Secret could be mounted with files unreadable by that user.
2. KubeBlocks mounts TLS files as `ca.crt`, `tls.crt`, and `tls.key`, while RustFS expects server cert/key files named `rustfs_cert.pem` and `rustfs_key.pem` under `RUSTFS_TLS_PATH`.

## Fix

- Set `ComponentDefinition.spec.tls.defaultMode: 0644`, so the non-root RustFS runtime user can read mounted TLS Secret files.
- Translate KB-mounted filenames during startup:
  - `tls.crt` -> `/data/.rustfs/certs/rustfs_cert.pem` mode `0644`
  - `tls.key` -> `/data/.rustfs/certs/rustfs_key.pem` mode `0600`
  - `ca.crt` -> `/data/.rustfs/certs/ca.crt` mode `0644`
- Fail fast if any required source file is missing/unreadable or any copied target is missing/empty.

## Validation

Local/static validation:

- `git diff --check` PASS
- `bash -n addons/rustfs/scripts/startup.sh` PASS
- `sh -n addons/rustfs/scripts/startup.sh` PASS
- `helm lint addons/rustfs` PASS
- `helm template rustfs addons/rustfs --namespace kb-system` renders `spec.tls.defaultMode: 0644`
- Local `setup_tls_certs()` simulation produced `rustfs_cert.pem` 0644, `rustfs_key.pem` 0600, `ca.crt` 0644; missing `tls.key` fails with rc=1

CI validation:

- Current GitHub checks are PASS: addon helm checks, generate-files, pr-label-check, shell-check, shellspec-test

Runtime validation:

- Tested current PR head `5f1ceb0` in vcluster with RustFS TLS/day2 suite
- Result: `12 PASS / 1 SKIP / 0 FAIL`
- TLS startup and HTTPS S3 connectivity passed: pods Ready, HTTPS health, `mc --insecure` put/get via `https://localhost:9000`, ClusterIP HTTPS S3, pod-kill data integrity, account/secret guard
- Boundary: the single SKIP is external NodePort S3 through vcluster virtual node IPs; this does not affect the TLS startup + HTTPS S3 validation for this fix
