### PR TITLE
fix(mariadb): do not kill mariadbd during an in-progress Galera SST

### DIFF
--- a/addons/mariadb/scripts-ut-spec/galera_start_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/galera_start_spec.sh
@@ -175,5 +175,28 @@ EOF
       The status should be success
       The output should include "GALERA_SOCKETLESS_MARIADBD_THRESHOLD"
     End
+
+    It "does not count socketless ticks while an SST is in progress"
+      # H9: a joiner performing SST runs mariadbd without a SQL socket until
+      # the transfer completes; the socketless killer must skip it, keyed on
+      # the Galera SST marker (sst_in_progress) or a live wsrep_sst_ helper.
+      When call script_contains "sst_in_progress"
+      The status should be success
+      The output should include "sst_in_progress"
+    End
+
+    It "gates the SST skip BEFORE the socketless-kill increment (source order)"
+      # The sst_in_progress guard branch must precede the NO_SOCKET_COUNT
+      # increment so an in-progress SST resets the counter instead of
+      # accumulating toward a kill.
+      When run sh -c '
+        f="$(printf "%s/addons/mariadb/scripts/galera-start.sh" "'"${SHELLSPEC_CWD:?}"'")"
+        sst=$(grep -n "sst_in_progress" "$f" | head -1 | cut -d: -f1)
+        inc=$(grep -n "NO_SOCKET_COUNT=\$((NO_SOCKET_COUNT + 1))" "$f" | head -1 | cut -d: -f1)
+        if [ -n "$sst" ] && [ -n "$inc" ] && [ "$sst" -lt "$inc" ]; then echo OK; else echo "FAIL sst=$sst inc=$inc"; fi
+      '
+      The status should be success
+      The output should equal "OK"
+    End
   End
 End

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -289,6 +289,17 @@ main() {
             _restart_mariadbd_for_self_heal "wsrep_cluster_status=${CLUSTER_STATUS} for $((NON_PRIMARY_COUNT * 3))s"
             NON_PRIMARY_COUNT=0
           fi
+        elif [ -f "${DATA_DIR}/sst_in_progress" ] || pgrep -f 'wsrep_sst_' >/dev/null 2>&1; then
+          # A joiner performing SST (State Snapshot Transfer) runs mariadbd
+          # WITHOUT a SQL socket until the transfer completes. A large-dataset
+          # rsync/mariabackup SST can take much longer than the socketless
+          # threshold, so killing mariadbd here would abort a healthy SST,
+          # restart, and abort it again — permanent non-convergence, and each
+          # round re-blocks the donor. The Galera SST-in-progress marker
+          # (${DATA_DIR}/sst_in_progress, created by wsrep_sst_common) and a
+          # live wsrep_sst_* helper process both mean SST is underway, not a
+          # stall. Do not count these ticks toward the socketless kill.
+          NO_SOCKET_COUNT=0
         else
           NON_PRIMARY_COUNT=0
           if pgrep -x mariadbd >/dev/null 2>&1 || pidof mariadbd >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #3040 — HIGH: the socketless self-heal watcher aborted any Galera SST longer than ~90s.

Root cause, the confirmed SST marker (wsrep_sst_common: sst_in_progress), and reproduction are in the issue. Change: skip the socketless kill while sst_in_progress exists or a wsrep_sst_ helper runs; NON_PRIMARY killer unchanged.

Validation: galera spec + full mariadb shellspec green (652 examples, 0 failures, 9 pre-existing pendings); helm renders. mariadb team full-suite verification per westonnnn.