### PR TITLE
fix(postgresql): pgdump/pgdumpall restore must fail on missing backup instead of reporting success

### DIFF
--- a/addons/postgresql/dataprotection/pgdump-restore.sh
+++ b/addons/postgresql/dataprotection/pgdump-restore.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
@@ -8,9 +9,22 @@ psql_cmd="psql -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT}"
 mkdir -p $BACKUP_DIR
 trap "[ -d $BACKUP_DIR ] && rm -rf $BACKUP_DIR" EXIT
 
+function remote_file_exists() {
+    local out=$(datasafed list $1)
+    if [ "${out}" == "$1" ]; then
+        echo "true"
+        return
+    fi
+    echo "false"
+}
+
+if [ $(remote_file_exists "${DP_BACKUP_NAME}.tar") != "true" ]; then
+  echo "ERROR: backup file ${DP_BACKUP_NAME}.tar not found in the backup repository, cannot restore" >&2
+  exit 1
+fi
+
 datasafed pull "${DP_BACKUP_NAME}.tar" - | tar -xf - -C $BACKUP_DIR
 
-# Set default values
 # Set default values
 if [ -z "$jobs" ]; then
   jobs=4
@@ -64,17 +78,26 @@ if [ "$conflict_policy" == "DROP" ]; then
   params="$params --clean --if-exists"
 elif [ "$conflict_policy" == "FAIL" ]; then
   params="$params --exit-on-error"
-else
-  set +e
 fi
 
 echo "parameters: $params"
 
-# Download and restore
-pg_restore -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT} ${params} $BACKUP_DIR 2> >(tee /tmp/pg_restore.log >&2)
-exit_code=$?
-if [ -f /tmp/pg_restore.log ] && grep "pg_restore: warning: errors ignored on restore" /tmp/pg_restore.log ; then
+# Restore; capture the exit code explicitly instead of letting set -e abort,
+# so the conflict policy can decide how ignored errors are reported.
+# stderr goes through a synchronous tee (not an async process substitution),
+# so /tmp/pg_restore.log is guaranteed complete before it is grepped below.
+exec 3>&1
+set +e
+pg_restore -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT} ${params} $BACKUP_DIR 2>&1 1>&3 | tee /tmp/pg_restore.log >&2
+exit_code=${PIPESTATUS[0]}
+set -e
+exec 3>&-
+# Without --exit-on-error pg_restore continues past per-object errors and
+# exits 1 with "errors ignored on restore". Only the non-FAIL policies may
+# treat that as success; FAIL must propagate the failure.
+if [ $exit_code -ne 0 ] && [ "$conflict_policy" != "FAIL" ] && [ -f /tmp/pg_restore.log ] \
+    && grep -q "pg_restore: warning: errors ignored on restore" /tmp/pg_restore.log; then
+  echo "pg_restore reported ignored errors; treating as success under conflict_policy=${conflict_policy:-CONTINUE}"
   exit_code=0
 fi
 exit $exit_code
-

--- a/addons/postgresql/dataprotection/pgdumpall-restore.sh
+++ b/addons/postgresql/dataprotection/pgdumpall-restore.sh
@@ -14,8 +14,10 @@ function remote_file_exists() {
     echo "false"
 }
 
-if [ $(remote_file_exists "${DP_BACKUP_NAME}.sql.zst") == "true" ]; then
-  datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.sql.zst" - | psql -U ${DP_DB_USER} -h ${DP_DB_HOST} -p ${DP_DB_PORT}
-  echo "restore complete!";
-  exit 0
+if [ $(remote_file_exists "${DP_BACKUP_NAME}.sql.zst") != "true" ]; then
+  echo "ERROR: backup file ${DP_BACKUP_NAME}.sql.zst not found in the backup repository, cannot restore" >&2
+  exit 1
 fi
+
+datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.sql.zst" - | psql -U ${DP_DB_USER} -h ${DP_DB_HOST} -p ${DP_DB_PORT}
+echo "restore complete!"

--- a/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
@@ -1,0 +1,134 @@
+# shellcheck shell=sh
+
+Describe "dataprotection/pgdump-restore.sh"
+
+  script_path() {
+    printf "%s" "../dataprotection/pgdump-restore.sh"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-dump-restore-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    rm -f /tmp/pg_restore.log
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/backup"
+    DP_BACKUP_NAME="backup-test"
+    POSTGRES_PASSWORD="secret"
+    POSTGRES_USER="postgres"
+    DP_DB_HOST="localhost"
+    DP_DB_PORT="5432"
+    BACKUP_DIR="${tmpdir}/restore-workdir"
+    export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
+      DP_BACKUP_NAME POSTGRES_PASSWORD POSTGRES_USER DP_DB_HOST DP_DB_PORT BACKUP_DIR
+    unset DATASAFED_LIST_OUT DATASAFED_PULL_EXIT PG_RESTORE_EXIT PG_RESTORE_STDERR \
+      jobs database schemas tables schema_only conflict_policy 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+    rm -f /tmp/pg_restore.log
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+cmd="$1"
+case "$cmd" in
+  list) printf '%s\n' "${DATASAFED_LIST_OUT:-}" ;;
+  pull)
+    if [ "${DATASAFED_PULL_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_PULL_EXIT}"
+    fi
+    printf '%s\n' "-- dump data"
+    ;;
+esac
+EOF
+    cat > "${bindir}/tar" <<'EOF'
+#!/bin/sh
+printf 'tar %s\n' "$*" >> "${CALL_LOG}"
+cat > /dev/null
+EOF
+    cat > "${bindir}/psql" <<'EOF'
+#!/bin/sh
+printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+exit 0
+EOF
+    cat > "${bindir}/pg_restore" <<'EOF'
+#!/bin/sh
+printf 'pg_restore %s\n' "$*" >> "${CALL_LOG}"
+if [ -n "${PG_RESTORE_STDERR:-}" ]; then
+  printf '%s\n' "${PG_RESTORE_STDERR}" >&2
+fi
+exit "${PG_RESTORE_EXIT:-0}"
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/tar" "${bindir}/psql" "${bindir}/pg_restore"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "fails loudly when the backup file does not exist in the repository"
+    export DATASAFED_LIST_OUT=""
+    When run bash "$(script_path)"
+    The status should be failure
+    The error should include "backup-test.tar not found"
+    The result of function call_log should not include "pg_restore"
+  End
+
+  It "restores successfully when the backup exists and pg_restore succeeds"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "parameters:"
+    The result of function call_log should include "pg_restore"
+  End
+
+  It "treats ignored per-object errors as success under the default CONTINUE policy"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export PG_RESTORE_EXIT=1
+    export PG_RESTORE_STDERR="pg_restore: warning: errors ignored on restore: 3"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "treating as success under conflict_policy=CONTINUE"
+    The error should include "errors ignored on restore"
+  End
+
+  It "propagates ignored-error failures when conflict_policy is FAIL"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export conflict_policy="FAIL"
+    export PG_RESTORE_EXIT=1
+    export PG_RESTORE_STDERR="pg_restore: warning: errors ignored on restore: 3"
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should include "--exit-on-error"
+    The error should include "errors ignored on restore"
+  End
+
+  It "fails when pg_restore fails without the ignored-errors warning"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export PG_RESTORE_EXIT=1
+    export PG_RESTORE_STDERR="pg_restore: error: could not connect to server"
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should include "parameters:"
+    The error should include "could not connect"
+  End
+
+  It "fails when datasafed pull fails mid-stream"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export DATASAFED_PULL_EXIT=1
+    When run bash "$(script_path)"
+    The status should be failure
+    The result of function call_log should not include "pg_restore"
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pgdumpall_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgdumpall_restore_spec.sh
@@ -1,0 +1,96 @@
+# shellcheck shell=sh
+
+Describe "dataprotection/pgdumpall-restore.sh"
+
+  script_path() {
+    printf "%s" "../dataprotection/pgdumpall-restore.sh"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-dumpall-restore-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/backup"
+    DP_BACKUP_NAME="backup-test"
+    DP_DB_PASSWORD="secret"
+    DP_DB_USER="postgres"
+    DP_DB_HOST="localhost"
+    DP_DB_PORT="5432"
+    export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
+      DP_BACKUP_NAME DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT
+    unset DATASAFED_LIST_OUT DATASAFED_PULL_EXIT PSQL_EXIT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+cmd="$1"
+case "$cmd" in
+  list) printf '%s\n' "${DATASAFED_LIST_OUT:-}" ;;
+  pull)
+    if [ "${DATASAFED_PULL_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_PULL_EXIT}"
+    fi
+    printf '%s\n' "-- dump data"
+    ;;
+esac
+EOF
+    cat > "${bindir}/psql" <<'EOF'
+#!/bin/sh
+printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+cat > /dev/null
+exit "${PSQL_EXIT:-0}"
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/psql"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "fails loudly when the backup file does not exist in the repository"
+    export DATASAFED_LIST_OUT=""
+    When run bash "$(script_path)"
+    The status should be failure
+    The error should include "backup-test.sql.zst not found"
+    The result of function call_log should not include "psql"
+  End
+
+  It "restores and reports success when the backup file exists"
+    export DATASAFED_LIST_OUT="backup-test.sql.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "restore complete!"
+    The result of function call_log should include "datasafed pull"
+    The result of function call_log should include "psql"
+  End
+
+  It "fails when psql fails to apply the dump"
+    export DATASAFED_LIST_OUT="backup-test.sql.zst"
+    export PSQL_EXIT=2
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should not include "restore complete!"
+  End
+
+  It "fails when datasafed pull fails mid-stream"
+    export DATASAFED_LIST_OUT="backup-test.sql.zst"
+    export DATASAFED_PULL_EXIT=1
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should not include "restore complete!"
+  End
+End

--- a/addons/postgresql/templates/actionset-pgdump.yaml
+++ b/addons/postgresql/templates/actionset-pgdump.yaml
@@ -66,6 +66,7 @@ spec:
       - schemas
       - tables
       - schema_only
+      - conflict_policy
     postReady:
     - job:
         image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:$(IMAGE_TAG)


### PR DESCRIPTION
## Problem

Both Selective restore paths can report success without restoring anything (`docs/addon-api/09c-restore-and-rebuild.md`: restore phase success must not be claimed when the artifact/business data was never applied):

1. **pgdumpall-restore.sh** — when `${DP_BACKUP_NAME}.sql.zst` is absent from the repository, the only if-block is skipped and the script falls through to an implicit `exit 0`. A missing backup restores nothing, and the restore job reports success. This is a silent downgrade of restore semantics.
2. **pgdump-restore.sh** — no `set -e`, so a failed `datasafed pull` (missing/corrupt artifact) doesn't stop the script; and the `errors ignored on restore` grep forced `exit 0` under **every** conflict policy, including `FAIL`.
3. **actionset-pgdump.yaml** — `conflict_policy` is declared in `parametersSchema` (enum `CONTINUE/FAIL/DROP`, default `CONTINUE`) and the restore script branches on it, but it was never listed in `restore.withParameters`, so the env was never injected: the `DROP`/`FAIL` branches were dead code and every restore silently ran as `CONTINUE`.

Fixes #3008

## Changes

- Both restore scripts verify the backup artifact exists in the repository before pulling, and exit 1 with a clear error otherwise.
- `pgdump-restore.sh` runs under `set -e` for the setup phase; the `pg_restore` exit code is captured explicitly, and the ignored-errors → success downgrade now applies only to non-`FAIL` policies (`CONTINUE`'s continue-past-conflicts semantics are unchanged).
- `pg_restore` stderr now goes through a synchronous `tee` (PIPESTATUS) instead of an async `2> >(tee …)` process substitution — the log that the policy decision greps is guaranteed complete before it is read.
- `conflict_policy` added to `restore.withParameters`.
- shellspec coverage for both scripts (10 examples): missing artifact fails loudly and never reaches `pg_restore`/`psql`, success path, mid-stream pull failure, `pg_restore`/`psql` failures, and CONTINUE vs FAIL policy semantics. Neither script had any coverage before.

## Evidence boundary

Static analysis + shellspec unit tests (postgresql suite 23/23 green locally, shellcheck clean at CI severity). Not reproduced on a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)