### PR TITLE
feat(valkey): cluster topology phase B — formation and shard scale

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
@@ -161,6 +161,81 @@ Describe "valkey-cluster-manage.sh"
       The stdout should include ""
     End
   End
+  Describe "drive_shard_completion() — r3 CT05 livelock fix"
+    # r3 live evidence: after one failed replica attach, the old
+    # present-branch only observed ("shard present but full membership
+    # not yet complete") and never re-drove the attach. The driver must
+    # ACT from any partial state, not defer.
+
+    It "drives the missing replica attach when the shard master is present with slots (livelock regression)"
+      node_id_of() { echo "mid-new"; }
+      slots_owned_by() { echo "120"; }
+      ensure_replica_bound() { echo "DRIVE ${2}"; }
+      shard_membership_bound() { return 0; }
+      all_expected_members_present() { return 0; }
+      build_cli() { _cli=(true); }
+      When call drive_shard_completion "via.h" "vk-shard-abc-0.h.ns.svc"
+      The status should be success
+      The stdout should include "DRIVE vk-shard-abc-1.h.ns.svc"
+      The stdout should include "membership bound"
+    End
+
+    It "re-drives rebalance when the shard master owns zero slots"
+      node_id_of() { echo "mid-new"; }
+      # command-substitution runs the stub in a subshell, so state must
+      # live in a file: first call reports 0 slots, later calls 200.
+      _slots_marker=$(mktemp)
+      slots_owned_by() {
+        if [ -s "${_slots_marker}" ]; then echo "200"; else echo seen > "${_slots_marker}"; echo "0"; fi
+      }
+      build_cluster_cli() { _ccli=(mock_reb); }
+      mock_reb() { echo "rebalanced"; }
+      ensure_replica_bound() { return 0; }
+      shard_membership_bound() { return 0; }
+      all_expected_members_present() { return 0; }
+      build_cli() { _cli=(true); }
+      When call drive_shard_completion "via.h" "vk-shard-abc-0.h.ns.svc"
+      The status should be success
+      The stdout should include "complete: 200 slots"
+    End
+
+    It "classifies a rebalance failure as retry-safe (re-entry re-drives)"
+      node_id_of() { echo "mid-new"; }
+      slots_owned_by() { echo "0"; }
+      build_cluster_cli() { _ccli=(mock_reb_fail); }
+      mock_reb_fail() { echo "[ERR] Nodes don't agree about configuration!" >&2; return 1; }
+      When call drive_shard_completion "via.h" "vk-shard-abc-0.h.ns.svc"
+      The status should be failure
+      The stderr should include "phase=join-rebalance"
+      The stderr should include "retry_safe=yes"
+    End
+
+    It "classifies a transient replica add-node preflight failure as retry-safe"
+      build_cli() { _cli=(mock_empty_nodes); }
+      mock_empty_nodes() { printf ''; }
+      build_cluster_cli() { _ccli=(mock_add_fail); }
+      mock_add_fail() { echo "[ERR] Nodes don't agree about configuration!" >&2; return 1; }
+      When call ensure_replica_bound "via.h" "vk-shard-abc-1.h.ns.svc" "mid-new" "shard-abc"
+      The status should be failure
+      The stderr should include "phase=attach-add-node"
+      The stderr should include "retry_safe=yes"
+    End
+
+    It "routes the present-branch of verify_or_join into the driver (no observe-only dead end)"
+      each_shard_fqdn_list() {
+        printf 'SHARD_ABC vk-shard-abc-0.h.ns.svc,vk-shard-abc-1.h.ns.svc\n'
+      }
+      cluster_state_of() { echo "ok"; }
+      build_cli() { _cli=(mock_nodes_present); }
+      mock_nodes_present() { printf 'mid-new vk-shard-abc-0.h.ns.svc:6379@16379 master - 0 0 1 connected 0-5460\n'; }
+      drive_shard_completion() { echo "DRIVEN via=${1} self=${2}"; }
+      When call verify_or_join
+      The status should be success
+      The stdout should include "DRIVEN"
+      The stdout should include "self=vk-shard-abc-0.h.ns.svc"
+    End
+  End
+
   Describe "shard_membership_bound()"
     nodes3ok='m1 vk-s-a-0.h:6379@16379 master - 0 0 1 connected 0-5460
 s1 vk-s-a-1.h:6379@16379 slave m1 0 0 1 connected'

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
@@ -47,6 +47,7 @@ Describe "valkey-cluster-manage.sh"
       export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-aaa:shard-aaa,shard-aaa:shard-aaa"
       When call coordinator_shard
       The status should be failure
+      The stderr should include "phase=shard-roster"
       The stderr should include "duplicate shard name"
     End
 
@@ -54,6 +55,7 @@ Describe "valkey-cluster-manage.sh"
       export ALL_SHARDS_COMPONENT_SHORT_NAMES=":,shard-bbb:shard-bbb"
       When call coordinator_shard
       The status should be failure
+      The stderr should include "phase=shard-roster"
       The stderr should include "empty shard name"
     End
   End
@@ -157,6 +159,30 @@ Describe "valkey-cluster-manage.sh"
       The stderr should include "retry_safe=yes"
       The stderr should include "still owns 5 slots"
       The stdout should include ""
+    End
+  End
+  Describe "shard_membership_bound()"
+    nodes3ok='m1 vk-s-a-0.h:6379@16379 master - 0 0 1 connected 0-5460
+s1 vk-s-a-1.h:6379@16379 slave m1 0 0 1 connected'
+    It "passes when the shard has one master and slaves bound to it"
+      When call shard_membership_bound "${nodes3ok}" "SHARD_A" "vk-s-a-0.h,vk-s-a-1.h"
+      The status should be success
+    End
+
+    It "fails when a non-first pod is a stray master"
+      nodes_bad='m1 vk-s-a-0.h:6379@16379 master - 0 0 1 connected 0-5460
+m2 vk-s-a-1.h:6379@16379 master - 0 0 2 connected'
+      When call shard_membership_bound "${nodes_bad}" "SHARD_A" "vk-s-a-0.h,vk-s-a-1.h"
+      The status should be failure
+      The stdout should include "2 in-shard master(s), expected exactly 1"
+    End
+
+    It "fails when a pod replicates a foreign master"
+      nodes_bad2='m1 vk-s-a-0.h:6379@16379 master - 0 0 1 connected 0-5460
+s1 vk-s-a-1.h:6379@16379 slave OTHER 0 0 1 connected'
+      When call shard_membership_bound "${nodes_bad2}" "SHARD_A" "vk-s-a-0.h,vk-s-a-1.h"
+      The status should be failure
+      The stdout should include "replicates OTHER, not this shard's master m1"
     End
   End
 End

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
@@ -30,7 +30,8 @@ Describe "valkey-cluster-manage.sh"
       The status should be failure
       The stderr should include "ALL_SHARDS_COMPONENT_SHORT_NAMES"
       The stderr should include "CURRENT_SHARD_COMPONENT_SHORT_NAME"
-      The stderr should include "hard fail (no fallback)"
+      The stderr should include "retry_safe=no"
+      The stderr should include "no fallback"
     End
   End
 
@@ -117,8 +118,8 @@ Describe "valkey-cluster-manage.sh"
       mock_pong() { echo PONG; }
       When call form_cluster
       The status should be failure
-      The stderr should include "needs >=3"
-      The stderr should include "retry-safe"
+      The stderr should include "phase=formation-wait-shards"
+      The stderr should include "retry_safe=yes"
       The stdout should include ""
     End
 
@@ -132,8 +133,8 @@ Describe "valkey-cluster-manage.sh"
       mock_silent() { return 1; }
       When call form_cluster
       The status should be failure
-      The stderr should include "not answering yet"
-      The stderr should include "retry-safe"
+      The stderr should include "phase=formation-wait-primaries"
+      The stderr should include "retry_safe=yes"
     End
   End
 
@@ -152,8 +153,9 @@ Describe "valkey-cluster-manage.sh"
       # shard_remove exits; run in subshell via run
       When run shard_remove
       The status should be failure
+      The stderr should include "phase=remove-slots-nonzero"
+      The stderr should include "retry_safe=yes"
       The stderr should include "still owns 5 slots"
-      The stderr should include "NOT removing nodes"
       The stdout should include ""
     End
   End

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_manage_spec.sh
@@ -1,0 +1,160 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+# Phase B behavioral tests for valkey-cluster-manage.sh (issue #3026):
+# deterministic coordinator election (hard-fail on bad input), slot
+# arithmetic, and the drain-then-prove shard-removal gate.
+
+Describe "valkey-cluster-manage.sh"
+  Include ../scripts/valkey-cluster-manage.sh
+
+  base_env() {
+    export CURRENT_POD_NAME="vk-shard-abc-0"
+    export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-abc"
+    export CURRENT_SHARD_POD_FQDN_LIST="vk-shard-abc-0.h.ns.svc,vk-shard-abc-1.h.ns.svc"
+    export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-abc:shard-abc,shard-def:shard-def,shard-ghi:shard-ghi"
+    export SERVICE_PORT="6379"
+    unset VALKEY_DEFAULT_PASSWORD VALKEY_CLI_TLS_ARGS
+  }
+  base_cleanup() {
+    unset CURRENT_POD_NAME CURRENT_SHARD_COMPONENT_SHORT_NAME CURRENT_SHARD_POD_FQDN_LIST \
+          ALL_SHARDS_COMPONENT_SHORT_NAMES SERVICE_PORT
+  }
+  Before "base_env"
+  After "base_cleanup"
+
+  Describe "validate_manage_env()"
+    It "hard-fails listing missing inputs"
+      unset ALL_SHARDS_COMPONENT_SHORT_NAMES CURRENT_SHARD_COMPONENT_SHORT_NAME
+      When call validate_manage_env
+      The status should be failure
+      The stderr should include "ALL_SHARDS_COMPONENT_SHORT_NAMES"
+      The stderr should include "CURRENT_SHARD_COMPONENT_SHORT_NAME"
+      The stderr should include "hard fail (no fallback)"
+    End
+  End
+
+  Describe "coordinator_shard()"
+    It "picks the lexicographically first shard deterministically"
+      export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-zzz:shard-zzz,shard-aaa:shard-aaa,shard-mmm:shard-mmm"
+      When call coordinator_shard
+      The status should be success
+      The stdout should equal "shard-aaa"
+    End
+
+    It "hard-fails on a duplicate shard name (unstable input, no fallback)"
+      export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-aaa:shard-aaa,shard-aaa:shard-aaa"
+      When call coordinator_shard
+      The status should be failure
+      The stderr should include "duplicate shard name"
+    End
+
+    It "hard-fails on an empty entry"
+      export ALL_SHARDS_COMPONENT_SHORT_NAMES=":,shard-bbb:shard-bbb"
+      When call coordinator_shard
+      The status should be failure
+      The stderr should include "empty shard name"
+    End
+  End
+
+  Describe "self_is_coordinator_pod()"
+    It "is true only for the first pod of the coordinator shard"
+      export CURRENT_POD_NAME="vk-shard-abc-0"
+      When call self_is_coordinator_pod "shard-abc"
+      The status should be success
+    End
+
+    It "is false for a non-first pod of the coordinator shard"
+      export CURRENT_POD_NAME="vk-shard-abc-1"
+      When call self_is_coordinator_pod "shard-abc"
+      The status should be failure
+    End
+
+    It "is false for pods of other shards"
+      When call self_is_coordinator_pod "shard-def"
+      The status should be failure
+    End
+  End
+
+  Describe "slots_owned_by()"
+    It "sums slot ranges and singles from the node line"
+      build_cli() { _cli=(mock_nodes); }
+      mock_nodes() {
+        printf 'aaaa111 10.0.0.1:6379@16379 master - 0 0 1 connected 0-99 200 300-309\n'
+        printf 'bbbb222 10.0.0.2:6379@16379 master - 0 0 2 connected 5461-10922\n'
+      }
+      When call slots_owned_by "any-host" "aaaa111"
+      The status should be success
+      The stdout should equal "111"
+    End
+
+    It "ignores migrating/importing markers"
+      build_cli() { _cli=(mock_nodes2); }
+      mock_nodes2() {
+        printf 'cccc333 10.0.0.3:6379@16379 master - 0 0 3 connected 0-9 [123->-abcdef]\n'
+      }
+      When call slots_owned_by "any-host" "cccc333"
+      The status should be success
+      The stdout should equal "10"
+    End
+
+    It "returns -1 when the node id is not in the cluster view"
+      build_cli() { _cli=(mock_nodes3); }
+      mock_nodes3() { printf 'dddd444 10.0.0.4:6379@16379 master - 0 0 4 connected 0-16383\n'; }
+      When call slots_owned_by "any-host" "absent-id"
+      The status should be success
+      The stdout should equal "-1"
+    End
+  End
+
+  Describe "form_cluster() defer classification"
+    It "defers (rc=1) when fewer than 3 shards are visible"
+      each_shard_fqdn_list() {
+        printf 'SHARD_ABC vk-shard-abc-0.h.ns.svc,vk-shard-abc-1.h.ns.svc\n'
+        printf 'SHARD_DEF vk-shard-def-0.h.ns.svc\n'
+      }
+      build_cli() { _cli=(mock_pong); }
+      mock_pong() { echo PONG; }
+      When call form_cluster
+      The status should be failure
+      The stderr should include "needs >=3"
+      The stderr should include "retry-safe"
+      The stdout should include ""
+    End
+
+    It "defers when a designated primary does not answer"
+      each_shard_fqdn_list() {
+        printf 'SHARD_ABC vk-shard-abc-0.h.ns.svc\n'
+        printf 'SHARD_DEF vk-shard-def-0.h.ns.svc\n'
+        printf 'SHARD_GHI vk-shard-ghi-0.h.ns.svc\n'
+      }
+      build_cli() { _cli=(mock_silent); }
+      mock_silent() { return 1; }
+      When call form_cluster
+      The status should be failure
+      The stderr should include "not answering yet"
+      The stderr should include "retry-safe"
+    End
+  End
+
+  Describe "shard removal drain gate"
+    It "refuses node deletion while slots remain (positive zero proof required)"
+      # Simulate: drain issued but 5 slots still owned afterwards.
+      validate_manage_env() { return 0; }
+      each_shard_fqdn_list() {
+        printf 'SHARD_DEF vk-shard-def-0.h.ns.svc\n'
+      }
+      cluster_state_of() { echo "ok"; }
+      shard_master_id_via() { echo "master-id-1"; }
+      slots_owned_by() { echo "5"; }
+      build_cluster_cli() { _ccli=(mock_reb); }
+      mock_reb() { echo "rebalanced"; }
+      # shard_remove exits; run in subshell via run
+      When run shard_remove
+      The status should be failure
+      The stderr should include "still owns 5 slots"
+      The stderr should include "NOT removing nodes"
+      The stdout should include ""
+    End
+  End
+End

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
@@ -186,6 +186,26 @@ Describe "Valkey cluster template contracts"
     The stdout should equal ""
   End
 
+  # kbagent-executed actions do NOT inherit the runtime container's
+  # downward-API env (r2 live first-blocker: manage script fail-fasted on
+  # missing CURRENT_POD_NAME). Pod identity must be pinned on the ACTION
+  # env itself — asserting the runtime container env is NOT sufficient.
+  action_env_has_pod_name() {
+    awk "/^    ${2}:/,/^      retryPolicy:/" "${1}" | grep -c "name: CURRENT_POD_NAME"
+  }
+
+  It "pins CURRENT_POD_NAME on the postProvision ACTION env (not just runtime)"
+    When call action_env_has_pod_name "${cmpd}" "postProvision"
+    The status should be success
+    The stdout should equal "1"
+  End
+
+  It "pins CURRENT_POD_NAME on the shardRemove ACTION env (not just runtime)"
+    When call action_env_has_pod_name "${shardingdef}" "shardRemove"
+    The status should be success
+    The stdout should equal "1"
+  End
+
   It "declares shardRemove backed by the drain-then-prove manage script"
     # Shard scale is only legal WITH the slot-drain script (the
     # shardRemove-vs-preTerminate data-safety trap): the action and the

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
@@ -170,6 +170,22 @@ Describe "Valkey cluster template contracts"
     The status should be failure
   End
 
+  It "wires postProvision preCondition at the action level (KB Action API shape)"
+    # Live install first-blocker (kubeblocks-tests #583): 'precondition'
+    # nested under exec is not a CRD field and fails addon install. The
+    # correct shape is action-level 'preCondition', a SIBLING of exec —
+    # same as the sentinel cmpd prior art.
+    When call grep -c "^      preCondition: RuntimeReady" "${cmpd}"
+    The status should be success
+    The stdout should equal "1"
+  End
+
+  It "carries no exec-nested lowercase 'precondition:' anywhere in the cluster cmpd"
+    When call grep -E "precondition:" "${cmpd}"
+    The status should be failure
+    The stdout should equal ""
+  End
+
   It "declares shardRemove backed by the drain-then-prove manage script"
     # Shard scale is only legal WITH the slot-drain script (the
     # shardRemove-vs-preTerminate data-safety trap): the action and the

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
@@ -170,11 +170,13 @@ Describe "Valkey cluster template contracts"
     The status should be failure
   End
 
-  It "declares no shard lifecycle actions yet (phase B owns shardRemove)"
-    # Guard: shard scale must not be enabled before the slot-drain script
-    # exists (shardRemove-vs-preTerminate data-safety trap). Match YAML
-    # keys only; the design comment legitimately mentions the action name.
-    When call grep -E "^[[:space:]]*(shardRemove|shardAdd|lifecycleActions):" "${shardingdef}"
-    The status should be failure
+  It "declares shardRemove backed by the drain-then-prove manage script"
+    # Shard scale is only legal WITH the slot-drain script (the
+    # shardRemove-vs-preTerminate data-safety trap): the action and the
+    # script must appear together.
+    When call grep -E "shardRemove:|valkey-cluster-manage.sh --shard-remove" "${shardingdef}"
+    The status should be success
+    The stdout should include "shardRemove:"
+    The stdout should include "--shard-remove"
   End
 End

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -131,14 +131,14 @@ coordinator_shard() {
   IFS=',' read -ra _entries <<< "${raw}"
   for entry in "${_entries[@]}"; do
     name="${entry%%:*}"
-    [ -z "${name}" ] && { echo "ERROR: empty shard name in ALL_SHARDS_COMPONENT_SHORT_NAMES='${raw}'." >&2; return 1; }
+    [ -z "${name}" ] && { classify shard-roster no "empty shard name in ALL_SHARDS_COMPONENT_SHORT_NAMES='${raw}'"; return 1; }
     if echo "${names}" | tr ' ' '\n' | grep -qx "${name}"; then
-      echo "ERROR: duplicate shard name '${name}' in ALL_SHARDS_COMPONENT_SHORT_NAMES='${raw}'." >&2
+      classify shard-roster no "duplicate shard name '${name}' in ALL_SHARDS_COMPONENT_SHORT_NAMES='${raw}'"
       return 1
     fi
     names="${names} ${name}"
   done
-  [ -z "${names// }" ] && { echo "ERROR: ALL_SHARDS_COMPONENT_SHORT_NAMES is empty." >&2; return 1; }
+  [ -z "${names// }" ] && { classify shard-roster no "ALL_SHARDS_COMPONENT_SHORT_NAMES is empty"; return 1; }
   echo "${names}" | tr ' ' '\n' | grep -v '^$' | sort | head -1
 }
 
@@ -148,7 +148,7 @@ each_shard_fqdn_list() {
   local var value shard
   while IFS='=' read -r var value; do
     shard="${var#ALL_SHARDS_POD_FQDN_LIST_}"
-    [ -z "${value}" ] && { echo "ERROR: ${var} is empty." >&2; return 1; }
+    [ -z "${value}" ] && { classify shard-roster no "${var} is empty"; return 1; }
     echo "${shard} ${value}"
   done < <(env | grep -E '^ALL_SHARDS_POD_FQDN_LIST_[A-Za-z0-9_]+=' | sort)
 }
@@ -185,25 +185,59 @@ cluster_formed_from_self() {
 # a master there. rc=0 must never settle for state/slot totals alone
 # (review: totals can be right while pods are missing or unattached).
 all_expected_members_present() {
-  local via="${1}" nodes shard_line shard fqdns fqdn missing=0
+  local via="${1}" nodes shard_line shard fqdns missing=0
   build_cli "${via}"
   nodes=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r')
   [ -z "${nodes}" ] && return 1
   while read -r shard_line; do
     shard="${shard_line%% *}"
     fqdns="${shard_line#* }"
-    for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$'); do
-      if ! echo "${nodes}" | grep -qF "${fqdn}"; then
-        echo "membership incomplete: ${fqdn} (shard ${shard}) not in cluster view."
-        missing=1
-      fi
-    done
-    if [ "$(echo "${nodes}" | grep -E "$(echo "${fqdns}" | tr ',' '|')" | awk '$3 ~ /master/' | grep -c .)" -lt 1 ]; then
-      echo "membership incomplete: shard ${shard} has no master in cluster view."
-      missing=1
-    fi
+    shard_membership_bound "${nodes}" "${shard}" "${fqdns}" || missing=1
   done < <(each_shard_fqdn_list)
   [ "${missing}" -eq 0 ]
+}
+
+# Strict per-shard binding (round-2 review): the shard must have exactly
+# one in-shard master, and EVERY other in-shard pod's node line must carry
+# the slave flag AND reference that master's id. Presence alone would let
+# a stray master or a cross-shard replica pass as success.
+shard_membership_bound() {
+  local nodes="${1}" shard="${2}" fqdns="${3}"
+  local pattern="" fqdn line master_line master_id master_count flags parent
+  for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$'); do
+    pattern="${pattern:+${pattern}|}${fqdn}"
+  done
+  master_count=$(echo "${nodes}" | grep -E "${pattern}" | awk '$3 ~ /master/' | grep -c .)
+  if [ "${master_count}" -ne 1 ]; then
+    echo "membership incomplete: shard ${shard} has ${master_count} in-shard master(s), expected exactly 1."
+    return 1
+  fi
+  master_line=$(echo "${nodes}" | grep -E "${pattern}" | awk '$3 ~ /master/ {print; exit}')
+  master_id=$(echo "${master_line}" | awk '{print $1}')
+  local bad=0
+  for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$'); do
+    line=$(echo "${nodes}" | grep -F "${fqdn}" | head -1)
+    if [ -z "${line}" ]; then
+      echo "membership incomplete: ${fqdn} (shard ${shard}) not in cluster view."
+      bad=1
+      continue
+    fi
+    flags=$(echo "${line}" | awk '{print $3}')
+    case "${flags}" in
+      *master*) continue ;;
+    esac
+    if ! echo "${flags}" | grep -q slave; then
+      echo "membership incomplete: ${fqdn} (shard ${shard}) is neither master nor slave (flags=${flags})."
+      bad=1
+      continue
+    fi
+    parent=$(echo "${line}" | awk '{print $4}')
+    if [ "${parent}" != "${master_id}" ]; then
+      echo "membership incomplete: ${fqdn} (shard ${shard}) replicates ${parent}, not this shard's master ${master_id}."
+      bad=1
+    fi
+  done
+  return "${bad}"
 }
 
 # Coordinator: create the cluster from one designated first-pod per shard,
@@ -334,17 +368,16 @@ verify_or_join() {
     classify join-slots yes "new shard joined but owns ${own} slots after rebalance"
     return 1
   fi
-  # positive completeness: every pod of THIS shard must be in the view
-  local nodes vfqdn
+  # positive completeness: strict binding for THIS shard (exactly one
+  # in-shard master; every other pod a slave of that master)
+  local nodes
   build_cli "${self_first}"
   nodes=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r')
-  for vfqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$'); do
-    if ! echo "${nodes}" | grep -qF "${vfqdn}"; then
-      classify join-membership yes "pod ${vfqdn} of this shard not yet in cluster view"
-      return 1
-    fi
-  done
-  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} joined with ${own} slots; all shard pods in view."
+  if ! shard_membership_bound "${nodes}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" "${CURRENT_SHARD_POD_FQDN_LIST}"; then
+    classify join-membership yes "this shard's pods not yet fully bound (master+replicas) in cluster view"
+    return 1
+  fi
+  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} joined with ${own} slots; membership bound."
 }
 
 attach_shard_replicas_to() {

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -1,0 +1,444 @@
+#!/bin/bash
+# valkey-cluster-manage.sh — cluster formation and shard scale for Valkey
+# Cluster (sharding) mode. Phase B of issue #3021 (issue #3026).
+#
+# Modes:
+#   --post-provision   form the cluster (coordinator) or verify/join (others)
+#   --shard-remove     drain this shard's slots, prove zero, remove its nodes
+#
+# Contract (single-shot bootstrap-or-defer, kbagent 60s clamp):
+#   Every invocation either POSITIVELY observes its goal state and exits 0,
+#   or classifies the deferral on stderr and exits 1 for the framework to
+#   retry. No in-script long polling; no random sleeps. Topology (CLUSTER
+#   NODES / INFO) is re-read on every invocation — never cached across runs.
+#
+# Coordinator election is deterministic: the lexicographically first shard
+# short name in ALL_SHARDS_COMPONENT_SHORT_NAMES owns formation, executed
+# from its lexicographically first pod. Empty/duplicated inputs hard-fail —
+# never fall back to "current pod" (design review, Slock #valkey:a7e4c67f).
+#
+# Member identity is always the engine-native CLUSTER MYID — pod names are
+# only transport addresses, never identity.
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  # when running in non-unit test mode, set the options "set -ex".
+  set -ex;
+}
+
+set -e
+
+load_common_library() {
+  # shellcheck source=/dev/null
+  source /scripts/common.sh
+}
+
+# ── env contract ─────────────────────────────────────────────────────────────
+
+validate_manage_env() {
+  local missing=""
+  [ -z "${CURRENT_POD_NAME:-}" ] && missing="${missing} CURRENT_POD_NAME"
+  [ -z "${CURRENT_SHARD_COMPONENT_SHORT_NAME:-}" ] && missing="${missing} CURRENT_SHARD_COMPONENT_SHORT_NAME"
+  [ -z "${CURRENT_SHARD_POD_FQDN_LIST:-}" ] && missing="${missing} CURRENT_SHARD_POD_FQDN_LIST"
+  [ -z "${ALL_SHARDS_COMPONENT_SHORT_NAMES:-}" ] && missing="${missing} ALL_SHARDS_COMPONENT_SHORT_NAMES"
+  [ -z "${SERVICE_PORT:-}" ] && missing="${missing} SERVICE_PORT"
+  if [ -n "${missing}" ]; then
+    echo "ERROR: valkey-cluster-manage.sh missing required env:${missing} — hard fail (no fallback)." >&2
+    return 1
+  fi
+  return 0
+}
+
+# ── cli helpers ──────────────────────────────────────────────────────────────
+
+build_cli() {
+  local host="${1}"
+  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${SERVICE_PORT}")
+  if [ -n "${VALKEY_DEFAULT_PASSWORD:-}" ]; then
+    _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS:-}" ]; then
+    # shellcheck disable=SC2206
+    _cli+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+# --cluster subcommands authenticate the same way
+build_cluster_cli() {
+  _ccli=(valkey-cli --no-auth-warning)
+  if [ -n "${VALKEY_DEFAULT_PASSWORD:-}" ]; then
+    _ccli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS:-}" ]; then
+    # shellcheck disable=SC2206
+    _ccli+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+cluster_state_of() {
+  local host="${1}"
+  build_cli "${host}"
+  "${_cli[@]}" CLUSTER INFO 2>/dev/null | grep "^cluster_state:" | tr -d '\r' | cut -d: -f2
+}
+
+assigned_slots_of() {
+  local host="${1}"
+  build_cli "${host}"
+  "${_cli[@]}" CLUSTER INFO 2>/dev/null | grep "^cluster_slots_assigned:" | tr -d '\r' | cut -d: -f2
+}
+
+node_id_of() {
+  local host="${1}"
+  build_cli "${host}"
+  "${_cli[@]}" CLUSTER MYID 2>/dev/null | tr -d '\r\n'
+}
+
+# Slot count currently owned by the master whose id is $2, read from $1's
+# view of CLUSTER NODES. Prints the count of slot ranges' total slots.
+slots_owned_by() {
+  local via_host="${1}" node_id="${2}"
+  local line ranges total=0 range
+  build_cli "${via_host}"
+  line=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | awk -v id="${node_id}" '$1 == id')
+  [ -z "${line}" ] && { echo "-1"; return 0; }
+  ranges=$(echo "${line}" | cut -d' ' -f9-)
+  for range in ${ranges}; do
+    case "${range}" in
+      \[*\]) continue ;;  # migrating/importing markers
+      *-*) total=$(( total + ${range#*-} - ${range%-*} + 1 )) ;;
+      ''|*[!0-9]*) continue ;;
+      *) total=$(( total + 1 )) ;;
+    esac
+  done
+  echo "${total}"
+}
+
+# ── deterministic coordinator ────────────────────────────────────────────────
+
+# Prints the coordinator shard short name. Hard-fails on empty/duplicate
+# entries — an unstable input must stop the action, not pick "myself".
+coordinator_shard() {
+  local raw="${ALL_SHARDS_COMPONENT_SHORT_NAMES}"
+  local entry name names=""
+  IFS=',' read -ra _entries <<< "${raw}"
+  for entry in "${_entries[@]}"; do
+    name="${entry%%:*}"
+    [ -z "${name}" ] && { echo "ERROR: empty shard name in ALL_SHARDS_COMPONENT_SHORT_NAMES='${raw}'." >&2; return 1; }
+    if echo "${names}" | tr ' ' '\n' | grep -qx "${name}"; then
+      echo "ERROR: duplicate shard name '${name}' in ALL_SHARDS_COMPONENT_SHORT_NAMES='${raw}'." >&2
+      return 1
+    fi
+    names="${names} ${name}"
+  done
+  [ -z "${names// }" ] && { echo "ERROR: ALL_SHARDS_COMPONENT_SHORT_NAMES is empty." >&2; return 1; }
+  echo "${names}" | tr ' ' '\n' | grep -v '^$' | sort | head -1
+}
+
+# All shard FQDN lists are exposed as ALL_SHARDS_POD_FQDN_LIST_<SHARD-SUFFIX>
+# env vars (KB 'individual' strategy). Prints "shard fqdn1,fqdn2" per line.
+each_shard_fqdn_list() {
+  local var value shard
+  while IFS='=' read -r var value; do
+    shard="${var#ALL_SHARDS_POD_FQDN_LIST_}"
+    [ -z "${value}" ] && { echo "ERROR: ${var} is empty." >&2; return 1; }
+    echo "${shard} ${value}"
+  done < <(env | grep -E '^ALL_SHARDS_POD_FQDN_LIST_[A-Za-z0-9_]+=' | sort)
+}
+
+first_fqdn_of_list() {
+  echo "${1}" | tr ',' '\n' | grep -v '^$' | sort | head -1
+}
+
+self_is_coordinator_pod() {
+  local coord_shard="${1}"
+  local self_short_upper coord_upper
+  # env var suffixes are uppercased with '-' mapped to '_'
+  coord_upper=$(echo "${coord_shard}" | tr '[:lower:]-' '[:upper:]_')
+  self_short_upper=$(echo "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" | tr '[:lower:]-' '[:upper:]_')
+  [ "${self_short_upper}" != "${coord_upper}" ] && return 1
+  local my_shard_first
+  my_shard_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
+  [ "${my_shard_first%%.*}" = "${CURRENT_POD_NAME}" ]
+}
+
+# ── formation ────────────────────────────────────────────────────────────────
+
+# Positive goal check used by every path: state ok and all 16384 slots
+# assigned, observed from this pod.
+cluster_formed_from_self() {
+  local self_fqdn state slots
+  self_fqdn=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")  # any shard member works; use self pod
+  state=$(cluster_state_of "127.0.0.1")
+  slots=$(assigned_slots_of "127.0.0.1")
+  [ "${state}" = "ok" ] && [ "${slots}" = "16384" ]
+}
+
+# Coordinator: create the cluster from one designated first-pod per shard,
+# then attach the remaining pods of each shard as replicas of that shard's
+# master. The first-pod choice is an ASSIGNMENT at creation time (roles may
+# move later via failover) — never an assumption elsewhere.
+form_cluster() {
+  local shard_line shard fqdns first rest fqdn
+  local primaries=()
+  local -A shard_first=()
+
+  while read -r shard_line; do
+    shard="${shard_line%% *}"
+    fqdns="${shard_line#* }"
+    first=$(first_fqdn_of_list "${fqdns}")
+    # every designated primary must answer before creation — else defer
+    if ! build_cli "${first}" || ! "${_cli[@]}" PING 2>/dev/null | grep -q PONG; then
+      echo "DEFER: shard ${shard} first pod ${first} not answering yet — retry (transient, retry-safe)." >&2
+      return 1
+    fi
+    primaries+=("${first}:${SERVICE_PORT}")
+    shard_first["${shard}"]="${first}"
+  done < <(each_shard_fqdn_list)
+
+  if [ "${#primaries[@]}" -lt 3 ]; then
+    echo "DEFER: only ${#primaries[@]} shard(s) visible; cluster create needs >=3 — retry (transient, retry-safe)." >&2
+    return 1
+  fi
+
+  build_cluster_cli
+  local create_out
+  create_out=$(echo yes | "${_ccli[@]}" --cluster create "${primaries[@]}" --cluster-yes 2>&1) || {
+    echo "ERROR: cluster create failed: ${create_out}" >&2
+    return 1
+  }
+  echo "cluster create issued across ${#primaries[@]} primaries."
+
+  attach_all_replicas || return 1
+  cluster_formed_from_self || {
+    echo "DEFER: create issued but state/slots not converged yet — retry (transient, retry-safe)." >&2
+    return 1
+  }
+  echo "cluster formed: state ok, 16384/16384 slots assigned."
+}
+
+# Attach every non-first pod of every shard as a replica of that shard's
+# master (identified by engine node id, resolved fresh each invocation).
+attach_all_replicas() {
+  local shard_line shard fqdns first rest fqdn master_id add_out
+  while read -r shard_line; do
+    shard="${shard_line%% *}"
+    fqdns="${shard_line#* }"
+    first=$(first_fqdn_of_list "${fqdns}")
+    master_id=$(node_id_of "${first}")
+    if [ -z "${master_id}" ]; then
+      echo "DEFER: cannot read CLUSTER MYID from ${first} — retry (transient, retry-safe)." >&2
+      return 1
+    fi
+    for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$' | sort); do
+      [ "${fqdn}" = "${first}" ] && continue
+      # already a member? (idempotency: skip nodes the master already knows)
+      build_cli "${first}"
+      if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${fqdn}"; then
+        continue
+      fi
+      build_cluster_cli
+      add_out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${first}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
+        echo "ERROR: add replica ${fqdn} to shard ${shard} failed: ${add_out}" >&2
+        return 1
+      }
+      echo "attached ${fqdn} as replica of shard ${shard} (master ${master_id})."
+    done
+  done < <(each_shard_fqdn_list)
+}
+
+# Non-coordinator (or late shard) path: if the cluster is formed and this
+# shard's members are attached, succeed; if formed but self not attached,
+# join as the scale-out path; otherwise defer.
+verify_or_join() {
+  local any_formed_host="" shard_line fqdns first state
+  while read -r shard_line; do
+    fqdns="${shard_line#* }"
+    first=$(first_fqdn_of_list "${fqdns}")
+    state=$(cluster_state_of "${first}")
+    if [ "${state}" = "ok" ]; then
+      any_formed_host="${first}"
+      break
+    fi
+  done < <(each_shard_fqdn_list)
+
+  if [ -z "${any_formed_host}" ]; then
+    echo "DEFER: no formed cluster visible yet (coordinator still working) — retry (transient, retry-safe)." >&2
+    return 1
+  fi
+
+  local self_first master_id
+  self_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
+  build_cli "${any_formed_host}"
+  if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${self_first}"; then
+    echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} already a cluster member."
+    return 0
+  fi
+
+  # scale-out: join this shard's first pod as a new master, rebalance slots
+  # to it, then attach the shard's replicas.
+  build_cluster_cli
+  local add_out
+  add_out=$("${_ccli[@]}" --cluster add-node "${self_first}:${SERVICE_PORT}" "${any_formed_host}:${SERVICE_PORT}" 2>&1) || {
+    echo "ERROR: add-node ${self_first} failed: ${add_out}" >&2
+    return 1
+  }
+  master_id=$(node_id_of "${self_first}")
+  if [ -z "${master_id}" ]; then
+    echo "DEFER: joined but CLUSTER MYID unreadable from ${self_first} — retry (transient, retry-safe)." >&2
+    return 1
+  fi
+  local rebalance_out
+  rebalance_out=$("${_ccli[@]}" --cluster rebalance "${any_formed_host}:${SERVICE_PORT}" --cluster-use-empty-masters 2>&1) || {
+    echo "ERROR: rebalance toward new shard failed: ${rebalance_out}" >&2
+    return 1
+  }
+  attach_shard_replicas_to "${self_first}" "${master_id}" || return 1
+  local own
+  own=$(slots_owned_by "${self_first}" "${master_id}")
+  if [ "${own}" -le 0 ]; then
+    echo "DEFER: new shard joined but owns ${own} slots after rebalance — retry (transient, retry-safe)." >&2
+    return 1
+  fi
+  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} joined with ${own} slots."
+}
+
+attach_shard_replicas_to() {
+  local master_fqdn="${1}" master_id="${2}" fqdn add_out
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | sort); do
+    [ "${fqdn}" = "${master_fqdn}" ] && continue
+    build_cli "${master_fqdn}"
+    if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${fqdn}"; then
+      continue
+    fi
+    build_cluster_cli
+    add_out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${master_fqdn}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
+      echo "ERROR: add replica ${fqdn} failed: ${add_out}" >&2
+      return 1
+    }
+  done
+}
+
+post_provision() {
+  validate_manage_env || exit 1
+  if cluster_formed_from_self; then
+    echo "cluster already formed (state ok, 16384 slots) — nothing to do."
+    exit 0
+  fi
+  local coord
+  coord=$(coordinator_shard) || exit 1
+  if self_is_coordinator_pod "${coord}"; then
+    echo "this pod is the formation coordinator (shard ${coord})."
+    form_cluster || exit 1
+  else
+    verify_or_join || exit 1
+  fi
+  exit 0
+}
+
+# ── shard removal ────────────────────────────────────────────────────────────
+
+# Drain this shard's slots, POSITIVELY prove the slot count is zero, then —
+# and only then — remove the shard's nodes from the cluster. del-node
+# success alone is never the completion signal (design review hard line).
+shard_remove() {
+  validate_manage_env || exit 1
+
+  local remaining_host="" shard_line shard fqdns first
+  while read -r shard_line; do
+    shard="${shard_line%% *}"
+    fqdns="${shard_line#* }"
+    [ "${shard}" = "$(echo "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" | tr '[:lower:]-' '[:upper:]_')" ] && continue
+    first=$(first_fqdn_of_list "${fqdns}")
+    if [ "$(cluster_state_of "${first}")" = "ok" ]; then
+      remaining_host="${first}"
+      break
+    fi
+  done < <(each_shard_fqdn_list)
+  if [ -z "${remaining_host}" ]; then
+    echo "ERROR: no healthy remaining shard visible to receive slots — refusing shard removal." >&2
+    exit 1
+  fi
+
+  local self_first master_id
+  self_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
+  # the shard's CURRENT master may not be the first pod (failovers move
+  # roles) — resolve the master id from the cluster's own view.
+  master_id=$(shard_master_id_via "${remaining_host}")
+  if [ -z "${master_id}" ]; then
+    # No master of this shard known to the cluster: shard is already out —
+    # classify NotFound explicitly as closable only when no slots dangle.
+    echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} has no master in cluster view — treating as already removed."
+    exit 0
+  fi
+
+  local own
+  own=$(slots_owned_by "${remaining_host}" "${master_id}")
+  if [ "${own}" -gt 0 ]; then
+    build_cluster_cli
+    local reb_out
+    reb_out=$("${_ccli[@]}" --cluster rebalance "${remaining_host}:${SERVICE_PORT}" --cluster-weight "${master_id}=0" 2>&1) || {
+      echo "ERROR: slot drain (rebalance weight=0) failed: ${reb_out}" >&2
+      exit 1
+    }
+    own=$(slots_owned_by "${remaining_host}" "${master_id}")
+  fi
+  if [ "${own}" -ne 0 ]; then
+    echo "DEFER: shard still owns ${own} slots after drain — NOT removing nodes; retry (retry-safe)." >&2
+    exit 1
+  fi
+  echo "slot drain proven: shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} owns 0 slots."
+
+  # remove replicas first, master last
+  local node_line node_id fqdn
+  build_cli "${remaining_host}"
+  while read -r node_line; do
+    node_id="${node_line%% *}"
+    build_cluster_cli
+    local del_out
+    del_out=$("${_ccli[@]}" --cluster del-node "${remaining_host}:${SERVICE_PORT}" "${node_id}" 2>&1) || {
+      echo "ERROR: del-node ${node_id} failed: ${del_out}" >&2
+      exit 1
+    }
+    echo "removed node ${node_id} from cluster."
+  done < <(shard_member_lines_via "${remaining_host}" | awk '{if ($3 ~ /slave/) print; }')
+  while read -r node_line; do
+    node_id="${node_line%% *}"
+    build_cluster_cli
+    local del_out2
+    del_out2=$("${_ccli[@]}" --cluster del-node "${remaining_host}:${SERVICE_PORT}" "${node_id}" 2>&1) || {
+      echo "ERROR: del-node ${node_id} failed: ${del_out2}" >&2
+      exit 1
+    }
+    echo "removed node ${node_id} from cluster."
+  done < <(shard_member_lines_via "${remaining_host}" | awk '{if ($3 ~ /master/) print; }')
+  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} removed cleanly (drained then deleted)."
+  exit 0
+}
+
+# CLUSTER NODES lines whose address matches any pod of the current shard.
+shard_member_lines_via() {
+  local via="${1}" fqdn pattern=""
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$'); do
+    pattern="${pattern:+${pattern}|}${fqdn}"
+  done
+  build_cli "${via}"
+  "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -E "${pattern}" || true
+}
+
+shard_master_id_via() {
+  local via="${1}"
+  shard_member_lines_via "${via}" | awk '$3 ~ /master/ {print $1; exit}'
+}
+
+# This is magic for shellspec ut framework, do not modify!
+${__SOURCED__:+false} : || return 0
+
+load_common_library
+case "${1:-}" in
+  --post-provision) post_provision ;;
+  --shard-remove)   shard_remove ;;
+  *)
+    echo "usage: $0 --post-provision | --shard-remove" >&2
+    exit 1 ;;
+esac

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -34,6 +34,13 @@ load_common_library() {
   source /scripts/common.sh
 }
 
+# Structured classification for every non-zero exit (stable, parseable):
+#   classify <phase> <retry_safe:yes|no> <detail...>
+classify() {
+  local phase="$1" retry_safe="$2"; shift 2
+  echo "action=valkey-cluster-manage phase=${phase} retry_safe=${retry_safe} detail=$*" >&2
+}
+
 # ── env contract ─────────────────────────────────────────────────────────────
 
 validate_manage_env() {
@@ -44,7 +51,7 @@ validate_manage_env() {
   [ -z "${ALL_SHARDS_COMPONENT_SHORT_NAMES:-}" ] && missing="${missing} ALL_SHARDS_COMPONENT_SHORT_NAMES"
   [ -z "${SERVICE_PORT:-}" ] && missing="${missing} SERVICE_PORT"
   if [ -n "${missing}" ]; then
-    echo "ERROR: valkey-cluster-manage.sh missing required env:${missing} — hard fail (no fallback)." >&2
+    classify env-contract no "missing required env:${missing} (no fallback)"
     return 1
   fi
   return 0
@@ -167,11 +174,36 @@ self_is_coordinator_pod() {
 # Positive goal check used by every path: state ok and all 16384 slots
 # assigned, observed from this pod.
 cluster_formed_from_self() {
-  local self_fqdn state slots
-  self_fqdn=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")  # any shard member works; use self pod
+  local state slots
   state=$(cluster_state_of "127.0.0.1")
   slots=$(assigned_slots_of "127.0.0.1")
-  [ "${state}" = "ok" ] && [ "${slots}" = "16384" ]
+  [ "${state}" = "ok" ] && [ "${slots}" = "16384" ] && all_expected_members_present "127.0.0.1"
+}
+
+# Positive membership completeness: EVERY pod of EVERY shard (KB roster)
+# must appear in the cluster view seen from $1, and every shard must have
+# a master there. rc=0 must never settle for state/slot totals alone
+# (review: totals can be right while pods are missing or unattached).
+all_expected_members_present() {
+  local via="${1}" nodes shard_line shard fqdns fqdn missing=0
+  build_cli "${via}"
+  nodes=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r')
+  [ -z "${nodes}" ] && return 1
+  while read -r shard_line; do
+    shard="${shard_line%% *}"
+    fqdns="${shard_line#* }"
+    for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$'); do
+      if ! echo "${nodes}" | grep -qF "${fqdn}"; then
+        echo "membership incomplete: ${fqdn} (shard ${shard}) not in cluster view."
+        missing=1
+      fi
+    done
+    if [ "$(echo "${nodes}" | grep -E "$(echo "${fqdns}" | tr ',' '|')" | awk '$3 ~ /master/' | grep -c .)" -lt 1 ]; then
+      echo "membership incomplete: shard ${shard} has no master in cluster view."
+      missing=1
+    fi
+  done < <(each_shard_fqdn_list)
+  [ "${missing}" -eq 0 ]
 }
 
 # Coordinator: create the cluster from one designated first-pod per shard,
@@ -181,7 +213,6 @@ cluster_formed_from_self() {
 form_cluster() {
   local shard_line shard fqdns first rest fqdn
   local primaries=()
-  local -A shard_first=()
 
   while read -r shard_line; do
     shard="${shard_line%% *}"
@@ -189,29 +220,28 @@ form_cluster() {
     first=$(first_fqdn_of_list "${fqdns}")
     # every designated primary must answer before creation — else defer
     if ! build_cli "${first}" || ! "${_cli[@]}" PING 2>/dev/null | grep -q PONG; then
-      echo "DEFER: shard ${shard} first pod ${first} not answering yet — retry (transient, retry-safe)." >&2
+      classify formation-wait-primaries yes "shard ${shard} first pod ${first} not answering yet"
       return 1
     fi
     primaries+=("${first}:${SERVICE_PORT}")
-    shard_first["${shard}"]="${first}"
   done < <(each_shard_fqdn_list)
 
   if [ "${#primaries[@]}" -lt 3 ]; then
-    echo "DEFER: only ${#primaries[@]} shard(s) visible; cluster create needs >=3 — retry (transient, retry-safe)." >&2
+    classify formation-wait-shards yes "only ${#primaries[@]} shard(s) visible; create needs >=3"
     return 1
   fi
 
   build_cluster_cli
   local create_out
   create_out=$(echo yes | "${_ccli[@]}" --cluster create "${primaries[@]}" --cluster-yes 2>&1) || {
-    echo "ERROR: cluster create failed: ${create_out}" >&2
+    classify formation-create no "cluster create failed: ${create_out}"
     return 1
   }
   echo "cluster create issued across ${#primaries[@]} primaries."
 
   attach_all_replicas || return 1
   cluster_formed_from_self || {
-    echo "DEFER: create issued but state/slots not converged yet — retry (transient, retry-safe)." >&2
+    classify formation-converge yes "create issued but state/slots/membership not converged yet"
     return 1
   }
   echo "cluster formed: state ok, 16384/16384 slots assigned."
@@ -227,7 +257,7 @@ attach_all_replicas() {
     first=$(first_fqdn_of_list "${fqdns}")
     master_id=$(node_id_of "${first}")
     if [ -z "${master_id}" ]; then
-      echo "DEFER: cannot read CLUSTER MYID from ${first} — retry (transient, retry-safe)." >&2
+      classify formation-myid yes "cannot read CLUSTER MYID from ${first}"
       return 1
     fi
     for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$' | sort); do
@@ -239,7 +269,7 @@ attach_all_replicas() {
       fi
       build_cluster_cli
       add_out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${first}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
-        echo "ERROR: add replica ${fqdn} to shard ${shard} failed: ${add_out}" >&2
+        classify formation-add-replica no "add replica ${fqdn} to shard ${shard} failed: ${add_out}"
         return 1
       }
       echo "attached ${fqdn} as replica of shard ${shard} (master ${master_id})."
@@ -263,7 +293,7 @@ verify_or_join() {
   done < <(each_shard_fqdn_list)
 
   if [ -z "${any_formed_host}" ]; then
-    echo "DEFER: no formed cluster visible yet (coordinator still working) — retry (transient, retry-safe)." >&2
+    classify join-wait-formed yes "no formed cluster visible yet (coordinator still working)"
     return 1
   fi
 
@@ -271,8 +301,12 @@ verify_or_join() {
   self_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
   build_cli "${any_formed_host}"
   if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${self_first}"; then
-    echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} already a cluster member."
-    return 0
+    if all_expected_members_present "${any_formed_host}"; then
+      echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} already a cluster member; membership complete."
+      return 0
+    fi
+    classify join-membership yes "shard present but full membership not yet complete"
+    return 1
   fi
 
   # scale-out: join this shard's first pod as a new master, rebalance slots
@@ -280,27 +314,37 @@ verify_or_join() {
   build_cluster_cli
   local add_out
   add_out=$("${_ccli[@]}" --cluster add-node "${self_first}:${SERVICE_PORT}" "${any_formed_host}:${SERVICE_PORT}" 2>&1) || {
-    echo "ERROR: add-node ${self_first} failed: ${add_out}" >&2
+    classify join-add-node no "add-node ${self_first} failed: ${add_out}"
     return 1
   }
   master_id=$(node_id_of "${self_first}")
   if [ -z "${master_id}" ]; then
-    echo "DEFER: joined but CLUSTER MYID unreadable from ${self_first} — retry (transient, retry-safe)." >&2
+    classify join-myid yes "joined but CLUSTER MYID unreadable from ${self_first}"
     return 1
   fi
   local rebalance_out
   rebalance_out=$("${_ccli[@]}" --cluster rebalance "${any_formed_host}:${SERVICE_PORT}" --cluster-use-empty-masters 2>&1) || {
-    echo "ERROR: rebalance toward new shard failed: ${rebalance_out}" >&2
+    classify join-rebalance no "rebalance toward new shard failed: ${rebalance_out}"
     return 1
   }
   attach_shard_replicas_to "${self_first}" "${master_id}" || return 1
   local own
   own=$(slots_owned_by "${self_first}" "${master_id}")
   if [ "${own}" -le 0 ]; then
-    echo "DEFER: new shard joined but owns ${own} slots after rebalance — retry (transient, retry-safe)." >&2
+    classify join-slots yes "new shard joined but owns ${own} slots after rebalance"
     return 1
   fi
-  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} joined with ${own} slots."
+  # positive completeness: every pod of THIS shard must be in the view
+  local nodes vfqdn
+  build_cli "${self_first}"
+  nodes=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r')
+  for vfqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$'); do
+    if ! echo "${nodes}" | grep -qF "${vfqdn}"; then
+      classify join-membership yes "pod ${vfqdn} of this shard not yet in cluster view"
+      return 1
+    fi
+  done
+  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} joined with ${own} slots; all shard pods in view."
 }
 
 attach_shard_replicas_to() {
@@ -313,7 +357,7 @@ attach_shard_replicas_to() {
     fi
     build_cluster_cli
     add_out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${master_fqdn}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
-      echo "ERROR: add replica ${fqdn} failed: ${add_out}" >&2
+      classify join-add-replica no "add replica ${fqdn} failed: ${add_out}"
       return 1
     }
   done
@@ -356,7 +400,7 @@ shard_remove() {
     fi
   done < <(each_shard_fqdn_list)
   if [ -z "${remaining_host}" ]; then
-    echo "ERROR: no healthy remaining shard visible to receive slots — refusing shard removal." >&2
+    classify remove-no-receiver no "no healthy remaining shard visible to receive slots — refusing removal"
     exit 1
   fi
 
@@ -378,13 +422,13 @@ shard_remove() {
     build_cluster_cli
     local reb_out
     reb_out=$("${_ccli[@]}" --cluster rebalance "${remaining_host}:${SERVICE_PORT}" --cluster-weight "${master_id}=0" 2>&1) || {
-      echo "ERROR: slot drain (rebalance weight=0) failed: ${reb_out}" >&2
+      classify remove-drain no "slot drain (rebalance weight=0) failed: ${reb_out}"
       exit 1
     }
     own=$(slots_owned_by "${remaining_host}" "${master_id}")
   fi
   if [ "${own}" -ne 0 ]; then
-    echo "DEFER: shard still owns ${own} slots after drain — NOT removing nodes; retry (retry-safe)." >&2
+    classify remove-slots-nonzero yes "shard still owns ${own} slots after drain — NOT removing nodes"
     exit 1
   fi
   echo "slot drain proven: shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} owns 0 slots."
@@ -397,7 +441,7 @@ shard_remove() {
     build_cluster_cli
     local del_out
     del_out=$("${_ccli[@]}" --cluster del-node "${remaining_host}:${SERVICE_PORT}" "${node_id}" 2>&1) || {
-      echo "ERROR: del-node ${node_id} failed: ${del_out}" >&2
+      classify remove-del-node no "del-node ${node_id} failed: ${del_out}"
       exit 1
     }
     echo "removed node ${node_id} from cluster."
@@ -407,7 +451,7 @@ shard_remove() {
     build_cluster_cli
     local del_out2
     del_out2=$("${_ccli[@]}" --cluster del-node "${remaining_host}:${SERVICE_PORT}" "${node_id}" 2>&1) || {
-      echo "ERROR: del-node ${node_id} failed: ${del_out2}" >&2
+      classify remove-del-node no "del-node ${node_id} failed: ${del_out2}"
       exit 1
     }
     echo "removed node ${node_id} from cluster."

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -296,17 +296,7 @@ attach_all_replicas() {
     fi
     for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$' | sort); do
       [ "${fqdn}" = "${first}" ] && continue
-      # already a member? (idempotency: skip nodes the master already knows)
-      build_cli "${first}"
-      if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${fqdn}"; then
-        continue
-      fi
-      build_cluster_cli
-      add_out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${first}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
-        classify formation-add-replica no "add replica ${fqdn} to shard ${shard} failed: ${add_out}"
-        return 1
-      }
-      echo "attached ${fqdn} as replica of shard ${shard} (master ${master_id})."
+      ensure_replica_bound "${first}" "${fqdn}" "${master_id}" "${shard}" || return 1
     done
   done < <(each_shard_fqdn_list)
 }
@@ -381,19 +371,44 @@ verify_or_join() {
 }
 
 attach_shard_replicas_to() {
-  local master_fqdn="${1}" master_id="${2}" fqdn add_out
+  local master_fqdn="${1}" master_id="${2}" fqdn
   for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | sort); do
     [ "${fqdn}" = "${master_fqdn}" ] && continue
-    build_cli "${master_fqdn}"
-    if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${fqdn}"; then
-      continue
-    fi
+    ensure_replica_bound "${master_fqdn}" "${fqdn}" "${master_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" || return 1
+  done
+}
+
+# Idempotent replica binding (round-2 review): visibility alone never
+# skips. Absent -> add-node --cluster-slave. Present but wrong role/parent
+# -> engine-native repair via CLUSTER REPLICATE on the pod itself (safe:
+# the target owns no slots as a would-be replica; REPLICATE is refused by
+# the engine if it did). Present and bound -> done.
+ensure_replica_bound() {
+  local via="${1}" fqdn="${2}" master_id="${3}" shard="${4}"
+  local line flags parent out
+  build_cli "${via}"
+  line=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -F "${fqdn}" | head -1)
+  if [ -z "${line}" ]; then
     build_cluster_cli
-    add_out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${master_fqdn}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
-      classify join-add-replica no "add replica ${fqdn} failed: ${add_out}"
+    out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${via}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
+      classify attach-add-node no "add replica ${fqdn} to shard ${shard} failed: ${out}"
       return 1
     }
-  done
+    echo "attached ${fqdn} as replica of shard ${shard} (master ${master_id})."
+    return 0
+  fi
+  flags=$(echo "${line}" | awk '{print $3}')
+  parent=$(echo "${line}" | awk '{print $4}')
+  if echo "${flags}" | grep -q slave && [ "${parent}" = "${master_id}" ]; then
+    return 0
+  fi
+  # visible but wrong role or wrong parent: repair on the pod itself
+  build_cli "${fqdn}"
+  out=$("${_cli[@]}" CLUSTER REPLICATE "${master_id}" 2>&1) || {
+    classify attach-replicate no "CLUSTER REPLICATE ${master_id} on ${fqdn} failed: ${out}"
+    return 1
+  }
+  echo "repaired ${fqdn}: now replicating shard ${shard} master ${master_id}."
 }
 
 post_provision() {

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -321,43 +321,55 @@ verify_or_join() {
     return 1
   fi
 
-  local self_first master_id
+  local self_first
   self_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
   build_cli "${any_formed_host}"
-  if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${self_first}"; then
-    if all_expected_members_present "${any_formed_host}"; then
-      echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} already a cluster member; membership complete."
-      return 0
-    fi
-    classify join-membership yes "shard present but full membership not yet complete"
-    return 1
+  if ! "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -q "${self_first}"; then
+    # scale-out first contact: introduce this shard's designated master.
+    # Wrapper preflight failures here are dominated by transient config
+    # agreement (gossip settling after a prior step) -> retry-safe defer;
+    # re-entry re-reads topology and re-drives (r3 CT05 evidence).
+    build_cluster_cli
+    local add_out
+    add_out=$("${_ccli[@]}" --cluster add-node "${self_first}:${SERVICE_PORT}" "${any_formed_host}:${SERVICE_PORT}" 2>&1) || {
+      classify join-add-node yes "add-node ${self_first} failed (re-entry re-drives): ${add_out}"
+      return 1
+    }
+    echo "introduced ${self_first} to the cluster as this shard's master."
   fi
+  # DRIVER (r3 CT05 livelock fix): once this shard is visible, every
+  # invocation must DRIVE the remaining steps -- slots, replica binding,
+  # roster completeness -- never observe-and-defer. The old present-branch
+  # deferred without acting, so a single failed attach never healed.
+  drive_shard_completion "${any_formed_host}" "${self_first}"
+}
 
-  # scale-out: join this shard's first pod as a new master, rebalance slots
-  # to it, then attach the shard's replicas.
-  build_cluster_cli
-  local add_out
-  add_out=$("${_ccli[@]}" --cluster add-node "${self_first}:${SERVICE_PORT}" "${any_formed_host}:${SERVICE_PORT}" 2>&1) || {
-    classify join-add-node no "add-node ${self_first} failed: ${add_out}"
-    return 1
-  }
+# Idempotent completion driver for THIS shard: ensure its master owns
+# slots (rebalance if zero), ensure every replica is bound, then require
+# strict in-shard binding and full-roster completeness. Safe to re-enter
+# from any partial state; every step re-reads engine truth first.
+drive_shard_completion() {
+  local via="${1}" self_first="${2}" master_id own
   master_id=$(node_id_of "${self_first}")
   if [ -z "${master_id}" ]; then
-    classify join-myid yes "joined but CLUSTER MYID unreadable from ${self_first}"
+    classify join-myid yes "CLUSTER MYID unreadable from ${self_first}"
     return 1
   fi
-  local rebalance_out
-  rebalance_out=$("${_ccli[@]}" --cluster rebalance "${any_formed_host}:${SERVICE_PORT}" --cluster-use-empty-masters 2>&1) || {
-    classify join-rebalance no "rebalance toward new shard failed: ${rebalance_out}"
-    return 1
-  }
-  attach_shard_replicas_to "${self_first}" "${master_id}" || return 1
-  local own
-  own=$(slots_owned_by "${self_first}" "${master_id}")
+  own=$(slots_owned_by "${via}" "${master_id}")
   if [ "${own}" -le 0 ]; then
-    classify join-slots yes "new shard joined but owns ${own} slots after rebalance"
-    return 1
+    build_cluster_cli
+    local rebalance_out
+    rebalance_out=$("${_ccli[@]}" --cluster rebalance "${via}:${SERVICE_PORT}" --cluster-use-empty-masters 2>&1) || {
+      classify join-rebalance yes "rebalance toward ${CURRENT_SHARD_COMPONENT_SHORT_NAME} failed (re-entry re-drives): ${rebalance_out}"
+      return 1
+    }
+    own=$(slots_owned_by "${via}" "${master_id}")
+    if [ "${own}" -le 0 ]; then
+      classify join-slots yes "shard master owns ${own} slots after rebalance"
+      return 1
+    fi
   fi
+  attach_shard_replicas_to "${self_first}" "${master_id}" || return 1
   # positive completeness: strict binding for THIS shard (exactly one
   # in-shard master; every other pod a slave of that master)
   local nodes
@@ -367,7 +379,11 @@ verify_or_join() {
     classify join-membership yes "this shard's pods not yet fully bound (master+replicas) in cluster view"
     return 1
   fi
-  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} joined with ${own} slots; membership bound."
+  if ! all_expected_members_present "${via}"; then
+    classify join-membership yes "this shard complete; full roster membership not yet complete"
+    return 1
+  fi
+  echo "shard ${CURRENT_SHARD_COMPONENT_SHORT_NAME} complete: ${own} slots, membership bound."
 }
 
 attach_shard_replicas_to() {
@@ -391,7 +407,7 @@ ensure_replica_bound() {
   if [ -z "${line}" ]; then
     build_cluster_cli
     out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${via}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
-      classify attach-add-node no "add replica ${fqdn} to shard ${shard} failed: ${out}"
+      classify attach-add-node yes "add replica ${fqdn} to shard ${shard} failed (re-entry re-drives): ${out}"
       return 1
     }
     echo "attached ${fqdn} as replica of shard ${shard} (master ${master_id})."

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -6,7 +6,7 @@ Phase A boundary (issue #3021): templates + config + server start only.
   - No roles / roleProbe yet: cluster-mode role detection (CLUSTER NODES) and
     switchover land together in phase C as one contract; declaring roles
     without a probe would leave pods permanently unlabeled.
-  - No lifecycle actions yet: cluster formation / shard scale land in phase B.
+  - Phase B (issue #3026) added postProvision formation and shardRemove.
 v1 boundary: Valkey 9 only; in-cluster networking only (pod-FQDN announce,
 no NodePort/LB advertise).
 */}}
@@ -124,6 +124,25 @@ spec:
         componentVarRef:
           optional: false
           podFQDNs: Required
+    ## all-shards discovery for formation/scale (KB 'individual' strategy
+    ## emits ALL_SHARDS_POD_FQDN_LIST_<SHARD> per shard; 'combined' gives the
+    ## short-name roster the coordinator election sorts).
+    - name: ALL_SHARDS_COMPONENT_SHORT_NAMES
+      valueFrom:
+        componentVarRef:
+          compDef: {{ printf "valkey-cluster-%s" .major }}
+          optional: false
+          shortName: Required
+          multipleClusterObjectOption:
+            strategy: combined
+    - name: ALL_SHARDS_POD_FQDN_LIST
+      valueFrom:
+        componentVarRef:
+          compDef: {{ printf "valkey-cluster-%s" .major }}
+          optional: false
+          podFQDNs: Required
+          multipleClusterObjectOption:
+            strategy: individual
     # ── Physical resource hints for config tuning (io-threads, maxmemory).
     # Optional: pods without explicit limits still render (template guards
     # every access with index — Emily's phase-A first-blocker, task #367).
@@ -144,6 +163,22 @@ spec:
       expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}--tls --cacert {{.TLS_MOUNT_PATH}}/ca.crt{{else}}{{end}}` | toYaml }}
     - name: TLS_MOUNT_PATH
       value: {{ $.Values.tlsMountPath }}
+
+  lifecycleActions:
+    # Formation-or-join: single-shot bootstrap-or-defer (rc=1 => framework
+    # retry). Coordinator pod creates the cluster; every other pod verifies
+    # membership or joins (scale-out path). See valkey-cluster-manage.sh.
+    postProvision:
+      exec:
+        container: valkey-cluster
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/valkey-cluster-manage.sh --post-provision
+        precondition: RuntimeReady
+      retryPolicy:
+        maxRetries: 20
+        retryInterval: 5
 
   runtime:
     containers:

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -175,7 +175,8 @@ spec:
           - /bin/bash
           - -c
           - /scripts/valkey-cluster-manage.sh --post-provision
-        precondition: RuntimeReady
+      # preCondition is a sibling of exec (KB Action API), not an exec field
+      preCondition: RuntimeReady
       retryPolicy:
         maxRetries: 20
         retryInterval: 5

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -175,6 +175,15 @@ spec:
           - /bin/bash
           - -c
           - /scripts/valkey-cluster-manage.sh --post-provision
+        env:
+          # kbagent-executed actions do NOT inherit the runtime container's
+          # downward-API env — pod identity must be declared on the action
+          # itself (r2 live first-blocker; same pattern as sentinel cmpd).
+          - name: CURRENT_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
       # preCondition is a sibling of exec (KB Action API), not an exec field
       preCondition: RuntimeReady
       retryPolicy:

--- a/addons/valkey/templates/shardingdefinition.yaml
+++ b/addons/valkey/templates/shardingdefinition.yaml
@@ -1,14 +1,8 @@
 {{- /*
 ShardingDefinition for Valkey Cluster (sharding) mode.
 
-Phase A boundary (issue #3021): shape only — no shard lifecycle actions yet.
-shardRemove (slot drain -> positive slots-zero proof -> del-node) lands in
-phase B together with cluster formation; declaring shard scale before those
-scripts exist would let a shard scale-in destroy data (the shardRemove-vs-
-preTerminate trap documented in kubeblocks-addon-docs).
-
-Until phase B merges, shardsLimit min==max effectively pins the shard count
-users can request at creation; scale in/out is rejected by the controller.
+Phase B (issue #3026) enables shard lifecycle: shardRemove drains this shard's slots and only deletes nodes after a
+POSITIVE zero-slots observation (never on del-node success alone).
 */}}
 apiVersion: apps.kubeblocks.io/v1
 kind: ShardingDefinition
@@ -26,8 +20,24 @@ spec:
     # 32 is the reviewed v1 upper bound (raise only with scale evidence).
     minShards: 3
     maxShards: 32
-  provisionStrategy: Serial
+  # Parallel provisioning is REQUIRED for single-shot formation: cluster
+  # create needs every shard's designated primary reachable at once; the
+  # coordinator defers (rc=1, framework retry) until all shards answer —
+  # deterministic convergence, no sleeps. Updates stay Serial for safe
+  # rolling behavior.
+  provisionStrategy: Parallel
   updateStrategy: Serial
   systemAccounts:
     - name: default
       shared: true
+  lifecycleActions:
+    shardRemove:
+      exec:
+        container: valkey-cluster
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/valkey-cluster-manage.sh --shard-remove
+      retryPolicy:
+        maxRetries: 20
+        retryInterval: 5

--- a/addons/valkey/templates/shardingdefinition.yaml
+++ b/addons/valkey/templates/shardingdefinition.yaml
@@ -38,6 +38,15 @@ spec:
           - /bin/bash
           - -c
           - /scripts/valkey-cluster-manage.sh --shard-remove
+        env:
+          # kbagent-executed actions do NOT inherit the runtime container's
+          # downward-API env — pod identity must be declared on the action
+          # itself (r2 live first-blocker; same pattern as sentinel cmpd).
+          - name: CURRENT_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
       retryPolicy:
         maxRetries: 20
         retryInterval: 5


### PR DESCRIPTION
Fixes #3026. **Stacked on #3024 (phase A)** — base branch is `athena/valkey-cluster-phase-a`; retarget to main after A merges.

Design contracts from the team review, each pinned by a behavioral spec:
- deterministic coordinator election; empty/duplicate shard rosters hard-fail (no fallback to current pod)
- single-shot bootstrap-or-defer everywhere (rc=1 + classified stderr; no in-script polling; per-invocation topology re-reads)
- KB shard == engine shard: creation designates one primary per shard and attaches that shard's replicas to that master's engine node id; identity is always CLUSTER MYID
- shardRemove: drain → positive zero-slots proof → delete (replicas first); slots remaining ⇒ defer, never delete
- provisioning switched to Parallel (single-shot `--cluster create` needs all shard primaries at once; convergence is defer-based) — updates remain Serial

Validation: full valkey shellspec suite local **358 examples, 0 failures** (13 new); addon + cluster chart renders pass. Runtime validation (3-shard formation, slot coverage, scale-out/in with data) is Emily's phase-B pass on the Saiyin vcluster.

Reviewers: @Alice (design contract) / @Bob (scripts).

---

**Retry-contract evidence (review blocker, Alice)**: the defer pattern's re-entry premise is grounded as follows —
- `postProvision` (ComponentDefinition action): [docs/addon-api/05b-lifecycle-action-fields.md] states the contract directly: *非 0 退出、HTTP 非 2xx、超时都会按策略失败或重试* (`timeoutSeconds` + `retryPolicy`). This PR sets `retryPolicy: maxRetries 20 / retryInterval 5` accordingly.
- `shardRemove` (ShardingDefinition action): the upstream api-docs do **not** explicitly state retry semantics for sharding-level actions (doc gap filed in kubeblocks-addon-docs). Until documented, issue #3026's acceptance includes a mandatory live probe: shardRemove returns one classified rc=1 (slots not yet zero), and the run must show the framework re-invoking it per retryPolicy before nodes are deleted. The redis addon's production ShardingDefinition uses the same `retryPolicy` field (prior art, not contract — stated as such).

All non-zero exits now carry a stable classification line: `action=valkey-cluster-manage phase=<phase> retry_safe=<yes|no> detail=...`.
