### PR TITLE
feat(rabbitmq): add TLS product wiring

### DIFF
--- a/addons-cluster/rabbitmq/Chart.yaml
+++ b/addons-cluster/rabbitmq/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
 apiVersion: v2
 name: rabbitmq-cluster
 type: application
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 description: A RabbitMQ cluster Helm chart for KubeBlocks
 dependencies:
   - name: kblib

--- a/addons-cluster/rabbitmq/templates/_helpers.tpl
+++ b/addons-cluster/rabbitmq/templates/_helpers.tpl
@@ -11,3 +11,19 @@ replicas: 1
 replicas: {{ max .Values.replicas 3 }}
 {{- end }}
 {{- end }}
+
+{{- define "rabbitmq-cluster.tls" }}
+tls: {{ .Values.tls.enabled }}
+{{- if .Values.tls.enabled }}
+issuer:
+  name: {{ .Values.tls.issuer }}
+{{- if eq .Values.tls.issuer "UserProvided" }}
+  secretRef:
+    name: {{ .Values.tls.secretName | default (printf "%s-tls" (include "kblib.clusterName" .)) }}
+    namespace: {{ .Release.Namespace }}
+    ca: ca.crt
+    cert: tls.crt
+    key: tls.key
+{{- end }}
+{{- end }}
+{{- end }}

--- a/addons-cluster/rabbitmq/templates/cluster-tls-secrets.yaml
+++ b/addons-cluster/rabbitmq/templates/cluster-tls-secrets.yaml
@@ -1,7 +1,7 @@
-{{- if and .Values.tls.enabled (eq .Values.tls.issuer "UserProvided") }}
+{{- if and .Values.tls.enabled (eq .Values.tls.issuer "UserProvided") (not .Values.tls.secretName) }}
 {{- $clusterName := include "kblib.clusterName" . }}
 {{- $namespace := .Release.Namespace }}
-{{- $secretName := .Values.tls.secretName | default (printf "%s-tls" $clusterName) }}
+{{- $secretName := printf "%s-tls" $clusterName }}
 {{- $dnsNames := list
   "localhost"
   (printf "%s-rabbitmq" $clusterName)

--- a/addons-cluster/rabbitmq/templates/cluster-tls-secrets.yaml
+++ b/addons-cluster/rabbitmq/templates/cluster-tls-secrets.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.tls.enabled (eq .Values.tls.issuer "UserProvided") }}
+{{- $clusterName := include "kblib.clusterName" . }}
+{{- $namespace := .Release.Namespace }}
+{{- $secretName := .Values.tls.secretName | default (printf "%s-tls" $clusterName) }}
+{{- $dnsNames := list
+  "localhost"
+  (printf "%s-rabbitmq" $clusterName)
+  (printf "%s-rabbitmq.%s.svc" $clusterName $namespace)
+  (printf "%s-rabbitmq.%s.svc.cluster.local" $clusterName $namespace)
+  (printf "*.%s-rabbitmq-headless.%s.svc" $clusterName $namespace)
+  (printf "*.%s-rabbitmq-headless.%s.svc.cluster.local" $clusterName $namespace)
+}}
+{{- $ca := genCA "KubeBlocks" 36500 }}
+{{- $cert := genSignedCert "rabbitmq" (list "127.0.0.1" "::1") $dnsNames 36500 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
+  annotations:
+    self-signed-cert: "true"
+type: kubernetes.io/tls
+data:
+  tls.key: {{ $cert.Key | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+{{- end }}

--- a/addons-cluster/rabbitmq/templates/cluster.yaml
+++ b/addons-cluster/rabbitmq/templates/cluster.yaml
@@ -8,7 +8,7 @@ spec:
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
   componentSpecs:
     - name: rabbitmq
-      componentDef: rabbitmq
+      componentDef: rabbitmq-{{ .Chart.Version }}
       serviceVersion: {{ .Values.version }}
       {{- include "rabbitmq-cluster.replicaCount" . | indent 6 }}
       {{- include "rabbitmq-cluster.tls" . | indent 6 }}

--- a/addons-cluster/rabbitmq/templates/cluster.yaml
+++ b/addons-cluster/rabbitmq/templates/cluster.yaml
@@ -11,5 +11,6 @@ spec:
       componentDef: rabbitmq
       serviceVersion: {{ .Values.version }}
       {{- include "rabbitmq-cluster.replicaCount" . | indent 6 }}
+      {{- include "rabbitmq-cluster.tls" . | indent 6 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- include "kblib.componentStorages" . | indent 6 }}

--- a/addons-cluster/rabbitmq/values.schema.json
+++ b/addons-cluster/rabbitmq/values.schema.json
@@ -76,6 +76,32 @@
       "title": "Storage Class Name",
       "description": "Storage class name of the data volume",
       "type": "string"
+    },
+    "tls": {
+      "title": "TLS",
+      "description": "RabbitMQ TLS settings. Enabling TLS adds AMQPS and HTTPS management endpoints while preserving plaintext compatibility ports.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable TLS",
+          "type": "boolean",
+          "default": false
+        },
+        "issuer": {
+          "title": "TLS issuer",
+          "type": "string",
+          "default": "UserProvided",
+          "enum": [
+            "KubeBlocks",
+            "UserProvided"
+          ]
+        },
+        "secretName": {
+          "title": "TLS Secret Name",
+          "description": "Existing TLS Secret name for UserProvided issuer; if empty, the example chart generates one.",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/addons-cluster/rabbitmq/values.yaml
+++ b/addons-cluster/rabbitmq/values.yaml
@@ -29,5 +29,12 @@ requests:
 ##
 storage: 20
 
+tls:
+  enabled: false
+  ## KubeBlocks or UserProvided. UserProvided auto-generates a self-signed
+  ## Secret for the example chart unless tls.secretName points to an existing Secret.
+  issuer: UserProvided
+  secretName: ""
+
 extra:
   terminationPolicy: Delete

--- a/addons/rabbitmq/Chart.yaml
+++ b/addons/rabbitmq/Chart.yaml
@@ -4,7 +4,7 @@ description: RabbitMQ is a reliable and mature messaging and streaming broker.
 
 type: application
 
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 
 appVersion: "3.13.7"
 

--- a/addons/rabbitmq/config/rabbitmq-config.tpl
+++ b/addons/rabbitmq/config/rabbitmq-config.tpl
@@ -43,6 +43,20 @@ cluster_name                               = {{ .KB_CLUSTER_NAME }}
 {{- $rabbitmq_port := 5672 }}
 listeners.tcp.1 = :::{{ $rabbitmq_port }}
 
+{{- if eq (index $ "TLS_ENABLED") "true" }}
+listeners.ssl.default = 5671
+ssl_options.cacertfile = {{ .TLS_MOUNT_PATH }}/ca.crt
+ssl_options.certfile = {{ .TLS_MOUNT_PATH }}/tls.crt
+ssl_options.keyfile = {{ .TLS_MOUNT_PATH }}/tls.key
+ssl_options.verify = verify_none
+ssl_options.fail_if_no_peer_cert = false
+
+management.ssl.port = 15671
+management.ssl.cacertfile = {{ .TLS_MOUNT_PATH }}/ca.crt
+management.ssl.certfile = {{ .TLS_MOUNT_PATH }}/tls.crt
+management.ssl.keyfile = {{ .TLS_MOUNT_PATH }}/tls.key
+{{- end }}
+
 {{- if gt (div $phy_memory 5) (mul 2 $GiB) }}
 total_memory_available_override_value = {{ sub $phy_memory (mul 2 $GiB) }}
 {{- else if gt $phy_memory 0 }}

--- a/addons/rabbitmq/scripts/startup.sh
+++ b/addons/rabbitmq/scripts/startup.sh
@@ -16,4 +16,14 @@ default_user = ${RABBITMQ_DEFAULT_USER}
 default_pass = ${RABBITMQ_DEFAULT_PASS}
 EOF
 
+if [ "${TLS_ENABLED:-false}" = "true" ]; then
+  : "${TLS_MOUNT_PATH:?TLS_MOUNT_PATH is required when TLS is enabled}"
+  for cert_file in ca.crt tls.crt tls.key; do
+    if [ ! -r "${TLS_MOUNT_PATH}/${cert_file}" ]; then
+      echo "ERROR: TLS is enabled but ${TLS_MOUNT_PATH}/${cert_file} is not readable" >&2
+      exit 1
+    fi
+  done
+fi
+
 exec /opt/rabbitmq/sbin/rabbitmq-server

--- a/addons/rabbitmq/templates/cmpd.yaml
+++ b/addons/rabbitmq/templates/cmpd.yaml
@@ -12,6 +12,12 @@ spec:
   serviceKind: rabbitmq
   serviceVersion: {{ .Values.componentServiceVersion.rabbitmq }}
   podManagementPolicy: Parallel
+  tls:
+    volumeName: tls
+    mountPath: {{ .Values.tlsMountPath }}
+    caFile: ca.crt
+    certFile: tls.crt
+    keyFile: tls.key
   services:
     - name: default
       spec:
@@ -19,9 +25,15 @@ spec:
           - name: amqp
             port: 5672
             targetPort: amqp
+          - name: amqps
+            port: 5671
+            targetPort: amqps
           - name: management
             port: 15672
             targetPort: management
+          - name: management-tls
+            port: 15671
+            targetPort: management-tls
           - name: web-stomp
             port: 15674
             targetPort: web-stomp
@@ -106,6 +118,8 @@ spec:
               fieldPath: metadata.namespace
         - name: SERVICE_PORT
           value: "15692"
+        - name: TLS_MOUNT_PATH
+          value: {{ .Values.tlsMountPath }}
         - name: RABBITMQ_MNESIA_BASE
           value: {{ .Values.dataMountPath }}/mnesia
         - name: RABBITMQ_LOG_BASE
@@ -144,8 +158,14 @@ spec:
         - containerPort: 5672
           name: amqp
           protocol: TCP
+        - containerPort: 5671
+          name: amqps
+          protocol: TCP
         - containerPort: 15672
           name: management
+          protocol: TCP
+        - containerPort: 15671
+          name: management-tls
           protocol: TCP
         - containerPort: 15674
           name: web-stomp
@@ -214,6 +234,11 @@ spec:
         componentVarRef:
           optional: false
           componentName: Required
+    - name: TLS_ENABLED
+      valueFrom:
+        tlsVarRef:
+          enabled: Optional
+          optional: true
     - name: PHY_MEMORY
       valueFrom:
         resourceVarRef:

--- a/addons/rabbitmq/templates/cmpd.yaml
+++ b/addons/rabbitmq/templates/cmpd.yaml
@@ -239,6 +239,8 @@ spec:
         tlsVarRef:
           enabled: Optional
           optional: true
+    - name: TLS_MOUNT_PATH
+      value: {{ .Values.tlsMountPath }}
     - name: PHY_MEMORY
       valueFrom:
         resourceVarRef:

--- a/addons/rabbitmq/values.yaml
+++ b/addons/rabbitmq/values.yaml
@@ -53,6 +53,8 @@ logCollector:
 
 dataMountPath: /var/lib/rabbitmq
 
+tlsMountPath: /etc/pki/tls
+
 
 ## @param enabledClusterVersions specifies the enabled cluster versions, if not set, all cluster versions are enabled
 ## and will be rendered, installed. Otherwise, only the specified cluster versions will be rendered and installed.


### PR DESCRIPTION
## Summary
- Adds RabbitMQ TLS product wiring to the addon chart: ComponentDefinition `spec.tls`, TLS env/vars, AMQPS `5671`, HTTPS management `15671`, and RabbitMQ TLS config paths under `/etc/pki/tls`.
- Adds `addons-cluster/rabbitmq` TLS values/rendering for `tls.enabled=true`, including UserProvided/self-signed example Secret when no existing Secret is supplied.
- Keeps first-cut compatibility semantics explicit: plaintext AMQP/HTTP remain open; this PR does not claim TLS-only mode.
- Fixes existing-Secret behavior: explicit `tls.secretName` now references an existing Secret and does not render a new self-signed Secret with the same name.
- Fixes the #57 product RED from existing-addon upgrade: TLS changes move to a new versioned ComponentDefinition `rabbitmq-1.2.0-alpha.1`, and the sample cluster chart now references that exact TLS-capable definition instead of mutating the existing `rabbitmq-1.2.0-alpha.0` ComponentDefinition in place.

## Contract / Design Anchors
- `kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md` for CMPD `tls`, Cluster `tls` / `issuer.secretRef`, and runtime TLS compatibility checks.
- `kubeblocks-addon-docs/docs/design/addon-componentdefinition-upgrade-guide.md` for spec-changing ComponentDefinition updates requiring a new versioned name and same-render reference-chain switch.

## Validation
- `git diff --check`
- `helm lint addons/rabbitmq`
- `helm lint addons-cluster/rabbitmq --set tls.enabled=true`
- `helm template rmqtls152732 addons-cluster/rabbitmq --namespace rabbitmq-test --set tls.enabled=true --set-string version=3.13.7` renders `componentDef: rabbitmq-1.2.0-alpha.1`.
- With kubeblocks-tests PR apecloud/kubeblocks-tests#568 head `f87782d34e771fd09b74ce73c6584cc6fffd4ec3`:
  `ADDONS_REPO=/Users/wei/.slock/agents/c632c003-9ed6-48d1-b375-6c00518e074b/repos/kubeblocks-addons ./rabbitmq/run-tests.sh -t static --skip-addon-install`
  Result: PASS 78 / FAIL 0 / SKIP 0
  Artifact: `rabbitmq/artifacts/20260702-155025/`

## Runtime Boundary
Approved-runner TLS runtime validation is tracked in #57. Previous #57 package `tls-3.13.7-20260702-152732/` is product RED history for the old same-name CmpD update path; the rerun must pin this addon head plus tests head `f87782d34e771fd09b74ce73c6584cc6fffd4ec3`.
