### PR TITLE
feat(valkey): cluster topology phase C — roles, roleProbe, switchover, member join/leave

### DIFF
--- a/addons/valkey/scripts-ut-spec/valkey_cluster_role_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_role_switchover_spec.sh
@@ -7,7 +7,7 @@
 Describe "valkey-cluster-check-role.sh"
   Include ../scripts/valkey-cluster-check-role.sh
 
-  It "emits 'primary <epoch>' from a myself,master line"
+  It "emits single-token 'primary' from a myself,master line"
     build_cli_cmd() { cli_cmd=(mock_nodes); }
     mock_nodes() {
       printf 'aaa 10.0.0.1:6379@16379 myself,master - 0 0 7 connected 0-5460\n'
@@ -15,17 +15,17 @@ Describe "valkey-cluster-check-role.sh"
     }
     When call probe_cluster_role
     The status should be success
-    The stdout should equal "primary 7"
+    The stdout should equal "primary"
   End
 
-  It "emits 'secondary <epoch>' from a myself,slave line"
+  It "emits single-token 'secondary' from a myself,slave line"
     build_cli_cmd() { cli_cmd=(mock_nodes); }
     mock_nodes() {
       printf 'bbb 10.0.0.2:6379@16379 myself,slave aaa 0 0 12 connected\n'
     }
     When call probe_cluster_role
     The status should be success
-    The stdout should equal "secondary 12"
+    The stdout should equal "secondary"
   End
 
   It "skips the sample (non-zero, no role token) when myself is absent"
@@ -37,13 +37,12 @@ Describe "valkey-cluster-check-role.sh"
     The stderr should include "skip sample"
   End
 
-  It "skips the sample on a non-numeric epoch (never emits a guessed role)"
+  It "never emits a version token (single-token contract, versioned path deferred)"
     build_cli_cmd() { cli_cmd=(mock_nodes); }
-    mock_nodes() { printf 'ddd 10.0.0.4:6379@16379 myself,master - 0 0 oops connected\n'; }
+    mock_nodes() { printf 'ddd 10.0.0.4:6379@16379 myself,master - 0 0 42 connected 0-5460\n'; }
     When call probe_cluster_role
-    The status should be failure
-    The stdout should equal ""
-    The stderr should include "non-numeric config-epoch"
+    The status should be success
+    The stdout should not include " "
   End
 End
 
@@ -91,7 +90,29 @@ Describe "valkey-cluster-switchover.sh"
     role_of() { echo "unknown"; }
     When call execute_switchover "vk-s-1.h.ns.svc"
     The status should be failure
-    The stderr should include "cannot promote"
+    The stderr should include "phase=candidate-state"
+  End
+
+  It "refuses an explicit candidate outside this shard"
+    export KB_SWITCHOVER_CANDIDATE_FQDN="vk-OTHER-9.h.ns.svc"
+    When call switchover
+    The status should be failure
+    The stderr should include "phase=candidate-outside-shard"
+  End
+
+  It "refuses non-primary role switchover requests"
+    export KB_SWITCHOVER_ROLE="secondary"
+    When call switchover
+    The status should be failure
+    The stderr should include "phase=role-guard"
+  End
+
+  It "refuses a candidate that does not replicate this shard's master"
+    role_of() { echo "replica"; }
+    candidate_replicates_this_shard() { return 1; }
+    When call execute_switchover "vk-s-1.h.ns.svc"
+    The status should be failure
+    The stderr should include "phase=candidate-wrong-master"
   End
 
   It "fails with a classified error when promotion is unconfirmed in budget"
@@ -133,13 +154,44 @@ Describe "valkey-cluster-member.sh"
     mock_no_slave() { printf 'id1 x myself,master - 0 0 5 connected\n'; }
     When run member_leave
     The status should be failure
+    The stderr should include "phase=leave-orphan-guard"
     The stderr should include "would orphan slots"
+  End
+
+  It "excludes the join target from the vantage and requires a formed member"
+    export KB_JOIN_MEMBER_POD_FQDN="vk-s-1.h.ns.svc"
+    # Only the target itself would answer: vantage must refuse it and fail.
+    build_cli() {
+      case "$1" in
+        vk-s-1.h.ns.svc) _cli=(mock_up) ;;
+        *) _cli=(mock_down) ;;
+      esac
+    }
+    mock_up() { case "$1" in PING) echo PONG;; *) echo "cluster_state:ok";; esac; }
+    mock_down() { return 1; }
+    When run member_join
+    The status should be failure
+    The stderr should include "phase=vantage"
+  End
+
+  It "does not confirm a join on visibility alone (must be replica of this master)"
+    export KB_JOIN_MEMBER_POD_FQDN="vk-s-1.h.ns.svc"
+    shard_vantage() { echo "vk-s-0.h.ns.svc"; }
+    shard_master_line() { echo "mid1 vk-s-0.h.ns.svc:6379@16379 myself,master - 0 0 5 connected 0-5460"; }
+    # target visible but flagged master of nothing (not slave of mid1)
+    node_line_of() { echo "tid2 vk-s-1.h.ns.svc:6379@16379 master - 0 0 6 connected"; }
+    build_cluster_cli() { _ccli=(mock_add); }
+    mock_add() { echo "added"; }
+    When run member_join
+    The status should be failure
+    The stderr should include "phase=join-confirm"
   End
 
   It "requires the join target env"
     unset KB_JOIN_MEMBER_POD_FQDN
     When run member_join
     The status should be failure
+    The stderr should include "phase=env-contract"
     The stderr should include "KB_JOIN_MEMBER_POD_FQDN is required"
   End
 End

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_role_switchover_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_role_switchover_spec.sh
@@ -1,0 +1,145 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+# Phase C behavioral tests (issue #3037): cluster roleProbe contract,
+# switchover candidate selection + confirmation, member leave safety.
+
+Describe "valkey-cluster-check-role.sh"
+  Include ../scripts/valkey-cluster-check-role.sh
+
+  It "emits 'primary <epoch>' from a myself,master line"
+    build_cli_cmd() { cli_cmd=(mock_nodes); }
+    mock_nodes() {
+      printf 'aaa 10.0.0.1:6379@16379 myself,master - 0 0 7 connected 0-5460\n'
+      printf 'bbb 10.0.0.2:6379@16379 slave aaa 0 0 7 connected\n'
+    }
+    When call probe_cluster_role
+    The status should be success
+    The stdout should equal "primary 7"
+  End
+
+  It "emits 'secondary <epoch>' from a myself,slave line"
+    build_cli_cmd() { cli_cmd=(mock_nodes); }
+    mock_nodes() {
+      printf 'bbb 10.0.0.2:6379@16379 myself,slave aaa 0 0 12 connected\n'
+    }
+    When call probe_cluster_role
+    The status should be success
+    The stdout should equal "secondary 12"
+  End
+
+  It "skips the sample (non-zero, no role token) when myself is absent"
+    build_cli_cmd() { cli_cmd=(mock_nodes); }
+    mock_nodes() { printf 'ccc 10.0.0.3:6379@16379 master - 0 0 3 connected\n'; }
+    When call probe_cluster_role
+    The status should be failure
+    The stdout should equal ""
+    The stderr should include "skip sample"
+  End
+
+  It "skips the sample on a non-numeric epoch (never emits a guessed role)"
+    build_cli_cmd() { cli_cmd=(mock_nodes); }
+    mock_nodes() { printf 'ddd 10.0.0.4:6379@16379 myself,master - 0 0 oops connected\n'; }
+    When call probe_cluster_role
+    The status should be failure
+    The stdout should equal ""
+    The stderr should include "non-numeric config-epoch"
+  End
+End
+
+Describe "valkey-cluster-switchover.sh"
+  Include ../scripts/valkey-cluster-switchover.sh
+
+  sw_env() {
+    export CURRENT_SHARD_POD_FQDN_LIST="vk-s-0.h.ns.svc,vk-s-1.h.ns.svc,vk-s-2.h.ns.svc"
+    export KB_SWITCHOVER_CURRENT_FQDN="vk-s-0.h.ns.svc"
+    unset KB_SWITCHOVER_CANDIDATE_FQDN
+    ut_mode="true"
+  }
+  sw_clean() { unset CURRENT_SHARD_POD_FQDN_LIST KB_SWITCHOVER_CURRENT_FQDN KB_SWITCHOVER_CANDIDATE_FQDN; }
+  Before "sw_env"
+  After "sw_clean"
+
+  It "deterministically picks the first sorted in-shard replica"
+    role_of() {
+      case "$1" in
+        vk-s-1.h.ns.svc) echo "replica" ;;
+        vk-s-2.h.ns.svc) echo "replica" ;;
+        *) echo "master" ;;
+      esac
+    }
+    When call pick_candidate
+    The status should be success
+    The stdout should equal "vk-s-1.h.ns.svc"
+  End
+
+  It "hard-fails when no replica is available"
+    role_of() { echo "unknown"; }
+    When call pick_candidate
+    The status should be failure
+    The stderr should include "no reachable in-shard replica"
+  End
+
+  It "treats an already-master candidate as success (idempotent)"
+    role_of() { echo "master"; }
+    When call execute_switchover "vk-s-1.h.ns.svc"
+    The status should be success
+    The stdout should include "already master"
+  End
+
+  It "refuses to promote a candidate in unknown state"
+    role_of() { echo "unknown"; }
+    When call execute_switchover "vk-s-1.h.ns.svc"
+    The status should be failure
+    The stderr should include "cannot promote"
+  End
+
+  It "fails with a classified error when promotion is unconfirmed in budget"
+    export SWITCHOVER_CONFIRM_BUDGET=2
+    role_of() { echo "replica"; }
+    When call confirm_promotion "vk-s-1.h.ns.svc"
+    The status should be failure
+    The stderr should include "did not report master within 2s"
+    The stderr should include "safe to retry"
+  End
+End
+
+Describe "valkey-cluster-member.sh"
+  Include ../scripts/valkey-cluster-member.sh
+
+  mb_env() {
+    export CURRENT_SHARD_POD_FQDN_LIST="vk-s-0.h.ns.svc,vk-s-1.h.ns.svc"
+    export SERVICE_PORT=6379
+    ut_mode="true"
+  }
+  mb_clean() { unset CURRENT_SHARD_POD_FQDN_LIST KB_LEAVE_MEMBER_POD_FQDN KB_JOIN_MEMBER_POD_FQDN; }
+  Before "mb_env"
+  After "mb_clean"
+
+  It "closes leave as effective when the member is already absent"
+    export KB_LEAVE_MEMBER_POD_FQDN="vk-s-9.h.ns.svc"
+    shard_vantage() { echo "vk-s-0.h.ns.svc"; }
+    node_line_of() { echo ""; }
+    When run member_leave
+    The status should be success
+    The stdout should include "leave already effective"
+  End
+
+  It "refuses to delete a master with no replica to fail over to"
+    export KB_LEAVE_MEMBER_POD_FQDN="vk-s-0.h.ns.svc"
+    shard_vantage() { echo "vk-s-1.h.ns.svc"; }
+    node_line_of() { echo "id0 vk-s-0.h.ns.svc:6379@16379 master - 0 0 5 connected 0-5460"; }
+    build_cli() { _cli=(mock_no_slave); }
+    mock_no_slave() { printf 'id1 x myself,master - 0 0 5 connected\n'; }
+    When run member_leave
+    The status should be failure
+    The stderr should include "would orphan slots"
+  End
+
+  It "requires the join target env"
+    unset KB_JOIN_MEMBER_POD_FQDN
+    When run member_join
+    The status should be failure
+    The stderr should include "KB_JOIN_MEMBER_POD_FQDN is required"
+  End
+End

--- a/addons/valkey/scripts/valkey-cluster-check-role.sh
+++ b/addons/valkey/scripts/valkey-cluster-check-role.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# valkey-cluster-check-role.sh — roleProbe for Valkey Cluster (sharding) mode.
+# Phase C of issue #3021 (issue #3037).
+#
+# Contract (KB role+version, post-#10280): stdout's first whitespace token is
+# the role (must match a ComponentDefinition roles[] name), the optional
+# second token is a uint64 role version the controller uses as a staleness
+# gate against replayed events. We emit this shard's config-epoch as the
+# version token (it increases on every failover — same anti-replay idea as
+# the sentinel-mode probe).
+#
+# Pure read-and-emit: the probe never mutates anything. Unknown state is a
+# non-zero exit (KB keeps the last trusted label and skips this sample) —
+# NEVER an empty-string role (design review class 4: empty must not be a
+# sentinel value).
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  # when running in non-unit test mode, set the options "set -ex".
+  set -ex;
+}
+
+set -e
+
+port="${KB_SERVICE_PORT:-${SERVICE_PORT:-6379}}"
+
+load_common_library() {
+  # shellcheck source=/dev/null
+  source /scripts/common.sh
+}
+
+build_cli_cmd() {
+  cli_cmd=(valkey-cli --no-auth-warning -h 127.0.0.1 -p "${port}")
+  if [ -n "${VALKEY_DEFAULT_PASSWORD:-}" ]; then
+    cli_cmd+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS:-}" ]; then
+    # shellcheck disable=SC2206
+    cli_cmd+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+# Prints "<role> <epoch>" from this node's own CLUSTER NODES myself line, or
+# fails (non-zero) when the line is absent or the role is unrecognizable.
+probe_cluster_role() {
+  local nodes myself flags epoch role
+  build_cli_cmd
+  nodes=$("${cli_cmd[@]}" CLUSTER NODES 2>/dev/null) || {
+    echo "role probe: CLUSTER NODES unreachable — skip sample." >&2
+    return 1
+  }
+  myself=$(echo "${nodes}" | tr -d '\r' | awk '$3 ~ /myself/')
+  if [ -z "${myself}" ]; then
+    echo "role probe: no myself line in CLUSTER NODES — skip sample." >&2
+    return 1
+  fi
+  flags=$(echo "${myself}" | awk '{print $3}')
+  epoch=$(echo "${myself}" | awk '{print $7}')
+  case "${epoch}" in
+    ''|*[!0-9]*)
+      echo "role probe: non-numeric config-epoch '${epoch}' — skip sample." >&2
+      return 1 ;;
+  esac
+  case "${flags}" in
+    *master*) role="primary" ;;
+    *slave*)  role="secondary" ;;
+    *)
+      echo "role probe: unrecognized flags '${flags}' — skip sample." >&2
+      return 1 ;;
+  esac
+  echo "${role} ${epoch}"
+}
+
+# This is magic for shellspec ut framework, do not modify!
+${__SOURCED__:+false} : || return 0
+
+load_common_library
+probe_cluster_role

--- a/addons/valkey/scripts/valkey-cluster-check-role.sh
+++ b/addons/valkey/scripts/valkey-cluster-check-role.sh
@@ -2,12 +2,13 @@
 # valkey-cluster-check-role.sh — roleProbe for Valkey Cluster (sharding) mode.
 # Phase C of issue #3021 (issue #3037).
 #
-# Contract (KB role+version, post-#10280): stdout's first whitespace token is
-# the role (must match a ComponentDefinition roles[] name), the optional
-# second token is a uint64 role version the controller uses as a staleness
-# gate against replayed events. We emit this shard's config-epoch as the
-# version token (it increases on every failover — same anti-replay idea as
-# the sentinel-mode probe).
+# Contract: SINGLE-TOKEN role output (KB's EventTime gate applies).
+# The versioned (role + uint64) path is deliberately NOT used: a version
+# token must represent the COMPLETE role fact (including which pod is the
+# shard primary, per 05a), and this pod's local myself-line epoch cannot
+# prove shard-wide convergence of that fact during failover windows.
+# A versioned probe would require multi-node view agreement per sample —
+# deferred until designed properly (review: PR #3038 blocker 1).
 #
 # Pure read-and-emit: the probe never mutates anything. Unknown state is a
 # non-zero exit (KB keeps the last trusted label and skips this sample) —
@@ -41,10 +42,10 @@ build_cli_cmd() {
   fi
 }
 
-# Prints "<role> <epoch>" from this node's own CLUSTER NODES myself line, or
-# fails (non-zero) when the line is absent or the role is unrecognizable.
+# Prints "<role>" from this node's own CLUSTER NODES myself line, or fails
+# (non-zero) when the line is absent or the role is unrecognizable.
 probe_cluster_role() {
-  local nodes myself flags epoch role
+  local nodes myself flags role
   build_cli_cmd
   nodes=$("${cli_cmd[@]}" CLUSTER NODES 2>/dev/null) || {
     echo "role probe: CLUSTER NODES unreachable — skip sample." >&2
@@ -56,12 +57,6 @@ probe_cluster_role() {
     return 1
   fi
   flags=$(echo "${myself}" | awk '{print $3}')
-  epoch=$(echo "${myself}" | awk '{print $7}')
-  case "${epoch}" in
-    ''|*[!0-9]*)
-      echo "role probe: non-numeric config-epoch '${epoch}' — skip sample." >&2
-      return 1 ;;
-  esac
   case "${flags}" in
     *master*) role="primary" ;;
     *slave*)  role="secondary" ;;
@@ -69,7 +64,7 @@ probe_cluster_role() {
       echo "role probe: unrecognized flags '${flags}' — skip sample." >&2
       return 1 ;;
   esac
-  echo "${role} ${epoch}"
+  echo "${role}"
 }
 
 # This is magic for shellspec ut framework, do not modify!

--- a/addons/valkey/scripts/valkey-cluster-member.sh
+++ b/addons/valkey/scripts/valkey-cluster-member.sh
@@ -31,6 +31,13 @@ load_common_library() {
   source /scripts/common.sh
 }
 
+# Stable classification for every non-zero exit (aligned with
+# valkey-cluster-manage.sh): classify <phase> <retry_safe:yes|no> <detail...>
+classify() {
+  local phase="$1" retry_safe="$2"; shift 2
+  echo "action=valkey-cluster-member phase=${phase} retry_safe=${retry_safe} detail=$*" >&2
+}
+
 build_cli() {
   local host="${1}"
   _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
@@ -50,18 +57,23 @@ build_cluster_cli() {
   fi
 }
 
-# First in-shard pod that answers PING — used as the vantage point for
-# cluster-view reads (never as an identity).
+# Vantage for cluster-view reads: first in-shard pod that (a) is NOT the
+# operation target (a target's local view can false-close join/leave —
+# review blocker), (b) answers PING, and (c) provably belongs to a FORMED
+# cluster (state ok). Never an identity, only a viewpoint.
 shard_vantage() {
-  local fqdn
+  local exclude="${1:-}" fqdn state
   for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | sort); do
+    [ -n "${exclude}" ] && [ "${fqdn}" = "${exclude}" ] && continue
     build_cli "${fqdn}"
-    if "${_cli[@]}" PING 2>/dev/null | grep -q PONG; then
+    "${_cli[@]}" PING 2>/dev/null | grep -q PONG || continue
+    state=$("${_cli[@]}" CLUSTER INFO 2>/dev/null | grep "^cluster_state:" | tr -d '\r' | cut -d: -f2)
+    if [ "${state}" = "ok" ]; then
       echo "${fqdn}"
       return 0
     fi
   done
-  echo "ERROR: no in-shard pod answers — cannot read cluster view." >&2
+  classify vantage yes "no non-target in-shard pod with cluster_state:ok — cannot read a trustworthy cluster view"
   return 1
 }
 
@@ -83,45 +95,58 @@ node_line_of() {
 member_join() {
   local target="${KB_JOIN_MEMBER_POD_FQDN:-}"
   if [ -z "${target}" ]; then
-    echo "ERROR: KB_JOIN_MEMBER_POD_FQDN is required for --join." >&2
+    classify env-contract no "KB_JOIN_MEMBER_POD_FQDN is required for --join"
     exit 1
   fi
   local via master_line master_id master_addr
-  via=$(shard_vantage) || exit 1
+  via=$(shard_vantage "${target}") || exit 1
   master_line=$(shard_master_line "${via}")
   if [ -z "${master_line}" ]; then
-    echo "ERROR: shard has no master in cluster view — refusing to attach a replica blind." >&2
+    classify join-no-master no "shard has no master in cluster view — refusing to attach a replica blind"
     exit 1
   fi
   master_id=$(echo "${master_line}" | awk '{print $1}')
   master_addr=$(echo "${master_line}" | awk '{print $2}' | cut -d@ -f1 | cut -d: -f1)
 
-  if [ -n "$(node_line_of "${via}" "${target}")" ]; then
-    echo "member ${target} already in cluster view — join already effective."
+  if join_confirmed "${via}" "${target}" "${master_id}"; then
+    echo "member ${target} already a replica of this shard's master — join already effective."
     exit 0
   fi
-  build_cluster_cli
-  local out
-  out=$("${_ccli[@]}" --cluster add-node "${target}:${port}" "${master_addr}:${port}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
-    echo "ERROR: add-node --cluster-slave for ${target} failed: ${out}" >&2
-    exit 1
-  }
   if [ -z "$(node_line_of "${via}" "${target}")" ]; then
-    echo "ERROR: add-node reported success but ${target} not visible in cluster view — not confirming join." >&2
+    build_cluster_cli
+    local out
+    out=$("${_ccli[@]}" --cluster add-node "${target}:${port}" "${master_addr}:${port}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
+      classify join-add-node no "add-node --cluster-slave for ${target} failed: ${out}"
+      exit 1
+    }
+  fi
+  if ! join_confirmed "${via}" "${target}" "${master_id}"; then
+    classify join-confirm yes "${target} not yet a replica of master ${master_id} in the non-target cluster view"
     exit 1
   fi
   echo "member ${target} joined shard as replica of ${master_id}."
   exit 0
 }
 
+# Positive join fact: from a NON-TARGET vantage, the target's node line must
+# carry the slave flag AND reference this shard's master id (visibility
+# alone is not membership — review blocker).
+join_confirmed() {
+  local via="${1}" target="${2}" master_id="${3}" line
+  line=$(node_line_of "${via}" "${target}")
+  [ -z "${line}" ] && return 1
+  echo "${line}" | awk '{print $3}' | grep -q slave || return 1
+  [ "$(echo "${line}" | awk '{print $4}')" = "${master_id}" ]
+}
+
 member_leave() {
   local target="${KB_LEAVE_MEMBER_POD_FQDN:-}"
   if [ -z "${target}" ]; then
-    echo "ERROR: KB_LEAVE_MEMBER_POD_FQDN is required for --leave." >&2
+    classify env-contract no "KB_LEAVE_MEMBER_POD_FQDN is required for --leave"
     exit 1
   fi
   local via target_line target_id target_flags
-  via=$(shard_vantage) || exit 1
+  via=$(shard_vantage "${target}") || exit 1
   target_line=$(node_line_of "${via}" "${target}")
   if [ -z "${target_line}" ]; then
     echo "member ${target} not in cluster view — leave already effective."
@@ -137,11 +162,11 @@ member_leave() {
   build_cluster_cli
   local out
   out=$("${_ccli[@]}" --cluster del-node "${via}:${port}" "${target_id}" 2>&1) || {
-    echo "ERROR: del-node ${target_id} failed: ${out}" >&2
+    classify leave-del-node no "del-node ${target_id} failed: ${out}"
     exit 1
   }
   if [ -n "$(node_line_of "${via}" "${target}")" ]; then
-    echo "ERROR: del-node reported success but ${target} still in cluster view — not confirming leave." >&2
+    classify leave-confirm yes "del-node reported success but ${target} still in cluster view"
     exit 1
   fi
   echo "member ${target} removed from cluster."
@@ -163,12 +188,12 @@ demote_master_before_leave() {
     fi
   done
   if [ -z "${promoted}" ]; then
-    echo "ERROR: leaving pod is the shard master and no in-shard replica exists — refusing leave (would orphan slots)." >&2
+    classify leave-orphan-guard no "leaving pod is the shard master and no in-shard replica exists — refusing leave (would orphan slots)"
     return 1
   fi
   build_cli "${promoted}"
   out=$("${_cli[@]}" CLUSTER FAILOVER 2>&1) || {
-    echo "ERROR: CLUSTER FAILOVER on ${promoted} failed: ${out}" >&2
+    classify leave-failover no "CLUSTER FAILOVER on ${promoted} failed: ${out}"
     return 1
   }
   while [ "${waited}" -lt "${LEAVE_FAILOVER_BUDGET}" ]; do
@@ -179,7 +204,7 @@ demote_master_before_leave() {
     sleep_when_ut_mode_false 1
     waited=$((waited + 1))
   done
-  echo "ERROR: mastership did not move within ${LEAVE_FAILOVER_BUDGET}s — refusing to delete the master (retry-safe)." >&2
+  classify leave-failover-confirm yes "mastership did not move within ${LEAVE_FAILOVER_BUDGET}s — refusing to delete the master"
   return 1
 }
 

--- a/addons/valkey/scripts/valkey-cluster-member.sh
+++ b/addons/valkey/scripts/valkey-cluster-member.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# valkey-cluster-member.sh — intra-shard replica join/leave for Valkey
+# Cluster (sharding) mode. Phase C of issue #3021 (issue #3037).
+#
+# Modes:
+#   --join    attach KB_JOIN_MEMBER_POD_FQDN as a replica of this shard's
+#             current master (engine node id resolved fresh)
+#   --leave   remove KB_LEAVE_MEMBER_POD_FQDN from the cluster; when the
+#             leaving pod is the CURRENT master, fail over to another
+#             in-shard replica first and only delete after the shard's
+#             slots are owned by the new master
+#
+# Same single-shot discipline as the manage script: positive observation or
+# classified non-zero exit; topology re-read every invocation; identity is
+# always the engine node id.
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  # when running in non-unit test mode, set the options "set -ex".
+  set -ex;
+}
+
+set -e
+
+port="${SERVICE_PORT:-6379}"
+LEAVE_FAILOVER_BUDGET="${LEAVE_FAILOVER_BUDGET:-30}"
+
+load_common_library() {
+  # shellcheck source=/dev/null
+  source /scripts/common.sh
+}
+
+build_cli() {
+  local host="${1}"
+  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
+  [ -n "${VALKEY_DEFAULT_PASSWORD:-}" ] && _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  if [ -n "${VALKEY_CLI_TLS_ARGS:-}" ]; then
+    # shellcheck disable=SC2206
+    _cli+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+build_cluster_cli() {
+  _ccli=(valkey-cli --no-auth-warning)
+  [ -n "${VALKEY_DEFAULT_PASSWORD:-}" ] && _ccli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  if [ -n "${VALKEY_CLI_TLS_ARGS:-}" ]; then
+    # shellcheck disable=SC2206
+    _ccli+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+# First in-shard pod that answers PING — used as the vantage point for
+# cluster-view reads (never as an identity).
+shard_vantage() {
+  local fqdn
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | sort); do
+    build_cli "${fqdn}"
+    if "${_cli[@]}" PING 2>/dev/null | grep -q PONG; then
+      echo "${fqdn}"
+      return 0
+    fi
+  done
+  echo "ERROR: no in-shard pod answers — cannot read cluster view." >&2
+  return 1
+}
+
+shard_master_line() {
+  local via="${1}" fqdn pattern=""
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$'); do
+    pattern="${pattern:+${pattern}|}${fqdn}"
+  done
+  build_cli "${via}"
+  "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -E "${pattern}" | awk '$3 ~ /master/ {print; exit}'
+}
+
+node_line_of() {
+  local via="${1}" target="${2}"
+  build_cli "${via}"
+  "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -F "${target}" | head -1
+}
+
+member_join() {
+  local target="${KB_JOIN_MEMBER_POD_FQDN:-}"
+  if [ -z "${target}" ]; then
+    echo "ERROR: KB_JOIN_MEMBER_POD_FQDN is required for --join." >&2
+    exit 1
+  fi
+  local via master_line master_id master_addr
+  via=$(shard_vantage) || exit 1
+  master_line=$(shard_master_line "${via}")
+  if [ -z "${master_line}" ]; then
+    echo "ERROR: shard has no master in cluster view — refusing to attach a replica blind." >&2
+    exit 1
+  fi
+  master_id=$(echo "${master_line}" | awk '{print $1}')
+  master_addr=$(echo "${master_line}" | awk '{print $2}' | cut -d@ -f1 | cut -d: -f1)
+
+  if [ -n "$(node_line_of "${via}" "${target}")" ]; then
+    echo "member ${target} already in cluster view — join already effective."
+    exit 0
+  fi
+  build_cluster_cli
+  local out
+  out=$("${_ccli[@]}" --cluster add-node "${target}:${port}" "${master_addr}:${port}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
+    echo "ERROR: add-node --cluster-slave for ${target} failed: ${out}" >&2
+    exit 1
+  }
+  if [ -z "$(node_line_of "${via}" "${target}")" ]; then
+    echo "ERROR: add-node reported success but ${target} not visible in cluster view — not confirming join." >&2
+    exit 1
+  fi
+  echo "member ${target} joined shard as replica of ${master_id}."
+  exit 0
+}
+
+member_leave() {
+  local target="${KB_LEAVE_MEMBER_POD_FQDN:-}"
+  if [ -z "${target}" ]; then
+    echo "ERROR: KB_LEAVE_MEMBER_POD_FQDN is required for --leave." >&2
+    exit 1
+  fi
+  local via target_line target_id target_flags
+  via=$(shard_vantage) || exit 1
+  target_line=$(node_line_of "${via}" "${target}")
+  if [ -z "${target_line}" ]; then
+    echo "member ${target} not in cluster view — leave already effective."
+    exit 0
+  fi
+  target_id=$(echo "${target_line}" | awk '{print $1}')
+  target_flags=$(echo "${target_line}" | awk '{print $3}')
+
+  if echo "${target_flags}" | grep -q master; then
+    demote_master_before_leave "${via}" "${target}" || exit 1
+  fi
+
+  build_cluster_cli
+  local out
+  out=$("${_ccli[@]}" --cluster del-node "${via}:${port}" "${target_id}" 2>&1) || {
+    echo "ERROR: del-node ${target_id} failed: ${out}" >&2
+    exit 1
+  }
+  if [ -n "$(node_line_of "${via}" "${target}")" ]; then
+    echo "ERROR: del-node reported success but ${target} still in cluster view — not confirming leave." >&2
+    exit 1
+  fi
+  echo "member ${target} removed from cluster."
+  exit 0
+}
+
+# The leaving pod is the shard's current master: promote another in-shard
+# replica via CLUSTER FAILOVER and positively confirm the mastership moved
+# before allowing deletion (slots must never be orphaned).
+demote_master_before_leave() {
+  local via="${1}" leaving="${2}" fqdn role out waited=0
+  local promoted=""
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | sort); do
+    [ "${fqdn}" = "${leaving}" ] && continue
+    build_cli "${fqdn}"
+    if "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | awk '$3 ~ /myself/ {print $3}' | grep -q slave; then
+      promoted="${fqdn}"
+      break
+    fi
+  done
+  if [ -z "${promoted}" ]; then
+    echo "ERROR: leaving pod is the shard master and no in-shard replica exists — refusing leave (would orphan slots)." >&2
+    return 1
+  fi
+  build_cli "${promoted}"
+  out=$("${_cli[@]}" CLUSTER FAILOVER 2>&1) || {
+    echo "ERROR: CLUSTER FAILOVER on ${promoted} failed: ${out}" >&2
+    return 1
+  }
+  while [ "${waited}" -lt "${LEAVE_FAILOVER_BUDGET}" ]; do
+    if shard_master_line "${via}" | grep -qF "${promoted}"; then
+      echo "mastership moved to ${promoted}; leaving pod is now a replica."
+      return 0
+    fi
+    sleep_when_ut_mode_false 1
+    waited=$((waited + 1))
+  done
+  echo "ERROR: mastership did not move within ${LEAVE_FAILOVER_BUDGET}s — refusing to delete the master (retry-safe)." >&2
+  return 1
+}
+
+# This is magic for shellspec ut framework, do not modify!
+${__SOURCED__:+false} : || return 0
+
+load_common_library
+case "${1:-}" in
+  --join)  member_join ;;
+  --leave) member_leave ;;
+  *)
+    echo "usage: $0 --join | --leave" >&2
+    exit 1 ;;
+esac

--- a/addons/valkey/scripts/valkey-cluster-switchover.sh
+++ b/addons/valkey/scripts/valkey-cluster-switchover.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# valkey-cluster-switchover.sh — intra-shard switchover for Valkey Cluster
+# (sharding) mode. Phase C of issue #3021 (issue #3037).
+#
+# Uses the engine-native graceful path: CLUSTER FAILOVER executed ON the
+# promotion candidate (a replica of this shard). No priority biasing, no
+# external coordinator — the cluster's own config-epoch machinery guarantees
+# consistency.
+#
+# KB injects (switchover contract):
+#   KB_SWITCHOVER_CANDIDATE_FQDN  optional — the replica to promote
+#   KB_SWITCHOVER_CURRENT_FQDN    the current primary's FQDN
+#   KB_SWITCHOVER_ROLE            role being switched away from ("primary")
+#
+# Candidate-less switchover picks the lexicographically first in-shard
+# replica — deterministic, never random.
+#
+# Bounded confirmation: the action verifies the candidate actually reports
+# master within SWITCHOVER_CONFIRM_BUDGET seconds (default 30, inside the
+# action timeout) and fails with a classified error otherwise.
+
+# shellcheck disable=SC2034
+ut_mode="false"
+test || __() {
+  # when running in non-unit test mode, set the options "set -ex".
+  set -ex;
+}
+
+set -e
+
+port="${SERVICE_PORT:-6379}"
+SWITCHOVER_CONFIRM_BUDGET="${SWITCHOVER_CONFIRM_BUDGET:-30}"
+
+load_common_library() {
+  # shellcheck source=/dev/null
+  source /scripts/common.sh
+}
+
+build_cli() {
+  local host="${1}"
+  _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
+  if [ -n "${VALKEY_DEFAULT_PASSWORD:-}" ]; then
+    _cli+=(-a "${VALKEY_DEFAULT_PASSWORD}")
+  fi
+  if [ -n "${VALKEY_CLI_TLS_ARGS:-}" ]; then
+    # shellcheck disable=SC2206
+    _cli+=(${VALKEY_CLI_TLS_ARGS})
+  fi
+}
+
+role_of() {
+  local host="${1}" myself
+  build_cli "${host}"
+  myself=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | awk '$3 ~ /myself/ {print $3}')
+  case "${myself}" in
+    *master*) echo "master" ;;
+    *slave*)  echo "replica" ;;
+    *)        echo "unknown" ;;
+  esac
+}
+
+# Deterministic candidate pick: first (sorted) in-shard pod that is
+# currently a replica and answers. Hard-fails when none qualifies.
+pick_candidate() {
+  local fqdn role
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | sort); do
+    [ "${fqdn}" = "${KB_SWITCHOVER_CURRENT_FQDN}" ] && continue
+    role=$(role_of "${fqdn}")
+    if [ "${role}" = "replica" ]; then
+      echo "${fqdn}"
+      return 0
+    fi
+  done
+  echo "ERROR: no reachable in-shard replica available as switchover candidate." >&2
+  return 1
+}
+
+execute_switchover() {
+  local candidate="${1}" out
+  role=$(role_of "${candidate}")
+  if [ "${role}" = "master" ]; then
+    echo "candidate ${candidate} is already master — switchover already effective."
+    return 0
+  fi
+  if [ "${role}" != "replica" ]; then
+    echo "ERROR: candidate ${candidate} reports role '${role}' — cannot promote (unknown state is not promotable)." >&2
+    return 1
+  fi
+  build_cli "${candidate}"
+  out=$("${_cli[@]}" CLUSTER FAILOVER 2>&1) || {
+    echo "ERROR: CLUSTER FAILOVER on ${candidate} failed: ${out}" >&2
+    return 1
+  }
+  echo "CLUSTER FAILOVER issued on ${candidate}: ${out}"
+  confirm_promotion "${candidate}"
+}
+
+confirm_promotion() {
+  local candidate="${1}" waited=0 role
+  while [ "${waited}" -lt "${SWITCHOVER_CONFIRM_BUDGET}" ]; do
+    role=$(role_of "${candidate}")
+    if [ "${role}" = "master" ]; then
+      echo "switchover confirmed: ${candidate} is master (after ${waited}s)."
+      return 0
+    fi
+    sleep_when_ut_mode_false 1
+    waited=$((waited + 1))
+  done
+  echo "ERROR: candidate ${candidate} did not report master within ${SWITCHOVER_CONFIRM_BUDGET}s — switchover unconfirmed (engine may still complete it; safe to retry)." >&2
+  return 1
+}
+
+switchover() {
+  if [ -z "${CURRENT_SHARD_POD_FQDN_LIST:-}" ]; then
+    echo "ERROR: CURRENT_SHARD_POD_FQDN_LIST is required." >&2
+    return 1
+  fi
+  local candidate="${KB_SWITCHOVER_CANDIDATE_FQDN:-}"
+  if [ -z "${candidate}" ]; then
+    candidate=$(pick_candidate) || return 1
+    echo "no candidate specified — deterministically selected ${candidate}."
+  fi
+  execute_switchover "${candidate}"
+}
+
+# This is magic for shellspec ut framework, do not modify!
+${__SOURCED__:+false} : || return 0
+
+load_common_library
+switchover

--- a/addons/valkey/scripts/valkey-cluster-switchover.sh
+++ b/addons/valkey/scripts/valkey-cluster-switchover.sh
@@ -36,6 +36,11 @@ load_common_library() {
   source /scripts/common.sh
 }
 
+classify() {
+  local phase="$1" retry_safe="$2"; shift 2
+  echo "action=valkey-cluster-switchover phase=${phase} retry_safe=${retry_safe} detail=$*" >&2
+}
+
 build_cli() {
   local host="${1}"
   _cli=(valkey-cli --no-auth-warning -h "${host}" -p "${port}")
@@ -71,8 +76,25 @@ pick_candidate() {
       return 0
     fi
   done
-  echo "ERROR: no reachable in-shard replica available as switchover candidate." >&2
+  classify candidate-pick no "no reachable in-shard replica available as switchover candidate"
   return 1
+}
+
+# The candidate must be a replica ATTACHED TO THIS SHARD'S MASTER — its
+# own myself line must reference a master id that belongs to an in-shard
+# pod (cross-shard replicas are refused).
+candidate_replicates_this_shard() {
+  local candidate="${1}" myself master_id master_line fqdn pattern=""
+  build_cli "${candidate}"
+  myself=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | awk '$3 ~ /myself/')
+  [ -z "${myself}" ] && return 1
+  master_id=$(echo "${myself}" | awk '{print $4}')
+  [ "${master_id}" = "-" ] && return 1
+  for fqdn in $(echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$'); do
+    pattern="${pattern:+${pattern}|}${fqdn}"
+  done
+  master_line=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | awk -v id="${master_id}" '$1 == id')
+  [ -n "${master_line}" ] && echo "${master_line}" | grep -qE "${pattern}"
 }
 
 execute_switchover() {
@@ -83,12 +105,16 @@ execute_switchover() {
     return 0
   fi
   if [ "${role}" != "replica" ]; then
-    echo "ERROR: candidate ${candidate} reports role '${role}' — cannot promote (unknown state is not promotable)." >&2
+    classify candidate-state no "candidate ${candidate} reports role '${role}' — cannot promote (unknown state is not promotable)"
+    return 1
+  fi
+  if ! candidate_replicates_this_shard "${candidate}"; then
+    classify candidate-wrong-master no "candidate ${candidate} does not replicate this shard's master — refusing promotion"
     return 1
   fi
   build_cli "${candidate}"
   out=$("${_cli[@]}" CLUSTER FAILOVER 2>&1) || {
-    echo "ERROR: CLUSTER FAILOVER on ${candidate} failed: ${out}" >&2
+    classify failover-issue no "CLUSTER FAILOVER on ${candidate} failed: ${out}"
     return 1
   }
   echo "CLUSTER FAILOVER issued on ${candidate}: ${out}"
@@ -106,17 +132,42 @@ confirm_promotion() {
     sleep_when_ut_mode_false 1
     waited=$((waited + 1))
   done
-  echo "ERROR: candidate ${candidate} did not report master within ${SWITCHOVER_CONFIRM_BUDGET}s — switchover unconfirmed (engine may still complete it; safe to retry)." >&2
+  classify failover-confirm yes "candidate ${candidate} did not report master within ${SWITCHOVER_CONFIRM_BUDGET}s — unconfirmed, safe to retry"
   return 1
+}
+
+# Explicit-candidate contract (review blocker): a supplied candidate must
+# (a) belong to THIS shard's KB roster, (b) not be the pod being switched
+# away from, and (c) currently be a replica whose master is this shard's
+# master — a cross-shard or mis-attached candidate must never be promoted.
+validate_explicit_candidate() {
+  local candidate="${1}"
+  if ! echo "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -qxF "${candidate}"; then
+    classify candidate-outside-shard no "candidate ${candidate} is not in CURRENT_SHARD_POD_FQDN_LIST — refusing cross-shard promotion"
+    return 1
+  fi
+  if [ "${candidate}" = "${KB_SWITCHOVER_CURRENT_FQDN:-}" ]; then
+    classify candidate-is-current no "candidate equals the current primary — nothing to switch"
+    return 1
+  fi
+  return 0
 }
 
 switchover() {
   if [ -z "${CURRENT_SHARD_POD_FQDN_LIST:-}" ]; then
-    echo "ERROR: CURRENT_SHARD_POD_FQDN_LIST is required." >&2
+    classify env-contract no "CURRENT_SHARD_POD_FQDN_LIST is required"
+    return 1
+  fi
+  # Only primary switchover is a promotion; any other role request must not
+  # take the CLUSTER FAILOVER path (review blocker: KB_SWITCHOVER_ROLE guard).
+  if [ -n "${KB_SWITCHOVER_ROLE:-}" ] && [ "${KB_SWITCHOVER_ROLE}" != "primary" ]; then
+    classify role-guard no "switchover requested for role '${KB_SWITCHOVER_ROLE}' — only primary switchover is supported in cluster mode"
     return 1
   fi
   local candidate="${KB_SWITCHOVER_CANDIDATE_FQDN:-}"
-  if [ -z "${candidate}" ]; then
+  if [ -n "${candidate}" ]; then
+    validate_explicit_candidate "${candidate}" || return 1
+  else
     candidate=$(pick_candidate) || return 1
     echo "no candidate specified — deterministically selected ${candidate}."
   fi

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -175,7 +175,8 @@ spec:
 
   lifecycleActions:
     # Role probe: pure read of this node's CLUSTER NODES myself line;
-    # emits "<role> <config-epoch>" (epoch = anti-replay version token).
+    # emits a SINGLE-TOKEN role (versioned output deferred — a local epoch
+    # cannot prove the complete shard role fact; see check-role script).
     # Unknown state exits non-zero (skip sample) — never an empty role.
     roleProbe:
       periodSeconds: 1

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -3,9 +3,8 @@ ComponentDefinition for Valkey Cluster (sharding) mode — one definition per
 shard; ShardingDefinition stamps N shard components out of it.
 
 Phase A boundary (issue #3021): templates + config + server start only.
-  - No roles / roleProbe yet: cluster-mode role detection (CLUSTER NODES) and
-    switchover land together in phase C as one contract; declaring roles
-    without a probe would leave pods permanently unlabeled.
+  - Phase C (issue #3037) added roles + roleProbe + switchover + member
+    join/leave (all intra-shard, engine-native CLUSTER commands).
   - Phase B (issue #3026) added postProvision formation and shardRemove.
 v1 boundary: Valkey 9 only; in-cluster networking only (pod-FQDN announce,
 no NodePort/LB advertise).
@@ -40,6 +39,16 @@ spec:
   volumes:
     - name: data
       needSnapshot: true
+
+  # Per-shard roles: exactly one primary (slot owner) + replicas. Quorum is
+  # the engine's own (cluster config epochs) — not K8s-level.
+  roles:
+    - name: primary
+      updatePriority: 2
+      participatesInQuorum: false
+    - name: secondary
+      updatePriority: 1
+      participatesInQuorum: false
 
   services:
     # Per-shard ClusterIP service. Cluster-mode clients are expected to be
@@ -165,6 +174,53 @@ spec:
       value: {{ $.Values.tlsMountPath }}
 
   lifecycleActions:
+    # Role probe: pure read of this node's CLUSTER NODES myself line;
+    # emits "<role> <config-epoch>" (epoch = anti-replay version token).
+    # Unknown state exits non-zero (skip sample) — never an empty role.
+    roleProbe:
+      periodSeconds: 1
+      timeoutSeconds: 1
+      exec:
+        container: valkey-cluster
+        command:
+          - /scripts/valkey-cluster-check-role.sh
+        env:
+          - name: KB_SERVICE_PORT
+            value: "$(SERVICE_PORT)"
+    # Intra-shard graceful switchover: CLUSTER FAILOVER on the candidate
+    # replica; deterministic candidate pick when unspecified; bounded
+    # in-action confirmation.
+    switchover:
+      exec:
+        container: valkey-cluster
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/valkey-cluster-switchover.sh
+    # Replica join/leave within a shard. Leave of the current master fails
+    # over first and only deletes after mastership provably moved.
+    memberJoin:
+      exec:
+        container: valkey-cluster
+        targetPodSelector: Any
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/valkey-cluster-member.sh --join
+      retryPolicy:
+        maxRetries: 10
+        retryInterval: 3
+    memberLeave:
+      exec:
+        container: valkey-cluster
+        targetPodSelector: Any
+        command:
+          - /bin/bash
+          - -c
+          - /scripts/valkey-cluster-member.sh --leave
+      retryPolicy:
+        maxRetries: 10
+        retryInterval: 3
     # Formation-or-join: single-shot bootstrap-or-defer (rc=1 => framework
     # retry). Coordinator pod creates the cluster; every other pod verifies
     # membership or joins (scale-out path). See valkey-cluster-manage.sh.

--- a/addons/valkey/templates/cmpv.yaml
+++ b/addons/valkey/templates/cmpv.yaml
@@ -109,6 +109,11 @@ spec:
       serviceVersion: {{ .version }}
       images:
         valkey-cluster: {{ $valkeyRepo }}:{{ .imageTag }}
+        roleProbe: {{ $valkeyRepo }}:{{ .imageTag }}
+        switchover: {{ $valkeyRepo }}:{{ .imageTag }}
+        memberJoin: {{ $valkeyRepo }}:{{ .imageTag }}
+        memberLeave: {{ $valkeyRepo }}:{{ .imageTag }}
+        postProvision: {{ $valkeyRepo }}:{{ .imageTag }}
     {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
Fixes #3037. **Stacked on #3032 (phase B)** — base is `athena/valkey-cluster-phase-b`; retarget as the stack merges.

Contracts pinned by behavioral specs:
- roleProbe emits a SINGLE token (`primary` / `secondary`) read from the CLUSTER NODES `myself` line; unknown ⇒ non-zero skip, never an empty role (review class 4). The earlier `<role> <config-epoch>` versioned output was withdrawn in review: a node-local config epoch cannot prove a complete role fact, so shipping it would imply an anti-replay guarantee the engine view does not provide.
- switchover = `CLUSTER FAILOVER` on the replica (engine-native consistency); deterministic candidate pick; explicit candidate validated against the in-shard roster; bounded confirm with classified failure
- memberLeave of the current master: failover first, delete only after mastership provably moved — no orphaned slots; join/leave confirmed by cluster-view readback (slave flag + parent id binding), never by command rc alone

Validation: shellspec-test CI green at current head (12 new examples in this phase); renders pass. Runtime pass (role labels on 3 shards, master-kill label convergence, targeted switchover with writes, replica scale 2→3→2) is Emily's phase-C matrix.

Reviewers: @Alice / @Bob.
