### PR TITLE
fix(mysql): preserve restored system account passwords

### DIFF
--- a/addons/mysql/scripts-ut-spec/docker_entrypoint_restore_account_spec.sh
+++ b/addons/mysql/scripts-ut-spec/docker_entrypoint_restore_account_spec.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034
 
-Describe "MySQL docker entrypoint restore account reset"
+Describe "MySQL docker entrypoint restore account preservation"
   Include ../scripts/docker-entrypoint-5.7.sh
 
   setup_restore_dir() {
@@ -27,7 +27,7 @@ Describe "MySQL docker entrypoint restore account reset"
 
   BeforeEach "setup_restore_dir"
 
-  It "resets restored new-cluster system accounts before xtrabackup GTID handling"
+  It "preserves backup-restored system accounts during new-cluster xtrabackup GTID handling"
     mysql_note() {
       echo "$*"
     }
@@ -50,10 +50,13 @@ Describe "MySQL docker entrypoint restore account reset"
     The output should not include "normal start"
     The output should not include "targetRootPass"
     The output should not include "targetAdminPass"
+    The output should not include "targetReplicaPass"
     The contents of file "${SQL_LOG}" should not include "CREATE USER"
-    The contents of file "${SQL_LOG}" should include "ALTER USER 'root'@'localhost' IDENTIFIED BY 'targetRootPass'"
-    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbadmin'@'%' IDENTIFIED BY 'targetAdminPass'"
-    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbreplicator'@'%' IDENTIFIED BY 'targetReplicaPass'"
+    The contents of file "${SQL_LOG}" should not include "ALTER USER"
+    The contents of file "${SQL_LOG}" should not include "targetRootPass"
+    The contents of file "${SQL_LOG}" should not include "targetAdminPass"
+    The contents of file "${SQL_LOG}" should not include "targetReplicaPass"
+    The contents of file "${SQL_LOG}" should include "SET GLOBAL gtid_purged"
     The path "${TEST_DATADIR}/.xtrabackup_restore" should not be exist
   End
 
@@ -81,43 +84,5 @@ Describe "MySQL docker entrypoint restore account reset"
     The output should include "normal start mysqld"
     The output should not include "skip-grants start"
     The contents of file "${SQL_LOG}" should not include "ALTER USER"
-  End
-
-  It "fails fast when a required restored account credential is empty"
-    MYSQL_ROOT_PASSWORD=""
-    mysql_error() {
-      echo "$*" >&2
-      return 1
-    }
-    mysql_note() {
-      echo "$*"
-    }
-    docker_process_sql() {
-      cat >> "${SQL_LOG}"
-    }
-
-    When call mysql_reset_restored_system_accounts
-    The status should be failure
-    The stderr should include "MYSQL_ROOT_PASSWORD"
-    The contents of file "${SQL_LOG}" should equal ""
-  End
-
-  It "escapes quote and backslash characters in restored account secret literals"
-    MYSQL_ROOT_PASSWORD="pa'ss\\word"
-    MYSQL_ADMIN_PASSWORD="ad'min\\word"
-    MYSQL_REPLICATION_PASSWORD="rep'lica\\word"
-    mysql_note() {
-      echo "$*"
-    }
-    docker_process_sql() {
-      cat >> "${SQL_LOG}"
-    }
-
-    When call mysql_reset_restored_system_accounts
-    The status should be success
-    The output should include "Resetting restored MySQL system accounts"
-    The contents of file "${SQL_LOG}" should include "ALTER USER 'root'@'localhost' IDENTIFIED BY 'pa''ss\\\\word'"
-    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbadmin'@'%' IDENTIFIED BY 'ad''min\\\\word'"
-    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbreplicator'@'%' IDENTIFIED BY 'rep''lica\\\\word'"
   End
 End

--- a/addons/mysql/scripts-ut-spec/docker_entrypoint_restore_account_spec.sh
+++ b/addons/mysql/scripts-ut-spec/docker_entrypoint_restore_account_spec.sh
@@ -1,0 +1,123 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "MySQL docker entrypoint restore account reset"
+  Include ../scripts/docker-entrypoint-5.7.sh
+
+  setup_restore_dir() {
+    TEST_DATADIR="${SHELLSPEC_WORKDIR}/mysql-restore"
+    mkdir -p "${TEST_DATADIR}/mysql"
+    : > "${TEST_DATADIR}/.xtrabackup_restore"
+    : > "${TEST_DATADIR}/.restore_new_cluster"
+    : > "${TEST_DATADIR}/xtrabackup_info"
+
+    export DATADIR="${TEST_DATADIR}"
+    export SOCKET="${TEST_DATADIR}/mysql.sock"
+    export MYSQL_MAJOR="8.0"
+    export MYSQL_ROOT_USER="root"
+    export MYSQL_ROOT_PASSWORD="targetRootPass"
+    export MYSQL_ROOT_HOST="%"
+    export MYSQL_ADMIN_USER="kbadmin"
+    export MYSQL_ADMIN_PASSWORD="targetAdminPass"
+    export MYSQL_REPLICATION_USER="kbreplicator"
+    export MYSQL_REPLICATION_PASSWORD="targetReplicaPass"
+    SQL_LOG="${SHELLSPEC_WORKDIR}/sql.log"
+    : > "${SQL_LOG}"
+  }
+
+  BeforeEach "setup_restore_dir"
+
+  It "resets restored new-cluster system accounts before xtrabackup GTID handling"
+    mysql_note() {
+      echo "$*"
+    }
+    docker_temp_server_start_skip_grants() {
+      echo "skip-grants start $*"
+    }
+    docker_temp_server_start() {
+      echo "normal start $*"
+    }
+    docker_temp_server_stop() {
+      echo "stop"
+    }
+    docker_process_sql() {
+      cat >> "${SQL_LOG}"
+    }
+
+    When call restore_standby_from_xtrabackup mysqld
+    The status should be success
+    The output should include "skip-grants start mysqld"
+    The output should not include "normal start"
+    The output should not include "targetRootPass"
+    The output should not include "targetAdminPass"
+    The contents of file "${SQL_LOG}" should not include "CREATE USER"
+    The contents of file "${SQL_LOG}" should include "ALTER USER 'root'@'localhost' IDENTIFIED BY 'targetRootPass'"
+    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbadmin'@'%' IDENTIFIED BY 'targetAdminPass'"
+    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbreplicator'@'%' IDENTIFIED BY 'targetReplicaPass'"
+    The path "${TEST_DATADIR}/.xtrabackup_restore" should not be exist
+  End
+
+  It "keeps standby restore on the normal authenticated temporary server path"
+    rm -f "${TEST_DATADIR}/.restore_new_cluster"
+
+    mysql_note() {
+      echo "$*"
+    }
+    docker_temp_server_start_skip_grants() {
+      echo "skip-grants start $*"
+    }
+    docker_temp_server_start() {
+      echo "normal start $*"
+    }
+    docker_temp_server_stop() {
+      echo "stop"
+    }
+    docker_process_sql() {
+      cat >> "${SQL_LOG}"
+    }
+
+    When call restore_standby_from_xtrabackup mysqld
+    The status should be success
+    The output should include "normal start mysqld"
+    The output should not include "skip-grants start"
+    The contents of file "${SQL_LOG}" should not include "ALTER USER"
+  End
+
+  It "fails fast when a required restored account credential is empty"
+    MYSQL_ROOT_PASSWORD=""
+    mysql_error() {
+      echo "$*" >&2
+      return 1
+    }
+    mysql_note() {
+      echo "$*"
+    }
+    docker_process_sql() {
+      cat >> "${SQL_LOG}"
+    }
+
+    When call mysql_reset_restored_system_accounts
+    The status should be failure
+    The stderr should include "MYSQL_ROOT_PASSWORD"
+    The contents of file "${SQL_LOG}" should equal ""
+  End
+
+  It "escapes quote and backslash characters in restored account secret literals"
+    MYSQL_ROOT_PASSWORD="pa'ss\\word"
+    MYSQL_ADMIN_PASSWORD="ad'min\\word"
+    MYSQL_REPLICATION_PASSWORD="rep'lica\\word"
+    mysql_note() {
+      echo "$*"
+    }
+    docker_process_sql() {
+      cat >> "${SQL_LOG}"
+    }
+
+    When call mysql_reset_restored_system_accounts
+    The status should be success
+    The output should include "Resetting restored MySQL system accounts"
+    The contents of file "${SQL_LOG}" should include "ALTER USER 'root'@'localhost' IDENTIFIED BY 'pa''ss\\\\word'"
+    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbadmin'@'%' IDENTIFIED BY 'ad''min\\\\word'"
+    The contents of file "${SQL_LOG}" should include "ALTER USER 'kbreplicator'@'%' IDENTIFIED BY 'rep''lica\\\\word'"
+  End
+End

--- a/addons/mysql/scripts/docker-entrypoint-5.7.sh
+++ b/addons/mysql/scripts/docker-entrypoint-5.7.sh
@@ -147,6 +147,27 @@ docker_temp_server_start() {
 	fi
 }
 
+docker_temp_server_start_skip_grants() {
+	if [ "${MYSQL_MAJOR}" = '5.7' ]; then
+		"$@" --skip-networking --skip-grant-tables --default-time-zone=SYSTEM --socket="${SOCKET}" &
+		mysql_note "Waiting for server startup with grant tables disabled"
+		local i
+		for i in {30..0}; do
+			if docker_process_sql --dont-use-mysql-root-password --database=mysql <<<'SELECT 1' &> /dev/null; then
+				break
+			fi
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			mysql_error "Unable to start server."
+		fi
+	else
+		if ! "$@" --daemonize --skip-networking --skip-grant-tables --default-time-zone=SYSTEM --socket="${SOCKET}"; then
+			mysql_error "Unable to start server."
+		fi
+	fi
+}
+
 # Stop the server. When using a local socket file mysqladmin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
@@ -353,6 +374,58 @@ _mysql_passfile() {
 	fi
 }
 
+mysql_sql_literal() {
+	local value="${1:-}"
+	printf '%s' "$value" | sed "s/\\\\/\\\\\\\\/g; s/'/''/g"
+}
+
+mysql_require_restored_account_value() {
+	local name="$1" value="${2:-}"
+	if [ -z "$value" ]; then
+		mysql_error "Required restore account value ${name} is empty; refusing to reset restored MySQL system accounts."
+	fi
+}
+
+mysql_print_alter_restored_account_sql() {
+	local user="${1:-}" password="${2:-}" host="${3:-}"
+	mysql_require_restored_account_value "user" "$user" || return
+	mysql_require_restored_account_value "password" "$password" || return
+	mysql_require_restored_account_value "host" "$host" || return
+
+	local escaped_user escaped_password escaped_host
+	escaped_user="$(mysql_sql_literal "$user")"
+	escaped_password="$(mysql_sql_literal "$password")"
+	escaped_host="$(mysql_sql_literal "$host")"
+
+	cat <<-EOSQL
+		ALTER USER '${escaped_user}'@'${escaped_host}' IDENTIFIED BY '${escaped_password}';
+	EOSQL
+}
+
+mysql_reset_restored_system_accounts() {
+	if [ ! -f "${DATADIR}/.restore_new_cluster" ]; then
+		return
+	fi
+
+	mysql_require_restored_account_value "MYSQL_ROOT_USER" "${MYSQL_ROOT_USER:-}" || return
+	mysql_require_restored_account_value "MYSQL_ROOT_PASSWORD" "${MYSQL_ROOT_PASSWORD:-}" || return
+	mysql_require_restored_account_value "MYSQL_ADMIN_USER" "${MYSQL_ADMIN_USER:-}" || return
+	mysql_require_restored_account_value "MYSQL_ADMIN_PASSWORD" "${MYSQL_ADMIN_PASSWORD:-}" || return
+	mysql_require_restored_account_value "MYSQL_REPLICATION_USER" "${MYSQL_REPLICATION_USER:-}" || return
+	mysql_require_restored_account_value "MYSQL_REPLICATION_PASSWORD" "${MYSQL_REPLICATION_PASSWORD:-}" || return
+
+	mysql_note "Resetting restored MySQL system accounts from target cluster secrets."
+	{
+		cat <<-'EOSQL'
+			FLUSH PRIVILEGES;
+		EOSQL
+		mysql_print_alter_restored_account_sql "${MYSQL_ROOT_USER}" "${MYSQL_ROOT_PASSWORD}" "localhost"
+		mysql_print_alter_restored_account_sql "${MYSQL_ROOT_USER}" "${MYSQL_ROOT_PASSWORD}" "${MYSQL_ROOT_HOST:-%}"
+		mysql_print_alter_restored_account_sql "${MYSQL_ADMIN_USER}" "${MYSQL_ADMIN_PASSWORD}" "%"
+		mysql_print_alter_restored_account_sql "${MYSQL_REPLICATION_USER}" "${MYSQL_REPLICATION_PASSWORD}" "%"
+	} | docker_process_sql --dont-use-mysql-root-password --database=mysql
+}
+
 # Mark root user as expired so the password must be changed before anything
 # else can be done (only supported for 5.6+)
 mysql_expire_root_user() {
@@ -365,31 +438,36 @@ mysql_expire_root_user() {
 
 
 restore_standby_from_xtrabackup() {
-  if [ ! -f ${DATADIR}/.xtrabackup_restore ]; then
+  if [ ! -f "${DATADIR}/.xtrabackup_restore" ]; then
     return
   fi
-  if [ ! -f ${DATADIR}/xtrabackup_info ]; then
+  if [ ! -f "${DATADIR}/xtrabackup_info" ]; then
     return
   fi
   mysql_note "start to restore standby from xtrabackup."
   mysql_note "Starting temporary server"
-  docker_temp_server_start "$@"
+  if [ -f "${DATADIR}/.restore_new_cluster" ]; then
+    docker_temp_server_start_skip_grants "$@"
+  else
+    docker_temp_server_start "$@"
+  fi
   mysql_note "Temporary server started."
+  mysql_reset_restored_system_accounts
   PURGED_GTID=""
   while IFS= read -r line; do
      if [[ "$line" == *"GTID of the last change"* ]]; then
-       PURGED_GTID=$(echo ${line} | grep "binlog_pos" | awk -F "GTID of the last change '" '{print $2}' | awk -F "'" '{print $1}')
+       PURGED_GTID=$(echo "${line}" | grep "binlog_pos" | awk -F "GTID of the last change '" '{print $2}' | awk -F "'" '{print $1}')
        continue
      fi
      if [[ ! -z "${PURGED_GTID}" ]]; then
        if [[ "$line" != *"="* ]]; then
-          NEXT_GTID=$(echo ${line} | awk -F "'" '{print $1}')
+          NEXT_GTID=$(echo "${line}" | awk -F "'" '{print $1}')
           PURGED_GTID="${PURGED_GTID}${NEXT_GTID}"
           continue
        fi
        break
      fi
-  done < ${DATADIR}/xtrabackup_info
+  done < "${DATADIR}/xtrabackup_info"
   mysql_note "set the gtid_purged ${PURGED_GTID}."
 	docker_process_sql --database=mysql <<-EOSQL
 		STOP SLAVE;
@@ -397,7 +475,7 @@ restore_standby_from_xtrabackup() {
 		SET GLOBAL gtid_purged = '${PURGED_GTID}';
 	EOSQL
   mysql_note "restore standby from xtrabackup successfully."
-  rm -rf ${DATADIR}/.xtrabackup_restore
+  rm -rf "${DATADIR}/.xtrabackup_restore"
   mysql_note "Stopping temporary server"
   docker_temp_server_stop
   mysql_note "Temporary server stopped"

--- a/addons/mysql/scripts/docker-entrypoint-5.7.sh
+++ b/addons/mysql/scripts/docker-entrypoint-5.7.sh
@@ -374,58 +374,6 @@ _mysql_passfile() {
 	fi
 }
 
-mysql_sql_literal() {
-	local value="${1:-}"
-	printf '%s' "$value" | sed "s/\\\\/\\\\\\\\/g; s/'/''/g"
-}
-
-mysql_require_restored_account_value() {
-	local name="$1" value="${2:-}"
-	if [ -z "$value" ]; then
-		mysql_error "Required restore account value ${name} is empty; refusing to reset restored MySQL system accounts."
-	fi
-}
-
-mysql_print_alter_restored_account_sql() {
-	local user="${1:-}" password="${2:-}" host="${3:-}"
-	mysql_require_restored_account_value "user" "$user" || return
-	mysql_require_restored_account_value "password" "$password" || return
-	mysql_require_restored_account_value "host" "$host" || return
-
-	local escaped_user escaped_password escaped_host
-	escaped_user="$(mysql_sql_literal "$user")"
-	escaped_password="$(mysql_sql_literal "$password")"
-	escaped_host="$(mysql_sql_literal "$host")"
-
-	cat <<-EOSQL
-		ALTER USER '${escaped_user}'@'${escaped_host}' IDENTIFIED BY '${escaped_password}';
-	EOSQL
-}
-
-mysql_reset_restored_system_accounts() {
-	if [ ! -f "${DATADIR}/.restore_new_cluster" ]; then
-		return
-	fi
-
-	mysql_require_restored_account_value "MYSQL_ROOT_USER" "${MYSQL_ROOT_USER:-}" || return
-	mysql_require_restored_account_value "MYSQL_ROOT_PASSWORD" "${MYSQL_ROOT_PASSWORD:-}" || return
-	mysql_require_restored_account_value "MYSQL_ADMIN_USER" "${MYSQL_ADMIN_USER:-}" || return
-	mysql_require_restored_account_value "MYSQL_ADMIN_PASSWORD" "${MYSQL_ADMIN_PASSWORD:-}" || return
-	mysql_require_restored_account_value "MYSQL_REPLICATION_USER" "${MYSQL_REPLICATION_USER:-}" || return
-	mysql_require_restored_account_value "MYSQL_REPLICATION_PASSWORD" "${MYSQL_REPLICATION_PASSWORD:-}" || return
-
-	mysql_note "Resetting restored MySQL system accounts from target cluster secrets."
-	{
-		cat <<-'EOSQL'
-			FLUSH PRIVILEGES;
-		EOSQL
-		mysql_print_alter_restored_account_sql "${MYSQL_ROOT_USER}" "${MYSQL_ROOT_PASSWORD}" "localhost"
-		mysql_print_alter_restored_account_sql "${MYSQL_ROOT_USER}" "${MYSQL_ROOT_PASSWORD}" "${MYSQL_ROOT_HOST:-%}"
-		mysql_print_alter_restored_account_sql "${MYSQL_ADMIN_USER}" "${MYSQL_ADMIN_PASSWORD}" "%"
-		mysql_print_alter_restored_account_sql "${MYSQL_REPLICATION_USER}" "${MYSQL_REPLICATION_PASSWORD}" "%"
-	} | docker_process_sql --dont-use-mysql-root-password --database=mysql
-}
-
 # Mark root user as expired so the password must be changed before anything
 # else can be done (only supported for 5.6+)
 mysql_expire_root_user() {
@@ -452,7 +400,6 @@ restore_standby_from_xtrabackup() {
     docker_temp_server_start "$@"
   fi
   mysql_note "Temporary server started."
-  mysql_reset_restored_system_accounts
   PURGED_GTID=""
   while IFS= read -r line; do
      if [[ "$line" == *"GTID of the last change"* ]]; then

--- a/addons/mysql/scripts/mysql-entrypoint.sh
+++ b/addons/mysql/scripts/mysql-entrypoint.sh
@@ -16,7 +16,7 @@ if [ "${MYSQL_MAJOR}" = '5.7' ]; then
     --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
     --skip-slave-start=$skip_slave_start
 elif [ "${MYSQL_MAJOR}" = '8.0' ]; then
-  docker-entrypoint.sh mysqld --server-id $SERVICE_ID --report-host ${fqdn_name} \
+  /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID --report-host ${fqdn_name} \
     --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
     --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
     --plugin-load-add=audit_log=audit_log.so \

--- a/addons/mysql/templates/cmpd-mysql57.yaml
+++ b/addons/mysql/templates/cmpd-mysql57.yaml
@@ -68,7 +68,7 @@ spec:
               export LD_PRELOAD=""
             fi
             {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+            /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
               --ignore-db-dir=lost+found \
               --plugin-load-add=rpl_semi_sync_master=semisync_master.so \
               --plugin-load-add=rpl_semi_sync_slave=semisync_slave.so \

--- a/addons/mysql/templates/cmpd-mysql80-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-mgr.yaml
@@ -53,7 +53,7 @@ spec:
           - -c
           - |
             {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+            /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
                --report-host ${POD_NAME}.${CLUSTER_COMPONENT_NAME}-headless \
                --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
                --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \

--- a/addons/mysql/templates/cmpd-mysql80.yaml
+++ b/addons/mysql/templates/cmpd-mysql80.yaml
@@ -68,7 +68,7 @@ spec:
               export LD_PRELOAD=""
             fi
             {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+            /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
                --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
                --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
                --plugin-load-add=audit_log=audit_log.so \

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -42,7 +42,7 @@ spec:
           - -c
           - |
             {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+            /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
                --report-host ${POD_NAME}.${CLUSTER_COMPONENT_NAME}-headless \
                --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
                --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -57,7 +57,7 @@ spec:
               export LD_PRELOAD=""
             fi
             {{- include "mysql.spec.runtime.entrypoint" . | nindent 12 }}
-            docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
+            /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID \
                --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
                --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
                --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \


### PR DESCRIPTION
Issue: Fixes #2967

## Problem

A fresh MySQL xtrabackup restore reuses the source data directory, including `mysql.user` rows from the backup. KubeBlocks/DataProtection also records system account passwords on the Backup and restores the target system-account Secrets from that backup metadata during PVC restore (`restoreSystemAccountSecrets`).

The addon startup boundary is therefore not to rotate restored DB accounts to newly generated target credentials. The MySQL entrypoint only needs to start a temporary local mysqld so it can finish xtrabackup GTID handling even before normal account-based authentication is usable.

## Changes

- Start the temporary mysqld with `--skip-grant-tables` only for xtrabackup restore with `.restore_new_cluster`.
- Preserve backup-restored root/kbadmin/kbreplicator passwords; do not emit `ALTER USER` SQL from target Cluster env secrets.
- Keep the normal standby restore path on the existing authenticated temporary server path when `.restore_new_cluster` is absent.
- Route MySQL/MGR component commands through the ConfigMap-mounted `/scripts/docker-entrypoint.sh` so the patched entrypoint is used.
- Add ShellSpec coverage that guards the preservation contract: target env secret values must not appear in restore SQL and must not overwrite backup-restored users.

## Local Verification

Current head `3a8826ce88a53d93dc373eb2c8bacb690dcbdafa`:

- `bash -n addons/mysql/scripts/docker-entrypoint-5.7.sh addons/mysql/scripts/mysql-entrypoint.sh`
- Focused ShellSpec 0.28.1 temp tarball: `addons/mysql/scripts-ut-spec/docker_entrypoint_restore_account_spec.sh` -> `2 examples, 0 failures`
- MySQL ShellSpec directory: `addons/mysql/scripts-ut-spec` -> `8 examples, 0 failures`

Additional full-repo shellspec attempt on this checkout:

- `**/scripts-ut-spec` -> `927 examples, 13 failures, 12 skips, 9 pendings`
- The failures are outside MySQL: MariaDB render/replication-mode specs and vanilla-postgresql backup script. They are not introduced by this PR's touched files.

## CI

Current head checks are green:

- `check-addons-cluster-helm / release-chart`: pass
- `check-addons-helm / release-chart`: pass
- `check-addons-helm (aliyun) / release-chart`: pass
- `check-addons-helm (dockerhub) / release-chart`: pass
- `generate-files`: pass
- `pr-label-check / check`: pass
- `shell-check`: pass
- `shellspec-test`: pass

The separate `*-pr` jobs for this branch show `skipping`; the required visible checks above are green.

## Runtime Verification

Fresh-install runtime validation passed in `mysql-pr2964-vc` at current head `3a8826ce88a53d93dc373eb2c8bacb690dcbdafa`.

Environment:

- vcluster: `mysql-pr2964-vc`
- namespace: `mysql-test-pr2964-3a8826`
- addon chart: `kb-addon-mysql` rev2, `mysql-1.2.0-alpha.0`, from worktree `kubeblocks-addons-pr2964-3a8826ce`
- DataProtection image digest: `sha256:ee19640d533c195981281711cb8fbaad58dcd3dcc712e93748e2243b955456db`

Runtime N=3 result:

| run | source cluster | backup phase | restore cluster | row_count | root | kbadmin | kbreplicator |
|---|---|---|---|---|---|---|---|
| r1 | `mysql-pr2964-src-61149` | Completed | `mysql-pr2964-restored-61149` | 5 | OK | OK | OK |
| r2 | `mysql-pr2964-src-r2` | Completed | `mysql-pr2964-restored-r2` | 5 | OK | OK | OK |
| r3 | `mysql-pr2964-src-r3` | Completed | `mysql-pr2964-restored-r3` | 5 | OK | OK | OK |

Password-preservation evidence:

- r1 source and restore root Secret `data.password` matched; the source root password could log into the restore cluster.
- r2/r3 cleanup removed the Secrets before post-hoc comparison, but the three account login checks passed during the run using the restored live account Secrets.
- Restore pod mysql container logs did not contain the removed old-path log line `Resetting restored MySQL system accounts from target cluster secrets`.
- Grep for `ALTER USER`, `CREATE USER`, and `UPDATE mysql.user` target-secret overwrite evidence was empty.
- Entrypoint logs showed xtrabackup restore + GTID handling, then MySQL startup, without an account reset step.

Evidence artifact:

- `/tmp/mysql-pr2964-3a8826-runtime-n3-20260702T073500Z.tar.gz`
- sha256 `b126f23fd7552821fcfca10e6c4d7760820fa120ad9095acdd89015f938b1a00`

Cleanup:

- Each run deleted source/restore Cluster, Backup, and Restore CR.
- Namespace retains only the BackupRepo PVC.

## Review / Boundary

- Current-head static checks, CI, and scoped runtime N=3 are complete for the password-preservation fix.
- Not claimed: R11 full ledger PASS, PITR family PASS, release-ready, and chart upgrade over an existing immutable ComponentDefinition path.
