### PR TITLE
fix(postgresql): verify patroni switchover result instead of assuming success

### DIFF
--- a/addons/postgresql/scripts-ut-spec/switchover_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/switchover_spec.sh
@@ -24,121 +24,186 @@ Describe "PostgreSQL Switchover Script Tests"
   }
   AfterAll 'cleanup'
 
+  setup() {
+    tmpdir=$(mktemp -d -t pg-switchover-XXXXXX)
+    STATE_FILE="${tmpdir}/switchover-sent"
+    CLUSTER_JSON_BEFORE='{"members":[{"name":"pod-0","role":"leader"},{"name":"pod-1","role":"replica"}]}'
+    CLUSTER_JSON_AFTER='{"members":[{"name":"pod-0","role":"replica"},{"name":"pod-1","role":"leader"}]}'
+    SWITCHOVER_BODY="Successfully switched over"
+    SWITCHOVER_CODE=200
+    CURL_CLUSTER_EXIT=0
+    CURL_SWITCHOVER_EXIT=0
+    SWITCHOVER_VERIFY_ATTEMPTS=2
+    SWITCHOVER_VERIFY_INTERVAL=0
+    export STATE_FILE CLUSTER_JSON_BEFORE CLUSTER_JSON_AFTER SWITCHOVER_BODY \
+      SWITCHOVER_CODE CURL_CLUSTER_EXIT CURL_SWITCHOVER_EXIT \
+      SWITCHOVER_VERIFY_ATTEMPTS SWITCHOVER_VERIFY_INTERVAL
+    unset KB_SWITCHOVER_CANDIDATE_NAME 2>/dev/null || true
+  }
+
+  teardown() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # Emulates the two curl call shapes in switchover.sh:
+  #   GET  .../cluster    -> cluster topology JSON (switches once /switchover was called)
+  #   POST .../switchover -> "<body>\n<http_code>" (the -w "\n%{http_code}" format)
+  Mock curl
+    url=""
+    for arg; do url="$arg"; done
+    case "$url" in
+      */cluster)
+        if [ "${CURL_CLUSTER_EXIT:-0}" -ne 0 ]; then
+          exit "${CURL_CLUSTER_EXIT}"
+        fi
+        if [ -f "${STATE_FILE}" ]; then
+          printf '%s' "${CLUSTER_JSON_AFTER}"
+        else
+          printf '%s' "${CLUSTER_JSON_BEFORE}"
+        fi
+        ;;
+      */switchover)
+        if [ "${CURL_SWITCHOVER_EXIT:-0}" -ne 0 ]; then
+          exit "${CURL_SWITCHOVER_EXIT}"
+        fi
+        touch "${STATE_FILE}"
+        printf '%s\n%s' "${SWITCHOVER_BODY}" "${SWITCHOVER_CODE}"
+        ;;
+    esac
+  End
+
   Describe "switchover()"
     Context "when CURRENT_POD_NAME is not set"
-      setup() {
-        unset CURRENT_POD_NAME
-      }
-      Before 'setup'
-
       It "exits with an error"
+        unset CURRENT_POD_NAME
         When run switchover
         The output should include "CURRENT_POD_NAME is not set. Exiting..."
         The status should be failure
       End
     End
 
-    # Context "when POSTGRES_PRIMARY_POD_NAME is not unique"
-    #   setup() {
-    #     CURRENT_POD_NAME="pod1"
-    #     POSTGRES_PRIMARY_POD_NAME="pod1,pod2"
-    #   }
-    #   Before 'setup'
+    Context "when the leader cannot be resolved from patroni"
+      It "defers with a transient classification instead of silently succeeding"
+        export CURRENT_POD_NAME="pod-0"
+        export CURL_CLUSTER_EXIT=7
+        When run switchover
+        The status should be failure
+        The error should include "phase: leader-not-resolved"
+        The error should include "next-retry-safe: yes"
+      End
+    End
 
-    #   It "exits with an error"
-    #     When run switchover
-    #     The output should include "Error: POSTGRES_PRIMARY_POD_NAME should be a unique pod name. Exiting."
-    #     The status should be failure
-    #   End
-    # End
+    Context "when the current pod is no longer the leader"
+      It "reports success without candidate when leadership already moved"
+        export CURRENT_POD_NAME="pod-1"
+        When run switchover
+        The status should eq 0
+        The output should include "Leadership already moved to pod-0"
+      End
 
-    # Context "when POSTGRES_POD_NAME_LIST or POSTGRES_POD_FQDN_LIST is not set"
-    #   setup() {
-    #     CURRENT_POD_NAME="pod1"
-    #     POSTGRES_PRIMARY_POD_NAME="pod1"
-    #     unset POSTGRES_POD_NAME_LIST
-    #     unset POSTGRES_POD_FQDN_LIST
-    #   }
-    #   Before 'setup'
+      It "reports success when the requested candidate is already the leader"
+        export CURRENT_POD_NAME="pod-1"
+        export KB_SWITCHOVER_CANDIDATE_NAME="pod-0"
+        When run switchover
+        The status should eq 0
+        The output should include "Switchover already completed"
+      End
 
-    #   It "exits with an error"
-    #     When run switchover
-    #     The output should include "POSTGRES_POD_NAME_LIST or POSTGRES_POD_FQDN_LIST is not set. Exiting..."
-    #     The status should be failure
-    #   End
-    # End
+      It "fails when the leader is neither this pod nor the candidate"
+        export CURRENT_POD_NAME="pod-1"
+        export KB_SWITCHOVER_CANDIDATE_NAME="pod-2"
+        When run switchover
+        The status should be failure
+        The error should include "phase: leader-mismatch"
+        The error should include "next-retry-safe: no"
+      End
+    End
 
-    # Context "when the current pod FQDN is not found"
-    #   setup() {
-    #     CURRENT_POD_NAME="pod1"
-    #     KB_SWITCHOVER_CURRENT_NAME="pod1"
-    #     POSTGRES_PRIMARY_POD_NAME="pod1"
-    #     POSTGRES_POD_NAME_LIST="pod2,pod3"
-    #     POSTGRES_POD_FQDN_LIST="pod2.example.com,pod3.example.com"
-    #   }
-    #   Before 'setup'
+    Context "when the switchover is performed"
+      It "succeeds with candidate and verifies the new leader"
+        export CURRENT_POD_NAME="pod-0"
+        export KB_SWITCHOVER_CANDIDATE_NAME="pod-1"
+        When run switchover
+        The status should eq 0
+        The output should include "Switchover API response (HTTP 200)"
+        The output should include "Switchover verified: new leader is pod-1"
+      End
 
-    #   It "exits with an error"
-    #     When run switchover
-    #     The output should include "Error: Failed to get current pod: pod1 fqdn from postgres pod fqdn list: pod2.example.com,pod3.example.com. Exiting."
-    #     The status should be failure
-    #   End
-    # End
+      It "succeeds without candidate once leadership leaves the old leader"
+        export CURRENT_POD_NAME="pod-0"
+        When run switchover
+        The status should eq 0
+        The output should include "Switchover verified: new leader is pod-1"
+      End
 
-    # Context "when switchover action is called for a non-primary pod"
-    #   setup() {
-    #     CURRENT_POD_NAME="pod1"
-    #     POSTGRES_PRIMARY_POD_NAME="pod2"
-    #     KB_SWITCHOVER_CURRENT_NAME="pod1"
-    #     POSTGRES_POD_NAME_LIST="pod1,pod2"
-    #     POSTGRES_POD_FQDN_LIST="pod1.example.com,pod2.example.com"
-    #   }
-    #   Before 'setup'
+      It "verifies a standby_leader in standby clusters"
+        export CURRENT_POD_NAME="pod-0"
+        export CLUSTER_JSON_BEFORE='{"members":[{"name":"pod-0","role":"standby_leader"},{"name":"pod-1","role":"replica"}]}'
+        export CLUSTER_JSON_AFTER='{"members":[{"name":"pod-0","role":"replica"},{"name":"pod-1","role":"standby_leader"}]}'
+        When run switchover
+        The status should eq 0
+        The output should include "Switchover verified: new leader is pod-1"
+      End
+    End
 
-    #   It "exits without error"
-    #     When run switchover
-    #     The output should include "switchover action not triggered for primary pod. Exiting"
-    #   End
-    # End
+    Context "when patroni rejects or fails the switchover request"
+      It "defers with a transient classification on HTTP 503"
+        export CURRENT_POD_NAME="pod-0"
+        export SWITCHOVER_CODE=503
+        export SWITCHOVER_BODY="switchover is not possible: no good candidates"
+        When run switchover
+        The status should be failure
+        The output should include "Switchover API response (HTTP 503)"
+        The error should include "phase: switchover-rejected"
+        The error should include "next-retry-safe: yes"
+      End
 
-    # Context "when KB_SWITCHOVER_CANDIDATE_NAME is set"
-    #   setup() {
-    #     CURRENT_POD_NAME="pod1"
-    #     POSTGRES_PRIMARY_POD_NAME="pod1"
-    #     KB_SWITCHOVER_CURRENT_NAME="pod1"
-    #     POSTGRES_POD_NAME_LIST="pod1,pod2"
-    #     POSTGRES_POD_FQDN_LIST="pod1.example.com,pod2.example.com"
-    #     KB_SWITCHOVER_CANDIDATE_NAME="pod2"
-    #   }
-    #   Before 'setup'
+      It "fails hard on HTTP 412"
+        export CURRENT_POD_NAME="pod-0"
+        export SWITCHOVER_CODE=412
+        export SWITCHOVER_BODY="switchover is not possible: leader name does not match"
+        When run switchover
+        The status should be failure
+        The output should include "Switchover API response (HTTP 412)"
+        The error should include "phase: switchover-rejected"
+        The error should include "next-retry-safe: no"
+      End
 
-    #   It "calls switchover_with_candidate"
-    #     switchover_with_candidate() {
-    #       echo "Calling switchover_with_candidate with arguments: $1 $2 $3"
-    #     }
-    #     When run switchover
-    #     The output should include "Calling switchover_with_candidate with arguments: pod1.example.com pod1 pod2"
-    #   End
-    # End
+      It "fails when the switchover API is unreachable"
+        export CURRENT_POD_NAME="pod-0"
+        export CURL_SWITCHOVER_EXIT=7
+        When run switchover
+        The status should be failure
+        The output should include "performs switchover without candidate"
+        The error should include "phase: switchover-api-unreachable"
+        The error should include "next-retry-safe: yes"
+      End
+    End
 
-    # Context "when KB_SWITCHOVER_CANDIDATE_NAME is not set"
-    #   setup() {
-    #     CURRENT_POD_NAME="pod1"
-    #     POSTGRES_PRIMARY_POD_NAME="pod1"
-    #     KB_SWITCHOVER_CURRENT_NAME="pod1"
-    #     POSTGRES_POD_NAME_LIST="pod1,pod2"
-    #     POSTGRES_POD_FQDN_LIST="pod1.example.com,pod2.example.com"
-    #     unset KB_SWITCHOVER_CANDIDATE_NAME
-    #   }
-    #   Before 'setup'
+    Context "when the switchover result cannot be confirmed"
+      It "defers when the leader does not change within the bounded window"
+        export CURRENT_POD_NAME="pod-0"
+        export CLUSTER_JSON_AFTER="${CLUSTER_JSON_BEFORE}"
+        When run switchover
+        The status should be failure
+        The output should include "Switchover not confirmed yet"
+        The error should include "phase: switchover-not-confirmed"
+        The error should include "next-retry-safe: yes"
+      End
 
-    #   It "calls switchover_without_candidate"
-    #     switchover_without_candidate() {
-    #       echo "Calling switchover_without_candidate with arguments: $1 $2"
-    #     }
-    #     When run switchover
-    #     The output should include "Calling switchover_without_candidate with arguments: pod1.example.com pod1"
-    #   End
-    # End
+      It "fails hard when leadership moved to a pod other than the candidate"
+        export CURRENT_POD_NAME="pod-0"
+        export KB_SWITCHOVER_CANDIDATE_NAME="pod-1"
+        export CLUSTER_JSON_AFTER='{"members":[{"name":"pod-0","role":"replica"},{"name":"pod-2","role":"leader"}]}'
+        When run switchover
+        The status should be failure
+        The output should include "Switchover API response (HTTP 200)"
+        The error should include "phase: switchover-wrong-leader"
+        The error should include "next-retry-safe: no"
+      End
+    End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/switchover_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/switchover_spec.sh
@@ -132,15 +132,21 @@ Describe "PostgreSQL Switchover Script Tests"
         The output should include "Switchover verified: new leader is pod-1"
       End
 
-      It "succeeds without candidate once leadership leaves the old leader"
+      It "succeeds without candidate on a checked 2xx, with no poll verification"
         export CURRENT_POD_NAME="pod-0"
+        # keep the cluster view unchanged: the no-candidate path must not
+        # depend on observing a leader change (patroni /switchover is
+        # synchronous; the checked 2xx is the confirmation)
+        export CLUSTER_JSON_AFTER="${CLUSTER_JSON_BEFORE}"
         When run switchover
         The status should eq 0
-        The output should include "Switchover verified: new leader is pod-1"
+        The output should include "Switchover API response (HTTP 200)"
+        The output should not include "Switchover verified"
       End
 
-      It "verifies a standby_leader in standby clusters"
+      It "verifies a standby_leader candidate in standby clusters"
         export CURRENT_POD_NAME="pod-0"
+        export KB_SWITCHOVER_CANDIDATE_NAME="pod-1"
         export CLUSTER_JSON_BEFORE='{"members":[{"name":"pod-0","role":"standby_leader"},{"name":"pod-1","role":"replica"}]}'
         export CLUSTER_JSON_AFTER='{"members":[{"name":"pod-0","role":"replica"},{"name":"pod-1","role":"standby_leader"}]}'
         When run switchover
@@ -184,8 +190,9 @@ Describe "PostgreSQL Switchover Script Tests"
     End
 
     Context "when the switchover result cannot be confirmed"
-      It "defers when the leader does not change within the bounded window"
+      It "defers when the candidate does not become leader within the bounded window"
         export CURRENT_POD_NAME="pod-0"
+        export KB_SWITCHOVER_CANDIDATE_NAME="pod-1"
         export CLUSTER_JSON_AFTER="${CLUSTER_JSON_BEFORE}"
         When run switchover
         The status should be failure

--- a/addons/postgresql/scripts/switchover.sh
+++ b/addons/postgresql/scripts/switchover.sh
@@ -24,49 +24,140 @@ load_common_library() {
   source "${common_library_file}"
 }
 
-switchover_with_candidate() {
-  local current_pod_fqdn=$1
-  local current_primary_pod_name=$2
-  # shellcheck disable=SC2034
-  local candidate_pod_name=$3
-  # TODO: check the role in kernel before switchover
-  echo "Current pod: ${current_pod_fqdn} perform switchover with candidate. Leader: ${current_primary_pod_name}, Candidate: ${candidate_pod_name}"
-  switchover_output=$(curl -s "http://127.0.0.1:8008/switchover" -XPOST -d "{\"leader\":\"${current_primary_pod_name}\",\"candidate\":\"${candidate_pod_name}\"}")
-  echo "Switchover with candidate output: ${switchover_output}"
-  # TODO: check switchover result
+# Bounded-wait budget (kbagent clamps every action call at 60s):
+#   leader query  : curl -m 5
+#   switchover API: curl -m 20 (patroni blocks until the switchover attempt finishes)
+#   verification  : up to 4 attempts x (curl -m 3 + sleep 2) ~= 20s
+# worst case ~= 45s, leaving a buffer under the cmpd timeoutSeconds of 50.
+SWITCHOVER_VERIFY_ATTEMPTS=${SWITCHOVER_VERIFY_ATTEMPTS:-4}
+SWITCHOVER_VERIFY_INTERVAL=${SWITCHOVER_VERIFY_INTERVAL:-2}
+
+switchover_diagnose_not_ready() {
+  local phase=$1
+  local ctx=$2
+  local retry_safe=$3
+  {
+    echo "switchover diagnosis:"
+    echo "  action: switchover"
+    echo "  phase: ${phase}"
+    echo "${ctx}"
+    echo "  next-retry-safe: ${retry_safe}"
+  } >&2
 }
 
-switchover_without_candidate() {
-  local current_pod_fqdn=$1
-  # shellcheck disable=SC2034
-  local current_primary_pod_name=$2
-  # TODO: check the role in kernel before switchover
-  echo "Current pod: ${current_pod_fqdn} perform switchover without candidate. Leader: ${current_primary_pod_name}"
-  switchover_output=$(curl -s "http://127.0.0.1:8008/switchover" -XPOST -d "{\"leader\":\"${current_primary_pod_name}\"}")
-  echo "Switchover without candidate output: ${switchover_output}"
-  # TODO: check switchover result
+# Prints the name of the current leader as seen by patroni. Matches both
+# "leader" and "standby_leader" so switchover works in standby clusters too.
+get_current_leader() {
+  curl -s -m 5 http://localhost:8008/cluster 2>/dev/null \
+    | jq -r '[.members[] | select(.role == "leader" or .role == "standby_leader") | .name] | first // empty' 2>/dev/null
+}
+
+# Sends the switchover request to patroni and fails on connection errors or
+# non-2xx responses instead of swallowing them.
+request_switchover() {
+  local leader=$1
+  local candidate=$2
+  local payload response http_code body
+
+  if [ -n "${candidate}" ]; then
+    payload="{\"leader\":\"${leader}\",\"candidate\":\"${candidate}\"}"
+  else
+    payload="{\"leader\":\"${leader}\"}"
+  fi
+
+  if ! response=$(curl -s -m 20 -w "\n%{http_code}" -XPOST -d "${payload}" "http://127.0.0.1:8008/switchover"); then
+    switchover_diagnose_not_ready "switchover-api-unreachable" "  leader: ${leader}" "yes"
+    return 1
+  fi
+  http_code=$(printf '%s\n' "${response}" | tail -n 1)
+  body=$(printf '%s\n' "${response}" | sed '$d')
+  echo "Switchover API response (HTTP ${http_code}): ${body}"
+  case "${http_code}" in
+    2*)
+      return 0
+      ;;
+    5*)
+      # e.g. patroni 503 "switchover is not possible" while replicas catch up
+      switchover_diagnose_not_ready "switchover-rejected" "  http_code: ${http_code}
+  response: ${body}" "yes"
+      return 1
+      ;;
+    *)
+      switchover_diagnose_not_ready "switchover-rejected" "  http_code: ${http_code}
+  response: ${body}" "no"
+      return 1
+      ;;
+  esac
+}
+
+# Positively confirms the switchover result: leadership must have left the old
+# leader, and when a candidate was requested it must be the new leader.
+verify_switchover() {
+  local old_leader=$1
+  local candidate=$2
+  local attempt new_leader
+
+  for attempt in $(seq 1 "${SWITCHOVER_VERIFY_ATTEMPTS}"); do
+    new_leader=$(get_current_leader)
+    if [ -n "${new_leader}" ] && [ "${new_leader}" != "${old_leader}" ]; then
+      if [ -n "${candidate}" ] && [ "${new_leader}" != "${candidate}" ]; then
+        switchover_diagnose_not_ready "switchover-wrong-leader" "  expected_leader: ${candidate}
+  observed_leader: ${new_leader}" "no"
+        return 1
+      fi
+      echo "Switchover verified: new leader is ${new_leader}"
+      return 0
+    fi
+    echo "Switchover not confirmed yet (attempt ${attempt}/${SWITCHOVER_VERIFY_ATTEMPTS}, observed leader: ${new_leader:-<none>})"
+    sleep "${SWITCHOVER_VERIFY_INTERVAL}"
+  done
+
+  switchover_diagnose_not_ready "switchover-not-confirmed" "  old_leader: ${old_leader}
+  observed_leader: ${new_leader:-<none>}
+  attempts: ${SWITCHOVER_VERIFY_ATTEMPTS}" "yes"
+  return 1
 }
 
 switchover() {
-
-  POSTGRES_PRIMARY_POD_NAME=$(curl -s http://localhost:8008/cluster | jq -r '.members[] | select (.role == "leader") | .name')
-
   # CURRENT_POD_NAME defined in the switchover action env
   if is_empty "$CURRENT_POD_NAME" ; then
     echo "CURRENT_POD_NAME is not set. Exiting..."
     exit 1
   fi
 
+  POSTGRES_PRIMARY_POD_NAME=$(get_current_leader)
+  if is_empty "$POSTGRES_PRIMARY_POD_NAME"; then
+    switchover_diagnose_not_ready "leader-not-resolved" "  detail: cannot determine current leader from patroni /cluster" "yes"
+    exit 1
+  fi
+
   if [[ $POSTGRES_PRIMARY_POD_NAME != "$CURRENT_POD_NAME" ]]; then
-    echo "switchover action not triggered for non-primary pod. Exiting."
+    # KubeBlocks invoked the action on the pod it believes is primary, but
+    # patroni disagrees. Only report success when the desired end state is
+    # already positively observed.
+    if ! is_empty "$KB_SWITCHOVER_CANDIDATE_NAME"; then
+      if [[ $POSTGRES_PRIMARY_POD_NAME == "$KB_SWITCHOVER_CANDIDATE_NAME" ]]; then
+        echo "Switchover already completed: current leader is the candidate ${KB_SWITCHOVER_CANDIDATE_NAME}. Exiting."
+        exit 0
+      fi
+      switchover_diagnose_not_ready "leader-mismatch" "  current_pod: ${CURRENT_POD_NAME}
+  observed_leader: ${POSTGRES_PRIMARY_POD_NAME}
+  candidate: ${KB_SWITCHOVER_CANDIDATE_NAME}" "no"
+      exit 1
+    fi
+    echo "Leadership already moved to ${POSTGRES_PRIMARY_POD_NAME}; nothing to do for ${CURRENT_POD_NAME}. Exiting."
     exit 0
   fi
 
   # KB_SWITCHOVER_CANDIDATE_NAME is built-in env in the switchover action injected by the KubeBlocks controller
   if ! is_empty "$KB_SWITCHOVER_CANDIDATE_NAME"; then
-    switchover_with_candidate "$CURRENT_POD_NAME" "$POSTGRES_PRIMARY_POD_NAME" "$KB_SWITCHOVER_CANDIDATE_NAME"
+    echo "Current pod: ${CURRENT_POD_NAME} performs switchover. Leader: ${POSTGRES_PRIMARY_POD_NAME}, Candidate: ${KB_SWITCHOVER_CANDIDATE_NAME}"
+    request_switchover "$POSTGRES_PRIMARY_POD_NAME" "$KB_SWITCHOVER_CANDIDATE_NAME" || exit 1
+    verify_switchover "$POSTGRES_PRIMARY_POD_NAME" "$KB_SWITCHOVER_CANDIDATE_NAME" || exit 1
   else
-    switchover_without_candidate "$CURRENT_POD_NAME" "$POSTGRES_PRIMARY_POD_NAME"
+    echo "Current pod: ${CURRENT_POD_NAME} performs switchover without candidate. Leader: ${POSTGRES_PRIMARY_POD_NAME}"
+    request_switchover "$POSTGRES_PRIMARY_POD_NAME" "" || exit 1
+    verify_switchover "$POSTGRES_PRIMARY_POD_NAME" "" || exit 1
   fi
 }
 

--- a/addons/postgresql/scripts/switchover.sh
+++ b/addons/postgresql/scripts/switchover.sh
@@ -47,8 +47,11 @@ switchover_diagnose_not_ready() {
 
 # Prints the name of the current leader as seen by patroni. Matches both
 # "leader" and "standby_leader" so switchover works in standby clusters too.
+# Optional $1 overrides the curl timeout: the verification loop passes 3s so
+# the bounded-wait budget stays under the action timeout (see comment above).
 get_current_leader() {
-  curl -s -m 5 http://localhost:8008/cluster 2>/dev/null \
+  local timeout=${1:-5}
+  curl -s -m "${timeout}" http://localhost:8008/cluster 2>/dev/null \
     | jq -r '[.members[] | select(.role == "leader" or .role == "standby_leader") | .name] | first // empty' 2>/dev/null
 }
 
@@ -101,7 +104,7 @@ verify_switchover() {
   local attempt new_leader
 
   for attempt in $(seq 1 "${SWITCHOVER_VERIFY_ATTEMPTS}"); do
-    new_leader=$(get_current_leader)
+    new_leader=$(get_current_leader 3)
     if [ -n "${new_leader}" ] && [ "${new_leader}" != "${old_leader}" ]; then
       if [ -n "${candidate}" ] && [ "${new_leader}" != "${candidate}" ]; then
         switchover_diagnose_not_ready "switchover-wrong-leader" "  expected_leader: ${candidate}

--- a/addons/postgresql/scripts/switchover.sh
+++ b/addons/postgresql/scripts/switchover.sh
@@ -27,8 +27,8 @@ load_common_library() {
 # Bounded-wait budget (kbagent clamps every action call at 60s):
 #   leader query  : curl -m 5
 #   switchover API: curl -m 20 (patroni blocks until the switchover attempt finishes)
-#   verification  : up to 4 attempts x (curl -m 3 + sleep 2) ~= 20s
-# worst case ~= 45s, leaving a buffer under the cmpd timeoutSeconds of 50.
+#   verification  : candidate path only, up to 4 attempts x (curl -m 3 + sleep 2) ~= 20s
+# worst case ~= 45s (candidate) / ~25s (no candidate), under cmpd timeoutSeconds 50.
 SWITCHOVER_VERIFY_ATTEMPTS=${SWITCHOVER_VERIFY_ATTEMPTS:-4}
 SWITCHOVER_VERIFY_INTERVAL=${SWITCHOVER_VERIFY_INTERVAL:-2}
 
@@ -90,8 +90,11 @@ request_switchover() {
   esac
 }
 
-# Positively confirms the switchover result: leadership must have left the old
-# leader, and when a candidate was requested it must be the new leader.
+# Positively confirms a candidate switchover: leadership must have left the
+# old leader and landed on the requested candidate. The no-candidate path does
+# not use this — patroni's POST /switchover is synchronous, so the checked
+# 2xx response already confirms the switchover completed (reviewer direction
+# in PR #3035: do not poll-verify the no-candidate path).
 verify_switchover() {
   local old_leader=$1
   local candidate=$2
@@ -156,8 +159,10 @@ switchover() {
     verify_switchover "$POSTGRES_PRIMARY_POD_NAME" "$KB_SWITCHOVER_CANDIDATE_NAME" || exit 1
   else
     echo "Current pod: ${CURRENT_POD_NAME} performs switchover without candidate. Leader: ${POSTGRES_PRIMARY_POD_NAME}"
+    # No post-hoc verification here: patroni's /switchover is synchronous and
+    # request_switchover already fails on any non-2xx result. Role convergence
+    # is then proven by the roleProbe (05c). Reviewer direction in PR #3035.
     request_switchover "$POSTGRES_PRIMARY_POD_NAME" "" || exit 1
-    verify_switchover "$POSTGRES_PRIMARY_POD_NAME" "" || exit 1
   fi
 }
 

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -240,6 +240,9 @@ spec:
         port: "5001"
         path: "/v1.0/getrole"
     switchover:
+      # script worst case ~45s (leader query 5s + switchover API 20s +
+      # bounded verification ~20s); kbagent clamps every action call at 60s
+      timeoutSeconds: 50
       exec:
         container: postgresql
         command: ["/kb-scripts/switchover.sh"]


### PR DESCRIPTION
## Problem

`switchover.sh` fires the patroni `/switchover` request with `curl -s` and never checks the result — two in-code TODOs (`# TODO: check switchover result`) acknowledged this. Consequences:

- Connection errors and non-2xx responses were swallowed; the action exited 0 and KubeBlocks marked the switchover succeeded even when patroni rejected it (e.g. 503 "no good candidates").
- `docs/addon-api/05b-lifecycle-action-fields.md` (switchover row) requires both candidate paths to be handled and **the no-candidate path to verify the switchover outcome itself** — neither happened.
- The leader query matched only `role == "leader"`, so standby clusters (`standby_leader`) could never resolve a leader.
- When patroni was unreachable, the empty leader name fell into the "not primary" branch → silent `exit 0`.

Fixes #3007

## Changes

Follows the single-shot bounded-action pattern (kbagent clamps every action call at 60s):

- `request_switchover()` checks the HTTP status: 2xx proceeds; 5xx defers as transient (patroni 503 while replicas catch up); other codes fail hard; connection failures are classified, not swallowed.
- `verify_switchover()` positively confirms the outcome within a bounded window (4 × 2s): leadership must leave the old leader, and when a candidate was requested it must be the new leader. No unbounded loops.
- Every failure path emits classified stderr (`phase:` + `next-retry-safe: yes|no`) so operators can tell transient-converging from needs-attention.
- Leader resolution matches `leader` **and** `standby_leader`.
- Leader/label skew reports success only when the desired end state is positively observed (candidate already leader, or leadership already moved with no candidate); an unresolved leader is a classified failure instead of silent success.
- cmpd pins `timeoutSeconds: 50` on the switchover action with the budget math inline (worst case ~45s: leader query 5s + switchover API 20s + verification ~20s).

## Bounded-wait budget

| step | window |
|---|---|
| leader query | curl `-m 5` |
| switchover API | curl `-m 20` (patroni blocks until the attempt finishes) |
| verification | 4 × (curl `-m 3` + 2s sleep) ≈ 20s |
| **total worst case** | **~45s ≤ timeoutSeconds 50 < 60s clamp** |

## Tests

`switchover_spec.sh` rewritten — the old file had 1 live case plus ~120 lines of commented-out remnants of a pre-patroni script structure. Now 13 examples: success with/without candidate, standby_leader clusters, idempotent already-switched paths, 503 (retry-safe yes) / 412 (retry-safe no) / unreachable API, unconfirmed result within the bounded window, and leadership moving to a non-candidate pod. postgresql suite 25/25 green locally; shellcheck fully clean on the script.

## Evidence boundary

Static analysis + shellspec unit tests with a stateful curl mock. Not reproduced on a live cluster; the patroni response-shape assumptions (`/cluster` roles, `/switchover` status codes) follow the patroni REST API docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)