### PR TITLE
fix(mysql): add innodb_redo_log_capacity to 8.0 cue schema (port from apecloud-addons)

### DIFF
--- a/addons/mysql/config/mysql8-config-constraint.cue
+++ b/addons/mysql/config/mysql8-config-constraint.cue
@@ -580,6 +580,9 @@
 	// Controls encryption of redo log data for tables encrypted using the InnoDB tablespace encryption feature.
 	innodb_redo_log_encrypt: string & "OFF" | "ON" | *"OFF"
 
+	// The total capacity in bytes of the redo log.
+	innodb_redo_log_capacity: int & >= 8388608
+
 	// The replication thread delay (in ms) on a slave server if innodb_thread_concurrency is reached.
 	innodb_replication_delay?: int & >=0 & <=4294967295
 

--- a/addons/mysql/config/mysql8-config-constraint.cue
+++ b/addons/mysql/config/mysql8-config-constraint.cue
@@ -580,8 +580,8 @@
 	// Controls encryption of redo log data for tables encrypted using the InnoDB tablespace encryption feature.
 	innodb_redo_log_encrypt: string & "OFF" | "ON" | *"OFF"
 
-	// The total capacity in bytes of the redo log.
-	innodb_redo_log_capacity: int & >= 8388608
+	// Optional because the template only derives it when a memory limit is available.
+	innodb_redo_log_capacity?: int & >= 8388608
 
 	// The replication thread delay (in ms) on a slave server if innodb_thread_concurrency is reached.
 	innodb_replication_delay?: int & >=0 & <=4294967295


### PR DESCRIPTION
Fixes #3083.

## Problem

The MySQL 8.0 configuration template and dynamic-effect list already expose `innodb_redo_log_capacity`, but the CUE schema omitted the field. That made the supported setting fail schema validation. The field must remain optional so existing configurations that do not set it keep rendering.

## Change

Add the schema entry at the matching position after `innodb_redo_log_encrypt`:

```cue
// The total capacity in bytes of the redo log.
innodb_redo_log_capacity?: int & >= 8388608
```

This preserves the minimum accepted value while avoiding a new required-field contract for every MySQL 8.0 configuration.

## Validation

- `helm lint addons/mysql`: PASS
- full chart render: PASS
- `git diff --check`: PASS
- PR CI on exact head: terminal green

## Evidence Boundary

This closes the schema contract and static rendering gates. Runtime reconfiguration remains N=0 and belongs to the test owner.
