### PR TITLE
fix(redis): allow lua-time-limit to be set to any value >= 0

### DIFF
--- a/addons/redis/config/redis-cluster5-config-constraint.cue
+++ b/addons/redis/config/redis-cluster5-config-constraint.cue
@@ -62,7 +62,7 @@
 
 	"list-max-listpack-size": int | *-2
 
-	"lua-time-limit": int & 5000 | *5000
+	"lua-time-limit": int & >=0 | *5000
 
 	"busy-reply-threshold": int | *5000
 

--- a/addons/redis/config/redis-cluster6-config-constraint.cue
+++ b/addons/redis/config/redis-cluster6-config-constraint.cue
@@ -264,7 +264,7 @@
 
      "auto-aof-rewrite-min-size": string | *"64mb"
 
-     "lua-time-limit": int | *5000
+     "lua-time-limit": int & >=0 | *5000
 
      "busy-reply-threshold": int | *5000
 

--- a/addons/redis/config/redis-cluster7-config-constraint.cue
+++ b/addons/redis/config/redis-cluster7-config-constraint.cue
@@ -78,7 +78,7 @@
 
 	"list-max-listpack-size": int | *-2
 
-	"lua-time-limit": int & 5000 | *5000
+	"lua-time-limit": int & >=0 | *5000
 
 	maxclients: int & >=1 & <=65000 | *65000
 
@@ -285,7 +285,7 @@
 
      "busy-reply-threshold": int | *5000
 
-     "lua-time-limit": int | *5000
+     "lua-time-limit": int & >=0 | *5000
 
      // By default latency monitoring is disabled since it is mostly not needed
      // if you don't have latency issues, and collecting data has a performance

--- a/addons/redis/config/redis-cluster8-config-constraint.cue
+++ b/addons/redis/config/redis-cluster8-config-constraint.cue
@@ -287,7 +287,7 @@
 
     "busy-reply-threshold": int | *5000
 
-    "lua-time-limit": int | *5000
+    "lua-time-limit": int & >=0 | *5000
 
     // By default latency monitoring is disabled since it is mostly not needed
     // if you don't have latency issues, and collecting data has a performance

--- a/addons/redis/config/redis5-config-constraint.cue
+++ b/addons/redis/config/redis5-config-constraint.cue
@@ -56,7 +56,7 @@
 
 	"list-max-listpack-size": int | *-2
 
-	"lua-time-limit": int & 5000 | *5000
+	"lua-time-limit": int & >=0 | *5000
 
 	"busy-reply-threshold": int | *5000
 

--- a/addons/redis/config/redis6-config-constraint.cue
+++ b/addons/redis/config/redis6-config-constraint.cue
@@ -70,7 +70,7 @@
 
 	"list-max-ziplist-size": int | *-2
 
-	"lua-time-limit": int & 5000 | *5000
+	"lua-time-limit": int & >=0 | *5000
 
 	"busy-reply-threshold": int | *5000
 
@@ -276,7 +276,7 @@
 
      "auto-aof-rewrite-min-size": string | *"64mb"
 
-     "lua-time-limit": int | *5000
+     "lua-time-limit": int & >=0 | *5000
 
      // By default latency monitoring is disabled since it is mostly not needed
      // if you don't have latency issues, and collecting data has a performance

--- a/addons/redis/config/redis7-config-constraint.cue
+++ b/addons/redis/config/redis7-config-constraint.cue
@@ -282,7 +282,7 @@
 
     "busy-reply-threshold": int | *5000
 
-    "lua-time-limit": int | *5000
+    "lua-time-limit": int & >=0 | *5000
 
     // By default latency monitoring is disabled since it is mostly not needed
     // if you don't have latency issues, and collecting data has a performance

--- a/addons/redis/config/redis8-config-constraint.cue
+++ b/addons/redis/config/redis8-config-constraint.cue
@@ -281,7 +281,7 @@
 
     "busy-reply-threshold": int | *5000
 
-    "lua-time-limit": int | *5000
+    "lua-time-limit": int & >=0 | *5000
 
     // By default latency monitoring is disabled since it is mostly not needed
     // if you don't have latency issues, and collecting data has a performance


### PR DESCRIPTION
## Problem

The `lua-time-limit` parameter was hardcoded to 5000 in Redis CUE constraints (`int & 5000 | *5000`), preventing users from changing this value to suit their workload.

## Fix

Changed the constraint to `int & >=0 | *5000` — this allows any non-negative integer while keeping the default at 5000ms (5 seconds).

## Scope

This change applies to all Redis variants:
- Redis 5, 6, 7, 8 standalone
- Redis 5, 6, 7, 8 cluster

## Breaking Change

None. The default value (5000ms) remains unchanged. Only the constraint is relaxed to accept user-specified values.