### PR TITLE
fix(mysql): honor image.pullPolicy (reversed sprig default args)

### DIFF
--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -302,7 +302,7 @@ env:
     value: $(MYSQL_ROOT_PASSWORD)
   - name: EXPORTER_WEB_PORT
     value: "{{ .Values.metrics.service.port }}"
-imagePullPolicy: IfNotPresent
+imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
 ports:
   - name: http-metrics
     containerPort: {{ .Values.metrics.service.port }}

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -248,7 +248,7 @@ switchover:
       cp -r /usr/bin/jq /kubeblocks/jq
       cp -r /scripts/orchestrator-client /kubeblocks/orchestrator-client
       cp -r /usr/local/bin/curl /kubeblocks/curl
-  imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+  imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
   name: init-jq
   volumeMounts:
     - mountPath: /kubeblocks
@@ -256,7 +256,7 @@ switchover:
 {{- end }}
 
 {{- define "mysql-orc.spec.runtime.mysql" -}}
-imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
 command:
   - bash
   - -c

--- a/addons/mysql/templates/cmpd-mysql57-orc.yaml
+++ b/addons/mysql/templates/cmpd-mysql57-orc.yaml
@@ -29,7 +29,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog,temp}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql57.yaml
+++ b/addons/mysql/templates/cmpd-mysql57.yaml
@@ -26,7 +26,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -53,7 +53,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql80-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-mgr.yaml
@@ -26,7 +26,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -43,7 +43,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql80-orc.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-orc.yaml
@@ -29,7 +29,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog,temp}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql80.yaml
+++ b/addons/mysql/templates/cmpd-mysql80.yaml
@@ -26,7 +26,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -53,7 +53,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -32,7 +32,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -42,7 +42,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
         command:
           - syncer
           - --port


### PR DESCRIPTION
Fixes #3093.

Mechanical, render-verified fix: swap the sprig `default` arguments at every reversed site (cmpd-mysql57/80/84, mgr and orc variants, `_orc.tpl`) and replace the exporter helper's hardcoded `imagePullPolicy: IfNotPresent` with the same expression.

Verification:
- `helm template --set image.pullPolicy=Always` → 35/35 sites render `Always` (main renders 21 stuck at `IfNotPresent`)
- default render → 35/35 `IfNotPresent` (unchanged behavior when the value is unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)