### PR TITLE
fix(mariadb): make cluster chart mode select replication/galera topology

### DIFF
--- a/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
+++ b/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
@@ -75,6 +75,18 @@ Describe "mariadb cluster topology replica invariants"
     The error should include "replication mode requires replicas >= 2"
   End
 
+  It "rejects replication above five replicas through values.schema.json"
+    When call render_chart replication 6
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects replication above five replicas in the template even when schema validation is skipped"
+    When call render_chart_without_schema replication 6
+    The status should be failure
+    The error should include "replication mode requires replicas between 2 and 5"
+  End
+
   It "rejects Galera with two replicas through values.schema.json"
     When call render_chart galera 2
     The status should be failure

--- a/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
+++ b/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
@@ -63,6 +63,66 @@ Describe "mariadb cluster topology replica invariants"
     The output should include "replicas: 5"
   End
 
+  It "rejects an unknown topology mode through values.schema.json"
+    When call render_chart invalid 3
+    The status should be failure
+    The error should include "mode"
+  End
+
+  It "rejects an unknown topology mode in the template even when schema validation is skipped"
+    When call render_chart_without_schema invalid 3
+    The status should be failure
+    The error should include "mode must be one of standalone, replication, or galera"
+  End
+
+  It "rejects replicas below the global minimum through values.schema.json"
+    When call render_chart standalone 0
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects replicas below the global minimum in the template even for standalone"
+    When call render_chart_without_schema standalone 0
+    The status should be failure
+    The error should include "replicas must be an integer between 1 and 5"
+  End
+
+  It "rejects replicas above the global maximum through values.schema.json"
+    When call render_chart standalone 6
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects replicas above the global maximum in the template even for standalone"
+    When call render_chart_without_schema standalone 6
+    The status should be failure
+    The error should include "replicas must be an integer between 1 and 5"
+  End
+
+  It "rejects fractional replicas through values.schema.json"
+    When call render_chart replication 2.5
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects fractional replicas in the template even when schema validation is skipped"
+    When call render_chart_without_schema replication 2.5
+    The status should be failure
+    The error should include "replicas must be an integer between 1 and 5"
+  End
+
+  It "rejects non-numeric replicas through values.schema.json"
+    When call render_chart replication invalid
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects non-numeric replicas in the template even when schema validation is skipped"
+    When call render_chart_without_schema replication invalid
+    The status should be failure
+    The error should include "replicas must be an integer between 1 and 5"
+  End
+
   It "rejects replication with one replica through values.schema.json"
     When call render_chart replication 1
     The status should be failure
@@ -84,7 +144,7 @@ Describe "mariadb cluster topology replica invariants"
   It "rejects replication above five replicas in the template even when schema validation is skipped"
     When call render_chart_without_schema replication 6
     The status should be failure
-    The error should include "replication mode requires replicas between 2 and 5"
+    The error should include "replicas must be an integer between 1 and 5"
   End
 
   It "rejects Galera with two replicas through values.schema.json"

--- a/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
+++ b/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
@@ -11,6 +11,12 @@ Describe "mariadb cluster topology replica invariants"
       || helm dependency build --skip-refresh "${chart}" >/dev/null
   }
 
+  render_chart_defaults() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default
+  }
+
   render_chart() {
     ensure_dependency
     helm template topoinv "$(chart_dir)" \
@@ -45,6 +51,23 @@ Describe "mariadb cluster topology replica invariants"
       --set-string "replicas=$2"
   }
 
+  render_chart_with_json_replicas() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default \
+      --set "mode=$1" \
+      --set-json "replicas=$2"
+  }
+
+  render_chart_with_json_replicas_without_schema() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default \
+      --skip-schema-validation \
+      --set "mode=$1" \
+      --set-json "replicas=$2"
+  }
+
   lint_chart() {
     ensure_dependency
     helm lint "$(chart_dir)" \
@@ -54,6 +77,13 @@ Describe "mariadb cluster topology replica invariants"
 
   It "renders standalone with one replica"
     When call render_chart standalone 1
+    The status should be success
+    The output should include "topology: standalone"
+    The output should include "replicas: 1"
+  End
+
+  It "renders the values.yaml defaults without overrides"
+    When call render_chart_defaults
     The status should be success
     The output should include "topology: standalone"
     The output should include "replicas: 1"
@@ -78,6 +108,20 @@ Describe "mariadb cluster topology replica invariants"
     The status should be success
     The output should include "topology: galera"
     The output should include "replicas: 5"
+  End
+
+  It "accepts an integral JSON number through values.schema.json"
+    When call render_chart_with_json_replicas replication 3.0
+    The status should be success
+    The output should include "topology: replication"
+    The output should include "replicas: 3"
+  End
+
+  It "accepts an integral JSON number when schema validation is skipped"
+    When call render_chart_with_json_replicas_without_schema replication 3.0
+    The status should be success
+    The output should include "topology: replication"
+    The output should include "replicas: 3"
   End
 
   It "rejects an unknown topology mode through values.schema.json"

--- a/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
+++ b/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
@@ -28,6 +28,23 @@ Describe "mariadb cluster topology replica invariants"
       --set "replicas=$2"
   }
 
+  render_chart_with_string_replicas() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default \
+      --set "mode=$1" \
+      --set-string "replicas=$2"
+  }
+
+  render_chart_with_string_replicas_without_schema() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default \
+      --skip-schema-validation \
+      --set "mode=$1" \
+      --set-string "replicas=$2"
+  }
+
   lint_chart() {
     ensure_dependency
     helm lint "$(chart_dir)" \
@@ -119,6 +136,32 @@ Describe "mariadb cluster topology replica invariants"
 
   It "rejects non-numeric replicas in the template even when schema validation is skipped"
     When call render_chart_without_schema replication invalid
+    The status should be failure
+    The error should include "replicas must be an integer between 1 and 5"
+  End
+
+  It "rejects a numeric string replica through values.schema.json"
+    When call render_chart_with_string_replicas replication 3
+    The status should be failure
+    The error should include "replicas"
+    The error should include "want integer"
+  End
+
+  It "rejects a numeric string replica in the template even when schema validation is skipped"
+    When call render_chart_with_string_replicas_without_schema replication 3
+    The status should be failure
+    The error should include "replicas must be an integer between 1 and 5"
+  End
+
+  It "rejects a leading-zero string replica through values.schema.json"
+    When call render_chart_with_string_replicas replication 03
+    The status should be failure
+    The error should include "replicas"
+    The error should include "want integer"
+  End
+
+  It "rejects a leading-zero string replica in the template even when schema validation is skipped"
+    When call render_chart_with_string_replicas_without_schema replication 03
     The status should be failure
     The error should include "replicas must be an integer between 1 and 5"
   End

--- a/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
+++ b/addons-cluster/mariadb/scripts-ut-spec/topology_replica_invariant_spec.sh
@@ -1,0 +1,102 @@
+# shellcheck shell=bash
+
+Describe "mariadb cluster topology replica invariants"
+  chart_dir() {
+    printf "%s/addons-cluster/mariadb" "${SHELLSPEC_CWD:?}"
+  }
+
+  ensure_dependency() {
+    chart="$(chart_dir)"
+    [ -f "${chart}/charts/kblib-0.1.2.tgz" ] \
+      || helm dependency build --skip-refresh "${chart}" >/dev/null
+  }
+
+  render_chart() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default \
+      --set "mode=$1" \
+      --set "replicas=$2"
+  }
+
+  render_chart_without_schema() {
+    ensure_dependency
+    helm template topoinv "$(chart_dir)" \
+      --namespace default \
+      --skip-schema-validation \
+      --set "mode=$1" \
+      --set "replicas=$2"
+  }
+
+  lint_chart() {
+    ensure_dependency
+    helm lint "$(chart_dir)" \
+      --set "mode=$1" \
+      --set "replicas=$2"
+  }
+
+  It "renders standalone with one replica"
+    When call render_chart standalone 1
+    The status should be success
+    The output should include "topology: standalone"
+    The output should include "replicas: 1"
+  End
+
+  It "renders replication with two replicas"
+    When call render_chart replication 2
+    The status should be success
+    The output should include "topology: replication"
+    The output should include "replicas: 2"
+  End
+
+  It "renders Galera with three replicas"
+    When call render_chart galera 3
+    The status should be success
+    The output should include "topology: galera"
+    The output should include "replicas: 3"
+  End
+
+  It "renders Galera with five replicas"
+    When call render_chart galera 5
+    The status should be success
+    The output should include "topology: galera"
+    The output should include "replicas: 5"
+  End
+
+  It "rejects replication with one replica through values.schema.json"
+    When call render_chart replication 1
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects replication with one replica in the template even when schema validation is skipped"
+    When call render_chart_without_schema replication 1
+    The status should be failure
+    The error should include "replication mode requires replicas >= 2"
+  End
+
+  It "rejects Galera with two replicas through values.schema.json"
+    When call render_chart galera 2
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects Galera with two replicas in the template even when schema validation is skipped"
+    When call render_chart_without_schema galera 2
+    The status should be failure
+    The error should include "galera mode requires replicas to be one of 3 or 5"
+  End
+
+  It "rejects Galera with four replicas through values.schema.json"
+    When call render_chart galera 4
+    The status should be failure
+    The error should include "replicas"
+  End
+
+  It "rejects Galera with four replicas during helm lint"
+    When call lint_chart galera 4
+    The status should be failure
+    The output should include "/replicas"
+    The error should include "1 chart(s) linted, 1 chart(s) failed"
+  End
+End

--- a/addons-cluster/mariadb/templates/_helpers.tpl
+++ b/addons-cluster/mariadb/templates/_helpers.tpl
@@ -11,6 +11,9 @@
 {{- if not (or (eq $mode "standalone") (eq $mode "replication") (eq $mode "galera")) -}}
 {{- fail "mode must be one of standalone, replication, or galera" -}}
 {{- end -}}
+{{- if not (kindIs "int64" .Values.replicas) -}}
+{{- fail "replicas must be an integer between 1 and 5" -}}
+{{- end -}}
 {{- $replicasText := printf "%v" .Values.replicas -}}
 {{- if not (regexMatch "^[0-9]+$" $replicasText) -}}
 {{- fail "replicas must be an integer between 1 and 5" -}}

--- a/addons-cluster/mariadb/templates/_helpers.tpl
+++ b/addons-cluster/mariadb/templates/_helpers.tpl
@@ -8,12 +8,19 @@
 
 {{- define "mariadb-cluster.validateTopology" -}}
 {{- $mode := .Values.mode -}}
+{{- if not (or (eq $mode "standalone") (eq $mode "replication") (eq $mode "galera")) -}}
+{{- fail "mode must be one of standalone, replication, or galera" -}}
+{{- end -}}
+{{- $replicasText := printf "%v" .Values.replicas -}}
+{{- if not (regexMatch "^[0-9]+$" $replicasText) -}}
+{{- fail "replicas must be an integer between 1 and 5" -}}
+{{- end -}}
 {{- $replicas := int .Values.replicas -}}
+{{- if or (lt $replicas 1) (gt $replicas 5) -}}
+{{- fail "replicas must be an integer between 1 and 5" -}}
+{{- end -}}
 {{- if and (eq $mode "replication") (lt $replicas 2) -}}
 {{- fail "replication mode requires replicas >= 2" -}}
-{{- end -}}
-{{- if and (eq $mode "replication") (gt $replicas 5) -}}
-{{- fail "replication mode requires replicas between 2 and 5" -}}
 {{- end -}}
 {{- if and (eq $mode "galera") (not (or (eq $replicas 3) (eq $replicas 5))) -}}
 {{- fail "galera mode requires replicas to be one of 3 or 5" -}}

--- a/addons-cluster/mariadb/templates/_helpers.tpl
+++ b/addons-cluster/mariadb/templates/_helpers.tpl
@@ -12,6 +12,9 @@
 {{- if and (eq $mode "replication") (lt $replicas 2) -}}
 {{- fail "replication mode requires replicas >= 2" -}}
 {{- end -}}
+{{- if and (eq $mode "replication") (gt $replicas 5) -}}
+{{- fail "replication mode requires replicas between 2 and 5" -}}
+{{- end -}}
 {{- if and (eq $mode "galera") (not (or (eq $replicas 3) (eq $replicas 5))) -}}
 {{- fail "galera mode requires replicas to be one of 3 or 5" -}}
 {{- end -}}

--- a/addons-cluster/mariadb/templates/_helpers.tpl
+++ b/addons-cluster/mariadb/templates/_helpers.tpl
@@ -11,7 +11,7 @@
 {{- if not (or (eq $mode "standalone") (eq $mode "replication") (eq $mode "galera")) -}}
 {{- fail "mode must be one of standalone, replication, or galera" -}}
 {{- end -}}
-{{- if not (kindIs "int64" .Values.replicas) -}}
+{{- if not (or (kindIs "int64" .Values.replicas) (kindIs "float64" .Values.replicas)) -}}
 {{- fail "replicas must be an integer between 1 and 5" -}}
 {{- end -}}
 {{- $replicasText := printf "%v" .Values.replicas -}}

--- a/addons-cluster/mariadb/templates/_helpers.tpl
+++ b/addons-cluster/mariadb/templates/_helpers.tpl
@@ -5,3 +5,14 @@
 {{- .Values.replicas -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "mariadb-cluster.validateTopology" -}}
+{{- $mode := .Values.mode -}}
+{{- $replicas := int .Values.replicas -}}
+{{- if and (eq $mode "replication") (lt $replicas 2) -}}
+{{- fail "replication mode requires replicas >= 2" -}}
+{{- end -}}
+{{- if and (eq $mode "galera") (not (or (eq $replicas 3) (eq $replicas 5))) -}}
+{{- fail "galera mode requires replicas to be one of 3 or 5" -}}
+{{- end -}}
+{{- end -}}

--- a/addons-cluster/mariadb/templates/cluster.yaml
+++ b/addons-cluster/mariadb/templates/cluster.yaml
@@ -6,9 +6,15 @@ metadata:
   labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
 spec:
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
+  # Select the topology from the mariadb ClusterDefinition so `mode` actually
+  # picks the component definition. `componentDef: mariadb` alone is a name
+  # prefix that matches all three CmpDs (mariadb-*, mariadb-replication-merged-*,
+  # mariadb-galera-*), so it could not deterministically select replication or
+  # galera. clusterDef + topology resolves the correct compDef per topology.
+  clusterDef: mariadb
+  topology: {{ .Values.mode }}
   componentSpecs:
     - name: mariadb
-      componentDef: mariadb
       replicas: {{ include "mariadb-cluster.replicas" . }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- include "kblib.componentStorages" . | indent 6 }}

--- a/addons-cluster/mariadb/templates/cluster.yaml
+++ b/addons-cluster/mariadb/templates/cluster.yaml
@@ -1,3 +1,4 @@
+{{- include "mariadb-cluster.validateTopology" . -}}
 apiVersion: apps.kubeblocks.io/v1
 kind: Cluster
 metadata:

--- a/addons-cluster/mariadb/values.schema.json
+++ b/addons-cluster/mariadb/values.schema.json
@@ -4,20 +4,22 @@
   "properties": {
     "mode": {
       "title": "Mode",
-      "description": "Cluster topology mode.",
+      "description": "Cluster topology mode. Maps to a topology in the mariadb ClusterDefinition: standalone (single node), replication (primary/secondary), or galera (multi-primary wsrep).",
       "type": "string",
       "default": "standalone",
       "enum": [
-        "standalone"
+        "standalone",
+        "replication",
+        "galera"
       ]
     },
     "replicas": {
       "title": "Replicas",
-      "description": "The number of replicas, for standalone mode, the replicas is 1.",
+      "description": "The number of replicas. standalone is always 1 (this value is ignored for standalone); replication needs at least 2; galera needs an odd number, at least 3, for quorum.",
       "type": "integer",
       "default": 1,
       "minimum": 1,
-      "maximum": 1
+      "maximum": 5
     },
     "cpu": {
       "title": "CPU",

--- a/addons-cluster/mariadb/values.schema.json
+++ b/addons-cluster/mariadb/values.schema.json
@@ -55,6 +55,48 @@
       "minimum": 1,
       "maximum": 10000
     }
-
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "mode": {
+            "const": "replication"
+          }
+        },
+        "required": [
+          "mode"
+        ]
+      },
+      "then": {
+        "properties": {
+          "replicas": {
+            "minimum": 2
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "mode": {
+            "const": "galera"
+          }
+        },
+        "required": [
+          "mode"
+        ]
+      },
+      "then": {
+        "properties": {
+          "replicas": {
+            "enum": [
+              3,
+              5
+            ]
+          }
+        }
+      }
+    }
+  ]
 }

--- a/addons-cluster/mariadb/values.yaml
+++ b/addons-cluster/mariadb/values.yaml
@@ -2,12 +2,17 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+## @param mode cluster topology: standalone (single node), replication
+## (primary/secondary), or galera (multi-primary wsrep). Selects the matching
+## topology in the mariadb ClusterDefinition.
+##
 mode: standalone
 ## @param version MARIADB cluster version
 ##
 version: mariadb
 
-## @param replicas specify cluster replicas
+## @param replicas specify cluster replicas. standalone is forced to 1;
+## replication needs >= 2; galera needs an odd number >= 3 for quorum.
 ##
 replicas: 1
 


### PR DESCRIPTION
## Summary

The `addons-cluster/mariadb` chart cannot select the replication or galera topology. `mode` only changes the replica count; the Cluster always resolves an ambiguous componentDef.

## Root cause

`templates/cluster.yaml` used:

```yaml
componentSpecs:
  - name: mariadb
    componentDef: mariadb
    replicas: {{ include "mariadb-cluster.replicas" . }}
```

`componentDef: mariadb` is a **name prefix**, and the addon ships three CmpDs:

- `mariadb-<version>` (standalone)
- `mariadb-replication-merged-<version>` (replication)
- `mariadb-galera-<version>` (galera)

The prefix `mariadb` matches all three, so it cannot deterministically select replication or galera. Meanwhile the only topology lever is `mode`, which `templates/_helpers.tpl` uses solely to compute `replicas` (standalone → 1, else `.Values.replicas`). It never selects a component definition.

`values.schema.json` further locked this down: `mode` enum was `["standalone"]` only, and `replicas` had `maximum: 1`. So even the schema forbade anything but a single standalone node.

The addon already ships a `ClusterDefinition` named `mariadb` with three named topologies (`standalone` default, `replication`, `galera`), each pinning the correct `compDef` by full name — but the cluster chart did not use it.

## Fix

Use the KB-native topology selector (same idiom as clickhouse / apecloud-mysql cluster charts):

```yaml
spec:
  clusterDef: mariadb
  topology: {{ .Values.mode }}
  componentSpecs:
    - name: mariadb
      replicas: {{ include "mariadb-cluster.replicas" . }}
```

- `mode` maps 1:1 to the ClusterDefinition topology names (standalone / replication / galera), so `topology: {{ .Values.mode }}` resolves the correct compDef.
- `values.schema.json`: `mode` enum expanded to `["standalone", "replication", "galera"]`; `replicas` maximum raised from 1 to 5 (standalone is still forced to 1 by the helper).
- `values.yaml`: documented the mode options and replica guidance (replication 2..5, galera 3 or 5).

## Verification

`helm template` for all three modes renders `clusterDef: mariadb` + the correct `topology:`, with no ambiguous `componentDef` field; standalone forces `replicas: 1`, replication/galera honor the set value.

## Current-head schema/template invariant contract

Current exact: `94013737a619a9861581d310619a06d4bc40baa9` (tree `f666cc5fa77954ca6c99d8eb4bbed5ed2919eaf9`). In addition to topology selection, schema-on and `--skip-schema-validation` template paths now enforce the same entry domain:

- `mode` must be exactly `standalone`, `replication`, or `galera`
- `replicas` accepts Helm's native numeric representations for schema-valid integers (the default `values.yaml` float64 representation and CLI/set-json int64 or integral float64), must be integral, and must be within `1..5`
- numeric strings (including leading-zero strings), fractions, non-numeric values, zero, and values above five fail before render
- replication requires `2..5`; Galera requires exactly `3` or `5`; standalone still renders one replica after valid input

TDD was staged against each immediate predecessor. The final representation-parity successor adds a no-override default render plus paired schema-on/skip-schema `--set-json replicas=3.0` cases: predecessor `a2680557...` fails all three, while current exact passes the final `29`-example matrix with `0` failures. The preceding type-parity stage separately proved numeric strings and leading-zero strings RED before GREEN; earlier stages proved the lower/upper/mode/fractional/non-numeric gaps RED before GREEN. Default `helm lint`, five explicit valid lint cases (standalone 1, replication 2/5, Galera 3/5), `git diff --check`, JSON parse, and ShellCheck error-level all pass. Current GitHub CI is running after this exact; product runtime remains `N=0` and is owned by Jack.
