### PR TITLE
fix(valkey): targeted switchover restores captured replica-priority values

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -1086,6 +1086,44 @@ Describe "Valkey Switchover Bash Script Tests"
       End
     End
 
+    Context "when pods carry user-configured replica-priority values"
+      It "restores the captured original priorities instead of hardcoded 100"
+        get_role() { echo "slave"; }
+        get_replica_priority() {
+          case "${1}" in
+            valkey-0.*) echo "42" ;;
+            valkey-1.*) echo "25" ;;
+            *) echo "100" ;;
+          esac
+        }
+        set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
+        execute_sentinel_failover() { echo "OK"; return 0; }
+        wait_for_new_master() { return 0; }
+        When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
+        The status should be success
+        # Bias still uses 1/100 so Sentinel deterministically picks the candidate...
+        The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:1"
+        The stdout should include "SET_PRIO:valkey-0.headless.default.svc.cluster.local:100"
+        # ...but the restore puts back the captured user values, not 100.
+        The stdout should include "SET_PRIO:valkey-0.headless.default.svc.cluster.local:42"
+        The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:25"
+      End
+
+      It "falls back to 100 when a pod's current priority cannot be read"
+        get_role() { echo "slave"; }
+        get_replica_priority() { echo ""; }
+        set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
+        execute_sentinel_failover() { echo "OK"; return 0; }
+        wait_for_new_master() { return 0; }
+        When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "SET_PRIO:valkey-0.headless.default.svc.cluster.local:100"
+        The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:100"
+      End
+    End
+
     Context "when successful candidate is absent from stale VALKEY_POD_FQDN_LIST"
       It "restores the requested candidate after wait_for_new_master"
         restore_order=""

--- a/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_switchover_spec.sh
@@ -1110,6 +1110,46 @@ Describe "Valkey Switchover Bash Script Tests"
         The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:25"
       End
 
+      It "preserves never-promote (priority 0) replicas through bias and restore"
+        get_role() { echo "slave"; }
+        get_replica_priority() {
+          case "${1}" in
+            valkey-0.*) echo "0" ;;     # never-promote replica
+            *) echo "100" ;;
+          esac
+        }
+        set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
+        execute_sentinel_failover() { echo "OK"; return 0; }
+        wait_for_new_master() { return 0; }
+        When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
+        The status should be success
+        The stdout should include "Preserving never-promote replica-priority=0 on valkey-0.headless.default.svc.cluster.local"
+        # The 0-replica must NEVER be written to 100 — not during bias, not later.
+        The stdout should not include "SET_PRIO:valkey-0.headless.default.svc.cluster.local:100"
+        # Candidate bias still applies, and restore writes back the captured 0.
+        The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:1"
+        The stdout should include "SET_PRIO:valkey-0.headless.default.svc.cluster.local:0"
+      End
+
+      It "warns but proceeds when the explicit candidate itself has priority 0"
+        get_role() { echo "slave"; }
+        get_replica_priority() {
+          case "${1}" in
+            valkey-1.*) echo "0" ;;
+            *) echo "100" ;;
+          esac
+        }
+        set_replica_priority() { echo "SET_PRIO:${1}:${2}"; return 0; }
+        wait_sentinel_sees_priority_bias() { return 0; }
+        execute_sentinel_failover() { echo "OK"; return 0; }
+        wait_for_new_master() { return 0; }
+        When call switchover_with_sentinel "valkey-1.headless.default.svc.cluster.local"
+        The status should be success
+        The stderr should include "never-promote"
+        The stdout should include "SET_PRIO:valkey-1.headless.default.svc.cluster.local:1"
+      End
+
       It "falls back to 100 when a pod's current priority cannot be read"
         get_role() { echo "slave"; }
         get_replica_priority() { echo ""; }

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -221,6 +221,20 @@ restore_replica_priorities() {
   done
 }
 
+# captured_replica_priority — look up the pre-bias value recorded by
+# capture_replica_priorities. Prints the captured value, or 100 when the
+# fqdn was never captured (defensive default, same as capture's fallback).
+captured_replica_priority() {
+  local fqdn="${1}" i
+  for i in "${!_orig_prio_fqdns[@]}"; do
+    if [ "${_orig_prio_fqdns[$i]}" = "${fqdn}" ]; then
+      echo "${_orig_prio_values[$i]}"
+      return 0
+    fi
+  done
+  echo "100"
+}
+
 sentinel_observed_replica_priority() {
   local sentinel_fqdn="${1}" replica_fqdn="${2}"
   local replica_host="${replica_fqdn%%.*}"
@@ -310,6 +324,8 @@ wait_sentinel_sees_priority_bias() {
         # The current master is not listed in SENTINEL REPLICAS before failover.
         [ "${pod}" = "${current_pod}" ] && continue
         expected_prio="100"
+        # Never-promote replicas keep their captured 0 (bias skipped, #3016).
+        [ "$(captured_replica_priority "${fqdn}")" = "0" ] && expected_prio="0"
         [ "${pod}" = "${candidate_pod}" ] && expected_prio="1"
         total=$((total + 1))
         observed_prio=$(sentinel_observed_replica_priority "${s_fqdn}" "${fqdn}") || true
@@ -402,11 +418,24 @@ switchover_with_sentinel() {
     for fqdn in "${all_fqdns[@]}"; do
       # Append "." so "valkey-1." is not a substring of "valkey-11.headless..." (substring false positive).
       if contains "${fqdn}" "${candidate_fqdn%%.*}."; then
+        if [ "$(captured_replica_priority "${fqdn}")" = "0" ]; then
+          echo "WARNING: candidate ${fqdn} has replica-priority=0 (never-promote); explicit targeted switchover overrides it for this operation." >&2
+        fi
         if ! set_replica_priority "${fqdn}" 1; then
           echo "ERROR: failed to set priority on candidate ${fqdn} — aborting targeted switchover" >&2
           priority_failed=1
         fi
       else
+        # replica-priority 0 means NEVER promote (backup/delayed replicas).
+        # Biasing it to 100 would make it promotable for the whole window —
+        # if the candidate dies mid-failover Sentinel could promote a
+        # never-promote replica (issue #3016). Leave 0 untouched: the
+        # candidate at priority 1 always outranks any positive priority,
+        # and 0 stays out of the election entirely.
+        if [ "$(captured_replica_priority "${fqdn}")" = "0" ]; then
+          echo "Preserving never-promote replica-priority=0 on ${fqdn} (bias skipped)."
+          continue
+        fi
         if ! set_replica_priority "${fqdn}" 100; then
           echo "ERROR: failed to normalize priority on ${fqdn} — aborting targeted switchover" >&2
           priority_failed=1

--- a/addons/valkey/scripts/switchover.sh
+++ b/addons/valkey/scripts/switchover.sh
@@ -186,6 +186,41 @@ set_replica_priority() {
   call_func_with_retry 3 3 _do_set_replica_priority "${fqdn}" "${prio}"
 }
 
+get_replica_priority() {
+  local fqdn="${1}"
+  build_cli "${fqdn}"
+  "${_cli[@]}" CONFIG GET replica-priority 2>/dev/null | tail -1 | tr -d '\r\n'
+}
+
+# capture_replica_priorities — record each pod's current replica-priority
+# before the targeted-switchover bias is applied, so the restore step can
+# put back the user-configured values instead of blindly writing 100
+# (replica-priority is a user-settable dynamic parameter; clobbering it
+# silently drifts the runtime away from the declared desired config).
+# Unreachable pods default to 100 (the engine default).
+capture_replica_priorities() {
+  local all_fqdns_csv="${1}"
+  _orig_prio_fqdns=()
+  _orig_prio_values=()
+  local _cap_fqdns=() fqdn prio
+  IFS=',' read -ra _cap_fqdns <<< "${all_fqdns_csv}"
+  for fqdn in "${_cap_fqdns[@]}"; do
+    prio=$(get_replica_priority "${fqdn}") || true
+    case "${prio}" in
+      ''|*[!0-9]*) prio="100" ;;
+    esac
+    _orig_prio_fqdns+=("${fqdn}")
+    _orig_prio_values+=("${prio}")
+  done
+}
+
+restore_replica_priorities() {
+  local i
+  for i in "${!_orig_prio_fqdns[@]}"; do
+    set_replica_priority "${_orig_prio_fqdns[$i]}" "${_orig_prio_values[$i]}" || true
+  done
+}
+
 sentinel_observed_replica_priority() {
   local sentinel_fqdn="${1}" replica_fqdn="${2}"
   local replica_host="${replica_fqdn%%.*}"
@@ -360,6 +395,9 @@ switchover_with_sentinel() {
 
     echo "Biasing Sentinel toward candidate ${candidate_fqdn}..."
     IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
+    # Record the current priorities first so every restore path below puts
+    # back user-configured values instead of hardcoded 100.
+    capture_replica_priorities "$(IFS=','; echo "${all_fqdns[*]}")"
     priority_failed=0
     for fqdn in "${all_fqdns[@]}"; do
       # Append "." so "valkey-1." is not a substring of "valkey-11.headless..." (substring false positive).
@@ -376,9 +414,7 @@ switchover_with_sentinel() {
       fi
     done
     if [ "${priority_failed}" -ne 0 ]; then
-      for fqdn in "${all_fqdns[@]}"; do
-        set_replica_priority "${fqdn}" 100 || true
-      done
+      restore_replica_priorities
       return 1
     fi
 
@@ -390,10 +426,7 @@ switchover_with_sentinel() {
     if ! wait_sentinel_sees_priority_bias "${candidate_fqdn}" "$(IFS=','; echo "${all_fqdns[*]}")"; then
       # Sentinel did not reflect the priority in time — restore before aborting
       # so the bias is never left in place after a failed switchover attempt.
-      IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
-      for fqdn in "${all_fqdns[@]}"; do
-        set_replica_priority "${fqdn}" 100 || true
-      done
+      restore_replica_priorities
       return 1
     fi
   fi
@@ -401,10 +434,7 @@ switchover_with_sentinel() {
   if ! execute_sentinel_failover; then
     # Restore priorities before failing so future Sentinel failovers are not biased.
     if ! is_empty "${candidate_fqdn}"; then
-      IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
-      for fqdn in "${all_fqdns[@]}"; do
-        set_replica_priority "${fqdn}" 100 || true
-      done
+      restore_replica_priorities
     fi
     return 1
   fi
@@ -418,10 +448,7 @@ switchover_with_sentinel() {
     wait_for_new_master "${candidate_fqdn}" "${KB_SWITCHOVER_CURRENT_FQDN}" || wfnm_rc=$?
     # Restore priorities on both success and failure paths — Sentinel has now
     # committed +switch-master (or timed out), so the bias is no longer needed.
-    IFS=',' read -ra all_fqdns <<< "$(pod_fqdns_with_candidate "${candidate_fqdn}")"
-    for fqdn in "${all_fqdns[@]}"; do
-      set_replica_priority "${fqdn}" 100 || true
-    done
+    restore_replica_priorities
     return "${wfnm_rc}"
   else
     # No candidate: any new master is a valid outcome, but we must confirm one


### PR DESCRIPTION
Fixes #2985 — see the issue for the deterministic reproduction (reconfigure replica-priority=50 → targeted switchover → value clobbered to 100) and the verification checklist.

Validation: switchover shellspec green locally (63 examples, 0 failures) including two new cases: captured user priorities are restored on success, and unreadable priorities fall back to 100. Needs a live targeted-switchover run per the issue to confirm end-to-end.

---

## Merge-gate status (updated 2026-07-06)

**Code side — reviewed.** Two commits: `b6e7eebb` (capture/restore of user priorities, reviewed by Athena + team) and `3998423b` (never-promote priority-0 preservation through the bias window, fixes #3016 — Alice + Bob PASS, 2 new spec cases).

**Live targeted-switchover evidence — ALL PASS** (Emily, 14 PASS / 0 FAIL / 0 SKIP, log sha256 `e8764bf5...`, namespace cleaned/NotFound).

*Head-equivalence note (TL-verified)*: the evidence run executed commit `3998423b`; the current head `47e9ec3c` is a message-only amend (attribution-trailer removal) of that commit — **both point to the identical tree `9768edfda3ace854987563c5b5450ba9d3660e71`**, and `git diff 3998423b..47e9ec3c` is empty. The evidence therefore covers the current head's code content byte-for-byte (evidence scoped to tree, not commit metadata):

| Check | Result |
|---|---|
| targeted switchover to a replica carrying user-set `replica-priority=50` — OpsRequest Succeed | PASS |
| after switchover, that pod still reports `replica-priority=50` (not clobbered to 100) | PASS |
| a `replica-priority=0` (never-promote) replica keeps 0 for the entire window (bias skips it) | PASS |
| old master restored to its captured value (100) | PASS |

Ready for human approve + merge (no conflicts with main).

