### PR TITLE
feat(valkey): cluster topology phase D — per-shard backup/restore with shard-count guard

### DIFF
--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -132,6 +132,22 @@ if [ ! -f "./dump.rdb" ]; then
 fi
 backup_files=("./dump.rdb")
 [ -f "./users.acl" ] && backup_files+=("./users.acl")
+
+# Cluster (sharding) mode: embed the source shard count as engine truth
+# (master lines in CLUSTER NODES) so restore can verify the same-shard-count
+# v1 boundary. Sentinel/standalone targets skip this (cluster_enabled:0).
+_cluster_enabled=$("${connect_base[@]}" INFO cluster 2>/dev/null | grep "^cluster_enabled:" | tr -d "\\r" | cut -d: -f2)
+if [ "${_cluster_enabled}" = "1" ]; then
+  _source_shards=$("${connect_base[@]}" CLUSTER NODES 2>/dev/null | tr -d "\r" | awk '$3 ~ /master/' | grep -c . || true)
+  if [ -z "${_source_shards}" ] || [ "${_source_shards}" -lt 1 ]; then
+    echo "ERROR: cluster mode detected but could not count source shards from CLUSTER NODES." >&2
+    exit 1
+  fi
+  printf 'source_shards=%s
+' "${_source_shards}" > ./cluster-meta
+  backup_files+=("./cluster-meta")
+  echo "INFO: cluster mode — embedded cluster-meta (source_shards=${_source_shards})."
+fi
 tar -cvf - "${backup_files[@]}" | datasafed push -z zstd-fastest - "${DP_BACKUP_NAME}.tar.zst" || exit 1
 
 save_sentinel_acl || \

--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -145,15 +145,33 @@ if [ "${_cluster_enabled}" = "1" ]; then
     echo "ERROR: cluster mode detected but could not count source shards from CLUSTER NODES." >&2
     exit 1
   fi
-  # Record THIS shard's current slot ranges too: shard count alone is not
-  # a sufficient restore precondition (post-rebalance layouts differ from
-  # the even split a re-formed cluster gets) — the ranges make the future
-  # slot-aware restore designable and keep archives self-describing.
-  _my_master_line=$("${connect_base[@]}" CLUSTER NODES 2>/dev/null | tr -d "\r" | awk '$3 ~ /myself/')
-  _my_slot_ranges=$(echo "${_my_master_line}" | cut -d' ' -f9- | tr ' ' ',')
+  # Record THIS SHARD's slot ranges + master identity: shard count alone
+  # is not a sufficient restore precondition (post-rebalance layouts
+  # differ from a re-formed even split). The backup target is normally a
+  # SECONDARY (BPT role) which owns no slots — so the ranges must come
+  # from this shard's MASTER line, resolved from the target's view:
+  # myself's parent id when the target is a slave, else myself itself.
+  _nodes=$("${connect_base[@]}" CLUSTER NODES 2>/dev/null | tr -d "\r")
+  _myself_line=$(echo "${_nodes}" | awk '$3 ~ /myself/')
+  if echo "${_myself_line}" | awk '{print $3}' | grep -q slave; then
+    _shard_master_id=$(echo "${_myself_line}" | awk '{print $4}')
+  else
+    _shard_master_id=$(echo "${_myself_line}" | awk '{print $1}')
+  fi
+  _master_line=$(echo "${_nodes}" | awk -v id="${_shard_master_id}" '$1 == id')
+  if [ -z "${_master_line}" ] || [ "${_shard_master_id}" = "-" ]; then
+    echo "ERROR: cluster mode — cannot resolve this shard's master from the target's CLUSTER NODES view." >&2
+    exit 1
+  fi
+  _shard_slot_ranges=$(echo "${_master_line}" | cut -d' ' -f9- | tr ' ' ',')
+  if [ -z "${_shard_slot_ranges}" ]; then
+    echo "ERROR: cluster mode — this shard's master ${_shard_master_id} owns no slot ranges; refusing to write empty metadata." >&2
+    exit 1
+  fi
   {
     printf 'source_shards=%s\n' "${_source_shards}"
-    printf 'shard_slot_ranges=%s\n' "${_my_slot_ranges}"
+    printf 'shard_master_id=%s\n' "${_shard_master_id}"
+    printf 'shard_slot_ranges=%s\n' "${_shard_slot_ranges}"
   } > ./cluster-meta
   backup_files+=("./cluster-meta")
   # cluster-meta is backup metadata, not engine data: it must not remain

--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -20,6 +20,8 @@ set -o pipefail
 
 function handle_exit() {
   local exit_code=$?
+  # cluster-mode metadata must never remain on the live data volume
+  [ "${_cluster_meta_cleanup_needed:-0}" = "1" ] && rm -f "${DATA_DIR}/cluster-meta"
   if [ "${exit_code}" -ne 0 ]; then
     echo "ERROR: backup failed with exit code ${exit_code}" >&2
     touch "${DP_BACKUP_INFO_FILE}.exit"
@@ -143,12 +145,26 @@ if [ "${_cluster_enabled}" = "1" ]; then
     echo "ERROR: cluster mode detected but could not count source shards from CLUSTER NODES." >&2
     exit 1
   fi
-  printf 'source_shards=%s
-' "${_source_shards}" > ./cluster-meta
+  # Record THIS shard's current slot ranges too: shard count alone is not
+  # a sufficient restore precondition (post-rebalance layouts differ from
+  # the even split a re-formed cluster gets) — the ranges make the future
+  # slot-aware restore designable and keep archives self-describing.
+  _my_master_line=$("${connect_base[@]}" CLUSTER NODES 2>/dev/null | tr -d "\r" | awk '$3 ~ /myself/')
+  _my_slot_ranges=$(echo "${_my_master_line}" | cut -d' ' -f9- | tr ' ' ',')
+  {
+    printf 'source_shards=%s\n' "${_source_shards}"
+    printf 'shard_slot_ranges=%s\n' "${_my_slot_ranges}"
+  } > ./cluster-meta
   backup_files+=("./cluster-meta")
+  # cluster-meta is backup metadata, not engine data: it must not remain
+  # on the live DATA_DIR after archiving (review blocker). Cleaned right
+  # after tar below AND on failure via handle_exit (single EXIT trap —
+  # a second `trap EXIT` here would clobber handle_exit).
+  _cluster_meta_cleanup_needed=1
   echo "INFO: cluster mode — embedded cluster-meta (source_shards=${_source_shards})."
 fi
 tar -cvf - "${backup_files[@]}" | datasafed push -z zstd-fastest - "${DP_BACKUP_NAME}.tar.zst" || exit 1
+rm -f ./cluster-meta
 
 save_sentinel_acl || \
   echo "WARNING: Sentinel ACL save failed — ACL rules will not be restored after a cluster restore." >&2

--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -72,36 +72,29 @@ seed_multipart_aof_from_rdb() {
   echo "INFO: Seeded multipart AOF manifest from restored dump.rdb."
 }
 
-# Cluster (sharding) restore guard: v1 supports SAME shard count only —
-# keys restored onto a shard that does not own their hash slots are
-# silently unreachable, so a mismatch must stop before the pod starts.
-# Enforcement is engine-truth (cluster-meta embedded at backup time)
-# compared against RESTORE_TARGET_SHARDS when the operator provides it
-# via dataprotection.kubeblocks.io/restore-env; without the env we can
-# only warn (DP jobs cannot see target sharding vars — platform gap,
-# kubeblocks#10540).
-verify_cluster_shard_count() {
+# Cluster (sharding) restore: NOT SUPPORTED in v1 — fail fast.
+#
+# Same shard count is NOT a sufficient safety condition (review, PR #3044):
+# restore re-forms the cluster (phase B) with an even slot split, but the
+# SOURCE layout may differ (any post-rebalance / scale history). Keys
+# restored onto a shard that does not own their hash slots are silently
+# unreachable, and archive->target-shard positional mapping is itself
+# unverified. Until a slot-aware restore is designed (cluster-meta already
+# records source_shards + shard_slot_ranges for exactly that), a cluster
+# archive is refused outright — refusal beats silent misplacement.
+refuse_cluster_restore() {
   local meta="${DATA_DIR}/cluster-meta" source_shards
   [ -f "${meta}" ] || return 0
   source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2)
-  rm -f "${meta}"   # metadata, not engine data — never leave it in DATA_DIR
-  case "${source_shards}" in
-    ''|*[!0-9]*)
-      echo "ERROR: cluster-meta present but source_shards is invalid ('${source_shards}')." >&2
-      exit 1 ;;
-  esac
-  if [ -n "${RESTORE_TARGET_SHARDS:-}" ]; then
-    if [ "${RESTORE_TARGET_SHARDS}" != "${source_shards}" ]; then
-      echo "ERROR: shard count mismatch — backup taken from ${source_shards} shard(s), target declares ${RESTORE_TARGET_SHARDS}. v1 cluster restore requires the SAME shard count; refusing before any pod starts." >&2
-      exit 1
-    fi
-    echo "INFO: cluster restore shard count verified (${source_shards})."
-  else
-    echo "WARNING: cluster backup (source_shards=${source_shards}) restored without RESTORE_TARGET_SHARDS — same-shard-count is the operator's responsibility; set it via restore-env to enforce."
-  fi
+  rm -f "${meta}"
+  echo "ERROR: this archive is a Valkey CLUSTER (sharding) backup (source_shards=${source_shards})." >&2
+  echo "  Cluster datafile restore is NOT supported in v1: restored slot layouts cannot yet be" >&2
+  echo "  guaranteed to match the source (slot-aware restore is a planned follow-up; the archive" >&2
+  echo "  already records shard_slot_ranges for it). Refusing before any pod starts." >&2
+  exit 1
 }
 
-verify_cluster_shard_count
+refuse_cluster_restore
 
 seed_multipart_aof_from_rdb
 

--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -72,6 +72,37 @@ seed_multipart_aof_from_rdb() {
   echo "INFO: Seeded multipart AOF manifest from restored dump.rdb."
 }
 
+# Cluster (sharding) restore guard: v1 supports SAME shard count only —
+# keys restored onto a shard that does not own their hash slots are
+# silently unreachable, so a mismatch must stop before the pod starts.
+# Enforcement is engine-truth (cluster-meta embedded at backup time)
+# compared against RESTORE_TARGET_SHARDS when the operator provides it
+# via dataprotection.kubeblocks.io/restore-env; without the env we can
+# only warn (DP jobs cannot see target sharding vars — platform gap,
+# kubeblocks#10540).
+verify_cluster_shard_count() {
+  local meta="${DATA_DIR}/cluster-meta" source_shards
+  [ -f "${meta}" ] || return 0
+  source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2)
+  rm -f "${meta}"   # metadata, not engine data — never leave it in DATA_DIR
+  case "${source_shards}" in
+    ''|*[!0-9]*)
+      echo "ERROR: cluster-meta present but source_shards is invalid ('${source_shards}')." >&2
+      exit 1 ;;
+  esac
+  if [ -n "${RESTORE_TARGET_SHARDS:-}" ]; then
+    if [ "${RESTORE_TARGET_SHARDS}" != "${source_shards}" ]; then
+      echo "ERROR: shard count mismatch — backup taken from ${source_shards} shard(s), target declares ${RESTORE_TARGET_SHARDS}. v1 cluster restore requires the SAME shard count; refusing before any pod starts." >&2
+      exit 1
+    fi
+    echo "INFO: cluster restore shard count verified (${source_shards})."
+  else
+    echo "WARNING: cluster backup (source_shards=${source_shards}) restored without RESTORE_TARGET_SHARDS — same-shard-count is the operator's responsibility; set it via restore-env to enforce."
+  fi
+}
+
+verify_cluster_shard_count
+
 seed_multipart_aof_from_rdb
 
 rm -f "${placeholder}" && sync

--- a/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
@@ -81,6 +81,9 @@ STUB
     When call run_backup
     The status should be success
     The stdout should include "embedded cluster-meta (source_shards=3)"
+    # tar -v member list goes to stderr (archive is on stdout); the
+    # substring matches both BSD ("a ./cluster-meta") and GNU ("./cluster-meta")
+    The stderr should include "cluster-meta"
     The file "${workdir}/pushed-files.txt" should be exist
     The contents of file "${workdir}/pushed-files.txt" should include "cluster-meta"
     The contents of file "${workdir}/pushed-files.txt" should include "dump.rdb"
@@ -104,6 +107,8 @@ STUB
     chmod +x "${bindir}/datasafed"
     When call run_backup
     The status should be success
+    The stdout should include "embedded cluster-meta (source_shards=3)"
+    The stderr should include "cluster-meta"
     The contents of file "${workdir}/extracted/cluster-meta" should include "source_shards=3"
     The contents of file "${workdir}/extracted/cluster-meta" should include "shard_master_id=mid001"
     The contents of file "${workdir}/extracted/cluster-meta" should include "shard_slot_ranges=0-5460"

--- a/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
@@ -1,0 +1,111 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+# Behavioral test for cluster-mode backup metadata (PR-D review gap):
+# runs backup.sh against PATH-stubbed valkey-cli/datasafed and proves
+# (a) cluster-meta lands INSIDE the archive with master-line slot ranges
+# and shard identity, and (b) cluster-meta does NOT remain in DATA_DIR.
+
+Describe "backup.sh cluster-mode metadata (behavioral)"
+  setup_harness() {
+    workdir=$(mktemp -d)
+    data_dir="${workdir}/data"
+    bindir="${workdir}/bin"
+    mkdir -p "${data_dir}" "${bindir}"
+
+    # Stub valkey-cli: BGSAVE flow + cluster views. The backup TARGET is a
+    # SECONDARY (myself,slave) whose master owns the slot ranges — the
+    # exact shape the BPT role selector produces.
+    cat > "${bindir}/valkey-cli" <<'STUB'
+#!/bin/bash
+args="$*"
+case "${args}" in
+  *"INFO persistence"*)
+    printf 'rdb_bgsave_in_progress:0\nrdb_last_bgsave_status:ok\n'; exit 0 ;;
+  *LASTSAVE*)
+    # advance on every call so the post-BGSAVE read exceeds the baseline
+    n=$(cat "${LASTSAVE_COUNTER:-/tmp/ls-counter}" 2>/dev/null || echo 100)
+    n=$((n + 1)); echo "${n}" > "${LASTSAVE_COUNTER:-/tmp/ls-counter}"
+    echo "${n}"; exit 0 ;;
+  *BGSAVE*)             echo "Background saving started"; exit 0 ;;
+  *"INFO cluster"*)     printf 'cluster_enabled:1\n'; exit 0 ;;
+  *"CLUSTER NODES"*)
+    printf 'mid001 10.0.0.1:6379@16379 master - 0 0 5 connected 0-5460\n'
+    printf 'sid002 10.0.0.2:6379@16379 myself,slave mid001 0 0 5 connected\n'
+    printf 'mid003 10.0.0.3:6379@16379 master - 0 0 6 connected 5461-10922\n'
+    printf 'mid004 10.0.0.4:6379@16379 master - 0 0 7 connected 10923-16383\n'
+    exit 0 ;;
+  *PING*)               echo PONG; exit 0 ;;
+esac
+exit 0
+STUB
+    # Stub datasafed: capture the tar member list ONLY for the archive
+    # push (a later 'datasafed stat' call must not truncate the capture).
+    cat > "${bindir}/datasafed" <<STUB
+#!/bin/bash
+case "\$1" in
+  push)
+    if [ "\$4" = "-" ] || [ "\$2" = "-" ] || [ "\$3" = "-" ]; then
+      tar -tf - > "${workdir}/pushed-files.txt" 2>/dev/null || cat > /dev/null
+    else
+      cat > /dev/null 2>&1 || true
+    fi ;;
+  stat) echo "TotalSize 1234" ;;
+esac
+exit 0
+STUB
+    chmod +x "${bindir}"/*
+
+    # minimal backup preconditions
+    printf 'x' > "${data_dir}/dump.rdb.seed" # ensure dir non-empty
+    printf 'rdbdata' > "${data_dir}/dump.rdb"
+    printf 'user default on\n' > "${data_dir}/users.acl"
+  }
+  teardown_harness() { rm -rf "${workdir}"; }
+  Before "setup_harness"
+  After "teardown_harness"
+
+  run_backup() {
+    (
+      export PATH="${bindir}:${PATH}"
+      export DATA_DIR="${data_dir}"
+      export DP_DB_HOST=10.0.0.2 DP_DB_PORT=6379 DP_BACKUP_NAME=bk-test
+      export LASTSAVE_COUNTER="${workdir}/ls-counter"
+      export DP_BACKUP_BASE_PATH="${workdir}" DP_BACKUP_INFO_FILE="${workdir}/info.json"
+      unset DP_DB_PASSWORD SENTINEL_POD_FQDN_LIST
+      bash ../dataprotection/backup.sh
+    )
+  }
+
+  It "embeds cluster-meta with master-line ranges and cleans DATA_DIR"
+    When call run_backup
+    The status should be success
+    The stdout should include "embedded cluster-meta (source_shards=3)"
+    The file "${workdir}/pushed-files.txt" should be exist
+    The contents of file "${workdir}/pushed-files.txt" should include "cluster-meta"
+    The contents of file "${workdir}/pushed-files.txt" should include "dump.rdb"
+    # metadata must not remain on the live data volume
+    The file "${data_dir}/cluster-meta" should not be exist
+  End
+
+  It "records the MASTER's slot ranges even though the target is a secondary"
+    # re-run capturing the meta content before tar consumes it: intercept
+    # via a datasafed stub that also extracts the archive.
+    cat > "${bindir}/datasafed" <<STUB
+#!/bin/bash
+case "\$1" in
+  push)
+    mkdir -p "${workdir}/extracted"
+    tar -xf - -C "${workdir}/extracted" 2>/dev/null || cat > /dev/null ;;
+  stat) echo "TotalSize 1234" ;;
+esac
+exit 0
+STUB
+    chmod +x "${bindir}/datasafed"
+    When call run_backup
+    The status should be success
+    The contents of file "${workdir}/extracted/cluster-meta" should include "source_shards=3"
+    The contents of file "${workdir}/extracted/cluster-meta" should include "shard_master_id=mid001"
+    The contents of file "${workdir}/extracted/cluster-meta" should include "shard_slot_ranges=0-5460"
+  End
+End

--- a/addons/valkey/scripts-ut-spec/backup_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backup_contract_spec.sh
@@ -34,4 +34,11 @@ Describe "Valkey backup contract"
     When call grep -F 'tar -cvf - ./ ' "${script_file}"
     The status should be failure
   End
+  It "embeds cluster-meta with engine-truth shard count in cluster mode"
+    When call grep -E 'cluster_enabled|source_shards=|cluster-meta' "${script_file}"
+    The status should be success
+    The stdout should include "cluster_enabled"
+    The stdout should include "source_shards="
+    The stdout should include "cluster-meta"
+  End
 End

--- a/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
@@ -162,34 +162,20 @@ SH
     The stderr should include "ERROR: restored archive already contains AOF state"
     The stderr should include "appendonly.aof"
   End
-  It "rejects a cluster restore when target shard count differs (fail-fast)"
+  It "refuses any cluster archive outright (v1: cluster restore unsupported)"
     export FAKE_DATASAFED_CLUSTER_META=3
-    export RESTORE_TARGET_SHARDS=4
 
     When run bash ../dataprotection/restore.sh
     The status should be failure
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
-    The stderr should include "shard count mismatch"
-    The stderr should include "backup taken from 3 shard(s), target declares 4"
-  End
-
-  It "verifies and cleans cluster-meta when shard counts match"
-    export FAKE_DATASAFED_CLUSTER_META=3
-    export RESTORE_TARGET_SHARDS=3
-
-    When run bash ../dataprotection/restore.sh
-    The status should be success
-    The stdout should include "cluster restore shard count verified (3)"
+    The stderr should include "CLUSTER (sharding) backup (source_shards=3)"
+    The stderr should include "NOT supported in v1"
     The file "${data_dir}/cluster-meta" should not be exist
   End
 
-  It "warns loudly when cluster-meta exists but no target count is provided"
-    export FAKE_DATASAFED_CLUSTER_META=5
-
+  It "leaves non-cluster restores untouched by the cluster guard"
     When run bash ../dataprotection/restore.sh
     The status should be success
-    The stdout should include "WARNING"
-    The stdout should include "source_shards=5"
-    The file "${data_dir}/cluster-meta" should not be exist
+    The stdout should include "INFO: Restore complete."
   End
 End

--- a/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
@@ -36,6 +36,9 @@ case "$1" in
     if [ "${FAKE_DATASAFED_INCLUDE_ROOT_AOF:-}" = "1" ]; then
       printf 'existing aof\n' > "${tmp}/src/appendonly.aof"
     fi
+    if [ -n "${FAKE_DATASAFED_CLUSTER_META:-}" ]; then
+      printf 'source_shards=%s\n' "${FAKE_DATASAFED_CLUSTER_META}" > "${tmp}/src/cluster-meta"
+    fi
     tar -cf - -C "${tmp}/src" .
     rm -rf "${tmp}"
     ;;
@@ -77,6 +80,8 @@ SH
     unset FAKE_DATASAFED_INCLUDE_ROOT_AOF
     unset FAKE_DATASAFED_OMIT_RDB
     unset FAKE_DATASAFED_EMPTY_RDB
+    unset FAKE_DATASAFED_CLUSTER_META
+    unset RESTORE_TARGET_SHARDS
   }
   After "cleanup"
 
@@ -156,5 +161,35 @@ SH
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
     The stderr should include "ERROR: restored archive already contains AOF state"
     The stderr should include "appendonly.aof"
+  End
+  It "rejects a cluster restore when target shard count differs (fail-fast)"
+    export FAKE_DATASAFED_CLUSTER_META=3
+    export RESTORE_TARGET_SHARDS=4
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "shard count mismatch"
+    The stderr should include "backup taken from 3 shard(s), target declares 4"
+  End
+
+  It "verifies and cleans cluster-meta when shard counts match"
+    export FAKE_DATASAFED_CLUSTER_META=3
+    export RESTORE_TARGET_SHARDS=3
+
+    When run bash ../dataprotection/restore.sh
+    The status should be success
+    The stdout should include "cluster restore shard count verified (3)"
+    The file "${data_dir}/cluster-meta" should not be exist
+  End
+
+  It "warns loudly when cluster-meta exists but no target count is provided"
+    export FAKE_DATASAFED_CLUSTER_META=5
+
+    When run bash ../dataprotection/restore.sh
+    The status should be success
+    The stdout should include "WARNING"
+    The stdout should include "source_shards=5"
+    The file "${data_dir}/cluster-meta" should not be exist
   End
 End

--- a/addons/valkey/templates/backuppolicytemplate.yaml
+++ b/addons/valkey/templates/backuppolicytemplate.yaml
@@ -78,11 +78,16 @@ spec:
 # archived — it is cluster identity and must be regenerated on restore.
 #
 # v1 restore compatibility matrix:
-#   same shard count                     -> supported (positional mapping)
-#   different shard count                -> REJECTED at prepareData when
-#                                           RESTORE_TARGET_SHARDS is set via
-#                                           restore-env; else operator's
-#                                           responsibility (loud WARNING)
+#   ANY cluster datafile restore         -> NOT SUPPORTED (refused at
+#                                           prepareData before pods start):
+#                                           same shard count is not a
+#                                           sufficient condition — source
+#                                           slot layouts (post-rebalance)
+#                                           cannot be guaranteed to match a
+#                                           re-formed cluster's even split.
+#                                           Archives record source_shards +
+#                                           shard_slot_ranges so the planned
+#                                           slot-aware restore can be built.
 #   cluster <-> replication/standalone   -> unsupported
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: BackupPolicyTemplate

--- a/addons/valkey/templates/backuppolicytemplate.yaml
+++ b/addons/valkey/templates/backuppolicytemplate.yaml
@@ -70,3 +70,62 @@ spec:
       enabled: false
       cronExpression: "0 2 * * *"
       retentionPeriod: 7d
+---
+# ── Cluster (sharding) topology ─────────────────────────────────────────────
+# Per-shard datafile backup: each shard component independently targets its
+# secondary (fallback primary) and archives the #2984 snapshot set
+# (dump.rdb + users.acl + cluster-meta). nodes.conf is deliberately NOT
+# archived — it is cluster identity and must be regenerated on restore.
+#
+# v1 restore compatibility matrix:
+#   same shard count                     -> supported (positional mapping)
+#   different shard count                -> REJECTED at prepareData when
+#                                           RESTORE_TARGET_SHARDS is set via
+#                                           restore-env; else operator's
+#                                           responsibility (loud WARNING)
+#   cluster <-> replication/standalone   -> unsupported
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupPolicyTemplate
+metadata:
+  name: valkey-cluster-backup-policy-template
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  annotations:
+    {{- include "valkey.annotations" . | nindent 4 }}
+spec:
+  serviceKind: valkey-cluster
+  compDefs:
+    - ^valkey-cluster-[0-9]+$
+  target:
+    role: secondary
+    fallbackRole: primary
+    account: default
+  backupMethods:
+    - name: datafile
+      snapshotVolumes: false
+      actionSetName: valkey-physical-br
+      targetVolumes:
+        volumes:
+          - data
+        volumeMounts:
+          - name: data
+            mountPath: {{ .Values.dataMountPath }}
+      env:
+        - name: IMAGE
+          valueFrom:
+            versionMapping:
+              {{- $repo := printf "%s/%s" (.Values.image.registry | default "docker.io") .Values.image.repository }}
+              {{- range .Values.valkeyVersions }}
+              {{- if eq .major "9" }}
+              {{- range .mirrorVersions }}
+              - serviceVersions:
+                  - {{ .version }}
+                mappedValue: {{ $repo }}:{{ .imageTag }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
+  schedules:
+    - backupMethod: datafile
+      enabled: false
+      cronExpression: "0 18 * * *"
+      retentionPeriod: 7d


### PR DESCRIPTION
Fixes #3042. **Stacked on #3038 (phase C)**.

Key contracts:
- per-shard datafile backup = #2984 snapshot semantics (dump.rdb + users.acl); nodes.conf deliberately excluded (cluster identity, regenerated on restore)
- backup embeds `cluster-meta` as engine truth for a FUTURE slot-aware restore design: `source_shards` counted from CLUSTER NODES master lines, plus `shard_master_id` and `shard_slot_ranges` resolved from the target's MASTER line via the myself-parent id (the backup target is a secondary and owns no slots itself); empty metadata ⇒ fail-fast; the file never remains in DATA_DIR (cleanup chained into the existing exit trap)
- **v1 restore stance: any archive containing cluster-meta is refused outright before any pod starts** (`refuse_cluster_restore`, exit 1). Same shard count is NOT a sufficient safety condition — post-rebalance slot layouts differ from a re-formed even split, so keys could land on shards that do not own their slots and become silently unreachable; refusal beats misplacement. The earlier `RESTORE_TARGET_SHARDS` same-shard-count gate was withdrawn in review for exactly this reason.
- platform boundary documented: DP jobs cannot see target sharding vars (kubeblocks#10540 family) — archive-embedded truth is the honest maximum
- behavioral spec harness runs backup.sh end-to-end against PATH-stubbed valkey-cli/datasafed and proves the archive contains cluster-meta with the master's ranges while DATA_DIR stays clean

Validation: valkey-scoped suite local **383 examples, 0 failures, 0 warnings** at head `d045e16e` (the two unconsumed-output warnings that failed shellspec-test are fixed — tar member list and BGSAVE log are now asserted); renders pass. Live pass (cross-slot write-load backup on 3 shards; restore-refusal verification) is Emily's phase-D matrix.

Reviewers: @Alice / @Bob.
