### PR TITLE
fix(mariadb): fail closed after uncertain DCS switchover to avoid split-brain

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -495,7 +495,12 @@ EOF
     End
 
     Context "when syncerctl cannot create DCS switchover"
-      It "returns failure"
+      # H2 split-brain fix: after syncerctl (invoked with --force under a
+      # timeout(1) wrapper) fails, the DCS record may already be persisted and
+      # syncer may be promoting the candidate. The current primary must be
+      # fenced fail-closed (read_only=1), NOT rolled back to writable — the old
+      # rollback path could leave two writable primaries.
+      It "fails closed by fencing the current primary (does not roll back to writable)"
         make_failing_syncerctl
         prepare_current_primary_for_switchover() {
           return 0
@@ -504,14 +509,24 @@ EOF
           record_call "rollback"
           return 0
         }
+        set_local_read_only() {
+          record_call "set_read_only=$1"
+          return 0
+        }
+        local_read_only_is() {
+          [ "$1" = "1" ]
+        }
         When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
         The status should be failure
         The output should include "Switchover: creating syncer DCS switchover"
-        The stderr should include "Switchover failed: syncerctl could not create DCS switchover"
-        The contents of file "${TEST_DIR}/calls" should include "rollback"
+        The output should include "fencing current primary read_only=1"
+        The stderr should include "current primary fenced fail-closed"
+        The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
+        The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
+        The contents of file "${TEST_DIR}/calls" should not include "rollback"
       End
 
-      It "treats a zero-status syncerctl failure message as failure and rolls back"
+      It "treats a zero-status syncerctl failure message as failure and fails closed by fencing"
         make_zero_status_failing_syncerctl
         prepare_current_primary_for_switchover() {
           return 0
@@ -520,12 +535,39 @@ EOF
           record_call "rollback"
           return 0
         }
+        set_local_read_only() {
+          record_call "set_read_only=$1"
+          return 0
+        }
+        local_read_only_is() {
+          [ "$1" = "1" ]
+        }
         When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
         The status should be failure
         The output should include "Switchover syncerctl output: switchover failed: operation precheck failed: mdb-mariadb-0 is not the primary"
         The stderr should include "Switchover failed: syncerctl did not report success"
         The stderr should include "Switchover failed: syncerctl could not create DCS switchover"
-        The contents of file "${TEST_DIR}/calls" should include "rollback"
+        The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
+        The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
+        The contents of file "${TEST_DIR}/calls" should not include "rollback"
+      End
+
+      It "surfaces a manual-verification error when the fail-closed fence itself cannot be applied"
+        make_failing_syncerctl
+        prepare_current_primary_for_switchover() {
+          return 0
+        }
+        set_local_read_only() {
+          record_call "set_read_only=$1"
+          return 1
+        }
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        The status should be failure
+        The output should include "fencing current primary read_only=1"
+        The stderr should include "could not set current primary read_only=1 after uncertain DCS switchover"
+        The stderr should include "manual verification required to avoid split-brain"
+        The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
+        The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
       End
 
       It "treats duplicate post-success invocation as idempotent success when final state is already reached"

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -521,6 +521,7 @@ EOF
         The output should include "Switchover: creating syncer DCS switchover"
         The output should include "fencing current primary read_only=1"
         The stderr should include "current primary fenced fail-closed"
+        The stderr should include "fail_closed=true"
         The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
         The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
         The contents of file "${TEST_DIR}/calls" should not include "rollback"
@@ -566,6 +567,8 @@ EOF
         The output should include "fencing current primary read_only=1"
         The stderr should include "could not set current primary read_only=1 after uncertain DCS switchover"
         The stderr should include "manual verification required to avoid split-brain"
+        The stderr should include "fail_closed=false"
+        The stderr should not include "current primary fenced fail-closed"
         The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
         The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
       End

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1224,6 +1224,42 @@ rollback_current_primary_switchover_guard() {
   [ "${failed}" -eq 0 ]
 }
 
+fence_current_primary_after_uncertain_dcs() {
+  # H2 split-brain guard for the Stage-3 (DCS switchover) failure path.
+  #
+  # syncerctl_switchover is invoked with --force and wrapped by timeout(1). A
+  # non-zero or timeout(1) (rc 124/125/137) return does NOT prove the DCS
+  # switchover record was never persisted: syncer can accept and persist the
+  # switchover request, begin asynchronously promoting the candidate, and then
+  # have its client (syncerctl) SIGTERM'd by the wall-clock budget. Under the
+  # alpha.79 minimalist model the current primary is still fully writable here
+  # (prepare is a no-op; the Stage-4 post-DCS fence has not run yet).
+  #
+  # The legacy rollback (rollback_current_primary_switchover_guard, which sets
+  # read_only=0 and restores remote-root write grants) would then leave BOTH
+  # the old primary AND the newly-promoted candidate accepting writes =
+  # split-brain. Rollback-to-writable is only safe BEFORE syncerctl is ever
+  # invoked (the Stage-2 pre-DCS path), where no DCS record can exist.
+  #
+  # First principles: once the DCS write cannot be proven to have not landed,
+  # fail closed. Fence the current primary (read_only=1) so that if syncer
+  # completes the switchover there is never a second writable primary. If the
+  # DCS record truly did not persist, KB roleProbe + reconcile converge the
+  # still-read_only old primary (and the failed OpsRequest may retry the whole
+  # switchover) — a bounded, recoverable availability blip. That is always
+  # preferable to unbounded split-brain writes.
+  log_switchover_info "Switchover fail-closed after uncertain DCS switchover: fencing current primary read_only=1 (never unfencing — the DCS switchover record may have persisted and syncer may be promoting the candidate)"
+  if ! set_local_read_only "ON"; then
+    log_switchover_error "Switchover fail-closed fence: could not set current primary read_only=1 after uncertain DCS switchover; manual verification required to avoid split-brain"
+    return 1
+  fi
+  if ! local_read_only_is "1"; then
+    log_switchover_error "Switchover fail-closed fence: current primary read_only did not reach 1 after uncertain DCS switchover; manual verification required to avoid split-brain"
+    return 1
+  fi
+  return 0
+}
+
 prepare_current_primary_for_switchover() {
   # alpha.79 v1 (Helen TL, per westonnnn 21:50 `48a132e2`/`b9a62176`
   # directive: "学 MySQL semisync 的极简思路，来改，现在 / 改完之后再测"):
@@ -2227,8 +2263,14 @@ run_switchover() {
     if switchover_final_state_already_reached "${current_name}" "${candidate_name}" "${candidate_fqdn}"; then
       return 0
     fi
-    rollback_current_primary_switchover_guard || true
-    log_switchover_error "Switchover failed: syncerctl could not create DCS switchover"
+    # H2: do NOT roll the current primary back to writable here. syncerctl runs
+    # with --force under a timeout(1) wrapper, so a non-zero/timeout return does
+    # not prove the DCS switchover record was not persisted — syncer may already
+    # be promoting the candidate. Unfencing the current primary would then make
+    # two writable primaries (split-brain). Fail closed by fencing instead; see
+    # fence_current_primary_after_uncertain_dcs for the full rationale.
+    fence_current_primary_after_uncertain_dcs || true
+    log_switchover_error "Switchover failed: syncerctl could not create DCS switchover; current primary fenced fail-closed (not rolled back to writable) to avoid split-brain if syncer completes the switchover"
     return 1
   fi
   # Defensive overrun guard mirrors prepare (DCS is bounded by the timeout(1)

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -2269,8 +2269,11 @@ run_switchover() {
     # be promoting the candidate. Unfencing the current primary would then make
     # two writable primaries (split-brain). Fail closed by fencing instead; see
     # fence_current_primary_after_uncertain_dcs for the full rationale.
-    fence_current_primary_after_uncertain_dcs || true
-    log_switchover_error "Switchover failed: syncerctl could not create DCS switchover; current primary fenced fail-closed (not rolled back to writable) to avoid split-brain if syncer completes the switchover"
+    if fence_current_primary_after_uncertain_dcs; then
+      log_switchover_error "Switchover failed: syncerctl could not create DCS switchover; current primary fenced fail-closed (not rolled back to writable) to avoid split-brain if syncer completes the switchover; fail_closed=true"
+    else
+      log_switchover_error "Switchover failed: syncerctl could not create DCS switchover and the current-primary fence did not close; fail_closed=false manual verification required to avoid split-brain"
+    fi
     return 1
   fi
   # Defensive overrun guard mirrors prepare (DCS is bounded by the timeout(1)


### PR DESCRIPTION
## Summary (H2)

In `addons/mariadb/scripts/replication-switchover.sh`, the Stage-3 (DCS switchover) failure path calls `rollback_current_primary_switchover_guard`, which sets the current primary back to `read_only=0` and restores its remote-root write grants. This can produce a **split-brain with two writable primaries**.

## Root cause

`syncerctl_switchover` is invoked with `--force` and wrapped by `timeout(1)`:

```sh
output=$(timeout "${wall}" "${SYNCERCTL_BIN}" ... switchover --force --primary ... --candidate ...)
rc=$?
...
case "${rc}" in 124|125|137) ... return 1 ;; esac   # timeout -> fail-closed sentinel
```

A non-zero / timeout return does **not** prove the DCS switchover record was never persisted. Syncer can accept and persist the request, begin **asynchronously** promoting the candidate, and then have its client (`syncerctl`) killed by the wall-clock budget.

On that return, `run_switchover` does:

```sh
if ! syncerctl_switchover ...; then
  if switchover_final_state_already_reached ...; then return 0; fi
  rollback_current_primary_switchover_guard || true   # <-- sets old primary read_only=0
  return 1
fi
```

`switchover_final_state_already_reached` only detects the **fully-completed** end state (candidate already primary + current following it). During the in-progress window (syncer still promoting), it returns false, so rollback runs and un-fences the old primary. Under the alpha.79 minimalist model the old primary is still fully writable at this point (`prepare_current_primary_for_switchover` is a no-op; the Stage-4 fence has not run yet), so rollback actively guarantees it stays writable. When syncer then finishes promoting the candidate (also writable), **both nodes accept writes**.

Rollback-to-writable is only safe **before** `syncerctl` is ever invoked — i.e. the Stage-2 pre-DCS failure path (`wait_candidate_sql_reachable_before_dcs`), where no DCS record can exist. That call site is unchanged.

## Fix

First principles: once the DCS write cannot be proven to have not landed, fail closed. On the Stage-3 failure path, fence the current primary (`read_only=1`) instead of rolling it back to writable, via a new `fence_current_primary_after_uncertain_dcs` helper. If the DCS record truly did not persist, KB roleProbe + reconcile converge the still-read_only old primary (and the failed OpsRequest may retry the whole switchover) — a bounded, recoverable availability blip, always preferable to unbounded split-brain writes.

## Predecessor tests

`addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh` updated: the two Stage-3-failure cases now assert the current primary is fenced (`set_read_only=ON`), never unfenced (`set_read_only=OFF`), and `rollback` is not called; plus a new case asserting a manual-verification error is surfaced when the fail-closed fence itself cannot be applied. Full mariadb suite: 664 examples, 0 failures.


## Current-head truthful fence-result successor

Current addon exact: `a4805b1d401f188a3fc1c0c47541b5f903f1f74d` (tree `2268c3b07f3647093eaef5fbfdd998c85c3b8e2e`). The uncertain-DCS fail-closed design above is unchanged; this successor fixes its result reporting. `fence_current_primary_after_uncertain_dcs` logs `fail_closed=true` only after the fence succeeds. If the fence fails, it logs `fail_closed=false` with manual-verification guidance and the action returns `1`; it never emits a false-success claim.

- old-source focused failure cases: `2` failures
- current focused successor: `4` examples, `0` failures
- current full switchover spec: `192` pass / `0` fail / `6` historical pending
- `git diff --check`, `sh -n`, and ShellCheck error-level: pass
- current exact GitHub Actions: terminal green
- no current-exact product runtime was run; runtime remains `N=0`
