### PR TITLE
feat(rustfs): add logical s3 backup actionset

### DIFF
--- a/addons/rustfs/dataprotection/backup.sh
+++ b/addons/rustfs/dataprotection/backup.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+set -eu
+
+rustfs_backup_on_exit() {
+  rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "ERROR: RustFS backup failed with exit code ${rc}" >&2
+    if [ -n "${DP_BACKUP_INFO_FILE:-}" ]; then
+      : > "${DP_BACKUP_INFO_FILE}.exit"
+    fi
+    exit "${rc}"
+  fi
+}
+trap rustfs_backup_on_exit EXIT
+
+rustfs_prepare_datasafed
+rustfs_prepare_mc
+
+backup_prefix="$(rustfs_archive_name)"
+work_dir="${TMPDIR:-/tmp}/rustfs-backup"
+objects_dir="${work_dir}/objects"
+rm -rf "${work_dir}"
+mkdir -p "${objects_dir}"
+
+echo "INFO: Listing RustFS buckets from ${RUSTFS_ENDPOINT}"
+rustfs_mc ls "${RUSTFS_ALIAS}/" > "${work_dir}/buckets.raw"
+: > "${work_dir}/buckets.txt"
+while IFS= read -r line; do
+  bucket_entry=""
+  for field in ${line}; do
+    bucket_entry="${field}"
+  done
+  [ -n "${bucket_entry}" ] || continue
+  bucket_name="${bucket_entry%/}"
+  [ -n "${bucket_name}" ] || continue
+  printf '%s\n' "${bucket_name}" >> "${work_dir}/buckets.txt"
+done < "${work_dir}/buckets.raw"
+
+rustfs_mc find "${RUSTFS_ALIAS}/" --name "*" > "${work_dir}/objects.txt" || true
+
+if [ -s "${work_dir}/buckets.txt" ]; then
+  echo "INFO: Mirroring RustFS buckets to local staging directory"
+  rustfs_mc mirror --overwrite "${RUSTFS_ALIAS}/" "${objects_dir}"
+else
+  echo "INFO: RustFS has no buckets; creating empty logical backup"
+fi
+
+echo "INFO: Pushing RustFS logical backup ${backup_prefix}"
+datasafed push "${work_dir}/buckets.txt" "${backup_prefix}/buckets.txt"
+datasafed push "${work_dir}/objects.txt" "${backup_prefix}/objects.txt"
+
+object_count=0
+: > "${work_dir}/expected-objects.txt"
+rustfs_mc find "${objects_dir}" --name "*" > "${work_dir}/local-files.txt" || true
+while IFS= read -r local_file; do
+  [ -f "${local_file}" ] || continue
+  relative_path="${local_file#"${objects_dir}"/}"
+  [ -n "${relative_path}" ] || continue
+  object_count=$((object_count + 1))
+  printf '%s\n' "${relative_path}" >> "${work_dir}/expected-objects.txt"
+  datasafed push "${local_file}" "${backup_prefix}/objects/${relative_path}"
+done < "${work_dir}/local-files.txt"
+
+bucket_count="$(rustfs_count_lines "${work_dir}/buckets.txt")"
+manifest="${work_dir}/manifest.txt"
+{
+  printf 'formatVersion=%s\n' "${RUSTFS_BACKUP_FORMAT_VERSION:-rustfs-s3-full.v1}"
+  printf 'method=s3-full\n'
+  printf 'backupName=%s\n' "${DP_BACKUP_NAME}"
+  printf 'endpointScheme=%s\n' "${RUSTFS_SCHEME_EFFECTIVE:-unknown}"
+  printf 'toolImage=%s\n' "${RUSTFS_MC_IMAGE:-unknown}"
+  printf 'bucketCount=%s\n' "${bucket_count}"
+  printf 'objectCount=%s\n' "${object_count}"
+  while IFS= read -r bucket; do
+    [ -n "${bucket}" ] || continue
+    printf 'bucket:%s\n' "${bucket}"
+  done < "${work_dir}/buckets.txt"
+  while IFS= read -r object; do
+    [ -n "${object}" ] || continue
+    printf 'object:%s\n' "${object}"
+  done < "${work_dir}/expected-objects.txt"
+} > "${manifest}"
+datasafed push "${manifest}" "${backup_prefix}/manifest.txt"
+
+rustfs_save_backup_size
+echo "INFO: RustFS logical backup ${backup_prefix} completed"

--- a/addons/rustfs/dataprotection/common.sh
+++ b/addons/rustfs/dataprotection/common.sh
@@ -30,6 +30,9 @@ rustfs_prepare_mc() {
 
   mkdir -p "${MC_CONFIG_DIR}"
   if [ -n "${RUSTFS_SCHEME:-}" ]; then
+    if [ "${RUSTFS_SCHEME}" = "https" ]; then
+      rustfs_prepare_mc_trust
+    fi
     rustfs_configure_mc_alias "${RUSTFS_SCHEME}" "${rustfs_access_key}" "${rustfs_secret_key}" || \
       rustfs_fail "failed to configure RustFS S3 alias with RUSTFS_SCHEME=${RUSTFS_SCHEME}"
     return
@@ -38,11 +41,32 @@ rustfs_prepare_mc() {
   if rustfs_configure_mc_alias http "${rustfs_access_key}" "${rustfs_secret_key}"; then
     return
   fi
+  rustfs_prepare_mc_trust
   if rustfs_configure_mc_alias https "${rustfs_access_key}" "${rustfs_secret_key}"; then
     return
   fi
 
   rustfs_fail "failed to configure RustFS S3 alias over http or https"
+}
+
+rustfs_prepare_mc_trust() {
+  rustfs_tls_ca_file="${RUSTFS_TLS_CA_FILE:-}"
+  [ -n "${rustfs_tls_ca_file}" ] || \
+    rustfs_fail "RUSTFS_TLS_CA_FILE is required for HTTPS"
+  [ -e "${rustfs_tls_ca_file}" ] || \
+    rustfs_fail "RustFS TLS CA file ${rustfs_tls_ca_file} does not exist"
+  [ -r "${rustfs_tls_ca_file}" ] || \
+    rustfs_fail "RustFS TLS CA file ${rustfs_tls_ca_file} is not readable"
+  [ -s "${rustfs_tls_ca_file}" ] || \
+    rustfs_fail "RustFS TLS CA file ${rustfs_tls_ca_file} is empty"
+
+  rustfs_mc_ca_dir="${MC_CONFIG_DIR}/certs/CAs"
+  mkdir -p "${rustfs_mc_ca_dir}"
+  cp -L "${rustfs_tls_ca_file}" "${rustfs_mc_ca_dir}/rustfs-ca.crt" || \
+    rustfs_fail "failed to install RustFS TLS CA into mc trust directory"
+  chmod 0644 "${rustfs_mc_ca_dir}/rustfs-ca.crt"
+  [ -s "${rustfs_mc_ca_dir}/rustfs-ca.crt" ] || \
+    rustfs_fail "installed RustFS TLS CA is empty"
 }
 
 rustfs_configure_mc_alias() {
@@ -64,7 +88,7 @@ rustfs_configure_mc_alias() {
 }
 
 rustfs_mc() {
-  mc --insecure --config-dir "${MC_CONFIG_DIR:-/tmp/rustfs-mc}" "$@"
+  mc --config-dir "${MC_CONFIG_DIR:-/tmp/rustfs-mc}" "$@"
 }
 
 rustfs_archive_name() {

--- a/addons/rustfs/dataprotection/common.sh
+++ b/addons/rustfs/dataprotection/common.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -eu
+
+rustfs_fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+rustfs_prepare_datasafed() {
+  : "${DP_BACKUP_BASE_PATH:?missing DP_BACKUP_BASE_PATH}"
+  if [ -n "${DP_DATASAFED_BIN_PATH:-}" ]; then
+    export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"
+  fi
+  export DATASAFED_BACKEND_BASE_PATH="${DP_BACKUP_BASE_PATH}"
+}
+
+rustfs_prepare_mc() {
+  : "${DP_DB_HOST:?missing DP_DB_HOST}"
+
+  rustfs_access_key="${DP_DB_USER:-${RUSTFS_ACCESS_KEY:-}}"
+  rustfs_secret_key="${DP_DB_PASSWORD:-${RUSTFS_SECRET_KEY:-}}"
+  [ -n "${rustfs_access_key}" ] || rustfs_fail "missing DP_DB_USER/RUSTFS_ACCESS_KEY"
+  [ -n "${rustfs_secret_key}" ] || rustfs_fail "missing DP_DB_PASSWORD/RUSTFS_SECRET_KEY"
+
+  rustfs_port="${DP_DB_PORT:-${RUSTFS_API_PORT:-9000}}"
+
+  export RUSTFS_ALIAS="${RUSTFS_ALIAS:-rustfs}"
+  export MC_CONFIG_DIR="${MC_CONFIG_DIR:-/tmp/rustfs-mc}"
+
+  mkdir -p "${MC_CONFIG_DIR}"
+  if [ -n "${RUSTFS_SCHEME:-}" ]; then
+    rustfs_configure_mc_alias "${RUSTFS_SCHEME}" "${rustfs_access_key}" "${rustfs_secret_key}" || \
+      rustfs_fail "failed to configure RustFS S3 alias with RUSTFS_SCHEME=${RUSTFS_SCHEME}"
+    return
+  fi
+
+  if rustfs_configure_mc_alias http "${rustfs_access_key}" "${rustfs_secret_key}"; then
+    return
+  fi
+  if rustfs_configure_mc_alias https "${rustfs_access_key}" "${rustfs_secret_key}"; then
+    return
+  fi
+
+  rustfs_fail "failed to configure RustFS S3 alias over http or https"
+}
+
+rustfs_configure_mc_alias() {
+  rustfs_scheme="$1"
+  rustfs_access_key="$2"
+  rustfs_secret_key="$3"
+  rustfs_port="${DP_DB_PORT:-${RUSTFS_API_PORT:-9000}}"
+  rustfs_endpoint="${rustfs_scheme}://${DP_DB_HOST}:${rustfs_port}"
+
+  rustfs_mc alias set "${RUSTFS_ALIAS}" "${rustfs_endpoint}" "${rustfs_access_key}" "${rustfs_secret_key}" --api S3v4 >/dev/null 2>&1 || \
+    return 1
+  rustfs_mc ls "${RUSTFS_ALIAS}/" >/dev/null 2>&1 || \
+    return 1
+
+  export RUSTFS_ENDPOINT="${rustfs_endpoint}"
+  export RUSTFS_SCHEME_EFFECTIVE="${rustfs_scheme}"
+  echo "INFO: RustFS S3 endpoint resolved with scheme=${rustfs_scheme}"
+  return 0
+}
+
+rustfs_mc() {
+  mc --insecure --config-dir "${MC_CONFIG_DIR:-/tmp/rustfs-mc}" "$@"
+}
+
+rustfs_archive_name() {
+  printf '%s\n' "${RUSTFS_BACKUP_PREFIX:-${DP_BACKUP_NAME:?missing DP_BACKUP_NAME}}"
+}
+
+rustfs_count_lines() {
+  rustfs_count=0
+  while IFS= read -r _; do
+    rustfs_count=$((rustfs_count + 1))
+  done < "$1"
+  printf '%s\n' "${rustfs_count}"
+}
+
+rustfs_save_backup_size() {
+  : "${DP_BACKUP_INFO_FILE:?missing DP_BACKUP_INFO_FILE}"
+  total_size=0
+  datasafed stat / 2>/dev/null > "${TMPDIR:-/tmp}/rustfs-datasafed-stat.txt" || true
+  while IFS=' ' read -r key value _; do
+    if [ "${key}" = "TotalSize" ] && [ -n "${value}" ]; then
+      total_size="${value}"
+      break
+    fi
+  done < "${TMPDIR:-/tmp}/rustfs-datasafed-stat.txt"
+  printf '{"totalSize":"%s"}' "${total_size}" > "${DP_BACKUP_INFO_FILE}"
+}

--- a/addons/rustfs/dataprotection/common.sh
+++ b/addons/rustfs/dataprotection/common.sh
@@ -84,7 +84,7 @@ rustfs_save_backup_size() {
   total_size=0
   datasafed stat / 2>/dev/null > "${TMPDIR:-/tmp}/rustfs-datasafed-stat.txt" || true
   while IFS=' ' read -r key value _; do
-    if [ "${key}" = "TotalSize" ] && [ -n "${value}" ]; then
+    if [ "${key}" = "TotalSize:" ] && [ -n "${value}" ]; then
       total_size="${value}"
       break
     fi

--- a/addons/rustfs/dataprotection/restore.sh
+++ b/addons/rustfs/dataprotection/restore.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+set -eu
+
+rustfs_prepare_datasafed
+rustfs_prepare_mc
+
+backup_prefix="$(rustfs_archive_name)"
+work_dir="${TMPDIR:-/tmp}/rustfs-restore"
+objects_dir="${work_dir}/objects"
+rm -rf "${work_dir}"
+mkdir -p "${work_dir}"
+
+if [ "$(datasafed list "${backup_prefix}/manifest.txt" 2>/dev/null || true)" != "${backup_prefix}/manifest.txt" ]; then
+  rustfs_fail "backup manifest ${backup_prefix}/manifest.txt not found"
+fi
+
+echo "INFO: Pulling RustFS logical backup ${backup_prefix}"
+datasafed pull "${backup_prefix}/manifest.txt" "${work_dir}/manifest.txt"
+
+manifest_format=""
+manifest_method=""
+manifest_bucket_count=""
+manifest_object_count=""
+: > "${work_dir}/buckets.txt"
+: > "${work_dir}/expected-objects.txt"
+
+while IFS= read -r line; do
+  case "${line}" in
+    formatVersion=*) manifest_format="${line#formatVersion=}" ;;
+    method=*) manifest_method="${line#method=}" ;;
+    bucketCount=*) manifest_bucket_count="${line#bucketCount=}" ;;
+    objectCount=*) manifest_object_count="${line#objectCount=}" ;;
+    bucket:*) printf '%s\n' "${line#bucket:}" >> "${work_dir}/buckets.txt" ;;
+    object:*) printf '%s\n' "${line#object:}" >> "${work_dir}/expected-objects.txt" ;;
+  esac
+done < "${work_dir}/manifest.txt"
+
+[ "${manifest_format}" = "${RUSTFS_BACKUP_FORMAT_VERSION:-rustfs-s3-full.v1}" ] || \
+  rustfs_fail "backup manifest formatVersion ${manifest_format:-<empty>} is unsupported"
+[ "${manifest_method}" = "s3-full" ] || \
+  rustfs_fail "backup manifest method ${manifest_method:-<empty>} is unsupported"
+
+bucket_count="$(rustfs_count_lines "${work_dir}/buckets.txt")"
+object_count="$(rustfs_count_lines "${work_dir}/expected-objects.txt")"
+[ "${manifest_bucket_count}" = "${bucket_count}" ] || \
+  rustfs_fail "backup manifest bucket count ${manifest_bucket_count:-<empty>} does not match list count ${bucket_count}"
+[ "${manifest_object_count}" = "${object_count}" ] || \
+  rustfs_fail "backup manifest object count ${manifest_object_count:-<empty>} does not match list count ${object_count}"
+
+if [ ! -s "${work_dir}/buckets.txt" ]; then
+  [ "${manifest_object_count}" = "0" ] || \
+    rustfs_fail "backup manifest has objects but no buckets"
+  echo "INFO: Backup contains no buckets; restore is complete"
+  exit 0
+fi
+
+mkdir -p "${objects_dir}"
+pulled_count=0
+while IFS= read -r relative_path; do
+  [ -n "${relative_path}" ] || continue
+  remote_object="${backup_prefix}/objects/${relative_path}"
+  if [ "$(datasafed list "${remote_object}" 2>/dev/null || true)" != "${remote_object}" ]; then
+    rustfs_fail "backup object artifact ${remote_object} not found"
+  fi
+  local_file="${objects_dir}/${relative_path}"
+  mkdir -p "$(dirname "${local_file}")"
+  datasafed pull "${remote_object}" "${local_file}"
+  pulled_count=$((pulled_count + 1))
+done < "${work_dir}/expected-objects.txt"
+
+[ "${pulled_count}" = "${manifest_object_count}" ] || \
+  rustfs_fail "pulled object count ${pulled_count} does not match manifest object count ${manifest_object_count}"
+
+echo "INFO: Restoring RustFS buckets to ${RUSTFS_ENDPOINT}"
+while IFS= read -r bucket; do
+  [ -n "${bucket}" ] || continue
+  rustfs_mc mb --ignore-existing "${RUSTFS_ALIAS}/${bucket}"
+done < "${work_dir}/buckets.txt"
+
+rustfs_mc find "${objects_dir}" --name "*" > "${work_dir}/local-objects.txt" || true
+if [ -s "${work_dir}/local-objects.txt" ]; then
+  rustfs_mc mirror --overwrite "${objects_dir}" "${RUSTFS_ALIAS}/"
+fi
+
+echo "INFO: RustFS restore from ${backup_prefix} completed"

--- a/addons/rustfs/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+Describe "RustFS backup/restore contract"
+  It "backs up and restores through a certificate-verifying S3 client"
+    When run sh ./backup_restore_contract_test.sh
+    The status should be success
+    The output should include "rustfs backup/restore contract test passed"
+    The stderr should include "RUSTFS_TLS_CA_FILE is required for HTTPS"
+    The stderr should include "does not exist"
+    The stderr should include "installed RustFS TLS CA is empty"
+    The stderr should include "backup object artifact rustfs-test/objects/a/hello.txt not found"
+  End
+End

--- a/addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh
+++ b/addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+mkdir -p "${TMP_ROOT}/bin" "${TMP_ROOT}/store"
+
+cat > "${TMP_ROOT}/bin/mc" <<'SH'
+#!/bin/sh
+set -eu
+
+log="${FAKE_MC_LOG:?missing FAKE_MC_LOG}"
+echo "mc $*" >> "${log}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --insecure) shift ;;
+    --config-dir) shift 2 ;;
+    *) break ;;
+  esac
+done
+
+case "$1" in
+  alias)
+    endpoint="$4"
+    printf '%s\n' "${endpoint}" > "${FAKE_MC_ALIAS_FILE:?missing FAKE_MC_ALIAS_FILE}"
+    exit 0 ;;
+  ls)
+    if [ "${FAKE_FORCE_HTTPS:-}" = "1" ]; then
+      case "$(cat "${FAKE_MC_ALIAS_FILE}")" in
+        http://*)
+          echo "fake http read probe rejected" >&2
+          exit 1 ;;
+      esac
+    fi
+    echo '2026-07-03 00:00:00 UTC a/'
+    exit 0 ;;
+  find)
+    target="$2"
+    case "${target}" in
+      rustfs*) echo 'rustfs/a/hello.txt' ;;
+      */rustfs-backup/objects)
+        echo "${target}"
+        echo "${target}/a"
+        echo "${target}/a/hello.txt" ;;
+      */rustfs-restore/objects)
+        echo "${target}"
+        echo "${target}/a"
+        echo "${target}/a/hello.txt" ;;
+    esac
+    exit 0 ;;
+  mirror)
+    src="$3"
+    dst="$4"
+    case "${src}" in
+      rustfs/*|rustfs)
+        mkdir -p "${dst}/a"
+        printf hello > "${dst}/a/hello.txt" ;;
+    esac
+    exit 0 ;;
+  mb)
+    exit 0 ;;
+  *)
+    echo "unexpected mc command: $*" >&2
+    exit 2 ;;
+esac
+SH
+
+cat > "${TMP_ROOT}/bin/datasafed" <<'SH'
+#!/bin/sh
+set -eu
+
+store="${FAKE_STORE:?missing FAKE_STORE}"
+cmd="$1"
+shift
+
+case "${cmd}" in
+  push)
+    src="$1"
+    dest="$2"
+    dest_path="${store}/${dest}"
+    mkdir -p "$(dirname "${dest_path}")"
+    cp "${src}" "${dest_path}" ;;
+  stat)
+    echo "TotalSize 11" ;;
+  list)
+    if [ "${1:-}" = "-f" ]; then
+      shift 2
+      prefix="$1"
+      find "${store}/${prefix}" -type f | while IFS= read -r f; do
+        printf '%s\n' "${f#"${store}"/}"
+      done
+    else
+      name="$1"
+      [ -f "${store}/${name}" ] && echo "${name}"
+    fi ;;
+  pull)
+    src="$1"
+    dest="$2"
+    mkdir -p "$(dirname "${dest}")"
+    cp "${store}/${src}" "${dest}" ;;
+  *)
+    echo "unexpected datasafed command: ${cmd}" >&2
+    exit 2 ;;
+esac
+SH
+
+chmod +x "${TMP_ROOT}/bin/mc" "${TMP_ROOT}/bin/datasafed"
+
+export PATH="${TMP_ROOT}/bin:${PATH}"
+export FAKE_STORE="${TMP_ROOT}/store"
+export FAKE_MC_LOG="${TMP_ROOT}/mc.log"
+export FAKE_MC_ALIAS_FILE="${TMP_ROOT}/mc-alias-endpoint"
+export FAKE_FORCE_HTTPS=1
+export DP_BACKUP_BASE_PATH=/fake/base
+export DP_BACKUP_INFO_FILE="${TMP_ROOT}/backup-info.json"
+export DP_BACKUP_NAME=rustfs-test
+export DP_DB_HOST=rustfs-0.rustfs-headless.demo.svc
+export DP_DB_PORT=9000
+export DP_DB_USER=root
+export DP_DB_PASSWORD=secret
+export RUSTFS_MC_IMAGE=docker.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
+export TMPDIR="${TMP_ROOT}/tmp"
+mkdir -p "${TMPDIR}"
+
+(
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/backup.sh"
+)
+
+(
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/restore.sh"
+)
+
+[ -f "${FAKE_STORE}/rustfs-test/buckets.txt" ] || {
+  echo "missing buckets.txt artifact" >&2
+  exit 1
+}
+[ -f "${FAKE_STORE}/rustfs-test/objects.txt" ] || {
+  echo "missing objects.txt artifact" >&2
+  exit 1
+}
+[ -f "${FAKE_STORE}/rustfs-test/manifest.txt" ] || {
+  echo "missing manifest.txt artifact" >&2
+  exit 1
+}
+[ -f "${FAKE_STORE}/rustfs-test/objects/a/hello.txt" ] || {
+  echo "missing object artifact" >&2
+  exit 1
+}
+[ "$(cat "${DP_BACKUP_INFO_FILE}")" = '{"totalSize":"11"}' ] || {
+  echo "unexpected backup info: $(cat "${DP_BACKUP_INFO_FILE}")" >&2
+  exit 1
+}
+
+grep -q '^formatVersion=rustfs-s3-full.v1$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest formatVersion missing" >&2
+  exit 1
+}
+grep -q '^method=s3-full$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest method missing" >&2
+  exit 1
+}
+grep -q '^bucketCount=1$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest bucket count missing" >&2
+  exit 1
+}
+grep -q '^objectCount=1$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest object count missing" >&2
+  exit 1
+}
+grep -q '^bucket:a$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest bucket list missing" >&2
+  exit 1
+}
+grep -q '^object:a/hello.txt$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest object list missing" >&2
+  exit 1
+}
+grep -q '^endpointScheme=https$' "${FAKE_STORE}/rustfs-test/manifest.txt" || {
+  echo "manifest endpoint scheme did not record https fallback" >&2
+  exit 1
+}
+
+grep -q 'mirror --overwrite rustfs/' "${FAKE_MC_LOG}" || {
+  echo "backup mirror command was not called" >&2
+  exit 1
+}
+grep -q 'mb --ignore-existing rustfs/a' "${FAKE_MC_LOG}" || {
+  echo "restore bucket creation command was not called" >&2
+  exit 1
+}
+grep -q 'mirror --overwrite .*/rustfs-restore/objects rustfs/' "${FAKE_MC_LOG}" || {
+  echo "restore mirror command was not called" >&2
+  exit 1
+}
+grep -q 'alias set rustfs https://rustfs-0.rustfs-headless.demo.svc:9000' "${FAKE_MC_LOG}" || {
+  echo "https alias fallback was not exercised" >&2
+  exit 1
+}
+
+rm -f "${FAKE_STORE}/rustfs-test/objects/a/hello.txt"
+if (
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/restore.sh"
+); then
+  echo "restore succeeded despite missing object artifact" >&2
+  exit 1
+fi
+
+echo "rustfs backup/restore contract test passed"

--- a/addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh
+++ b/addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh
@@ -89,7 +89,7 @@ case "${cmd}" in
     mkdir -p "$(dirname "${dest_path}")"
     cp "${src}" "${dest_path}" ;;
   stat)
-    echo "TotalSize 11" ;;
+    echo "TotalSize: 11" ;;
   list)
     if [ "${1:-}" = "-f" ]; then
       shift 2

--- a/addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh
+++ b/addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh
@@ -4,6 +4,8 @@ set -eu
 
 ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 TMP_ROOT="$(mktemp -d)"
+REAL_CP_BIN="$(command -v cp)"
+export REAL_CP_BIN
 
 cleanup() {
   rm -rf "${TMP_ROOT}"
@@ -19,10 +21,18 @@ set -eu
 log="${FAKE_MC_LOG:?missing FAKE_MC_LOG}"
 echo "mc $*" >> "${log}"
 
+config_dir=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --insecure) shift ;;
-    --config-dir) shift 2 ;;
+    --insecure)
+      if [ "${FAKE_REJECT_INSECURE:-}" = "1" ]; then
+        echo "fake mc rejected --insecure" >&2
+        exit 1
+      fi
+      shift ;;
+    --config-dir)
+      config_dir="$2"
+      shift 2 ;;
     *) break ;;
   esac
 done
@@ -38,6 +48,15 @@ case "$1" in
         http://*)
           echo "fake http read probe rejected" >&2
           exit 1 ;;
+      esac
+    fi
+    if [ "${FAKE_REQUIRE_CA:-}" = "1" ]; then
+      case "$(cat "${FAKE_MC_ALIAS_FILE}")" in
+        https://*)
+          [ -s "${config_dir}/certs/CAs/rustfs-ca.crt" ] || {
+            echo "fake https trust probe rejected missing CA" >&2
+            exit 1
+          } ;;
       esac
     fi
     echo '2026-07-03 00:00:00 UTC a/'
@@ -112,13 +131,33 @@ case "${cmd}" in
 esac
 SH
 
-chmod +x "${TMP_ROOT}/bin/mc" "${TMP_ROOT}/bin/datasafed"
+cat > "${TMP_ROOT}/bin/cp" <<'SH'
+#!/bin/sh
+set -eu
+
+destination=""
+for arg in "$@"; do
+  destination="${arg}"
+done
+if [ "${FAKE_TRUNCATE_CA_COPY:-}" = "1" ]; then
+  case "${destination}" in
+    */certs/CAs/rustfs-ca.crt)
+      : > "${destination}"
+      exit 0 ;;
+  esac
+fi
+exec "${REAL_CP_BIN:?missing REAL_CP_BIN}" "$@"
+SH
+
+chmod +x "${TMP_ROOT}/bin/mc" "${TMP_ROOT}/bin/datasafed" "${TMP_ROOT}/bin/cp"
 
 export PATH="${TMP_ROOT}/bin:${PATH}"
 export FAKE_STORE="${TMP_ROOT}/store"
 export FAKE_MC_LOG="${TMP_ROOT}/mc.log"
 export FAKE_MC_ALIAS_FILE="${TMP_ROOT}/mc-alias-endpoint"
 export FAKE_FORCE_HTTPS=1
+export FAKE_REJECT_INSECURE=1
+export FAKE_REQUIRE_CA=1
 export DP_BACKUP_BASE_PATH=/fake/base
 export DP_BACKUP_INFO_FILE="${TMP_ROOT}/backup-info.json"
 export DP_BACKUP_NAME=rustfs-test
@@ -128,7 +167,63 @@ export DP_DB_USER=root
 export DP_DB_PASSWORD=secret
 export RUSTFS_MC_IMAGE=docker.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
 export TMPDIR="${TMP_ROOT}/tmp"
-mkdir -p "${TMPDIR}"
+export MC_CONFIG_DIR="${TMP_ROOT}/mc-config"
+export RUSTFS_TLS_CA_FILE="${TMP_ROOT}/tls/ca.crt"
+mkdir -p "${TMPDIR}" "$(dirname "${RUSTFS_TLS_CA_FILE}")"
+printf '%s\n' 'rustfs-test-ca' > "${RUSTFS_TLS_CA_FILE}"
+
+(
+  export RUSTFS_TLS_CA_FILE="${TMP_ROOT}/tls/http-does-not-mount-ca.crt"
+  export FAKE_FORCE_HTTPS=0
+  export MC_CONFIG_DIR="${TMP_ROOT}/mc-http"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  rustfs_prepare_mc
+  [ "${RUSTFS_SCHEME_EFFECTIVE}" = "http" ]
+) || {
+  echo "TLS-off RustFS alias did not resolve over HTTP" >&2
+  exit 1
+}
+
+if (
+  unset RUSTFS_TLS_CA_FILE
+  export FAKE_FORCE_HTTPS=1
+  export MC_CONFIG_DIR="${TMP_ROOT}/mc-missing-ca"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  rustfs_prepare_mc
+); then
+  echo "HTTPS alias succeeded without a trusted RustFS CA" >&2
+  exit 1
+fi
+
+if (
+  export RUSTFS_TLS_CA_FILE="${TMP_ROOT}/tls/missing-ca.crt"
+  export RUSTFS_SCHEME=https
+  export FAKE_FORCE_HTTPS=1
+  export FAKE_REQUIRE_CA=0
+  export MC_CONFIG_DIR="${TMP_ROOT}/mc-missing-ca-path"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  rustfs_prepare_mc
+); then
+  echo "HTTPS alias succeeded with a configured but missing RustFS CA" >&2
+  exit 1
+fi
+
+if (
+  export RUSTFS_SCHEME=https
+  export FAKE_FORCE_HTTPS=1
+  export FAKE_REQUIRE_CA=0
+  export FAKE_TRUNCATE_CA_COPY=1
+  export MC_CONFIG_DIR="${TMP_ROOT}/mc-empty-installed-ca"
+  # shellcheck disable=SC1091
+  . "${ROOT_DIR}/dataprotection/common.sh"
+  rustfs_prepare_mc
+); then
+  echo "HTTPS alias succeeded after installing an empty RustFS CA" >&2
+  exit 1
+fi
 
 (
   # shellcheck disable=SC1091
@@ -208,6 +303,14 @@ grep -q 'mirror --overwrite .*/rustfs-restore/objects rustfs/' "${FAKE_MC_LOG}" 
 }
 grep -q 'alias set rustfs https://rustfs-0.rustfs-headless.demo.svc:9000' "${FAKE_MC_LOG}" || {
   echo "https alias fallback was not exercised" >&2
+  exit 1
+}
+if grep -q -- '--insecure' "${FAKE_MC_LOG}"; then
+  echo "backup/restore mc commands bypassed TLS certificate verification" >&2
+  exit 1
+fi
+[ "$(cat "${MC_CONFIG_DIR}/certs/CAs/rustfs-ca.crt")" = 'rustfs-test-ca' ] || {
+  echo "RustFS CA was not installed into the mc trust directory" >&2
   exit 1
 }
 

--- a/addons/rustfs/templates/_helpers.tpl
+++ b/addons/rustfs/templates/_helpers.tpl
@@ -72,6 +72,19 @@ rustfs-{{ .Chart.Version }}
 {{- end -}}
 
 {{/*
+Render the RustFS logical backup S3 client image.
+*/}}
+{{- define "rustfs.mcImage" -}}
+{{- $registry := .Values.image.registry | default "docker.io" -}}
+{{- $repository := .Values.image.mc.repository -}}
+{{- if .Values.image.mc.digest -}}
+{{- printf "%s/%s@%s" $registry $repository .Values.image.mc.digest -}}
+{{- else -}}
+{{- printf "%s/%s:%s" $registry $repository (.Values.image.mc.tag | default "latest") -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Define rustfs component definition regular expression name prefix
 */}}
 {{- define "rustfs.cmpdRegexpPattern" -}}

--- a/addons/rustfs/templates/actionset.yaml
+++ b/addons/rustfs/templates/actionset.yaml
@@ -13,9 +13,12 @@ spec:
       value: "rustfs-s3-full.v1"
     - name: RUSTFS_MC_IMAGE
       value: {{ include "rustfs.mcImage" . | quote }}
+    - name: RUSTFS_TLS_CA_FILE
+      value: {{ printf "%s/ca.crt" (trimSuffix "/" .Values.certsPath) | quote }}
   backup:
     backupData:
       image: {{ include "rustfs.mcImage" . }}
+      runOnTargetPodNode: true
       syncProgress:
         enabled: true
         intervalSeconds: 5
@@ -29,6 +32,7 @@ spec:
     postReady:
       - job:
           image: {{ include "rustfs.mcImage" . }}
+          runOnTargetPodNode: true
           command:
             - sh
             - -c

--- a/addons/rustfs/templates/actionset.yaml
+++ b/addons/rustfs/templates/actionset.yaml
@@ -1,0 +1,37 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: ActionSet
+metadata:
+  name: rustfs-s3-full-br
+  labels:
+    {{- include "rustfs.labels" . | nindent 4 }}
+spec:
+  backupType: Full
+  env:
+    - name: RUSTFS_API_PORT
+      value: {{ .Values.rustfsAPIPort | quote }}
+    - name: RUSTFS_BACKUP_FORMAT_VERSION
+      value: "rustfs-s3-full.v1"
+    - name: RUSTFS_MC_IMAGE
+      value: {{ include "rustfs.mcImage" . | quote }}
+  backup:
+    backupData:
+      image: {{ include "rustfs.mcImage" . }}
+      syncProgress:
+        enabled: true
+        intervalSeconds: 5
+      command:
+        - sh
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/common.sh" | nindent 10 }}
+          {{- .Files.Get "dataprotection/backup.sh" | nindent 10 }}
+  restore:
+    postReady:
+      - job:
+          image: {{ include "rustfs.mcImage" . }}
+          command:
+            - sh
+            - -c
+            - |
+              {{- .Files.Get "dataprotection/common.sh" | nindent 14 }}
+              {{- .Files.Get "dataprotection/restore.sh" | nindent 14 }}

--- a/addons/rustfs/templates/backuppolicytemplate.yaml
+++ b/addons/rustfs/templates/backuppolicytemplate.yaml
@@ -15,6 +15,10 @@ spec:
     - name: s3-full
       snapshotVolumes: false
       actionSetName: rustfs-s3-full-br
+      targetVolumes:
+        volumeMounts:
+          - name: tls
+            mountPath: {{ .Values.certsPath | quote }}
   schedules:
     - backupMethod: s3-full
       enabled: false

--- a/addons/rustfs/templates/backuppolicytemplate.yaml
+++ b/addons/rustfs/templates/backuppolicytemplate.yaml
@@ -1,0 +1,22 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupPolicyTemplate
+metadata:
+  name: rustfs-backup-policy-template
+  labels:
+    {{- include "rustfs.labels" . | nindent 4 }}
+spec:
+  serviceKind: rustfs
+  compDefs:
+    - {{ include "rustfs.cmpdRegexpPattern" . }}
+  target:
+    role: readwrite
+    account: root
+  backupMethods:
+    - name: s3-full
+      snapshotVolumes: false
+      actionSetName: rustfs-s3-full-br
+  schedules:
+    - backupMethod: s3-full
+      enabled: false
+      cronExpression: "0 18 * * *"
+      retentionPeriod: 7d

--- a/addons/rustfs/values.yaml
+++ b/addons/rustfs/values.yaml
@@ -8,6 +8,10 @@ image:
   registry: docker.io
   repository: rustfs/rustfs
   pullPolicy: IfNotPresent
+  mc:
+    repository: minio/mc
+    tag: latest
+    digest: sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
 
 ## @param versions RustFS versions configuration
 versions:


### PR DESCRIPTION
## Summary

Closes #2998.

Adds the first RustFS logical S3 full-backup implementation surface:

- `BackupPolicyTemplate` `rustfs-backup-policy-template`
- `ActionSet` `rustfs-s3-full-br`
- DataProtection scripts: `common.sh`, `backup.sh`, `restore.sh`
- local fake `mc` + fake `datasafed` contract test
- pinned backup/restore tool image render via `docker.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727`

The method is `s3-full` and uses RustFS S3 API logical export/import rather than CSI snapshots.

## Contract Boundaries

This PR only claims addon-side logical S3 full backup and new-cluster restore wiring plus local/static/pinned-tool validation.

It does not claim:

- full KubeBlocks restore-controller E2E PASS in this vcluster
- RebuildInstance support
- `scaleOut.fromBackup` support
- distributed CSI snapshot consistency
- hot logical backup snapshot isolation under concurrent writes
- TLS server-certificate trust validation

The hot-backup consistency boundary and TLS trust boundary are intentionally left for runtime test design and later hardening.

## Design Notes

- Target account/role: `root` account on `readwrite` target.
- `snapshotVolumes: false` because this is a logical S3 method.
- Restore runs in `postReady` and imports into the already-created target RustFS cluster via S3 API.
- TLS scheme selection does not rely on inherited CmpD runtime env. The script tries HTTP then HTTPS when `RUSTFS_SCHEME` is unset, but accepts a scheme only after `mc alias set` and a read-only `mc ls <alias>/` probe both succeed.
- Backup artifacts include `manifest.txt`, `buckets.txt`, `objects.txt`, and `objects/<bucket>/<key>` under the datasafed backup prefix.
- Restore hard-requires `manifest.txt`, validates `formatVersion`, method, bucket/object counts, and explicit bucket/object lists, then checks every expected object artifact before mutating RustFS buckets.

## Local Evidence

Validated locally only; no Kubernetes runtime test in this PR yet.

- `addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh` PASS
  - exercises HTTPS fallback
  - verifies manifest fields
  - verifies missing-object restore fails closed before success
- `shellcheck addons/rustfs/dataprotection/common.sh addons/rustfs/dataprotection/backup.sh addons/rustfs/dataprotection/restore.sh addons/rustfs/scripts-ut-spec/backup_restore_contract_test.sh` PASS
- `helm template rustfs addons/rustfs --namespace demo` PASS
- `helm lint addons/rustfs` PASS
- `git diff --check` PASS
- pinned image local behavior checked:
  - `mc alias set rustfs http://127.0.0.1:1 ...` returns `rc=0`
  - `mc ls rustfs/` returns `rc=1` with connection refused
  - the script gates scheme acceptance on the read probe, not alias creation alone
- pinned image local tool surface checked for required commands: `mc`, `sh`, `mkdir`, `rm`, `cat`, `cp`, `wc`, `dirname`, `ls`

## Runtime Evidence

Current-head runtime evidence was added in PR comment:

- https://github.com/apecloud/kubeblocks-addons/pull/2994#issuecomment-4872884826

Boundary:

- B01 logical backup path is verified on head `9d96595c` with a real BackupRepo and artifact verification.
- `Cluster.spec.restore.source` end-to-end restore is environment-blocked in the current vcluster by PVC sync-loop errors, so this PR does not claim full restore-controller E2E PASS from that run.
- Manual ActionSet artifact replay validates restore script/artifact behavior, but does not replace KubeBlocks restore-controller E2E evidence.
- TLS/server certificate trust validation remains a follow-up.

## Next Validation Lane

Jean is preparing the runtime `backup-restore.sh` lane:

1. install addon build with this BPT/ActionSet
2. create RustFS cluster and marker objects
3. run DataProtection backup through real BackupRepo
4. attempt restore into a new RustFS cluster
5. classify vcluster restore-source PVC sync issues as SKIP/ENV-BLOCKED instead of silent pass if reproduced
6. verify manual ActionSet replay separately as script/artifact validation
7. add TLS backup/restore as a separate follow-up that distinguishes `--insecure` HTTPS connectivity from server certificate trust validation
8. collect cleanup proof
