### PR TITLE
fix(valkey): verify TLS server certificates instead of --insecure

### DIFF
--- a/addons-cluster/valkey/templates/secret.yaml
+++ b/addons-cluster/valkey/templates/secret.yaml
@@ -1,7 +1,29 @@
 {{- if .Values.tlsEnable }}
 {{- $cn := (printf "%s-%s" (include "kblib.clusterName" .) .Release.Namespace) }}
 {{- $ca := genCA "KubeBlocks" 36500 -}}
-{{- $cert := genSignedCert $cn (list "127.0.0.1" "::1") (list "localhost" "*.svc.cluster.local") 36500 $ca -}}
+{{/*
+SAN contract: a DNS wildcard matches exactly ONE label, so
+"*.svc.cluster.local" can never match a pod FQDN like
+"pod.comp-headless.ns.svc.cluster.local" (three labels). Issue
+per-component wildcards for the headless domains (pod FQDNs used by
+replication, probes and scripts) plus the client service names, so that
+valkey-cli --cacert verification and strict external clients can succeed.
+Component names ("valkey", "valkey-sentinel") follow the ClusterDefinition
+topology component names used by this chart.
+*/}}
+{{- $clusterName := include "kblib.clusterName" . }}
+{{- $ns := .Release.Namespace }}
+{{- $sans := list
+      "localhost"
+      (printf "*.%s-valkey-headless.%s.svc.cluster.local" $clusterName $ns)
+      (printf "*.%s-valkey-sentinel-headless.%s.svc.cluster.local" $clusterName $ns)
+      (printf "%s-valkey-valkey.%s.svc.cluster.local" $clusterName $ns)
+      (printf "%s-valkey-valkey" $clusterName)
+      (printf "%s-valkey-sentinel-valkey-sentinel.%s.svc.cluster.local" $clusterName $ns)
+      (printf "%s-valkey-sentinel-valkey-sentinel" $clusterName)
+      "*.svc.cluster.local"
+}}
+{{- $cert := genSignedCert $cn (list "127.0.0.1" "::1") $sans 36500 $ca -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -32,8 +32,10 @@ trap handle_exit EXIT
 export DATASAFED_BACKEND_BASE_PATH="${DP_BACKUP_BASE_PATH}"
 
 # Detect TLS via connection probe.
-# The backup job does not mount the TLS volume (it may not exist in non-TLS clusters),
-# so we probe: try a plain connection first; if it fails, retry with --tls --insecure.
+# The backup job does not mount the TLS volume (it may not exist in non-TLS
+# clusters), so we probe: plain connection first, then --tls --insecure.
+# --insecure is intentional HERE ONLY: no CA file is available in this execution face,
+# so certificate verification is impossible; in-cluster CLIs verify via --cacert.
 _tls_args=()
 _probe_base=(valkey-cli --no-auth-warning -h "${DP_DB_HOST}" -p "${DP_DB_PORT}")
 [ -n "${DP_DB_PASSWORD:-}" ] && _probe_base+=(-a "${DP_DB_PASSWORD}")

--- a/addons/valkey/dataprotection/post-restore-sentinel.sh
+++ b/addons/valkey/dataprotection/post-restore-sentinel.sh
@@ -63,6 +63,8 @@ positive_int_or_empty() {
 # Detect TLS via connection probe on the data pod.
 # Restore jobs do not mount the TLS volume (it may not exist in non-TLS
 # clusters), so probe: try plain first, then --tls --insecure.
+# --insecure is intentional HERE ONLY: no CA file is available in this execution face,
+# so certificate verification is impossible; in-cluster CLIs verify via --cacert.
 detect_tls_args() {
   _tls_args=()
   local _probe_base=(valkey-cli --no-auth-warning -h "${DP_DB_HOST}" -p "${data_port}")

--- a/addons/valkey/scripts-ut-spec/tls_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/tls_contract_spec.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Valkey TLS verification contract"
+  data_cmpd="../templates/cmpd.yaml"
+  sentinel_cmpd="../templates/cmpd-valkey-sentinel.yaml"
+  sentinel_start="../scripts/valkey-sentinel-start.sh"
+  cluster_secret="../../../addons-cluster/valkey/templates/secret.yaml"
+
+  It "builds VALKEY_CLI_TLS_ARGS with CA verification, not --insecure"
+    When call grep -F -- "--tls --cacert" "${data_cmpd}" "${sentinel_cmpd}"
+    The status should be success
+    The stdout should include "cmpd.yaml"
+    The stdout should include "cmpd-valkey-sentinel.yaml"
+  End
+
+  It "does not skip certificate verification in the CMPD CLI args"
+    When call grep -F -- "--insecure" "${data_cmpd}" "${sentinel_cmpd}"
+    The status should be failure
+  End
+
+  It "does not skip certificate verification in the sentinel start script"
+    When call grep -F -- "--insecure" "${sentinel_start}"
+    The status should be failure
+  End
+
+  It "issues the self-signed cert with per-component pod-FQDN wildcard SANs"
+    # "*.svc.cluster.local" only matches ONE label; pod FQDNs have three
+    # (pod.comp-headless.ns), so per-component wildcards are required for
+    # verification to ever succeed.
+    When call grep -F -- "-headless.%s.svc.cluster.local" "${cluster_secret}"
+    The status should be success
+    The stdout should include "valkey-headless"
+    The stdout should include "valkey-sentinel-headless"
+  End
+
+  It "keeps --insecure in DataProtection jobs only, with the execution-face rationale"
+    # Backup/restore jobs do not mount the TLS volume, so they cannot verify;
+    # that exception must stay documented where it is used.
+    When call grep -l "no CA file is available in this execution face" ../dataprotection/backup.sh ../dataprotection/post-restore-sentinel.sh
+    The status should be success
+    The stdout should include "backup.sh"
+    The stdout should include "post-restore-sentinel.sh"
+  End
+End

--- a/addons/valkey/scripts/valkey-sentinel-start.sh
+++ b/addons/valkey/scripts/valkey-sentinel-start.sh
@@ -148,7 +148,7 @@ _find_master_fqdn() {
     [ -z "${fqdn}" ] && continue
     local cmd=(valkey-cli -h "${fqdn}" -p "${data_port}")
     if [ "${TLS_ENABLED}" = "true" ]; then
-      cmd+=(--tls --insecure)
+      cmd+=(--tls --cacert "${TLS_MOUNT_PATH:-/etc/pki/tls}/ca.crt")
     fi
     if ! is_empty "${VALKEY_DEFAULT_PASSWORD}"; then
       cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
@@ -167,7 +167,7 @@ _find_master_fqdn() {
 _sentinel_cli() {
   local _scli=(valkey-cli -h 127.0.0.1 -p "${sentinel_port}" --no-auth-warning)
   if [ "${TLS_ENABLED}" = "true" ]; then
-    _scli+=(--tls --insecure)
+    _scli+=(--tls --cacert "${TLS_MOUNT_PATH:-/etc/pki/tls}/ca.crt")
   fi
   if ! is_empty "${SENTINEL_PASSWORD}"; then
     _scli+=(-a "${SENTINEL_PASSWORD}")

--- a/addons/valkey/templates/_helpers.tpl
+++ b/addons/valkey/templates/_helpers.tpl
@@ -57,7 +57,7 @@ valkey-config-template
 
 {{/*
 Inline helper to build the valkey-cli base command with optional TLS flags.
-Produces a variable assignment: VALKEY_CLI_TLS_ARGS="--tls --insecure"
+Produces a variable assignment: VALKEY_CLI_TLS_ARGS="--tls --cacert <mount>/ca.crt"
 This is used inside shell scripts rather than as a Helm template.
 */}}
 

--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -181,9 +181,11 @@ spec:
           optional: true
     - name: TLS_MOUNT_PATH
       value: {{ $.Values.tlsMountPath }}
+    # Verify the server certificate against the mounted CA instead of
+    # skipping verification (see cmpd.yaml for the SAN contract).
     - name: VALKEY_CLI_TLS_ARGS
       value: ""
-      expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}--tls --insecure{{else}}{{end}}` | toYaml }}
+      expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}--tls --cacert {{.TLS_MOUNT_PATH}}/ca.crt{{else}}{{end}}` | toYaml }}
 
   lifecycleActions:
     accountProvision:

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -319,10 +319,13 @@ spec:
       expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}rediss://localhost:{{.SERVICE_PORT}}{{else}}redis://localhost:{{.SERVICE_PORT}}{{end}}` | toYaml }}
     {{- end }}
 
-    # ── TLS CLI flag (empty when TLS is off) ──
+    # ── TLS CLI flags (empty when TLS is off) ──
+    # Verify the server certificate against the mounted CA instead of
+    # skipping verification: the cluster chart issues certs whose SANs
+    # cover the per-component pod FQDNs and service names.
     - name: VALKEY_CLI_TLS_ARGS
       value: ""
-      expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}--tls --insecure{{else}}{{end}}` | toYaml }}
+      expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}--tls --cacert {{.TLS_MOUNT_PATH}}/ca.crt{{else}}{{end}}` | toYaml }}
 
     # ── Sentinel cross-component references (optional — absent in standalone) ──
     # compDef uses a regexp prefix; KubeBlocks resolves the concrete name at runtime.


### PR DESCRIPTION
Fixes #2989 — failure chain, SAN math, and the TLS e2e verification checklist (including the UserProvided-cert hostname-verification caveat that must be recorded before merge) are in the issue.

Rendered-cert SANs verified locally via openssl:
DNS:localhost, DNS:*.<cluster>-valkey-headless.<ns>.svc.cluster.local, DNS:*.<cluster>-valkey-sentinel-headless.<ns>.svc.cluster.local, client service names, DNS:*.svc.cluster.local, IP:127.0.0.1, IP:::1.

Validation: new TLS contract spec green (5 examples, 0 failures); both charts render with tlsEnable=true. Needs TLS-on e2e per the issue before merge.

---

## Merge-gate status (updated 2026-07-06)

**Code side — reviewed** (Athena independent review: SAN single-label analysis confirmed correct; DP-job `--insecure` exception verified as the only remaining use, documented in-file; TLS upgrade-compat concern waived by owner decision — no existing valkey users).

**TLS runtime evidence — ALL PASS** (Emily, focused r2 on this PR's head `bab57300`, 44 PASS / 0 FAIL / 0 SKIP, evidence `artifacts/valkey-live/2990-r2/`, log sha256 `c5b24a9d...`, namespace cleaned):

| Check | Result |
|---|---|
| TLS cluster provisioning | PASS |
| data pod FQDN PING via `--tls --cacert` (no `--insecure`) | PASS |
| sentinel pod FQDN PING via `--tls --cacert` | PASS |
| cert SAN contains per-component pod wildcard FQDNs | PASS (live cert inspected) |
| writes over TLS, readable on all data pods | PASS (20 keys) |
| data 3→4 scale-out under TLS, data consistent | PASS |
| data 4→3 scale-in under TLS, data consistent | PASS |
| master kill → TLS failover with 3 sentinels, new master serves, data intact | PASS |

Incidental positive evidence: a sentinel 3→5 scale attempt on this head was correctly rejected by the controller (`violates the replica limit`) — the pre-#2988 `replicasLimit: 3` contract enforces as declared.

Ready for human approve; merge after #2982 (this branch then needs the known comment-merge rebase, handled by the code owner).
