### PR TITLE
fix(postgresql): stop world-readable superuser password in pgbouncer auth_file

### DIFF
--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -27,8 +27,8 @@ build_pgbouncer_conf() {
   echo -e "\\n[databases]" >> $pgbouncer_conf_file
   echo "postgres=host=$CURRENT_POD_IP port=5432 dbname=postgres" >> $pgbouncer_conf_file
   echo "*=host=$CURRENT_POD_IP port=5432" >> $pgbouncer_conf_file
-  chmod 777 $pgbouncer_conf_file
-  chmod 777 $pgbouncer_user_list_file
+  chmod 644 $pgbouncer_conf_file
+  chmod 600 $pgbouncer_user_list_file
 
   # Try to add user
   useradd pgbouncer 2>/dev/null || true


### PR DESCRIPTION
## Problem

`pgbouncer-setup.sh` wrote the **postgres superuser password** into pgbouncer's auth_file and made it world-readable and writable:

```sh
echo "\"$POSTGRESQL_USERNAME\" \"$POSTGRESQL_PASSWORD\"" > $pgbouncer_user_list_file
chmod 777 $pgbouncer_conf_file
chmod 777 $pgbouncer_user_list_file
```

Any process/user in the container can read or tamper with the credential. Trivially observable: exec into the pgbouncer container as a non-root user and `cat /opt/bitnami/pgbouncer/conf/userlist.txt`. Details: #3009

## Change

`chmod 600` for userlist.txt, `chmod 644` for pgbouncer.ini. No ownership change needed: the script already runs `chown -R pgbouncer:pgbouncer` on the conf dir *after* these chmods and starts pgbouncer via `su pgbouncer`, so the process reads the 600 file as its owner.

This PR is deliberately minimal (proven exposure only). The related practice issue — `auth_user = postgres` with a direct `pg_shadow` auth_query instead of a dedicated low-privilege auth role — is left to a follow-up as noted in the issue.

## Validation

Static + file-permission semantics; not runtime-reproduced. Startup path unchanged (owner read access preserved through the existing chown).

Origin: postgresql addon function-by-function review (Slock #addon-reviewer4 task #1).

Fixes #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
