### PR TITLE
fix(mariadb): start mariadbd with portable --read-only=ON, not enum NO_LOCK_NO_ADMIN

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_entrypoint_readonly_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_entrypoint_readonly_spec.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=sh
+#
+# E1 contract: the mariadbd command line must start fail-closed with a
+# PORTABLE read_only value. NO_LOCK_NO_ADMIN is a runtime-variable enum,
+# not a valid command-line boolean — my_getopt does not recognize it and
+# silently sets read_only=OFF on every shipped version (verified on
+# mariadb 11.4 AND 11.8 via `mariadbd --read-only=NO_LOCK_NO_ADMIN
+# --verbose --help` → "boolean value 'NO_LOCK_NO_ADMIN' wasn't recognized.
+# Set to OFF."), turning fail-closed intent into a fail-open startup window.
+# The SQL path (set_fail_closed_read_only) keeps the NO_LOCK_NO_ADMIN →
+# ON → 1 tiering for the stronger runtime fence where the engine supports it.
+
+Describe "replication-entrypoint read_only fail-closed startup contract"
+  ENTRYPOINT="${SHELLSPEC_CWD:?}/addons/mariadb/scripts/replication-entrypoint.sh"
+
+  extract_mariadbd_launch() {
+    # The bootstrap launch: from the `docker-entrypoint.sh mariadbd \`
+    # line to the line ending the backslash-continued argv (bind-address).
+    awk '
+      /docker-entrypoint\.sh mariadbd \\/ { in_cmd = 1 }
+      in_cmd { print }
+      in_cmd && /--bind-address=/ { exit }
+    ' "${ENTRYPOINT}"
+  }
+
+  It "starts mariadbd with the portable boolean --read-only=ON"
+    When call extract_mariadbd_launch
+    The status should be success
+    The output should include "--read-only=ON"
+  End
+
+  It "does NOT pass the non-portable enum NO_LOCK_NO_ADMIN on the command line"
+    When call extract_mariadbd_launch
+    The status should be success
+    The output should not include "--read-only=NO_LOCK_NO_ADMIN"
+  End
+
+  It "keeps the SQL fail-closed helper tiering NO_LOCK_NO_ADMIN -> ON -> 1"
+    # Runtime fence via SQL retains the stronger value where supported,
+    # then falls back to ON and 1 (both universally valid).
+    When run sh -c "grep -A12 'set_fail_closed_read_only()' '${ENTRYPOINT}'"
+    The status should be success
+    The output should include "SET GLOBAL read_only = NO_LOCK_NO_ADMIN;"
+    The output should include "SET GLOBAL read_only = ON;"
+    The output should include "SET GLOBAL read_only = 1;"
+  End
+End

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -1689,13 +1689,21 @@ start_mariadbd_process() {
   # orphan events can still occur during a long pod-1
   # restart. A complete fix requires syncer Demote-time
   # catch-up wait (Path B, separate PR).
+  #
+  # --read-only=ON (below) starts fail-closed so there is no writable window
+  # before the SQL-based set_fail_closed_read_only runs. NO_LOCK_NO_ADMIN is a
+  # runtime-variable enum value, NOT a valid command-line boolean: my_getopt
+  # does not recognize it and silently sets read_only=OFF (verified on mariadb
+  # 11.4 AND 11.8), turning fail-closed intent into fail-open on every shipped
+  # version. The portable boolean ON is used here; set_fail_closed_read_only
+  # still upgrades to NO_LOCK_NO_ADMIN post-start where the engine supports it.
   docker-entrypoint.sh mariadbd \
     --defaults-extra-file=${DATA_DIR}/runtime-overrides.cnf \
     --server-id=${SERVICE_ID} \
     --gtid-domain-id=${SERVICE_ID} \
     --log-bin=${DATA_DIR}/binlog/${POD_NAME}-bin \
     --skip-slave-start=ON \
-    --read-only=NO_LOCK_NO_ADMIN \
+    --read-only=ON \
     --thread-cache-size=100 \
     --rpl-semi-sync-master-wait-point=AFTER_SYNC \
     --bind-address="${bind_address}" &


### PR DESCRIPTION
Fixes #3022 — HIGH fail-closed-startup-flag-goes-fail-open.

Runtime evidence in the issue (11.4 AND 11.8 both: `boolean value 'NO_LOCK_NO_ADMIN' wasn't recognized. Set to OFF.`; `--read-only=ON` on 11.4 → @@global.read_only=1, no warning).

Change: one-line CLI value + explanatory comment; SQL fail-closed tiering unchanged. Validation: focused source-contract shellspec green (3 examples), helm renders. mariadb team full-suite verification per westonnnn.