### PR TITLE
fix(mysql): MGR roles participate in quorum

### DIFF
--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -250,6 +250,9 @@ tls:
   caFile: ca.pem
   certFile: cert.pem
   keyFile: key.pem
+{{- end }}
+
+{{- define "mysql.spec.roles.semisync" -}}
 roles:
   - name: primary
     updatePriority: 2
@@ -258,6 +261,22 @@ roles:
   - name: secondary
     updatePriority: 1
     participatesInQuorum: false
+{{- end }}
+
+{{/*
+Group Replication is a majority-based protocol: members participate in quorum
+so KubeBlocks will not take down a majority at once during rolling updates,
+scale-in, stop, or failure recovery.
+*/}}
+{{- define "mysql.spec.roles.mgr" -}}
+roles:
+  - name: primary
+    updatePriority: 2
+    participatesInQuorum: true
+    isExclusive: true
+  - name: secondary
+    updatePriority: 1
+    participatesInQuorum: true
 {{- end }}
 
 {{- define "mysql.spec.runtime.entrypoint" -}}

--- a/addons/mysql/templates/cmpd-mysql57.yaml
+++ b/addons/mysql/templates/cmpd-mysql57.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
   {{- include "mysql.spec.common" . | nindent 2 }}
+  {{- include "mysql.spec.roles.semisync" . | nindent 2 }}
   serviceVersion: 5.7.44
   configs:
     - name: mysql-replication-config

--- a/addons/mysql/templates/cmpd-mysql80-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-mgr.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
   {{- include "mysql.spec.common" . | nindent 2 }}
+  {{- include "mysql.spec.roles.mgr" . | nindent 2 }}
   serviceVersion: 8.0.46
   configs:
     - name: mysql-replication-config

--- a/addons/mysql/templates/cmpd-mysql80.yaml
+++ b/addons/mysql/templates/cmpd-mysql80.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
   {{- include "mysql.spec.common" . | nindent 2 }}
+  {{- include "mysql.spec.roles.semisync" . | nindent 2 }}
   serviceVersion: 8.0.46
   configs:
     - name: mysql-replication-config

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
   {{- include "mysql.spec.common" . | nindent 2 }}
+  {{- include "mysql.spec.roles.mgr" . | nindent 2 }}
   serviceVersion: 8.4.10
   configs:
     - name: mysql-replication-config

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "mysql.annotations" . | nindent 4 }}
 spec:
   {{- include "mysql.spec.common" . | nindent 2 }}
+  {{- include "mysql.spec.roles.semisync" . | nindent 2 }}
   serviceVersion: 8.4.10
   configs:
     - name: mysql-replication-config


### PR DESCRIPTION
Fixes #3091.

Refactor-free-in-behavior for non-MGR: the roles block moves out of `mysql.spec.common` into `mysql.spec.roles.semisync` (verbatim copy) and `mysql.spec.roles.mgr` (`participatesInQuorum: true`); each of the five consuming cmpds includes the matching helper.

Render-verified with `helm template`:
```
mysql-5.7 / mysql-8.0 / mysql-8.4 / orc variants: [false, false]  (unchanged)
mysql-mgr-8.0 / mysql-mgr-8.4:                    [true, true]
```

Runtime validation before undraft: 3-replica MGR cluster Restart/upgrade keeps majority (never 2 of 3 down simultaneously); semisync rolling behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)