### PR TITLE
fix(mariadb): galera OrderedReady stop ordering — preserve a safe bootstrap point across Stop/Start

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.26
+version: 1.2.0-alpha.29
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -958,9 +958,9 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is current (alpha.26 - replication merged topology)"
+    It "Chart.yaml literal version is current (alpha.29 - galera OrderedReady stop ordering)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.26$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.29$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -3012,13 +3012,13 @@ EOF
     }
     Before "setup_chart_alpha65_env"
 
-    It "alpha.65 v1: Chart.yaml chart bump pattern from alpha.64 due to CmpD immutability — current bumped further to alpha.26 [contract-no-regression]"
+    It "alpha.65 v1: Chart.yaml chart bump pattern from alpha.64 due to CmpD immutability — current bumped further to alpha.29 [contract-no-regression]"
       # alpha.65 v1 originally locked chart at alpha.65; subsequent alphas
       # bumped further under the SAME CmpD immutability rule. Literal
       # kept in sync with latest chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.26"
+      The output should equal "version: 1.2.0-alpha.29"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -3073,13 +3073,13 @@ EOF
     Before "setup_chart_alpha66_env"
 
     Context "chart bump for CmpD immutability (per alpha.65 lesson)"
-      It "alpha.66 v1: Chart.yaml chart bump pattern locked — current bumped to alpha.26 [contract-no-regression]"
+      It "alpha.66 v1: Chart.yaml chart bump pattern locked — current bumped to alpha.29 [contract-no-regression]"
         # Subsequent alphas all bumped further under the same CmpD
         # immutability rule. Literal kept in sync with latest chart
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.26"
+        The output should equal "version: 1.2.0-alpha.29"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3289,13 +3289,13 @@ EOF
     Before "setup_chart_alpha67_env"
 
     Context "chart bump alpha.66 → alpha.67 → alpha.68 (CmpD immutability rule)"
-      It "alpha.67 v1: Chart.yaml chart bump pattern locked — current bumped to alpha.26 [contract-no-regression]"
+      It "alpha.67 v1: Chart.yaml chart bump pattern locked — current bumped to alpha.29 [contract-no-regression]"
         # Subsequent alphas all bumped further under the same CmpD
         # immutability rule. Literal kept in sync with latest chart
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.26"
+        The output should equal "version: 1.2.0-alpha.29"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -80,8 +80,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.26 (alpha.26 bump: replication merged topology)"
-      When call grep -c '^version: 1.2.0-alpha.26$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.29 (alpha.29 bump: galera OrderedReady stop ordering)"
+      When call grep -c '^version: 1.2.0-alpha.29$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -12,7 +12,17 @@ spec:
   serviceKind: mariadb
   serviceVersion: {{ .Values.defaultServiceVersion.galera }}
   updateStrategy: Serial
-  podManagementPolicy: Parallel
+  # OrderedReady makes Stop and scale-in delete instances strictly one at a
+  # time, highest ordinal first, waiting for each pod to fully terminate
+  # before deleting the next — pod-0 shuts down last, as the final Primary
+  # Component member, so Galera grants it grastate safe_to_bootstrap=1 and
+  # the next Start can bootstrap automatically. Parallel deletion killed all
+  # members concurrently: the cluster never shrank to a last member, every
+  # grastate ended safe_to_bootstrap=0, and the (correct) fail-closed
+  # should_bootstrap refusal left Stop/Start permanently in manual recovery.
+  # Creation also becomes sequential, which matches Galera anyway: joiners
+  # SST from a donor one at a time.
+  podManagementPolicy: OrderedReady
   exporter:
     containerName: exporter
     scrapePath: /metrics


### PR DESCRIPTION
Fixes #3104（根因分析、实测证据 sha、方案 A/B 划分见 issue 及其把关评论）

## Scope（单变量）

仅两处行为相关变更：
1. `addons/mariadb/templates/cmpd-galera.yaml`：galera 组件 `podManagementPolicy: Parallel → OrderedReady`（replication 拓扑本就是 OrderedReady）。
2. `addons/mariadb/Chart.yaml`：`1.2.0-alpha.26 → 1.2.0-alpha.29`（CMPD 名含 chart version，spec 字段变更需新 CMPD；跳过 27/28 因验证环境的测试分支谱系已占用这两个 CMPD 名，避免 immutability 冲突）。

随附：4 个版本 pin 契约测试同步到 alpha.29（纯测试维护）。**明确不含**：preStop 重写、TGP 调整、B 方案（恢复侧 seqno 选举）——均为 #3104 follow-up，避免混变量导致 runtime 结果无法归因。已知遗留：galera-roleprobe 脚本内一处注释仍引用旧 Parallel 语境，行为无关，v2 一并清理。

## 控制器合同依据（影响面声明）

KubeBlocks Stop 复用 scale-in 的实例对齐删除循环（`pkg/controller/instanceset/reconciler_instance_alignment.go:185-225`）：`Spec.Stop=true` → 期望实例集为空 → 全部现存实例进入删除循环。排序 `instance_util.go:83-126` 按序号降序：
- **OrderedReady**：每轮 reconcile 只删一个实例，且等前一个 pod **完全终止消失**后才删下一个（terminating pod 仍占据 deleteNameSet，循环 break）；pod-0 确定性最后关闭 → 作为 Primary Component 最后成员获得 `safe_to_bootstrap=1`。
- **Parallel（改前）**：默认 100% 并发一次删光 → 集群从未收缩到最后成员 → 无人获 safe=1 → fail-closed 拒选（#2997 的正确行为）→ Stop/Start 永久卡死需人工恢复。
- **create/scale-out 影响**：OrderedReady 使创建/扩容也串行。Galera joiner SST 从 donor 拉取本就接近串行，预期影响小；由验收矩阵第 2 项（fresh 3-node create）实测兜底。
- Stop 路径不触发任何 lifecycle action（memberLeave/switchover/preTerminate 均只在 scale-in/删除时执行）——本修复不依赖任何 action 钩子。

## 实测证据

- rerun3 T6 first-red（Parallel）：Stop/Start 后三 PV 全部 `seqno=44 safe_to_bootstrap=0`，`wsrep_cluster_size` 180s 不恢复，pod-0 拒绝 crash-recovery bootstrap。packet sha `80f3ab5d...937`，pod-0 readOnly 补证 sha `9ef59701...af0`。
- v2c 诊断样本（Parallel，N=1）：同路径 Stop 留下 exactly one safe（pod-1 seqno=8 safe=1）且 Start 恢复 —— 证明 Parallel 下结果**时序随机**（至少一次全灭），进一步支持改为确定性排序。packet sha `9fd0f1b2...584`。

## 验证状态

- 已做：helm lint 通过；helm template 渲染确认 galera CMPD `podManagementPolicy: OrderedReady` + CMPD 名 `mariadb-galera-1.2.0-alpha.29`；mariadb 全量 ShellSpec **663 examples / 0 failures / 9 pending（已知）**。
- 待做（PR ready 前，由 mariadb team 按 exact 本 chart/head 执行）：①fresh 3-node Galera create（验证 OrderedReady 未拖慢/破坏正常启动与加入）；②focused T6：clean Stop 后三 PV **exactly one** `safe_to_bootstrap=1` + Start 后 3-member Primary 自动恢复；附 cleanup proof。

Draft 保持到上述两项 runtime 验证通过。
