### PR TITLE
fix(postgresql): remove static IMAGE_TAG fallback that hid version-mapping misses

### DIFF
--- a/addons/postgresql/templates/actionset-pgbasebackup.yaml
+++ b/addons/postgresql/templates/actionset-pgbasebackup.yaml
@@ -10,8 +10,6 @@ spec:
   env:
     - name: DATA_DIR
       value: {{ .Values.dataMountPath }}/pgroot/data
-    - name: IMAGE_TAG
-      value: 14.8.0-pgvector-v0.6.1
   backup:
     preBackup: []
     postBackup: []

--- a/addons/postgresql/templates/actionset-pgdumpall.yaml
+++ b/addons/postgresql/templates/actionset-pgdumpall.yaml
@@ -7,9 +7,6 @@ metadata:
     {{- include "postgresql.labels" . | nindent 4 }}
 spec:
   backupType: Selective
-  env:
-    - name: IMAGE_TAG
-      value: 14.8.0-pgvector-v0.6.1
   parametersSchema:
     openAPIV3Schema:
       type: object

--- a/addons/postgresql/templates/actionset-postgresql-pitr.yaml
+++ b/addons/postgresql/templates/actionset-postgresql-pitr.yaml
@@ -28,8 +28,6 @@ spec:
       value: "3"
     - name: SWITCH_WAL_INTERVAL_SECONDS
       value: "600"
-    - name: IMAGE_TAG
-      value: 14.8.0-pgvector-v0.6.1
   restore:
     prepareData:
       image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:$(IMAGE_TAG)

--- a/addons/postgresql/templates/actionset-wal-g-pitr.yaml
+++ b/addons/postgresql/templates/actionset-wal-g-pitr.yaml
@@ -20,8 +20,6 @@ spec:
       value: $(VOLUME_DATA_DIR)/pgroot/data/pg_wal
     - name: LOG_ARCHIVE_SECONDS
       value: "5"
-    - name: IMAGE_TAG
-      value: 14.8.0-pgvector-v0.6.1
     - name: TARGET_POD_ROLE
       # TODO input by backup policy
       value: primary


### PR DESCRIPTION
## Problem

Deep-review finding 三.19 (issue #3062): four ActionSets (postgresql-pitr, pgbasebackup, wal-g-pitr, pgdumpall) default `IMAGE_TAG` to `14.8.0-pgvector-v0.6.1`. The BPT's `versionMapping` overrides it whenever the target serviceVersion is in the chart's declared versions — so the static default only ever takes effect on a **mapping miss**, at which point a PG 16/17/18 cluster silently runs its backup/restore tooling with the PG 14 image. Wrong-major `pg_dump`/`pg_basebackup`/`wal-g` should fail loudly, not run quietly.

## Change

Remove the four static defaults (and the now-empty `env:` block in pgdumpall). On a mapping miss the image renders with a literal `$(IMAGE_TAG)` tag → the job fails at image resolution with the unexpanded variable in the error — attributable fail-fast. `wal-g`/`wal-g-incremental` methods are unaffected (fixed `walgImage` helper).

## Evidence boundary

Static + rendered chart: the only remaining `14.8.0-pgvector` occurrences are the 14.8.0 serviceVersion's own mapping entries and the pg14 cmpd/cmpv images (legitimate). Not runtime-tested; the change removes a fallback rather than altering any matched-path behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)