### PR TITLE
fix(mysql): orc memberLeave uses the contract member identity and fails closed

### DIFF
--- a/addons/mysql/scripts/orc-member-leave.sh
+++ b/addons/mysql/scripts/orc-member-leave.sh
@@ -16,8 +16,16 @@ mysql_error() {
   exit 1
 }
 
+# memberLeave contract: KubeBlocks injects the LEAVING member's identity as
+# KB_LEAVE_MEMBER_POD_NAME; the action may execute on a different pod, so
+# KB_AGENT_POD_NAME (the execution pod) is only a fallback for older runtimes.
+leave_member="${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME}}"
+if [ -z "$leave_member" ]; then
+  mysql_error "Neither KB_LEAVE_MEMBER_POD_NAME nor KB_AGENT_POD_NAME is set"
+fi
+
 # Forget instance from Orchestrator
-if /kubeblocks/orchestrator-client -c forget -i "${KB_AGENT_POD_NAME}" 2>&1; then
+if /kubeblocks/orchestrator-client -c forget -i "${leave_member}" 2>&1; then
   mysql_note "Forget command executed"
 else
   mysql_note "Forget command failed, continuing anyway"
@@ -25,12 +33,17 @@ fi
 
 sleep 3
 
-# Verify instance was forgotten
+# Verify instance was forgotten. "Instance not found" and "Orchestrator is
+# down" both yield an empty query result, so prove Orchestrator is reachable
+# first - otherwise an outage would be reported as a successful removal.
 mysql_note "Verifying instance was forgotten..."
-instance_info=$(/kubeblocks/orchestrator-client -c instance -i "${KB_AGENT_POD_NAME}" 2>/dev/null || echo "")
+if ! /kubeblocks/orchestrator-client -c clusters >/dev/null 2>&1; then
+  mysql_error "Orchestrator unreachable; cannot verify removal of ${leave_member}"
+fi
+instance_info=$(/kubeblocks/orchestrator-client -c instance -i "${leave_member}" 2>/dev/null || true)
 
 if [ -z "$instance_info" ]; then
-  mysql_note "Instance ${KB_AGENT_POD_NAME} successfully removed from Orchestrator"
+  mysql_note "Instance ${leave_member} successfully removed from Orchestrator"
   exit 0
 fi
-mysql_error "Instance ${KB_AGENT_POD_NAME} still exists in Orchestrator"
+mysql_error "Instance ${leave_member} still exists in Orchestrator"


### PR DESCRIPTION
Fixes #3095.

Two scoped changes in `orc-member-leave.sh`:
- `leave_member="${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME}}"` — the 05b contract variable, with the old behavior as explicit fallback; forget/verify/log all use it.
- Verification now probes Orchestrator reachability (`-c clusters`) before treating an empty `-c instance` result as "forgotten", because outage and absence are otherwise indistinguishable. Outage → exit 1 (kbagent retry), absence → success, still-present → exit 1 (unchanged).

Validation: `bash -n` pass. Runtime matrix before undraft: normal scale-in (member forgotten, Ops succeeds); scale-in with Orchestrator down (action fails, retries after recovery); scale-in where the action executes on a pod other than the leaving member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)