### PR TITLE
fix(postgresql): make reload_patroni_config retry reachable, check PATCH results, fail closed on missing PG_MODE

### DIFF
--- a/addons/postgresql/scripts-ut-spec/reload_patroni_config_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/reload_patroni_config_spec.sh
@@ -1,0 +1,133 @@
+# shellcheck shell=sh
+
+Describe "scripts/reload_patroni_config.sh"
+
+  script_path() {
+    printf "%s" "../scripts/reload_patroni_config.sh"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-reload-config-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    RELOAD_CONFIG_MAX_RETRIES=2
+    RELOAD_CONFIG_RETRY_INTERVAL=0
+    CURRENT_POD_IP="127.0.0.1"
+    export PATH CALL_LOG RELOAD_CONFIG_MAX_RETRIES RELOAD_CONFIG_RETRY_INTERVAL CURRENT_POD_IP
+    unset PG_MODE primaryEndpoint CURL_GET_EXIT CURL_PATCH_EXIT 2>/dev/null || true
+    write_curl_stub
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Emulates the two curl call shapes: GET /config returns the current config
+  # JSON; PATCH /config returns the patched config. curl -f semantics are
+  # emulated via the CURL_*_EXIT controls (22 = HTTP error under -f).
+  write_curl_stub() {
+    cat > "${bindir}/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "${CALL_LOG}"
+case "$*" in
+  *"-X PATCH"*)
+    if [ "${CURL_PATCH_EXIT:-0}" -ne 0 ]; then exit "${CURL_PATCH_EXIT}"; fi
+    printf '%s' '{"patched":true}'
+    ;;
+  *)
+    if [ "${CURL_GET_EXIT:-0}" -ne 0 ]; then exit "${CURL_GET_EXIT}"; fi
+    printf '%s' '{"postgresql":{"parameters":{}}}'
+    ;;
+esac
+EOF
+    chmod +x "${bindir}/curl"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "fails closed when PG_MODE is not set instead of clearing standby config"
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should include "Reload patroni config begin"
+    The error should include "PG_MODE is not set"
+    The result of function call_log should not include "PATCH"
+  End
+
+  It "clears standby config for a primary cluster"
+    export PG_MODE="primary"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "Clear standby config"
+    The output should include "Reload patroni config done"
+    The result of function call_log should include '-X PATCH -d {"standby_cluster":null}'
+  End
+
+  It "patches standby_cluster host/port for a standby cluster"
+    export PG_MODE="standby"
+    export primaryEndpoint="primary.example.com:5432"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "Set STANDBY_HOST=primary.example.com, STANDBY_PORT=5432"
+    The result of function call_log should include '"host":"primary.example.com","port":5432'
+  End
+
+  It "rejects an invalid primaryEndpoint format"
+    export PG_MODE="standby"
+    export primaryEndpoint="not-a-host-port"
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should include "Invalid primary_endpoint format"
+    The result of function call_log should not include "PATCH"
+  End
+
+  It "retries the config GET and succeeds when it recovers"
+    # first GET fails, second succeeds: flip the control file the stub reads
+    cat > "${bindir}/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "${CALL_LOG}"
+case "$*" in
+  *"-X PATCH"*) printf '%s' '{"patched":true}' ;;
+  *)
+    if [ ! -f "${CALL_LOG}.once" ]; then
+      touch "${CALL_LOG}.once"
+      exit 7
+    fi
+    printf '%s' '{"postgresql":{"parameters":{}}}'
+    ;;
+esac
+EOF
+    chmod +x "${bindir}/curl"
+    export PG_MODE="primary"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "retrying in 0s (attempt 1/2)"
+    The output should include "Reload patroni config done"
+  End
+
+  It "gives up after max retries when the config GET keeps failing"
+    export PG_MODE="primary"
+    export CURL_GET_EXIT=7
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should include "giving up"
+    The result of function call_log should not include "PATCH"
+  End
+
+  It "fails when the PATCH is rejected"
+    export PG_MODE="primary"
+    export CURL_PATCH_EXIT=22
+    When run bash "$(script_path)"
+    The status should be failure
+    The output should include "Clear standby config"
+    The error should include "PATCH"
+    The output should not include "Reload patroni config done"
+  End
+End

--- a/addons/postgresql/scripts/reload_patroni_config.sh
+++ b/addons/postgresql/scripts/reload_patroni_config.sh
@@ -2,26 +2,52 @@
 # Script to reload Patroni configuration for PostgreSQL
 set -e
 
+# Tunables (overridable for tests)
+RELOAD_CONFIG_MAX_RETRIES=${RELOAD_CONFIG_MAX_RETRIES:-5}
+RELOAD_CONFIG_RETRY_INTERVAL=${RELOAD_CONFIG_RETRY_INTERVAL:-10}
+
+# PATCH the patroni config and fail loudly on connection errors or non-2xx
+# responses (curl -f), instead of printing 'done' over a rejected change.
+patch_patroni_config() {
+    local patroniurl=$1
+    local payload=$2
+    local response
+    if ! response=$(curl -s -f -X PATCH -d "$payload" "${patroniurl}/config"); then
+        echo "ERROR: PATCH ${patroniurl}/config failed (payload: $payload)" >&2
+        return 1
+    fi
+    echo "Patched patroni config: $response"
+}
+
 process_standby_config() {
+    # PG_MODE decides whether this cluster is a standby. It is injected by the
+    # cluster chart; when it is missing entirely, taking the non-standby branch
+    # would PATCH standby_cluster:null and silently destroy a standby cluster's
+    # replication config — so fail closed instead.
+    if [ -z "${PG_MODE:-}" ]; then
+        echo "ERROR: PG_MODE is not set; refusing to reconcile standby config (an empty PG_MODE would clear standby_cluster)" >&2
+        return 1
+    fi
+
     local is_standby
-    is_standby=$(echo "${PG_MODE:-}" | tr '[:upper:]' '[:lower:]' | grep -q "standby" && echo "true" || echo "false")
+    is_standby=$(echo "${PG_MODE}" | tr '[:upper:]' '[:lower:]' | grep -q "standby" && echo "true" || echo "false")
     local patroniurl="http://${CURRENT_POD_IP:-localhost}:8008"
     echo "patroniurl: $patroniurl, isStandby: $is_standby"
-    # Get current config
-    local result
+    # Get current config; the assignment runs in an if-condition so a curl
+    # failure feeds the retry loop instead of tripping set -e.
+    local result=""
     local retry_count=0
-    local max_retries=5
+    local max_retries=$RELOAD_CONFIG_MAX_RETRIES
 
     while [ $retry_count -lt $max_retries ]; do
-        result=$(curl -s ${patroniurl}/config)
-        if [ $? -eq 0 ] && [ -n "$result" ]; then
+        if result=$(curl -s -f ${patroniurl}/config) && [ -n "$result" ]; then
             break
         fi
 
         retry_count=$((retry_count + 1))
         if [ $retry_count -lt $max_retries ]; then
-            echo "Failed to get config, retrying in 10s (attempt $retry_count/$max_retries)..."
-            sleep 10
+            echo "Failed to get config, retrying in ${RELOAD_CONFIG_RETRY_INTERVAL}s (attempt $retry_count/$max_retries)..."
+            sleep "$RELOAD_CONFIG_RETRY_INTERVAL"
         else
             echo "Failed to get config after $max_retries attempts, giving up."
             return 1
@@ -50,16 +76,21 @@ process_standby_config() {
         if [[ -n "$env_host" && -n "$env_port" ]]; then
             local patch_config="{\"standby_cluster\":{\"create_replica_methods\":[\"basebackup_fast_xlog\"],\"host\":\"$env_host\",\"port\":$env_port}}"
             echo "patch_config: $patch_config"
-            curl -X PATCH -d "$patch_config" ${patroniurl}/config
+            patch_patroni_config "$patroniurl" "$patch_config"
         else
             echo "env_host: $env_host, env_port: $env_port, need_patch: false"
         fi
     else
         # Clear standby config if it exists and we're not in remote backup mode
         echo "Clear standby config"
-        curl -X PATCH -d '{"standby_cluster":null}' ${patroniurl}/config
+        patch_patroni_config "$patroniurl" '{"standby_cluster":null}'
     fi
 }
+
+# This is magic for shellspec ut framework.
+# When included from shellspec, __SOURCED__ variable defined and script
+# end here. The script path is assigned to the __SOURCED__ variable.
+${__SOURCED__:+false} : || return 0
 
 echo -e "\n==== Reload patroni config begin ====\n"
 process_standby_config


### PR DESCRIPTION
## Problem

Three related defects in `scripts/reload_patroni_config.sh` (the pg-update-standby-config path) — details and reproduction in #3047:

1. The 5-attempt retry loop was **dead code**: under `set -e`, `result=$(curl …)` kills the script on the first failure, so the `$?` check and retry branch never ran (same class as #3010's finding).
2. Both `PATCH /config` calls ran `curl -s` with no `-f`/status check: a patroni rejection still printed '==== Reload patroni config done ====' and exited 0 (same class as #3006).
3. **PG_MODE failed open**: when unset (only the cluster chart injects it — a directly-created Cluster CR never gets it), the script took the non-standby branch and PATCHed `standby_cluster: null`, silently destroying a standby cluster's replication config.

Fixes #3047 (deep-review findings 一.9 + 一.8(3), priority approved by weston)

## Changes

- Config GET moved into an if-condition so the bounded retry actually retries (set -e-safe); retry count/interval env-tunable.
- PATCH calls go through `patch_patroni_config()`: `curl -f` + classified stderr on failure; 'done' banner can no longer print over a rejected change.
- Unset PG_MODE is now a hard error naming the risk, instead of a silent standby-config wipe. (Set-but-non-standby values, e.g. `primary`, keep today's clear-standby behavior.)
- `__SOURCED__` guard added; new spec — 7 examples: fail-closed PG_MODE, primary clear path, standby patch path, invalid endpoint format, GET retry recovery, GET exhausting retries, rejected PATCH.

## Evidence boundary

Static analysis + shellspec (postgresql suite 20/20 green locally, shellcheck clean at CI severity). Not reproduced on a live cluster; the PG_MODE fail-open consequence follows from the code path and the cluster-chart-only injection point (report 一.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)