### PR TITLE
fix(postgresql): stop hardcoding the default component name in wal-g host and config version lookup

### DIFF
--- a/addons/postgresql/config/pg14-config.tpl
+++ b/addons/postgresql/config/pg14-config.tpl
@@ -29,7 +29,7 @@
 
 {{- $pgVersion := "14.0" }}
 {{- range $i, $spec := $.cluster.spec.componentSpecs }}
-{{- if eq "postgresql" $spec.name }}
+{{- if or (eq "postgresql" $spec.name) (hasPrefix "postgresql" (default "" $spec.componentDef)) }}
 {{- if $spec.serviceVersion }}
 {{- $pgVersion = $spec.serviceVersion }}
 {{- end }}

--- a/addons/postgresql/config/pg15-config.tpl
+++ b/addons/postgresql/config/pg15-config.tpl
@@ -29,7 +29,7 @@
 
 {{- $pgVersion := "15.0" }}
 {{- range $i, $spec := $.cluster.spec.componentSpecs }}
-{{- if eq "postgresql" $spec.name }}
+{{- if or (eq "postgresql" $spec.name) (hasPrefix "postgresql" (default "" $spec.componentDef)) }}
 {{- if $spec.serviceVersion }}
 {{- $pgVersion = $spec.serviceVersion }}
 {{- end }}

--- a/addons/postgresql/config/pg16-config.tpl
+++ b/addons/postgresql/config/pg16-config.tpl
@@ -29,7 +29,7 @@
 
 {{- $pgVersion := "16.0" }}
 {{- range $i, $spec := $.cluster.spec.componentSpecs }}
-{{- if eq "postgresql" $spec.name }}
+{{- if or (eq "postgresql" $spec.name) (hasPrefix "postgresql" (default "" $spec.componentDef)) }}
 {{- if $spec.serviceVersion }}
 {{- $pgVersion = $spec.serviceVersion }}
 {{- end }}

--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -9,7 +9,10 @@ export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 export WALG_DELTA_MAX_STEPS=0
 # 20Gi for bundle file
 export WALG_TAR_SIZE_THRESHOLD=21474836480
-PSQL="psql -h ${CLUSTER_COMPONENT_NAME}-${COMPONENT_NAME} -U ${DP_DB_USER} -d postgres"
+# The cmpd pins Service serviceName=postgresql with roleSelector=primary; the
+# suffix must be that fixed serviceName, not the user-chosen component name.
+# pg_switch_wal()/archive checks below must run on the primary.
+PSQL="psql -h ${CLUSTER_COMPONENT_NAME}-postgresql -U ${DP_DB_USER} -d postgres"
 
 # if the script exits with a non-zero exit code, touch a file to indicate that the backup failed,
 # the sync progress container will check this file and exit if it exists
@@ -91,7 +94,7 @@ PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=5432 wal-g backup-push ${DATA_D
 
 set +e
 echo "switch wal log"
-PSQL="psql -h ${CLUSTER_COMPONENT_NAME}-${COMPONENT_NAME} -U ${DP_DB_USER} -d postgres"
+PSQL="psql -h ${CLUSTER_COMPONENT_NAME}-postgresql -U ${DP_DB_USER} -d postgres"
 ${PSQL} -c "select pg_switch_wal();"
 
 # 2. get backup name of the wal-g

--- a/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
@@ -109,7 +109,10 @@ fi
 
 set +e
 echo "switch wal log"
-PSQL="psql -h ${CLUSTER_COMPONENT_NAME}-${COMPONENT_NAME} -U ${DP_DB_USER} -d postgres"
+# The cmpd pins Service serviceName=postgresql with roleSelector=primary; the
+# suffix must be that fixed serviceName, not the user-chosen component name.
+# pg_switch_wal()/archive checks below must run on the primary.
+PSQL="psql -h ${CLUSTER_COMPONENT_NAME}-postgresql -U ${DP_DB_USER} -d postgres"
 ${PSQL} -c "select pg_switch_wal();"
 
 # 3. add sentinel file for this backup CR


### PR DESCRIPTION
## Problem

Deep-review finding 一.8 (issue #3058) — two "accidentally correct only under default naming" assumptions:

1. wal-g full/incremental backup scripts assemble the primary Service host as `${CLUSTER_COMPONENT_NAME}-${COMPONENT_NAME}`; the real Service is `<cluster>-<comp>-<serviceName>` with `serviceName: postgresql` pinned in the cmpd — so it only resolves when the component short name is "postgresql". `pg_switch_wal()` and the archive_command wait-loop must hit the **primary**; `DP_DB_HOST` is not a safe substitute because the BPT target has `fallbackRole: secondary`.
2. pg14/15/16 config templates find serviceVersion by matching `$spec.name == "postgresql"` literally and silently fall back to 14.0/15.0/16.0 — silently rendering the pre-pg_duckdb `shared_preload_libraries` list for any custom-named component.

## Changes

- Host suffix → the fixed serviceName: `${CLUSTER_COMPONENT_NAME}-postgresql` (comment explains the primary-only constraint).
- Version match → `or (eq "postgresql" $spec.name) (hasPrefix "postgresql" (default "" $spec.componentDef))`: topology-mode clusters keep matching by name (the topology names the component postgresql), direct-componentDef clusters with custom names now match by definition prefix. The per-major default stays only for the legitimate omitted-serviceVersion case.

## Boundary

Static change; chart renders. The config templates render in KB's config engine — `hasPrefix`/`default` are sprig functions, asserted available from the same templates' existing `semverCompare`/`div`/`min` usage; flagging for reviewer confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)