### PR TITLE
fix(postgresql): raise ssl_min_protocol_version from TLSv1 to TLSv1.2

### DIFF
--- a/addons/postgresql/config/pg12-config-constraint.cue
+++ b/addons/postgresql/config/pg12-config-constraint.cue
@@ -881,7 +881,7 @@
 	ssl_max_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
 
 	// Sets the minimum SSL/TLS protocol version to use.
-	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
+	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2" | "TLSv1.3"
 
 	// Causes ... strings to treat backslashes literally.
 	standard_conforming_strings?: bool & false | true

--- a/addons/postgresql/config/pg12-config.tpl
+++ b/addons/postgresql/config/pg12-config.tpl
@@ -226,7 +226,7 @@ ssl_ca_file = '/etc/pki/tls/ca.pem'
 ssl_cert_file = '/etc/pki/tls/cert.pem'
 ssl_key_file = '/etc/pki/tls/key.pem'
 {{- end }}
-ssl_min_protocol_version = 'TLSv1'
+ssl_min_protocol_version = 'TLSv1.2'
 standard_conforming_strings = 'True'
 statement_timeout = '0'
 superuser_reserved_connections = '20'

--- a/addons/postgresql/config/pg14-config-constraint.cue
+++ b/addons/postgresql/config/pg14-config-constraint.cue
@@ -938,7 +938,7 @@
 	ssl_max_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
 
 	// Sets the minimum SSL/TLS protocol version to use.
-	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
+	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2" | "TLSv1.3"
 
 	// Causes ... strings to treat backslashes literally.
 	standard_conforming_strings?: bool & false | true

--- a/addons/postgresql/config/pg14-config.tpl
+++ b/addons/postgresql/config/pg14-config.tpl
@@ -241,7 +241,7 @@ ssl_ca_file = '/etc/pki/tls/ca.pem'
 ssl_cert_file = '/etc/pki/tls/cert.pem'
 ssl_key_file = '/etc/pki/tls/key.pem'
 {{- end }}
-ssl_min_protocol_version = 'TLSv1'
+ssl_min_protocol_version = 'TLSv1.2'
 standard_conforming_strings = 'True'
 statement_timeout = '0'
 superuser_reserved_connections = '20'

--- a/addons/postgresql/config/pg15-config-constraint.cue
+++ b/addons/postgresql/config/pg15-config-constraint.cue
@@ -938,7 +938,7 @@
 	ssl_max_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
 
 	// Sets the minimum SSL/TLS protocol version to use.
-	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
+	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2" | "TLSv1.3"
 
 	// Causes ... strings to treat backslashes literally.
 	standard_conforming_strings?: bool & false | true

--- a/addons/postgresql/config/pg15-config.tpl
+++ b/addons/postgresql/config/pg15-config.tpl
@@ -241,7 +241,7 @@ ssl_ca_file = '/etc/pki/tls/ca.pem'
 ssl_cert_file = '/etc/pki/tls/cert.pem'
 ssl_key_file = '/etc/pki/tls/key.pem'
 {{- end }}
-ssl_min_protocol_version = 'TLSv1'
+ssl_min_protocol_version = 'TLSv1.2'
 standard_conforming_strings = 'True'
 statement_timeout = '0'
 superuser_reserved_connections = '20'

--- a/addons/postgresql/config/pg16-config-constraint.cue
+++ b/addons/postgresql/config/pg16-config-constraint.cue
@@ -935,7 +935,7 @@
 	ssl_max_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
 
 	// Sets the minimum SSL/TLS protocol version to use.
-	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
+	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2" | "TLSv1.3"
 
 	// Causes ... strings to treat backslashes literally.
 	standard_conforming_strings?: bool & false | true

--- a/addons/postgresql/config/pg16-config.tpl
+++ b/addons/postgresql/config/pg16-config.tpl
@@ -240,7 +240,7 @@ ssl_ca_file = '/etc/pki/tls/ca.pem'
 ssl_cert_file = '/etc/pki/tls/cert.pem'
 ssl_key_file = '/etc/pki/tls/key.pem'
 {{- end }}
-ssl_min_protocol_version = 'TLSv1'
+ssl_min_protocol_version = 'TLSv1.2'
 standard_conforming_strings = 'True'
 statement_timeout = '0'
 superuser_reserved_connections = '20'

--- a/addons/postgresql/config/pg17-config-constraint.cue
+++ b/addons/postgresql/config/pg17-config-constraint.cue
@@ -932,7 +932,7 @@
 	ssl_max_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
 
 	// Sets the minimum SSL/TLS protocol version to use.
-	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
+	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2" | "TLSv1.3"
 
 	// Causes ... strings to treat backslashes literally.
 	standard_conforming_strings?: bool & false | true

--- a/addons/postgresql/config/pg17-config.tpl
+++ b/addons/postgresql/config/pg17-config.tpl
@@ -226,7 +226,7 @@ ssl_ca_file = '/etc/pki/tls/ca.pem'
 ssl_cert_file = '/etc/pki/tls/cert.pem'
 ssl_key_file = '/etc/pki/tls/key.pem'
 {{- end }}
-ssl_min_protocol_version = 'TLSv1'
+ssl_min_protocol_version = 'TLSv1.2'
 standard_conforming_strings = 'True'
 statement_timeout = '0'
 superuser_reserved_connections = '20'

--- a/addons/postgresql/config/pg18-config-constraint.cue
+++ b/addons/postgresql/config/pg18-config-constraint.cue
@@ -932,7 +932,7 @@
 	ssl_max_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
 
 	// Sets the minimum SSL/TLS protocol version to use.
-	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2"
+	ssl_min_protocol_version?: string & "TLSv1" | "TLSv1.1" | "TLSv1.2" | "TLSv1.3"
 
 	// Causes ... strings to treat backslashes literally.
 	standard_conforming_strings?: bool & false | true

--- a/addons/postgresql/config/pg18-config.tpl
+++ b/addons/postgresql/config/pg18-config.tpl
@@ -226,7 +226,7 @@ ssl_ca_file = '/etc/pki/tls/ca.pem'
 ssl_cert_file = '/etc/pki/tls/cert.pem'
 ssl_key_file = '/etc/pki/tls/key.pem'
 {{- end }}
-ssl_min_protocol_version = 'TLSv1'
+ssl_min_protocol_version = 'TLSv1.2'
 standard_conforming_strings = 'True'
 statement_timeout = '0'
 superuser_reserved_connections = '20'


### PR DESCRIPTION
## Problem

All six config templates (pg12–pg18) set `ssl_min_protocol_version = 'TLSv1'`, permitting TLS 1.0/1.1 — deprecated by RFC 8996 and below PostgreSQL's own engine default (`TLSv1.2` since v12). Diverging below the engine default to a weaker floor is exactly the adapt-to-tooling drift the review flags.

Fixes #3046 (deep-review finding 二.13, priority approved by weston)

## Changes

- `ssl_min_protocol_version = 'TLSv1.2'` in all six version templates.
- The cue enum for this GUC gains `TLSv1.3` — a valid engine value (PG ≥ 12) that the schema previously refused, so users could not raise the floor further even manually.

## Evidence boundary

Static config change; value matches the engine default, cue schema validated by CI render. No runtime TLS handshake test — the setting only takes effect on TLS-enabled clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)