### PR TITLE
fix(postgresql): correct patroni parameter name retry_timeout in reloader list

### DIFF
--- a/addons/postgresql/reloader/patroni-parameter.yaml
+++ b/addons/postgresql/reloader/patroni-parameter.yaml
@@ -1,4 +1,4 @@
 - ttl
 - loop_wait
-- retry_timeouts
+- retry_timeout
 - maximum_lag_on_failover


### PR DESCRIPTION
## Problem

`addons/postgresql/reloader/patroni-parameter.yaml` listed `retry_timeouts` (plural). Patroni's parameter is `retry_timeout` — the addon's own `config/patroni-yaml.tpl` uses the correct singular form. Because `update-parameter.sh` only routes parameters found in this list to Patroni top-level config, reconfiguring `retry_timeout` was misrouted into `postgresql.parameters` (a nonexistent PostgreSQL GUC), leaving Patroni's actual `retry_timeout` unchanged.

Full analysis and verification scenario: #3005

## Change

One-line rename `retry_timeouts` → `retry_timeout`. Audited the remaining entries (`ttl`, `loop_wait`, `maximum_lag_on_failover`) against Patroni's dynamic-configuration names — all correct.

## Validation

Static: name now matches `config/patroni-yaml.tpl` and Patroni docs. Boundary: not runtime-reproduced; verification scenario documented in the issue (reconfigure retry_timeout, then check `GET :8008/config` top level).

Origin: postgresql addon function-by-function review (Slock #addon-reviewer4 task #1).

Fixes #3005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
