### PR TITLE
fix(postgresql): undefined leader_pod broke pending-restart watchdog

### DIFF
--- a/addons/postgresql/scripts-ut-spec/postgres_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/postgres_setup_spec.sh
@@ -105,7 +105,7 @@ Describe "PostgreSQL Initialization Script Tests"
         :
       }
       When call regenerate_spilo_configuration_and_start_postgres
-      The stdout should include "/home/postgres/.kb_set_up.log: No such file or directory"
+      # with the ">> file 2>&1" redirect order, failed redirections report on stderr only
       The stderr should include "/home/postgres/.kb_set_up.log: No such file or directory"
       The status should be success
       The file "tmp_patroni.yaml" should be exist
@@ -114,6 +114,38 @@ Describe "PostgreSQL Initialization Script Tests"
       The variable SPILO_CONFIGURATION should not be undefined
       The variable SPILO_CONFIGURATION should include "bootstrap:"
       The variable SPILO_CONFIGURATION should include "auth-host: md5"
+    End
+  End
+
+  Describe "need_restart_for_pending()"
+    setup() {
+      CURRENT_POD_NAME="pg-cluster-postgresql-0"
+    }
+    Before 'setup'
+
+    un_setup() {
+      unset CURRENT_POD_NAME
+    }
+    After 'un_setup'
+
+    It "restarts when pending and no leader is pending"
+      When call need_restart_for_pending "true" ""
+      The status should be success
+    End
+
+    It "restarts when pending and the pending leader is the current pod"
+      When call need_restart_for_pending "true" "pg-cluster-postgresql-0"
+      The status should be success
+    End
+
+    It "does not restart when pending but another pod is the pending leader"
+      When call need_restart_for_pending "true" "pg-cluster-postgresql-1"
+      The status should be failure
+    End
+
+    It "does not restart when not pending"
+      When call need_restart_for_pending "false" ""
+      The status should be failure
     End
   End
 End

--- a/addons/postgresql/scripts/postgres-setup.sh
+++ b/addons/postgresql/scripts/postgres-setup.sh
@@ -18,6 +18,15 @@ function pending_restart_parameters_values() {
   echo $result
 }
 
+# decide whether the current pod should restart now: only when it has
+# pending_restart, and either no leader is pending or the pending leader
+# is the current pod (the leader restarts first, secondaries follow).
+function need_restart_for_pending() {
+  local pending_restart=$1
+  local leader_pending_restart_pod=$2
+  [[ "${pending_restart}" == "true" && ( -z "${leader_pending_restart_pod}" || "${leader_pending_restart_pod}" == "${CURRENT_POD_NAME}" ) ]]
+}
+
 function restart_for_pending_restart_flag() {
   while true; do
     sleep 5
@@ -64,7 +73,7 @@ function restart_for_pending_restart_flag() {
     # Re-check pending_restart to avoid duplicate restarts
     sleep 5
     pending_restart=$(curl --connect-timeout 3 -s http://localhost:8008 | jq -r .pending_restart)
-    if [[ "${pending_restart}" == "true" && (-z $leader_pending_restart_pod || "${leader_pod}" == "${CURRENT_POD_NAME}") ]]; then
+    if need_restart_for_pending "${pending_restart}" "${leader_pending_restart_pod}"; then
       # if leader pod is not pending_restart or current pod is leader pod, restart it
       echo "$(date) ${CURRENT_POD_NAME} is pending restart, restart it"
       curl -XPOST http://localhost:8008/restart
@@ -100,7 +109,7 @@ init_etcd_dcs_config_if_needed() {
 }
 
 regenerate_spilo_configuration_and_start_postgres() {
-  restart_for_pending_restart_flag 2>&1 >> /home/postgres/.kb_set_up.log &
+  restart_for_pending_restart_flag >> /home/postgres/.kb_set_up.log 2>&1 &
   echo "$(date) restart_for_pending_restart_flag PID=$!" >> /home/postgres/.kb_set_up.log
   if [ -f "${RESTORE_DATA_DIR}"/kb_restore.signal ]; then
       chown -R postgres "${RESTORE_DATA_DIR}"


### PR DESCRIPTION
## Problem

`postgres-setup.sh:67` referenced `${leader_pod}`, which is never assigned (the assigned variable is `leader_pending_restart_pod`, line 53). Whenever the Patroni leader itself is pending_restart, the watchdog condition is always false, so no pod — including the leader — is ever restarted by `restart_for_pending_restart_flag`. Restart-required parameter changes then fail to converge in that state.

Independent confirmation: shellcheck 0.11.0 SC2154 on the old line.

Details, effect analysis and runtime construction scenario: #3004

## Change

- Extract the restart decision into `need_restart_for_pending()` and use `leader_pending_restart_pod` (semantics per the original comment: restart when no leader is pending, or when the pending leader is the current pod — leader first, secondaries follow).
- Fix the watchdog background-job redirect `2>&1 >> log` → `>> log 2>&1` (SC2069; stderr previously never reached `.kb_set_up.log`).
- Add 4 shellspec cases for the decision function — this function previously had zero UT coverage, which is how the bug survived. Also updated one existing assertion in `regenerate_spilo_configuration_and_start_postgres` that had encoded the buggy redirect order (it asserted the redirect error appeared on stdout, which only happens with the wrong order).

## Validation

- `shellspec --shell bash5`: 13 examples, 0 failures (9 pre-existing + 4 new).
- `shellcheck -S warning postgres-setup.sh`: SC2154/SC2069 gone; no new findings.
- Boundary: static + UT validation only; no runtime cluster reproduction yet. The fix is a pure decision-logic correction with unchanged external behavior in the common path (leader not pending).

Origin: function-by-function review of the postgresql addon requested by westonnnn (Slock #addon-reviewer4 task #1).

Fixes #3004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
