### PR TITLE
fix(mariadb): skip invalid reloader parameter errors

### DIFF
--- a/addons/mariadb/reloader/update-parameter.sh
+++ b/addons/mariadb/reloader/update-parameter.sh
@@ -37,6 +37,14 @@ else
 fi
 
 if [[ ${status} -ne 0 ]]; then
+    error_code=$(printf '%s' "${output}" | grep -oE 'ERROR [0-9]+' | head -1 | awk '{print $2}')
+    case "${error_code}" in
+        1231|1232|1193|1064)
+            echo "[REJECT] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}"
+            echo "[REJECT] parameter ${param_name}=${param_value} rejected by engine (error ${error_code}): ${output}" >&2
+            exit 0
+            ;;
+    esac
     echo "Failed to set parameter ${param_name} to value ${param_value}: ${output}" >&2
     exit 1
 fi

--- a/addons/mariadb/scripts-ut-spec/reloader_update_parameter_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/reloader_update_parameter_spec.sh
@@ -1,0 +1,71 @@
+# shellcheck shell=sh
+
+Describe "reloader/update-parameter.sh"
+
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mariadb/reloader/update-parameter.sh" "$(repo_root)"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t mariadb-reloader-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    MARIADB_ROOT_USER="root"
+    MARIADB_ROOT_PASSWORD="secret"
+    export PATH MARIADB_ROOT_USER MARIADB_ROOT_PASSWORD
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_mariadb_stub() {
+    rc="$1"
+    stderr="$2"
+    cat > "${bindir}/mariadb" <<EOF
+#!/bin/sh
+printf '%s\n' "$stderr" >&2
+exit "$rc"
+EOF
+    chmod +x "${bindir}/mariadb"
+  }
+
+  Describe "classified user-input SQL errors"
+    It "skips ERROR 1232 without returning failure"
+      write_mariadb_stub 1 "ERROR 1232 (42000) at line 1: Incorrect argument type to variable 'log_warnings'"
+
+      When run bash "$(script_path)" "log_warnings" "nonsense"
+      The status should eq 0
+      The output should include "[REJECT] parameter log_warnings=nonsense rejected by engine (error 1232)"
+      The error should include "[REJECT] parameter log_warnings=nonsense rejected by engine (error 1232)"
+      The error should not include "Failed to set parameter"
+    End
+
+    It "skips ERROR 1231 without returning failure"
+      write_mariadb_stub 1 "ERROR 1231 (42000) at line 1: Variable 'long_query_time' can't be set to the value of 'bad'"
+
+      When run bash "$(script_path)" "long_query_time" "bad"
+      The status should eq 0
+      The output should include "[REJECT] parameter long_query_time=bad rejected by engine (error 1231)"
+      The error should not include "Failed to set parameter"
+    End
+  End
+
+  Describe "unclassified SQL errors"
+    It "still fails closed"
+      write_mariadb_stub 1 "ERROR 1045 (28000): Access denied for user"
+
+      When run bash "$(script_path)" "long_query_time" "7"
+      The status should eq 1
+      The error should include "Failed to set parameter long_query_time to value 7"
+    End
+  End
+End


### PR DESCRIPTION
## Summary
- closes #2977
- skip classified user-input SQL errors in addons/mariadb/reloader/update-parameter.sh
- add focused ShellSpec coverage for ERROR 1232, ERROR 1231, and unclassified failures

## Background
#2889 fixed the ComponentDefinition reconfigure helper, but post-merge validation showed the InstanceSet reloader path can still keep reconcile on the failing path for all-invalid input.

Observed on main head f77873618d9eacb2bd10ca2376641b77a30c14e1:
- T1 valid reconfigure: PASS
- T2 all-invalid slow_query_log=nonsense + log_warnings=nonsense: OpsRequest Succeed, but Cluster stayed Updating
- InstanceSet stderr included ERROR 1232 Incorrect argument type to variable log_warnings
- DB variables remained unchanged: slow_query_log=OFF, log_warnings=2
- Evidence package: /tmp/mariadb-2889-postmerge-blocker-mdb2889-t2-3292.tar.gz
- sha256: ffcf690869643cde64e57962de5279409394edf6a8b7f2f329649ed1c01d8fb8

## Static validation
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/reloader_update_parameter_spec.sh
- shellspec --load-path ./shellspec --shell bash addons/mariadb/scripts-ut-spec/reconfigure_persisted_alpha86_spec.sh
- bash -n addons/mariadb/reloader/update-parameter.sh
- bash -n addons/mariadb/scripts-ut-spec/reloader_update_parameter_spec.sh

## Runtime validation
Validated PR head fe6a6e36f85ec7f750bb2364a43c40c52dec1267 with chart mariadb-1.2.0-alpha.26:
- T1 standalone valid reconfigure: PASS
- T2 standalone all-invalid slow_query_log=nonsense + log_warnings=nonsense: PASS; OpsRequest Succeed, Cluster returned Running, and slow_query_log/log_warnings were not incorrectly modified
- T3 standalone mixed valid + invalid reconfigure: PASS
- T4 async persisted mixed + restart: PASS
- Total: PASS 6 / FAIL 0
- Evidence package: /tmp/mariadb-2889-focused-idc2-79578.tar.gz
- sha256: 8041c7d1a959f1e9db60669c57eb3c8826c3afa26d798bfa81293b0e435149f1
- Cleanup: patched-run mdb2889-prefixed cluster/component/instanceset/pod/pvc/cm/secret/ops resources all none

Action-level [REJECT] capture was verified on PR #2978 patch chart:
- cluster: mdb2889-reject3-31427 standalone
- kbagent log confirms [REJECT] parameter log_warnings=nonsense rejected by engine (error 1232)
- kbagent log confirms [REJECT] parameter slow_query_log=nonsense rejected by engine (error 1231)
- end-to-end state: OpsRequest Succeed, Cluster Running, database variables unchanged
- Evidence package: /tmp/mariadb-2889-reject-capture3-31427.tar.gz
- sha256: cb78727c06c6b282fc6676d3a307f96c2b18367b2f15af7a0f76b812dd718fdb

Boundary: this validates #2889 focused reconfigure regression on PR head fe6a6e36. It is not merged-main post-merge validation and not a release-ready claim.
