### PR TITLE
fix(oceanbase-ce): update reconfigure script to argv-reading

### DIFF
--- a/addons/oceanbase-ce/templates/_helpers.tpl
+++ b/addons/oceanbase-ce/templates/_helpers.tpl
@@ -95,31 +95,8 @@ reconfigure:
       - |
         set -eu
 
-        env_file="/tmp/oceanbase-reconfigure-env.$$"
-        trap 'rm -f "$env_file"' EXIT
-        tr '\0' '\n' < /proc/self/environ > "$env_file"
-
-        rc=0
-        matched=0
-        while IFS= read -r line; do
-          paramName="${line%%=*}"
-          paramValue="${line#*=}"
-          [ "$paramName" != "$line" ] || continue
-          case "$paramName" in
-            ""|"_"|KB_*|*[!abcdefghijklmnopqrstuvwxyz0123456789_]*)
-              continue
-              ;;
-          esac
-
-          matched=$((matched + 1))
-          /scripts/{{ .script }} "$paramName" "$paramValue" || rc=$?
-        done < "$env_file"
-
-        if [ "$matched" -eq 0 ]; then
-          echo "no reconfigure parameters found in kbagent environment" >&2
-          exit 1
-        fi
-        exit "$rc"
+        /scripts/{{ .script }} "$1" "$2"
+      - --
 {{- end -}}
 
 


### PR DESCRIPTION
## Problem

PR #2862 changed the OBCE reconfigure action script from argv-reading ( with  placeholder) to env-scanning (). This broke reconfigure on KB 1.2+, which delivers reconfigure params as **argv** via:
-  in InstanceSet spec
-  ()
-  iterates pairs, each → one action call ()
-  appends arguments to command argv ()
- Result: `sh -c "script" -- system_memory 2G` → `=system_memory`, `=2G`

The env-scanning script finds no matching env vars → `no reconfigure parameters found in kbagent environment` → exit 1.

## Root cause confirmation

Edward (KB controller team) traced the full code chain and confirmed:
- KB 1.2 passes reconfigure params as **argv**, not env
- The env-scanning pattern was introduced by PR #2862 (commit `78f66c03`)
- PostgreSQL sibling addon uses the correct argv pattern: `sh -c 'script "$1" "$2"' --`

## Fix

Clean revert of commit `78f66c03` — restore the original argv-reading pattern.

### Before (broken):
```sh
env_file="/tmp/oceanbase-reconfigure-env.27563"
trap 'rm -f "$env_file"' EXIT
tr '\0' '\n' < /proc/self/environ > "$env_file"
# ... 20+ lines of env-scanning loop ...
```

### After (fixed):
```sh
/scripts/{{ .script }} "$1" "$2"
```

## Validation

- Smoke: 6/6 PASS (cluster creation, SQL read/write, service)
- O05 Reconfiguring: SUCCEEDED in 3s (was stuck 176min with env-reading)
- Controller log: `successfully reconfigure the pod`
- InstanceSet argv proof: `reconfigureArgs: [["system_memory", "2G"]]`

## Scope

Only `addons/oceanbase-ce/templates/_helpers.tpl` changed. 1 file, 2 insertions, 25 deletions.