### PR TITLE
fix(mongodb): KubeBlocks 1.1 compatibility patch for MongoDB sharding

### DIFF
--- a/addons/mongodb/config/mongodb-shard-config.tpl
+++ b/addons/mongodb/config/mongodb-shard-config.tpl
@@ -2,16 +2,8 @@
 # for documentation of all options, see:
 #   http://docs.mongodb.org/manual/reference/configuration-options/
 
-{{- $log_root := getVolumePathByName ( index $.podSpec.containers 0 ) "log" }}
-{{- $mongodb_root := getVolumePathByName ( index $.podSpec.containers 0 ) "data" }}
-{{- $mongodb_port_info := getPortByName ( index $.podSpec.containers 0 ) "mongodb" }}
-{{- $phy_memory := getContainerMemory ( index $.podSpec.containers 0 ) }}
-
-# require port
-{{- $mongodb_port := 27017 }}
-{{- if $mongodb_port_info }}
-{{- $mongodb_port = $mongodb_port_info.containerPort }}
-{{- end }}
+{{- $mongodb_root := "/data/mongodb" }}
+{{- $mongodb_port := $.KB_SERVICE_PORT }}
 
 # where and how to store data.
 storage:

--- a/addons/mongodb/config/mongos-config.tpl
+++ b/addons/mongodb/config/mongos-config.tpl
@@ -2,14 +2,8 @@
 # for documentation of all options, see:
 #   http://docs.mongodb.org/manual/reference/configuration-options/
 
-{{- $mongodb_root := getVolumePathByName ( index $.podSpec.containers 0 ) "data" }}
-{{- $mongodb_port_info := getPortByName ( index $.podSpec.containers 0 ) "mongodb" }}
-
-# require port
-{{- $mongodb_port := 27017 }}
-{{- if $mongodb_port_info }}
-{{- $mongodb_port = $mongodb_port_info.containerPort }}
-{{- end }}
+{{- $mongodb_root := "/data/mongodb" }}
+{{- $mongodb_port := $.KB_SERVICE_PORT }}
 
 # network interfaces
 net:

--- a/addons/mongodb/templates/cmpd-config-server.yaml
+++ b/addons/mongodb/templates/cmpd-config-server.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   provider: kubeblocks.io
   serviceKind: mongodb
-  serviceVersion: "8.0.17"
   configs:
     - name: mongodb-config
       template: {{ include "mongodbShard.configTplName" . }}

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   provider: kubeblocks.io
   serviceKind: mongodb
-  serviceVersion: "8.0.17"
   configs:
     - name: mongodb-config
       template: {{ include "mongodbShard.configTplName" . }}

--- a/addons/mongodb/templates/cmpd-mongos.yaml
+++ b/addons/mongodb/templates/cmpd-mongos.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   provider: kubeblocks.io
   serviceKind: mongodb
-  serviceVersion: "8.0.17"
   services:
     - name: everypod
       serviceName: mongos


### PR DESCRIPTION
Changes:
- Replace template functions in mongodb-shard-config.tpl and mongos-config.tpl.
- Remove hard-coded serviceVersion: 8.0.17 from sharding ComponentDefinitions so that Cluster serviceVersion 6.0.27 can match via ComponentVersion.