### PR TITLE
fix(mysql): orc switchover fails closed when Orchestrator is unreachable

### DIFF
--- a/addons/mysql/scripts/orc-switchover.sh
+++ b/addons/mysql/scripts/orc-switchover.sh
@@ -21,10 +21,14 @@ if [[ "$KB_SWITCHOVER_ROLE" != "primary" ]]; then
   exit 0
 fi
 
-# Skip if KB_SWITCHOVER_CURRENT_NAME is not the master
-master_from_orc=$(/kubeblocks/orchestrator-client -c which-cluster-master -i "${KB_SWITCHOVER_CURRENT_NAME}" 2>&1)
-if [ -z "$master_from_orc" ]; then
-  mysql_error "Could not determine current master from Orchestrator"
+# Skip if KB_SWITCHOVER_CURRENT_NAME is not the master.
+# Keep stderr out of the command substitution: on an Orchestrator outage the
+# client's error text must not be mistaken for a master name (it previously
+# made this guard exit 0 and the switchover was silently skipped as success).
+master_from_orc=$(/kubeblocks/orchestrator-client -c which-cluster-master -i "${KB_SWITCHOVER_CURRENT_NAME}")
+rc=$?
+if [ $rc -ne 0 ] || [ -z "$master_from_orc" ]; then
+  mysql_error "Could not determine current master from Orchestrator (rc=${rc})"
 fi
 
 if [ "${KB_SWITCHOVER_CURRENT_NAME}" != "${master_from_orc%%:*}" ]; then
@@ -33,8 +37,13 @@ if [ "${KB_SWITCHOVER_CURRENT_NAME}" != "${master_from_orc%%:*}" ]; then
 fi
 
 # Skip switch if there is only one instance
-instance_count=$(/kubeblocks/orchestrator-client -c which-cluster-instances -i "${KB_SWITCHOVER_CURRENT_NAME}" 2>&1 | wc -l)
-if [ "$instance_count" -eq 1 ]; then
+instances=$(/kubeblocks/orchestrator-client -c which-cluster-instances -i "${KB_SWITCHOVER_CURRENT_NAME}")
+rc=$?
+if [ $rc -ne 0 ]; then
+  mysql_error "Could not list cluster instances from Orchestrator (rc=${rc})"
+fi
+instance_count=$(printf '%s\n' "$instances" | sed '/^$/d' | wc -l)
+if [ "$instance_count" -le 1 ]; then
   mysql_note "Only one instance in cluster, cannot switchover."
   exit 0
 fi
@@ -55,5 +64,5 @@ else
 fi
 
 if [ $exit_code -ne 0 ]; then
-  mysql_error "Switchover command failed with exit code: ${result}"
+  mysql_error "Switchover command failed with exit code ${exit_code}: ${result}"
 fi


### PR DESCRIPTION
Fixes #3077.

Root-cause-only change in `orc-switchover.sh`:
- `which-cluster-master` / `which-cluster-instances` no longer capture stderr into the result; the client's exit code is checked explicitly and query failure exits 1 (kbagent retry drives convergence per the 05c contract).
- instance count now counts non-empty lines and uses `-le 1`.
- the failure message prints the actual exit code plus output.

Pre-flight guards (role check, not-the-master skip, single-instance skip, graceful-master-takeover-auto flow) are unchanged.

Validation: `bash -n` pass. Runtime validation (switchover with Orchestrator down must fail the Ops, switchover with Orchestrator up must succeed) to be run by the mysql addon team via kubeblocks-tests before undraft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)