### PR TITLE
fix(postgresql): remove unreachable readinessProbe sentinel check

### DIFF
--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -342,7 +342,6 @@ spec:
               - -ee
               - |
                 exec pg_isready -U {{ default "postgres" | quote }} -h 127.0.0.1 -p 5432
-                [ -f /postgresql/tmp/.initialized ] || [ -f /postgresql/.initialized ]
         volumeMounts:
           - name: dshm
             mountPath: /dev/shm


### PR DESCRIPTION
## Problem

The readinessProbe script is:

```sh
exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
[ -f /postgresql/tmp/.initialized ] || [ -f /postgresql/.initialized ]
```

`exec` replaces the shell process, so the sentinel line has never run — and `/postgresql/…` is not this addon's layout (data is under `/home/postgres/pgdata`; `rg '.initialized' addons/postgresql/` shows no writer). It is residue from a different addon.

Fixes #3050 (deep-review finding 一.7, priority approved by weston)

## Change

Delete the unreachable line. **Behavior-preserving by construction** — runtime readiness has always been pure `pg_isready`; the probe's rendered semantics are unchanged.

## Evidence boundary

Static (`exec` semantics + no-writer grep); chart renders clean. No runtime test needed — the removed line was unreachable, so there is no behavior delta to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)