### PR TITLE
chore(postgresql): use dynamic compression flag in pgdump based on PG version

### DIFF
--- a/addons/postgresql/dataprotection/pgdump-backup.sh
+++ b/addons/postgresql/dataprotection/pgdump-backup.sh
@@ -29,7 +29,14 @@ if [ -z "$jobs" ]; then
 fi
 
 # Build pg_dump parameters
-params="-j $jobs -Fd -f $BACKUP_DIR -Z lz4 -v"
+# Detect PostgreSQL server version to choose compression flag
+PG_MAJOR_VERSION=$(psql -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT} -Atc "SHOW server_version;" 2>/dev/null | cut -d'.' -f1)
+if [ -z "$PG_MAJOR_VERSION" ] || [ "$PG_MAJOR_VERSION" -le 15 ] 2>/dev/null; then
+  pg_zopt="-Z 6"
+else
+  pg_zopt="-Z lz4"
+fi
+params="-j $jobs -Fd -f $BACKUP_DIR ${pg_zopt} -v"
 
 # Handle database selection
 if [ -n "$database" ]; then


### PR DESCRIPTION
## Problem

The `pgdump-backup.sh` script hardcoded `-Z lz4` as the compression flag for `pg_dump`. However, lz4 compression in `pg_dump` is only supported from PostgreSQL 16+. On PG ≤ 15, this flag causes the backup to fail.

## Fix

Detect the PostgreSQL server major version at runtime using:

```bash
psql -Atc "SHOW server_version;"
```

Then dynamically select the compression flag:
- **PG > 15** → `-Z lz4` (native lz4 compression)
- **PG ≤ 15** → `-Z 6` (gzip level 6, backward compatible with all PG versions)
- **Query fails** → fall back to `-Z 6` for safety

This ensures compatibility across all supported PostgreSQL versions while still leveraging lz4 compression on newer PG installations.