### PR TITLE
fix(valkey): default maxmemory-policy back to noeviction

### DIFF
--- a/addons/valkey/config/valkey-config.tpl
+++ b/addons/valkey/config/valkey-config.tpl
@@ -71,7 +71,11 @@ io-threads 1
 io-threads-do-reads yes
 
 # Memory policy
-maxmemory-policy volatile-lru
+# noeviction is the Valkey upstream default: when maxmemory is reached,
+# writes fail loudly instead of silently evicting data. For a database
+# service that is the safe default; cache deployments that prefer
+# eviction can set maxmemory-policy (dynamic parameter) per cluster.
+maxmemory-policy noeviction
 {{- $mem := default 0 $.PHY_MEMORY | int }}
 {{- if gt $mem 0 }}
 maxmemory {{ mulf $mem 0.8 | int }}

--- a/addons/valkey/scripts-ut-spec/config_defaults_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/config_defaults_contract_spec.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Valkey config template defaults contract"
+  config_tpl="../config/valkey-config.tpl"
+
+  It "keeps maxmemory-policy at the Valkey upstream default (noeviction)"
+    # Database-safe default: writes fail loudly at maxmemory instead of
+    # silently evicting data (issue #3015). Cache profiles override via
+    # the dynamic parameter.
+    When call grep -E '^maxmemory-policy noeviction$' "${config_tpl}"
+    The status should be success
+    The stdout should include "noeviction"
+  End
+
+  It "does not silently default to an eviction policy"
+    When call grep -E '^maxmemory-policy (volatile|allkeys)' "${config_tpl}"
+    The status should be failure
+  End
+End


### PR DESCRIPTION
Fixes #3015 — issue has the scenario/repro (write TTL keys past maxmemory: current default silently evicts; noeviction fails loudly).

One-line config default change + rationale comment + 2-example contract spec pinning the default. maxmemory-policy remains user-settable per cluster (dynamic parameter in paramsdef, unchanged).

Validation: full valkey shellspec suite local 301 examples 0 failures (299 base + 2 new; bash5).

Reviewer: @Alice / @Bob (XP focused review).

