### PR TITLE
fix(valkey): datafile backup archives only the BGSAVE snapshot and ACL file

### DIFF
--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -114,10 +114,23 @@ if [ "${_bgsave_elapsed}" -ge "${_bgsave_timeout}" ]; then
   exit 1
 fi
 
-echo "INFO: Archiving data directory..."
+echo "INFO: Archiving consistent snapshot artifacts..."
 cd "${DATA_DIR}" || { echo "ERROR: cannot cd to DATA_DIR '${DATA_DIR}'" >&2; exit 1; }
-# Archive the entire data directory (includes dump.rdb, appendonlydir/, users.acl)
-tar -cvf - ./ | datasafed push -z zstd-fastest - "${DP_BACKUP_NAME}.tar.zst" || exit 1
+# Archive ONLY the BGSAVE-produced RDB plus the ACL file — NOT the whole
+# data directory. With appendonly enabled the server keeps writing
+# appendonlydir/ while tar runs, so a wholesale copy captures a torn AOF
+# manifest/segment set; on startup the engine PREFERS the AOF over the RDB,
+# which would make restore fidelity ride on that racy copy instead of the
+# consistent BGSAVE snapshot we just waited for. With no AOF manifest in
+# the restored data directory, the engine loads dump.rdb and seeds a fresh
+# AOF from it, making the BGSAVE moment the well-defined restore point.
+if [ ! -f "./dump.rdb" ]; then
+  echo "ERROR: dump.rdb not found in ${DATA_DIR} after BGSAVE" >&2
+  exit 1
+fi
+backup_files=("./dump.rdb")
+[ -f "./users.acl" ] && backup_files+=("./users.acl")
+tar -cvf - "${backup_files[@]}" | datasafed push -z zstd-fastest - "${DP_BACKUP_NAME}.tar.zst" || exit 1
 
 save_sentinel_acl || \
   echo "WARNING: Sentinel ACL save failed — ACL rules will not be restored after a cluster restore." >&2

--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# backup.sh — physical (RDB+AOF) backup for Valkey.
+# backup.sh — physical RDB+ACL snapshot backup for Valkey.
 #
 # KubeBlocks DataProtection injects:
 #   DP_DB_HOST           — target pod hostname/FQDN
@@ -121,9 +121,9 @@ cd "${DATA_DIR}" || { echo "ERROR: cannot cd to DATA_DIR '${DATA_DIR}'" >&2; exi
 # appendonlydir/ while tar runs, so a wholesale copy captures a torn AOF
 # manifest/segment set; on startup the engine PREFERS the AOF over the RDB,
 # which would make restore fidelity ride on that racy copy instead of the
-# consistent BGSAVE snapshot we just waited for. With no AOF manifest in
-# the restored data directory, the engine loads dump.rdb and seeds a fresh
-# AOF from it, making the BGSAVE moment the well-defined restore point.
+# consistent BGSAVE snapshot we just waited for. restore.prepareData seeds
+# a multipart AOF manifest from dump.rdb before Valkey starts, making the
+# BGSAVE moment the well-defined restore point even with appendonly enabled.
 if [ ! -f "./dump.rdb" ]; then
   echo "ERROR: dump.rdb not found in ${DATA_DIR} after BGSAVE" >&2
   exit 1

--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -36,5 +36,43 @@ else
   exit 1
 fi
 
+seed_multipart_aof_from_rdb() {
+  local rdb="${DATA_DIR}/dump.rdb"
+  local append_dirname="${VALKEY_APPEND_DIRNAME:-appendonlydir}"
+  local append_filename="${VALKEY_APPEND_FILENAME:-appendonly.aof}"
+  local append_dir="${DATA_DIR}/${append_dirname}"
+  local base_file="${append_dir}/${append_filename}.1.base.rdb"
+  local incr_file="${append_dir}/${append_filename}.1.incr.aof"
+  local manifest_file="${append_dir}/${append_filename}.manifest"
+  local restored_aof_state=""
+
+  if [ ! -s "${rdb}" ]; then
+    echo "ERROR: restored archive must contain a non-empty dump.rdb." >&2
+    exit 1
+  fi
+
+  restored_aof_state=$(find "${DATA_DIR}" -mindepth 1 \( \
+    -name "${append_dirname}" -o \
+    -name "${append_filename}" -o \
+    -name "${append_filename}.*" -o \
+    -name "*.aof" \
+  \) -print -quit)
+  if [ -n "${restored_aof_state}" ]; then
+    echo "ERROR: restored archive already contains AOF state at ${restored_aof_state}; refusing to synthesize AOF from dump.rdb." >&2
+    exit 1
+  fi
+
+  mkdir -p "${append_dir}"
+  cp "${rdb}" "${base_file}"
+  : > "${incr_file}"
+  {
+    printf 'file %s seq 1 type b\n' "$(basename "${base_file}")"
+    printf 'file %s seq 1 type i\n' "$(basename "${incr_file}")"
+  } > "${manifest_file}"
+  echo "INFO: Seeded multipart AOF manifest from restored dump.rdb."
+}
+
+seed_multipart_aof_from_rdb
+
 rm -f "${placeholder}" && sync
 echo "INFO: Restore complete."

--- a/addons/valkey/scripts-ut-spec/backup_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backup_contract_spec.sh
@@ -21,4 +21,17 @@ Describe "Valkey backup contract"
     When call grep -E '^\$\{connect_url\}|\$\{_probe_base\}[^@]' "${script_file}"
     The status should be failure
   End
+
+  It "archives only the BGSAVE snapshot and the ACL file"
+    When call grep -F 'tar -cvf - "${backup_files[@]}"' "${script_file}"
+    The status should be success
+    The stdout should include 'backup_files'
+  End
+
+  It "does not archive the live data directory wholesale (torn-AOF risk)"
+    # Tarring ./ captures appendonlydir/ mid-write; on restore the engine
+    # prefers the AOF over the consistent BGSAVE RDB.
+    When call grep -F 'tar -cvf - ./ ' "${script_file}"
+    The status should be failure
+  End
 End

--- a/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
@@ -22,6 +22,20 @@ case "$1" in
     rm -rf "${tmp}"
     mkdir -p "${tmp}/src"
     printf 'restored\n' > "${tmp}/src/restored.txt"
+    if [ "${FAKE_DATASAFED_OMIT_RDB:-}" != "1" ]; then
+      if [ "${FAKE_DATASAFED_EMPTY_RDB:-}" = "1" ]; then
+        : > "${tmp}/src/dump.rdb"
+      else
+        printf 'valkey-rdb\n' > "${tmp}/src/dump.rdb"
+      fi
+    fi
+    if [ "${FAKE_DATASAFED_INCLUDE_AOF:-}" = "1" ]; then
+      mkdir -p "${tmp}/src/appendonlydir"
+      printf 'existing manifest\n' > "${tmp}/src/appendonlydir/appendonly.aof.manifest"
+    fi
+    if [ "${FAKE_DATASAFED_INCLUDE_ROOT_AOF:-}" = "1" ]; then
+      printf 'existing aof\n' > "${tmp}/src/appendonly.aof"
+    fi
     tar -cf - -C "${tmp}/src" .
     rm -rf "${tmp}"
     ;;
@@ -59,6 +73,10 @@ SH
     unset DP_BACKUP_NAME
     unset DP_BACKUP_BASE_PATH
     unset DP_DATASAFED_BIN_PATH
+    unset FAKE_DATASAFED_INCLUDE_AOF
+    unset FAKE_DATASAFED_INCLUDE_ROOT_AOF
+    unset FAKE_DATASAFED_OMIT_RDB
+    unset FAKE_DATASAFED_EMPTY_RDB
   }
   After "cleanup"
 
@@ -67,7 +85,19 @@ SH
     The status should be success
     The stdout should include "INFO: Restore complete."
     The file "${data_dir}/restored.txt" should be exist
+    The file "${data_dir}/appendonlydir/appendonly.aof.manifest" should be exist
+    The file "${data_dir}/appendonlydir/appendonly.aof.1.base.rdb" should be exist
+    The file "${data_dir}/appendonlydir/appendonly.aof.1.incr.aof" should be exist
     The file "${data_dir}/.kb-data-protection" should not be exist
+  End
+
+  It "seeds a multipart AOF manifest from the restored RDB"
+    When run bash ../dataprotection/restore.sh
+    The status should be success
+    The stdout should include "INFO: Seeded multipart AOF manifest from restored dump.rdb."
+    The contents of file "${data_dir}/appendonlydir/appendonly.aof.manifest" should include "file appendonly.aof.1.base.rdb seq 1 type b"
+    The contents of file "${data_dir}/appendonlydir/appendonly.aof.manifest" should include "file appendonly.aof.1.incr.aof seq 1 type i"
+    The contents of file "${data_dir}/appendonlydir/appendonly.aof.1.base.rdb" should include "valkey-rdb"
   End
 
   It "restores when only the data-protection placeholder exists"
@@ -88,5 +118,43 @@ SH
     The status should be failure
     The stderr should include "ERROR: ${data_dir} is not empty"
     The file "${data_dir}/restored.txt" should not be exist
+  End
+
+  It "fails closed when the restored archive is missing dump.rdb"
+    export FAKE_DATASAFED_OMIT_RDB=1
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "ERROR: restored archive must contain a non-empty dump.rdb."
+  End
+
+  It "fails closed when the restored dump.rdb is empty"
+    export FAKE_DATASAFED_EMPTY_RDB=1
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "ERROR: restored archive must contain a non-empty dump.rdb."
+  End
+
+  It "fails closed when the restored archive already contains an AOF directory"
+    export FAKE_DATASAFED_INCLUDE_AOF=1
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "ERROR: restored archive already contains AOF state"
+    The stderr should include "appendonlydir"
+  End
+
+  It "fails closed when the restored archive already contains root AOF state"
+    export FAKE_DATASAFED_INCLUDE_ROOT_AOF=1
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "ERROR: restored archive already contains AOF state"
+    The stderr should include "appendonly.aof"
   End
 End

--- a/addons/valkey/templates/backupactionset.yaml
+++ b/addons/valkey/templates/backupactionset.yaml
@@ -1,12 +1,14 @@
 {{/*
-ActionSet for Valkey physical (RDB+AOF) backup and restore.
+ActionSet for Valkey RDB+ACL snapshot backup and restore.
 
 Backup flow:
   1. backupData: run BGSAVE on the target pod (secondary preferred), wait for
-     completion, tar the entire /data directory and push with zstd compression.
+     completion, archive dump.rdb plus users.acl when present, and push with
+     zstd compression.
 
 Restore flow:
-  1. prepareData: pull the archive and extract it into DATA_DIR before the pod starts.
+  1. prepareData: pull the archive, extract it into DATA_DIR, and seed the
+     multipart AOF manifest/base/incr files from dump.rdb before the pod starts.
   2. postReady: fail-closed Sentinel monitor re-registration after data restore.
 
 KubeBlocks DataProtection passes standard DP_* variables into all job containers;


### PR DESCRIPTION
Fixes #2983 — see the issue for the failure chain, reproduction under write load, the restore-point trade-off to confirm, and the verification checklist (archive contents, RDB fallback loading on 8.x/9.x, ACL survival).

Validation: backup/restore contract specs green locally (8 examples, 0 failures); needs live backup->restore verification under write load per the issue.

---

## Merge-gate status (updated 2026-07-06)

**Code side — reviewed** (Athena independent review: multipart-AOF seeding technique verified against Valkey 7+ manifest format; hardcoded file names safe because `dir`/`dbfilename`/`appendfilename`/`appenddirname` are `immutableParameters`; legacy-archive refusal accepted by owner decision — no existing users).

**Live backup→restore evidence under write load — ALL PASS** (Emily, r3 on this PR's head `529e461c`, 32 PASS / 0 FAIL / 0 SKIP, evidence `artifacts/valkey-live/2984-r3/`, log sha256 `575ae976...`, namespace cleaned):

| Check | Result |
|---|---|
| backup on replica target with continuous writer running | PASS (`vlk2984-valkey-1`) |
| archive contains ONLY `./dump.rdb` + `./users.acl` (no AOF artifacts) | PASS (tar listing inspected) |
| restore prepareData seeds multipart AOF manifest from RDB | PASS (log evidence) |
| snapshot-point fidelity: `baseline(100) ≤ restore(109) ≤ post-BGSAVE(123) < final(156)` | PASS — restore lands inside the fork window, post-snapshot writes excluded (the torn-AOF behavior this PR eliminates would land near 156) |
| restored DBSIZE non-zero and equals snapshot-window value | PASS (109) |
| custom ACL account (`backupuser`) survives restore | PASS |

Ready for human approve + merge (second in the train, after #2982).
