### PR TITLE
fix(mariadb): stop persisting wsrep_sst_auth root credential to the data volume

### DIFF
--- a/addons/mariadb/scripts-ut-spec/galera_start_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/galera_start_spec.sh
@@ -199,4 +199,27 @@ EOF
       The output should equal "OK"
     End
   End
+
+  Describe "wsrep_sst_auth is not persisted (H11)"
+    # rsync SST does not use wsrep_sst_auth; writing it to DATA_DIR (a
+    # needSnapshot volume) leaked the plaintext root password into snapshots.
+
+    It "does not write wsrep_sst_auth to any file"
+      When run sh -c "grep -nE 'wsrep_sst_auth=.*>|> +\"?\\\$?\\{?sst_conf' \"$(script_file)\" || true"
+      The status should be success
+      The output should equal ""
+    End
+
+    It "does not load a defaults-extra-file for SST auth"
+      When run sh -c "grep -F 'defaults-extra-file=' \"$(script_file)\" | grep -F 'sst' || true"
+      The status should be success
+      The output should equal ""
+    End
+
+    It "removes any stale .galera-sst-auth.cnf left by a previous chart version"
+      When call script_contains "rm -f \"\${DATA_DIR}/.galera-sst-auth.cnf\""
+      The status should be success
+      The output should include ".galera-sst-auth.cnf"
+    End
+  End
 End

--- a/addons/mariadb/scripts-ut-spec/galera_start_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/galera_start_spec.sh
@@ -221,5 +221,37 @@ EOF
       The status should be success
       The output should include ".galera-sst-auth.cnf"
     End
+
+    It "deletes an existing stale credential and verifies absence"
+      printf '%s\n' "wsrep_sst_auth=root:secret" > "${DATA_DIR}/.galera-sst-auth.cnf"
+
+      When call remove_stale_galera_sst_auth
+      The status should be success
+      The path "${DATA_DIR}/.galera-sst-auth.cnf" should not be exist
+    End
+
+    It "fails startup when deletion of the stale credential fails"
+      printf '%s\n' "wsrep_sst_auth=root:secret" > "${DATA_DIR}/.galera-sst-auth.cnf"
+      rm() {
+        return 1
+      }
+
+      When call remove_stale_galera_sst_auth
+      The status should be failure
+      The stderr should include "failed to delete stale SST credential"
+      The path "${DATA_DIR}/.galera-sst-auth.cnf" should be exist
+    End
+
+    It "fails startup when deletion reports success but readback still finds the credential"
+      printf '%s\n' "wsrep_sst_auth=root:secret" > "${DATA_DIR}/.galera-sst-auth.cnf"
+      rm() {
+        return 0
+      }
+
+      When call remove_stale_galera_sst_auth
+      The status should be failure
+      The stderr should include "still exists after deletion"
+      The path "${DATA_DIR}/.galera-sst-auth.cnf" should be exist
+    End
   End
 End

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -199,17 +199,16 @@ main() {
   local cluster_address
   cluster_address=$(build_cluster_address)
 
-  # wsrep_sst_auth must not appear on the command line (visible in ps output).
-  # Write it to a file under DATA_DIR (the persistent volume, always writable)
-  # and load it via --defaults-extra-file so MariaDB picks it up at startup.
-  local sst_conf="${DATA_DIR}/.galera-sst-auth.cnf"
-  printf '[mysqld]\nwsrep_sst_auth=%s:%s\n' \
-    "${MARIADB_ROOT_USER}" "${MARIADB_ROOT_PASSWORD}" > "$sst_conf"
-  chown mysql:mysql "$sst_conf"
-  chmod 600 "$sst_conf"
+  # Do NOT persist wsrep_sst_auth. It is only consumed by the mariabackup/
+  # xtrabackup/mysqldump SST methods; this addon uses `wsrep_sst_method = rsync`
+  # (config/mariadb-galera.tpl), which does not authenticate via wsrep_sst_auth,
+  # so the credential was unused. Worse, it was written to DATA_DIR — a
+  # `needSnapshot: true` volume — so the plaintext root password rode into every
+  # volume snapshot / backup. Remove any stale file left by a previous chart
+  # version; do not recreate it.
+  rm -f "${DATA_DIR}/.galera-sst-auth.cnf" 2>/dev/null || true
 
   local wsrep_args=(
-    "--defaults-extra-file=${sst_conf}"
     "--wsrep-cluster-address=${cluster_address}"
     "--wsrep-cluster-name=${CLUSTER_NAME:-mariadb-galera}"
     "--wsrep-node-name=${POD_NAME}"

--- a/addons/mariadb/scripts/galera-start.sh
+++ b/addons/mariadb/scripts/galera-start.sh
@@ -193,6 +193,24 @@ setup_data_dir() {
   chown -R mysql:mysql "${DATA_DIR}" || true
 }
 
+remove_stale_galera_sst_auth() {
+  local stale_sst_auth="${DATA_DIR}/.galera-sst-auth.cnf"
+
+  # A broken symlink is still a credential-path residue, so test both normal
+  # existence and symlink existence before deciding there is nothing to scrub.
+  if [ ! -e "${stale_sst_auth}" ] && [ ! -L "${stale_sst_auth}" ]; then
+    return 0
+  fi
+  if ! rm -f "${DATA_DIR}/.galera-sst-auth.cnf" 2>/dev/null; then
+    echo "Galera startup failed: failed to delete stale SST credential ${stale_sst_auth}" >&2
+    return 1
+  fi
+  if [ -e "${stale_sst_auth}" ] || [ -L "${stale_sst_auth}" ]; then
+    echo "Galera startup failed: stale SST credential ${stale_sst_auth} still exists after deletion" >&2
+    return 1
+  fi
+}
+
 main() {
   setup_data_dir
 
@@ -206,7 +224,7 @@ main() {
   # `needSnapshot: true` volume — so the plaintext root password rode into every
   # volume snapshot / backup. Remove any stale file left by a previous chart
   # version; do not recreate it.
-  rm -f "${DATA_DIR}/.galera-sst-auth.cnf" 2>/dev/null || true
+  remove_stale_galera_sst_auth || return 1
 
   local wsrep_args=(
     "--wsrep-cluster-address=${cluster_address}"


### PR DESCRIPTION
Fixes #3056 — HIGH: plaintext root credential leaked into Galera volume snapshots.

Root cause in the issue: wsrep_sst_auth (unused under rsync SST) was written to ${DATA_DIR} (needSnapshot:true), so it rode into every snapshot. Change: stop writing it, drop --defaults-extra-file, and scrub any stale file on upgrade.

Validation: helm renders; full mariadb shellspec green (653 examples, 0 failures, 9 pre-existing pendings) incl. new contract spec. Note: snapshots taken before this fix still contain the old credential; root password rotation after upgrade advised. mariadb team full-suite verification per westonnnn.

## Current-head stale-credential removal successor

Current addon exact: `71174128cf814db6178719587966ecfe7b6c01df` (tree `e247719931092625a9fe60e9a702e5e83ae5b115`). This successor makes the upgrade scrub required rather than best-effort: if the stale SST credential path exists, deletion must succeed and an absence readback must confirm it is gone. A delete error or false-success leaves startup at `rc=1` with clear stderr instead of starting with the credential still on the snapshot-backed volume.

- old-source delete-error / false-success cases: `3` failures
- current focused Galera-start spec: `18` examples, `0` failures
- `git diff --check`, Bash syntax, and ShellCheck error-level: pass
- current exact GitHub Actions: terminal green
- snapshots created before this fix may still contain the credential; rotation guidance remains unchanged
- no current-exact product runtime was run; runtime remains `N=0`
