### PR TITLE
fix(mysql): default general_log to OFF (port from apecloud-addons)

### DIFF
--- a/addons/mysql/config/mysql5.7-config.tpl
+++ b/addons/mysql/config/mysql5.7-config.tpl
@@ -89,7 +89,7 @@ log_error_verbosity=2
 log_output=FILE
 slow_query_log=ON
 long_query_time=5
-general_log=ON
+general_log=OFF
 
 #innodb
 innodb_flush_method=O_DIRECT

--- a/addons/mysql/config/mysql8.0-config.tpl
+++ b/addons/mysql/config/mysql8.0-config.tpl
@@ -93,7 +93,7 @@ log_error_verbosity=2
 log_output=FILE
 slow_query_log=ON
 long_query_time=5
-general_log=ON
+general_log=OFF
 
 #innodb
 innodb_doublewrite_batch_size=16


### PR DESCRIPTION
Fixes #3081.

Two-line port of the enterprise-repo fix: `general_log=ON` → `general_log=OFF` in `mysql8.0-config.tpl` and `mysql5.7-config.tpl`. The parameter remains dynamic, so it can still be turned on at runtime for debugging.

Runtime validation before undraft: fresh cluster shows `@@general_log = 0`; reconfigure to ON still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)