### PR TITLE
fix(postgresql): remove ActionSet set -e that killed Continuous backup retry logic

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 export PGPASSWORD=${DP_DB_PASSWORD}
 # use datasafed and default config
 export WALG_DATASAFED_CONFIG=""
@@ -45,7 +46,7 @@ function switch_wal_log() {
     LAST_TRANS=$(pg_waldump $(${PSQL} -Atc "select pg_walfile_name(pg_current_wal_lsn())") --rmgr=Transaction 2>/dev/null |tail -n 1)
     if [ "${LAST_TRANS}" != "" ] && [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" = "" ]; then
       DP_log "start to switch wal file"
-      ${PSQL} -c "select pg_switch_wal()"
+      ${PSQL} -c "select pg_switch_wal()" || DP_error_log "pg_switch_wal failed, will retry on the next round"
       for i in $(seq 1 60); do
         if [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" != "" ]; then
           DP_log "switch wal file successfully"
@@ -60,7 +61,7 @@ function switch_wal_log() {
 # upload wal log
 function upload_wal_log() {
     local TODAY_INCR_LOG=$(date +%Y%m%d);
-    cd ${LOG_DIR}
+    cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
     for i in $(ls -tr ./archive_status/ | grep .ready); do
       wal_name=${i%.*}
       LOG_STOP_TIME=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
@@ -69,8 +70,14 @@ function upload_wal_log() {
       fi
       if [ -f ${wal_name} ]; then
         DP_log "upload ${wal_name}"
-        datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"
-        mv -f ./archive_status/${i} ./archive_status/${wal_name}.done;
+        # Rename .ready to .done only after a successful upload. Marking a
+        # failed upload as .done lets PostgreSQL recycle a WAL segment that
+        # never reached the repository, leaving a hole in the PITR chain.
+        if datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
+          mv -f ./archive_status/${i} ./archive_status/${wal_name}.done;
+        else
+          DP_error_log "failed to upload ${wal_name}, keeping ${i} for retry"
+        fi
       fi
     done
 }
@@ -138,7 +145,7 @@ function check_pg_process() {
 function uploadMissingLogs() {
     DP_log "start to upload the wal log which maybe misses"
     local TODAY_INCR_LOG=$(date +%Y%m%d)
-    cd ${LOG_DIR}
+    cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
     uploadedLogs=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) | .[] | .path')
     if [[ -z ${uploadedLogs} ]]; then
       return
@@ -157,7 +164,7 @@ function uploadMissingLogs() {
       fi
       if [ -f ${wal_name} ]; then
         DP_log "upload ${wal_name}"
-        datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"
+        datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst" || DP_error_log "failed to upload ${wal_name}"
       fi
     done
     save_backup_status

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -29,8 +29,10 @@ function config_wal_g() {
         exit 1
     fi
 
-    mkdir -p ${walg_dir}/env
-    cp /etc/datasafed/datasafed.conf ${walg_dir}/datasafed.conf
+    # bootstrap failures are fatal: continuing with an incomplete wal-g env
+    # would make every subsequent wal-push fail
+    mkdir -p ${walg_dir}/env || { DP_error_log "failed to create ${walg_dir}/env"; exit 1; }
+    cp /etc/datasafed/datasafed.conf ${walg_dir}/datasafed.conf || { DP_error_log "failed to copy datasafed.conf"; exit 1; }
 
     echo "${walg_dir}/datasafed.conf" > ${walg_env}/WALG_DATASAFED_CONFIG
     echo "${datasafed_base_path}" > ${walg_env}/DATASAFED_BACKEND_BASE_PATH

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -1,0 +1,132 @@
+# shellcheck shell=bash
+# Tests the error contract of dataprotection/postgresql-pitr-backup.sh.
+# The ActionSet wrapper deliberately does NOT set -e for this script (see
+# actionset-postgresql-pitr.yaml): upload failures must be tolerated per file,
+# and a failed upload must never mark the WAL segment as .done.
+#
+# The script runs an infinite archive loop at top level, so the functions are
+# extracted with an awk shim instead of Include.
+
+Describe "dataprotection/postgresql-pitr-backup.sh"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-pitr-backup-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+
+    LOG_DIR="${tmpdir}/pg_wal"
+    KB_BACKUP_WORKDIR="${tmpdir}/kb-backup"
+    DP_BACKUP_INFO_FILE="${tmpdir}/backup.info"
+    DP_TARGET_POD_NAME="pod-0"
+    TARGET_POD_ROLE="primary"
+    mkdir -p "${LOG_DIR}/archive_status"
+    export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
+      DP_TARGET_POD_NAME TARGET_POD_ROLE
+    unset DATASAFED_PUSH_EXIT PSQL_EXIT 2>/dev/null || true
+
+    write_stubs
+    build_shim
+
+    # globals normally assigned by the script's top-level code
+    PSQL="psql -h localhost -U postgres -d postgres"
+    global_backup_in_secondary="f"
+    global_old_size=0
+    global_stop_time=
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+case "$1" in
+  push)
+    exit "${DATASAFED_PUSH_EXIT:-0}"
+    ;;
+  stat)
+    echo "TotalSize 0"
+    ;;
+esac
+EOF
+    cat > "${bindir}/psql" <<'EOF'
+#!/bin/sh
+printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+if [ "${PSQL_EXIT:-0}" -ne 0 ]; then exit "${PSQL_EXIT}"; fi
+echo "f"
+EOF
+    cat > "${bindir}/pg_waldump" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump"
+  }
+
+  build_shim() {
+    shim="${tmpdir}/shim.sh"
+    awk '/^function [a-zA-Z_]/ { capture=1 } capture { print } capture && /^\}/ { capture=0 }' \
+      ../dataprotection/postgresql-pitr-backup.sh > "${shim}"
+    # shellcheck disable=SC1090
+    . ../dataprotection/common-scripts.sh
+    # shellcheck disable=SC1090
+    . "${shim}"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  Describe "upload_wal_log()"
+    It "does not mark the WAL segment done when the upload fails"
+      touch "${LOG_DIR}/000000010000000000000001"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.ready"
+      export DATASAFED_PUSH_EXIT=1
+      When call upload_wal_log
+      The status should eq 0
+      The output should include "failed to upload 000000010000000000000001, keeping 000000010000000000000001.ready for retry"
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.ready" should be exist
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.done" should not be exist
+    End
+
+    It "marks the WAL segment done after a successful upload"
+      touch "${LOG_DIR}/000000010000000000000001"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.ready"
+      When call upload_wal_log
+      The status should eq 0
+      The output should include "upload 000000010000000000000001"
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.done" should be exist
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.ready" should not be exist
+    End
+
+    It "fails with a clear error when LOG_DIR is not accessible"
+      export LOG_DIR="${tmpdir}/does-not-exist"
+      When call upload_wal_log
+      The status should be failure
+      The output should include "failed to cd to ${LOG_DIR}"
+      The error should include "No such file or directory"
+    End
+  End
+
+  Describe "check_pg_process()"
+    It "passes when the probe matches the expected role"
+      When call check_pg_process
+      The status should eq 0
+    End
+
+    It "rescues remaining WALs and exits 1 after three failed probes"
+      export PSQL_EXIT=1
+      When run check_pg_process
+      The status should be failure
+      The output should include "retry detection!"
+      The output should include "Before switching to a new instance, back up any remaining WAL logs."
+    End
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -71,7 +71,9 @@ EOF
 #!/bin/sh
 if [ "$1" = "-r" ]; then
   f=$2
-  stat -f %m "$f" 2>/dev/null || stat -c %Y "$f"
+  # GNU form first: on GNU, `stat -f %m <file>` is not an error — it prints
+  # the filesystem mount point — so a BSD-first chain returns garbage.
+  stat -c %Y "$f" 2>/dev/null || stat -f %m "$f"
 else
   exec /bin/date "$@"
 fi

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -1,0 +1,154 @@
+# shellcheck shell=bash
+# Tests the retry/error-handling contract of dataprotection/wal-g-archive.sh.
+# The ActionSet wrapper deliberately does NOT set -e for this script (see
+# actionset-wal-g-pitr.yaml): these branches must be reachable and correct.
+#
+# The script runs an infinite archive loop at top level, so the functions are
+# extracted with an awk shim instead of Include.
+
+Describe "dataprotection/wal-g-archive.sh"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-walg-archive-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+
+    VOLUME_DATA_DIR="${tmpdir}/data"
+    LOG_DIR="${tmpdir}/data/pgroot/data/pg_wal"
+    KB_BACKUP_WORKDIR="${tmpdir}/data/kb-backup"
+    DP_BACKUP_INFO_FILE="${tmpdir}/backup.info"
+    UPLOAD_MISSING_LOGS_RETRY_INTERVAL=180
+    DP_TARGET_POD_NAME="pod-0"
+    TARGET_POD_ROLE="primary"
+    mkdir -p "${VOLUME_DATA_DIR}/wal-g/env" "${LOG_DIR}/archive_status"
+    echo "conf" > "${VOLUME_DATA_DIR}/wal-g/env/WALG_DATASAFED_CONFIG"
+    export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
+      DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
+      DP_TARGET_POD_NAME TARGET_POD_ROLE
+    unset WALG_EXIT PSQL_EXIT 2>/dev/null || true
+
+    write_stubs
+    build_shim
+
+    # globals normally assigned by the script's top-level code
+    PSQL="psql -h localhost -U postgres -d postgres"
+    global_backup_in_secondary="f"
+    GLOBAL_OLD_SIZE=0
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    # wal-g is invoked by absolute path, so the stub lives there
+    cat > "${VOLUME_DATA_DIR}/wal-g/wal-g" <<'EOF'
+#!/bin/sh
+printf 'wal-g %s\n' "$*" >> "${CALL_LOG}"
+exit "${WALG_EXIT:-0}"
+EOF
+    cat > "${bindir}/psql" <<'EOF'
+#!/bin/sh
+printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+if [ "${PSQL_EXIT:-0}" -ne 0 ]; then exit "${PSQL_EXIT}"; fi
+echo "f"
+EOF
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+case "$1" in
+  stat) echo "TotalSize 0" ;;
+esac
+EOF
+    # `date -r <file> +%s` is GNU-only; make it portable for local macOS runs
+    cat > "${bindir}/date" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-r" ]; then
+  f=$2
+  stat -f %m "$f" 2>/dev/null || stat -c %Y "$f"
+else
+  exec /bin/date "$@"
+fi
+EOF
+    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" "${bindir}/date"
+  }
+
+  build_shim() {
+    shim="${tmpdir}/shim.sh"
+    awk '/^function [a-zA-Z_]/ { capture=1 } capture { print } capture && /^\}/ { capture=0 }' \
+      ../dataprotection/wal-g-archive.sh > "${shim}"
+    # shellcheck disable=SC1090
+    . ../dataprotection/common-scripts.sh
+    # shellcheck disable=SC1090
+    . "${shim}"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  Describe "uploadMissingLogs()"
+    It "keeps the .ready file and the tracking file when wal-push fails"
+      touch "${LOG_DIR}/000000010000000000000001"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.ready"
+      export WALG_EXIT=1
+      When call uploadMissingLogs
+      The status should eq 0
+      The output should include "Failed to upload 000000010000000000000001"
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.ready" should be exist
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.uploading" should be exist
+    End
+
+    It "renames .ready to .done and clears tracking when wal-push succeeds"
+      touch "${LOG_DIR}/000000010000000000000001"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.ready"
+      When call uploadMissingLogs
+      The status should eq 0
+      The output should include "WAL-G upload succeeded for 000000010000000000000001"
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.done" should be exist
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.ready" should not be exist
+      The path "${LOG_DIR}/archive_status/000000010000000000000001.uploading" should not be exist
+    End
+
+    It "skips files with a recent tracking file instead of retrying immediately"
+      touch "${LOG_DIR}/000000010000000000000001"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.ready"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.uploading"
+      When call uploadMissingLogs
+      The status should eq 0
+      The output should include "Skipping 000000010000000000000001 - recent upload attempt in progress"
+      The result of function call_log should not include "wal-g"
+    End
+  End
+
+  Describe "check_pg_process()"
+    It "retries the probe and survives a single psql failure round-trip"
+      # psql succeeds and reports pg_is_in_recovery=f matching primary role
+      When call check_pg_process
+      The status should eq 0
+    End
+
+    It "rescues remaining WALs and exits 1 after three failed probes"
+      export PSQL_EXIT=1
+      When run check_pg_process
+      The status should be failure
+      The output should include "retry detection!"
+      The output should include "Before switching to a new instance, back up any remaining WAL logs."
+    End
+  End
+
+  Describe "config_wal_g()"
+    It "exits when the wal-g binary is missing"
+      rm -f "${VOLUME_DATA_DIR}/wal-g/wal-g"
+      When run config_wal_g "some/path"
+      The status should be failure
+      The output should include "wal-g binary not found"
+    End
+  End
+End

--- a/addons/postgresql/templates/actionset-postgresql-pitr.yaml
+++ b/addons/postgresql/templates/actionset-postgresql-pitr.yaml
@@ -62,6 +62,10 @@ spec:
       - -c
       - |
         #!/bin/bash
-        set -e;
+        # No set -e here: postgresql-pitr-backup.sh is a long-running archiver
+        # that owns its error contract (bounded pg probing, rescue upload
+        # before exit, per-file upload checks). A wrapper set -e kills the
+        # process on the first failure and makes all of that unreachable.
+        set -o pipefail
         {{- .Files.Get "dataprotection/common-scripts.sh" | nindent 8 }}
         {{- .Files.Get "dataprotection/postgresql-pitr-backup.sh" | nindent 8 }}

--- a/addons/postgresql/templates/actionset-wal-g-pitr.yaml
+++ b/addons/postgresql/templates/actionset-wal-g-pitr.yaml
@@ -37,7 +37,10 @@ spec:
       - -c
       - |
         #!/bin/bash
-        set -e
+        # No set -e here: wal-g-archive.sh is a long-running archiver that owns
+        # its error contract (upload retry with tracking files, bounded pg
+        # probing, rescue upload before exit). A wrapper set -e kills the
+        # process on the first failure and makes all of that unreachable.
         set -o pipefail
         {{- .Files.Get "dataprotection/common-scripts.sh" | nindent 8 }}
         {{- .Files.Get "dataprotection/wal-g-archive.sh" | nindent 8 }}


### PR DESCRIPTION
## Problem

Both Continuous backup ActionSets inject `set -e` ahead of long-running archiver scripts whose error handling is written for `set +e` semantics — so the error handling was dead code:

- **actionset-wal-g-pitr.yaml → wal-g-archive.sh**: `uploadMissingLogs`' tracking-file retry system (`eval wal-g wal-push; exit_code=$?` + the failure branch that preserves the tracking file for a delayed retry) was unreachable: the first failed wal-push killed the process. Same for `uploadDoneHistoryWALs` and for `check_pg_process`' bounded 3-probe loop, whose rescue path (upload remaining WALs before exit) never ran. During a failover window the Continuous backup pod crash-loops instead of retrying gracefully as designed.
- **actionset-postgresql-pitr.yaml → postgresql-pitr-backup.sh**: same pattern.

Fixes #3010. Methodology: [addon-actionset-wrapper-set-e-vs-in-script-error-handling-guide.md](https://github.com/apecloud/kubeblocks-addon-docs/blob/main/docs/addon-actionset-wrapper-set-e-vs-in-script-error-handling-guide.md) — the error contract must live in exactly one layer; for long-running archiver loops that layer is the script.

## set -e removal audit (per the guide's hard rule 4)

Before touching the wrappers I audited what `set -e` was actually blocking. One statement was load-bearing:

- `postgresql-pitr-backup.sh` `upload_wal_log`: `datasafed push` followed by an **unchecked** `mv .ready → .done`. `set -e` was the only thing preventing a failed push from being marked done — which would let PostgreSQL recycle a never-uploaded WAL segment and hole the PITR chain. That statement now has an explicit success gate (`if datasafed push …; then mv …; else keep .ready for retry`), landed **before** the wrapper change in the same PR.

Everything else the wrapper's `set -e` covered is either explicitly checked now (wal-g env bootstrap fails fast) or is designed failure-tolerance that the next loop round retries.

## Changes

- Both Continuous `backupData` wrappers: `set -e` removed, `set -o pipefail` kept, comment states the contract. The **restore-side** wrapper of actionset-postgresql-pitr keeps `set -e` — one-shot job, fail-fast is correct there (guide's decision rule 5).
- `postgresql-pitr-backup.sh`: rename-after-successful-push only; failed uploads logged and retried next round; `cd` / `pg_switch_wal` failures logged.
- `wal-g-archive.sh`: bootstrap (`mkdir`/`cp` of wal-g env) fails fast explicitly.
- New specs (11 examples) extract the archiver functions via awk shim (the scripts run infinite loops at top level, so `Include` is impossible) and pin the contract: failed upload keeps `.ready` + tracking file and is **never** marked `.done`; success renames and clears tracking; a fresh tracking file suppresses immediate retry; 3 failed probes trigger the rescue upload then exit 1.

## Evidence boundary

Static analysis + shellspec unit tests (postgresql suite 24/24 green locally, shellcheck clean at CI severity, helm template renders). The crash-loop-during-failover consequence is inferred from code paths, not reproduced on a live cluster; the unit tests pin the retry semantics that set -e previously made unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)