### PR TITLE
fix restore examples source target name

### DIFF
--- a/examples/apecloud-mysql/restore.yaml
+++ b/examples/apecloud-mysql/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: acmysql-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: mysql
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: apecloud-mysql

--- a/examples/etcd/restore.yaml
+++ b/examples/etcd/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: etcd-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: etcd
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:

--- a/examples/falkordb/restore.yaml
+++ b/examples/falkordb/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: falkordb-backup-datafile
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: falkordb
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: falkordb

--- a/examples/mongodb/restore.yaml
+++ b/examples/mongodb/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: mongo-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: mongodb
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: mongodb

--- a/examples/mysql/restore.yaml
+++ b/examples/mysql/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: mysql-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: mysql
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:

--- a/examples/oceanbase-ce/restore.yaml
+++ b/examples/oceanbase-ce/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: ob-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: oceanbase
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: oceanbase-ce

--- a/examples/postgresql/restore.yaml
+++ b/examples/postgresql/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: pg-cluster-pg-basebackup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: postgresql
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: postgresql

--- a/examples/qdrant/restore.yaml
+++ b/examples/qdrant/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: qdrant-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: qdrant
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: qdrant

--- a/examples/redis/restore.yaml
+++ b/examples/redis/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: redis-replication-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: redis
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: redis

--- a/examples/valkey/restore.yaml
+++ b/examples/valkey/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: valkey-backup-datafile
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: valkey
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: valkey

--- a/examples/vanilla-postgresql/restore.yaml
+++ b/examples/vanilla-postgresql/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: vanpg-cluster-pg-basebackup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: postgresql
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   clusterDef: vanilla-postgresql

--- a/examples/zookeeper/restore.yaml
+++ b/examples/zookeeper/restore.yaml
@@ -11,6 +11,7 @@ spec:
       name: zk-cluster-backup
       namespace: demo
     parameters:
+      dataprotection.kubeblocks.io/source-target-name: zookeeper
       dataprotection.kubeblocks.io/volume-restore-policy: Parallel
   terminationPolicy: Delete
   componentSpecs:


### PR DESCRIPTION
## Summary
- add dataprotection.kubeblocks.io/source-target-name to non-sharding restore examples
- keep the value aligned with the restored data component target name
- leave the ClickHouse sharding restore example unchanged because it uses KubeBlocks sharding target mapping

## Root Cause
Without source-target-name, KubeBlocks can fall back to matching the source backup target selector against restored PVC labels. For cross-cluster restores, the source and target cluster names differ, so PVC restore can be skipped as provision-only.

Fixes #2995

## Validation
- make scripts-test SHELLSPEC_DEFAULT_PATH=examples/scripts-ut-spec
- shellcheck --severity=error examples/scripts-ut-spec/restore_source_target_name_spec.sh
- Ruby YAML parse for touched restore examples
- git diff --check