### PR TITLE
fix(kafka): reject unsupported combined KRaft scale-out

### DIFF
--- a/addons/kafka/README.md
+++ b/addons/kafka/README.md
@@ -267,23 +267,25 @@ When the cluster creation is done, refer to a secret named `$(CLUSTER_NAME)$-kaf
 
 #### Scale-out
 
-Horizontal scaling out `kafka-combine` component in cluster `kafka-combined-cluster` by adding ONE more replica:
+> **Warning**: Combined KRaft mode (`kafka-combine`) does **not** support online horizontal scale-out for serviceVersion 3.3.2. Adding a combined node requires the Kafka controller quorum membership and per-broker metadata view to converge; this addon does not implement that workflow yet. The `memberJoin` action will reject combined-mode scale-out. Use separated topology and scale broker-only components when you need online broker scale-out.
+
+Horizontal scaling out the broker-only `kafka-broker` component in cluster `kafka-separated-cluster` by adding ONE more replica:
 
 ```yaml
 # cat examples/kafka/scale-out.yaml
 apiVersion: operations.kubeblocks.io/v1alpha1
 kind: OpsRequest
 metadata:
-  name: kafka-combined-scale-out
+  name: kafka-broker-scale-out
   namespace: demo
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
-  clusterName: kafka-combined-cluster
+  clusterName: kafka-separated-cluster
   type: HorizontalScaling
   # Lists HorizontalScaling objects, each specifying scaling requirements for a Component, including desired total replica counts, configurations for new instances, modifications for existing instances, and instance downscaling options
   horizontalScaling:
     # Specifies the name of the Component.
-  - componentName: kafka-combine
+  - componentName: kafka-broker
     # Specifies the replica changes for scaling in components
     scaleOut:
       # Specifies the replica changes for the component.
@@ -299,14 +301,14 @@ kubectl apply -f examples/kafka/scale-out.yaml
 After applying the operation, you will see a new pod created. You can check the progress of the scaling operation with following command:
 
 ```bash
-kubectl describe -n demo ops kafka-combined-scale-out
+kubectl describe -n demo ops kafka-broker-scale-out
 ```
 
 #### Scale-in
 
 > **Warning**: Combined KRaft mode (`kafka-combine`) does **not** support scale-in. The `memberLeave` action will reject the request because quorum voter removal is not yet implemented — scaling in a combined node that is both broker and controller would break the KRaft quorum. Only broker-only components support scale-in.
 
-The following example scales in a **broker-only** component in a **separated-topology** cluster. For combined mode clusters, use scale-out only.
+The following example scales in a **broker-only** component in a **separated-topology** cluster. Combined mode clusters reject online scale-in and scale-out; use separated topology when online horizontal scaling is required.
 
 ```yaml
 # cat examples/kafka/scale-in.yaml
@@ -332,7 +334,7 @@ kubectl apply -f examples/kafka/scale-in.yaml
 
 Alternatively, you can update the `replicas` field in the `spec.componentSpecs.replicas` section to your desired non-zero number.
 
-> **Note**: For combined KRaft mode (`kafka-combine`), only scale-out (increasing replicas) is supported. Scale-in will be rejected by `memberLeave` because quorum voter removal is not implemented.
+> **Note**: For combined KRaft mode (`kafka-combine`), online scale-out and scale-in are both rejected by lifecycle actions because quorum voter add/remove convergence is not implemented in this addon. Use separated topology and scale broker-only components for online horizontal scaling.
 
 ```yaml
 # snippet of cluster-separated.yaml — broker-only example

--- a/addons/kafka/templates/_helpers.tpl
+++ b/addons/kafka/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Common annotations
 API version annotation.
 skip-immutable-check: KB webhook rejects CmpD upgrades that add or change lifecycleActions,
 runtime, and similar fields classified as immutable. This annotation bypasses that check so
-addon chart upgrades can land new fields (e.g. memberLeave for scale-in blocking).
+addon chart upgrades can land new fields (e.g. memberJoin/memberLeave for hscale blocking).
 */}}
 {{- define "kafka.apiVersion" -}}
 kubeblocks.io/crd-api-version: apps.kubeblocks.io/v1

--- a/addons/kafka/templates/cmpd-combine.yaml
+++ b/addons/kafka/templates/cmpd-combine.yaml
@@ -107,6 +107,16 @@ spec:
       namespace: {{ .Release.Namespace }}
       defaultMode: 0755
   lifecycleActions:
+    memberJoin:
+      timeoutSeconds: 30
+      exec:
+        container: kafka
+        command:
+          - /bin/sh
+          - -c
+          - |
+            echo "Kafka combined KRaft scale-out is not supported for serviceVersion {{ .Values.defaultServiceVersion.combine }}: adding a combined broker/controller requires Kafka quorum voter convergence that this addon does not implement yet." >&2
+            exit 1
     memberLeave:
       timeoutSeconds: 30
       exec:

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -74,11 +74,12 @@ When the cluster creation is done, refer to a secret named `$(CLUSTER_NAME)$-kaf
 
 > [!IMPORTANT]
 > As per the Kafka documentation, the number of KRaft replicas should be odd to avoid split-brain scenarios.
-> Make sure the number of KRaft replicas, i.e. Controller replicas,  is always odd after Horizontal Scaling, either in Separated or Combined mode.
+> Make sure the number of KRaft replicas, i.e. Controller replicas, is always odd after Horizontal Scaling.
+> Combined KRaft mode (`kafka-combine`) rejects online scale-out and scale-in because quorum voter add/remove convergence is not implemented in this addon. Use separated topology and scale broker-only components for online horizontal scaling.
 
 #### [Scale-out](scale-out.yaml)
 
-Horizontal scaling out `kafka-combine` component in cluster `kafka-combined-cluster` by adding ONE more replica:
+Horizontal scaling out the `kafka-broker` component in separated-topology cluster `kafka-separated-cluster` by adding ONE more replica:
 
 ```bash
 kubectl apply -f examples/kafka/scale-out.yaml
@@ -87,7 +88,7 @@ kubectl apply -f examples/kafka/scale-out.yaml
 After applying the operation, you will see a new pod created. You can check the progress of the scaling operation with following command:
 
 ```bash
-kubectl describe -n demo ops kafka-combined-scale-out
+kubectl describe -n demo ops kafka-broker-scale-out
 ```
 
 #### [Scale-in](scale-in.yaml)
@@ -104,7 +105,7 @@ kubectl apply -f examples/kafka/scale-in.yaml
 
 #### Scale-in/out using Cluster API
 
-Alternatively, you can update the `replicas` field in the `spec.componentSpecs.replicas` section to your desired non-zero number. For scale-in, use a broker-only component such as `kafka-broker`; combined KRaft mode (`kafka-combine`) only supports scale-out.
+Alternatively, you can update the `replicas` field in the `spec.componentSpecs.replicas` section to your desired non-zero number. Use a broker-only component such as `kafka-broker`; combined KRaft mode (`kafka-combine`) rejects online scale-in and scale-out.
 
 ```yaml
 # snippet of cluster.yaml

--- a/examples/kafka/scale-out.yaml
+++ b/examples/kafka/scale-out.yaml
@@ -1,16 +1,16 @@
 apiVersion: operations.kubeblocks.io/v1alpha1
 kind: OpsRequest
 metadata:
-  name: kafka-combined-scale-out
+  name: kafka-broker-scale-out
   namespace: demo
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
-  clusterName: kafka-combined-cluster
+  clusterName: kafka-separated-cluster
   type: HorizontalScaling
   # Lists HorizontalScaling objects, each specifying scaling requirements for a Component, including desired total replica counts, configurations for new instances, modifications for existing instances, and instance downscaling options
   horizontalScaling:
     # Specifies the name of the Component.
-  - componentName: kafka-combine
+  - componentName: kafka-broker
     # Specifies the replica changes for scaling in components
     scaleOut:
       # Specifies the replica changes for the component.


### PR DESCRIPTION
## Problem

Task #20 N8 v4 hit the same `ops-scale-out` path after helper-level topic readiness fixes. The frozen evidence package shows that `Cluster`/`OpsRequest` can report ready/succeeded while combined KRaft quorum/topic metadata is still not usable for topic roundtrip:

- evidence: `/evidence/kafka-release-full-main-n8-v4-20260702-204855/diagnosis-index/`
- broker-0 bootstrap can describe `kb-kafka-scale-out`, while broker-1/2 report the topic does not exist
- metadata quorum transitions later, but per-broker topic metadata still splits
- produce returns rc=0, but there is no durable offset and consume reads 0 messages

Current README contract exposed combined-mode scale-out as supported. For Kafka 3.3.2 combined KRaft, this addon does not implement online quorum voter add/convergence semantics, so allowing the OpsRequest to succeed creates a false supported path.

## Change

- Add an explicit `lifecycleActions.memberJoin` guard to `cmpd-combine.yaml` so combined-mode scale-out fails early with a clear unsupported reason.
- Update README scale-out examples to route online scale-out to separated topology broker-only components.
- Update the skip-immutable-check comment to cover both `memberJoin` and `memberLeave` hscale blockers.

## Validation

- `helm dependency build addons/kafka`
- `helm lint addons/kafka`
- `helm template kafka addons/kafka >/tmp/kafka-task21-render.yaml && rg -n "memberJoin|combined KRaft scale-out|memberLeave|combined KRaft scale-in" /tmp/kafka-task21-render.yaml`

## Boundary

This is a spec-boundary hardening PR, not a flaky-test workaround and not a release-ready claim. It prevents the known unsupported combined KRaft hscale path from being counted as a valid product/test path. If we later implement safe combined KRaft quorum membership convergence, this guard should be replaced by a real `memberJoin` implementation plus focused hscale validation.
