### PR TITLE
fix(mysql): exec the entrypoint chain so TERM reaches mysqld

### DIFF
--- a/addons/mysql/scripts/mysql-entrypoint.sh
+++ b/addons/mysql/scripts/mysql-entrypoint.sh
@@ -7,8 +7,13 @@ if [ ${#fqdn_name} -gt 60 ] && [ "${MYSQL_MAJOR}" = "5.7" ]; then
 fi
 SERVICE_ID=$((${POD_NAME##*-} + 1))
 
+# exec so this shell is replaced by the entrypoint (which itself execs mysqld):
+# the orc runtime wrapper backgrounds this script and sends TERM to $! on pod
+# stop; without exec that TERM killed this intermediate bash and mysqld was
+# orphaned until the grace-period SIGKILL, forcing InnoDB crash recovery on
+# every pod stop.
 if [ "${MYSQL_MAJOR}" = '5.7' ]; then
-  /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID --report-host ${fqdn_name} \
+  exec /scripts/docker-entrypoint.sh mysqld --server-id $SERVICE_ID --report-host ${fqdn_name} \
     --ignore-db-dir=lost+found \
     --plugin-load-add=rpl_semi_sync_master=semisync_master.so \
     --plugin-load-add=rpl_semi_sync_slave=semisync_slave.so \
@@ -16,7 +21,7 @@ if [ "${MYSQL_MAJOR}" = '5.7' ]; then
     --log-bin=/var/lib/mysql/binlog/${POD_NAME}-bin \
     --skip-slave-start=$skip_slave_start
 elif [ "${MYSQL_MAJOR}" = '8.0' ]; then
-  docker-entrypoint.sh mysqld --server-id $SERVICE_ID --report-host ${fqdn_name} \
+  exec docker-entrypoint.sh mysqld --server-id $SERVICE_ID --report-host ${fqdn_name} \
     --plugin-load-add=rpl_semi_sync_source=semisync_source.so \
     --plugin-load-add=rpl_semi_sync_replica=semisync_replica.so \
     --plugin-load-add=audit_log=audit_log.so \


### PR DESCRIPTION
Fixes #3089.

Two-word-level change: `exec` added to both docker-entrypoint invocations in `mysql-entrypoint.sh` (5.7 and 8.0 branches), plus a comment stating the wrapper contract. The official docker-entrypoint.sh itself execs mysqld, so $! seen by the orc wrapper now IS the mysqld process and its TERM handler performs a clean shutdown.

Runtime validation before undraft: delete an orc mysql pod normally; new pod's error log must show clean shutdown (no "was not shut down normally"); switchover/memberLeave unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)