### PR TITLE
fix(postgresql): remove eval from accountProvision and wal-g upload paths

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -113,14 +113,6 @@ function save_backup_status() {
 function uploadDoneHistoryWALs() {
   DP_log "Checking for historical .history files with .done status to upload..."
 
-  # Build environment variables command prefix without affecting global env
-  env_cmd_prefix="env"
-  while read -r env_file; do
-    env_name=$(basename "$env_file")
-    env_value=$(cat "$env_file")
-    env_cmd_prefix="$env_cmd_prefix $env_name=\"$env_value\""
-  done < <(find "${VOLUME_DATA_DIR}/wal-g/env" -type f)
-
   # Find all .done status files for .history files in archive_status directory
   for done_file in $(find "${LOG_DIR}/archive_status/" -name "*.history.done" -type f | sort); do
     history_name=$(basename "$done_file" .done)
@@ -128,8 +120,10 @@ function uploadDoneHistoryWALs() {
 
     # Check if the actual .history file still exists
     if [ -f "$history_path" ]; then
-      # Try upload with WAL-G
-      eval ${env_cmd_prefix} ${VOLUME_DATA_DIR}/wal-g/wal-g wal-push "${history_path}"
+      # Try upload with WAL-G. envdir reads the env files directly: no shell
+      # re-parse of values, no passphrase on the command line (same pattern as
+      # the archive_command in backuppolicytemplate.yaml).
+      envdir "${VOLUME_DATA_DIR}/wal-g/env" "${VOLUME_DATA_DIR}/wal-g/wal-g" wal-push "${history_path}"
       exit_code=$?
       if [ "$exit_code" -eq 0 ]; then
         DP_log "Successfully uploaded file: ${history_name}"
@@ -148,14 +142,6 @@ function uploadDoneHistoryWALs() {
 # Uses a tracking file system to prevent continuous retries on problem files.
 # If upload fails, we keep the tracking file and only retry after UPLOAD_MISSING_LOGS_RETRY_INTERVAL minutes.
 function uploadMissingLogs() {
-  # Build environment variables command prefix without affecting global env
-  env_cmd_prefix="env"
-  while read -r env_file; do
-    env_name=$(basename "$env_file")
-    env_value=$(cat "$env_file")
-    env_cmd_prefix="$env_cmd_prefix $env_name=\"$env_value\""
-  done < <(find "${VOLUME_DATA_DIR}/wal-g/env" -type f)
-
   # Now iterate through ready WAL files and push them
   for ready_file in $(find "${LOG_DIR}/archive_status/" -name "*.ready" -type f | sort); do
     i=$(basename "$ready_file")
@@ -174,8 +160,9 @@ function uploadMissingLogs() {
     fi
     touch "$tracking_file"
 
-    # Try upload with WAL-G using the env command to avoid affecting global variables
-    eval ${env_cmd_prefix} ${VOLUME_DATA_DIR}/wal-g/wal-g wal-push ${LOG_DIR}/${wal_name}
+    # Try upload with WAL-G. envdir reads the env files directly: no shell
+    # re-parse of values, no passphrase on the command line.
+    envdir "${VOLUME_DATA_DIR}/wal-g/env" "${VOLUME_DATA_DIR}/wal-g/wal-g" wal-push "${LOG_DIR}/${wal_name}"
     exit_code=$?
 
     # Check if rename succeeded by checking if .ready file still exists

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -257,10 +257,22 @@ spec:
           - -c
           - |
             # Expand the ${KB_ACCOUNT_NAME}/${KB_ACCOUNT_PASSWORD} placeholders
-            # without eval: bash pattern substitution treats the replacement as
-            # a literal, so credential values never go through a shell parse.
-            statement="${KB_ACCOUNT_STATEMENT//\$\{KB_ACCOUNT_NAME\}/${KB_ACCOUNT_NAME}}"
-            statement="${statement//\$\{KB_ACCOUNT_PASSWORD\}/${KB_ACCOUNT_PASSWORD}}"
+            # without eval, so credential values never go through a shell parse.
+            # bash >= 5.2 enables patsub_replacement by default, making `&` and
+            # `\` special in the (unquoted) replacement — a password containing
+            # them would be silently rewritten. Disable it explicitly; the shopt
+            # is a no-op on older bash.
+            shopt -u patsub_replacement 2>/dev/null || true
+            # SQL-literal boundary: the statement embeds the values inside
+            # single quotes, so escape embedded single quotes ('' is the SQL
+            # escape) — otherwise a quote in a user-supplied password breaks
+            # the statement, leaks the fragment via psql's error context, and
+            # opens an injection path in a superuser session.
+            sq="'"
+            account_name="${KB_ACCOUNT_NAME//${sq}/${sq}${sq}}"
+            account_password="${KB_ACCOUNT_PASSWORD//${sq}/${sq}${sq}}"
+            statement="${KB_ACCOUNT_STATEMENT//\$\{KB_ACCOUNT_NAME\}/${account_name}}"
+            statement="${statement//\$\{KB_ACCOUNT_PASSWORD\}/${account_password}}"
             psql -h 127.0.0.1 -c "${statement}"
         env:
           - name: PGUSER

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -256,7 +256,11 @@ spec:
           - bash
           - -c
           - |
-            eval statement=\"${KB_ACCOUNT_STATEMENT}\"
+            # Expand the ${KB_ACCOUNT_NAME}/${KB_ACCOUNT_PASSWORD} placeholders
+            # without eval: bash pattern substitution treats the replacement as
+            # a literal, so credential values never go through a shell parse.
+            statement="${KB_ACCOUNT_STATEMENT//\$\{KB_ACCOUNT_NAME\}/${KB_ACCOUNT_NAME}}"
+            statement="${statement//\$\{KB_ACCOUNT_PASSWORD\}/${KB_ACCOUNT_PASSWORD}}"
             psql -h 127.0.0.1 -c "${statement}"
         env:
           - name: PGUSER


### PR DESCRIPTION
## Problem

Two credential-bearing strings go through `eval` (deep-review finding 二.15, issue #3052):

1. **accountProvision** (`cmpd.yaml`): `eval statement=\"${KB_ACCOUNT_STATEMENT}\"` expands the account-statement placeholders through a full shell parse — metacharacters in a password **execute** instead of substituting. The platform's generated passwords (`numSymbols: 0`) can't trigger it, but user-supplied secrets for the same accounts flow through the same eval.
2. **wal-g-archive.sh** (`uploadDoneHistoryWALs` / `uploadMissingLogs`): builds an `env NAME=\"value\"…` prefix from the wal-g env dir — including `DATASAFED_ENCRYPTION_PASS_PHRASE` — and `eval`s it: values get re-parsed and the passphrase lands on a visible command line.

## Changes

- accountProvision expands placeholders with bash pattern substitution (`${var//pat/replacement}`) — the replacement is **literal**, no shell parse. Same contract mariadb-galera implements with escaped `printf | sed`. Verified locally: a password of `x\";touch /tmp/pwned;\"$(id)` remains a literal string in the resulting SQL (no execution).
- wal-g uploads switch to `envdir \"${VOLUME_DATA_DIR}/wal-g/env\" wal-g wal-push …` — the exact pattern this addon already uses in **five** other call sites (the BPT `archive_command` itself, wal-g-wal-archive.sh, wal-g-wal-restore.sh, both archive-restore scripts), which also proves `envdir` availability in the image. No values on argv, no re-parse.

## Boundary notes

- SQL-literal quoting is a separate layer: generated passwords contain no quotes (`numSymbols: 0`), so this PR fixes the shell layer only.
- **Interaction with #3036** (approved, unmerged): it touches other parts of wal-g-archive.sh and adds `walg_archive_spec.sh`; the diffs don't overlap so both merge cleanly, but the spec's wal-g stub needs a one-line `envdir` stub once both are in — I'll follow up on whichever lands second.

## Evidence

Static + rendered chart (block renders verbatim) + local substitution proof; shellcheck clean at CI severity; `bash -n` passes. No runtime cluster test — behavior change is confined to how the identical command lines are constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)