### PR TITLE
fix(postgresql): guard pg-basebackup restore data directory

### DIFF
--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -5,12 +5,82 @@ export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 function remote_file_exists() {
-    local out=$(datasafed list $1)
+    local out
+    out=$(datasafed list "$1")
     if [ "${out}" == "$1" ]; then
         echo "true"
         return
     fi
     echo "false"
+}
+
+function validate_data_dir_contract() {
+    if [[ -z "${DATA_DIR:-}" ]]; then
+        echo "ERROR: DATA_DIR is required for pg-basebackup restore" >&2
+        exit 1
+    fi
+
+    DATA_DIR="${DATA_DIR%/}"
+    if [[ -n "${VOLUME_DATA_DIR:-}" ]]; then
+        VOLUME_DATA_DIR="${VOLUME_DATA_DIR%/}"
+        local expected_data_dir="${VOLUME_DATA_DIR}/pgroot/data"
+        if [[ "${DATA_DIR}" != "${expected_data_dir}" ]]; then
+            echo "ERROR: pg-basebackup restore DATA_DIR must be ${expected_data_dir}, got ${DATA_DIR}" >&2
+            echo "ERROR: refusing to restore PostgreSQL files into the volume root or an unexpected subdirectory" >&2
+            exit 1
+        fi
+    fi
+}
+
+function log_restore_layout() {
+    echo "restore layout: VOLUME_DATA_DIR=${VOLUME_DATA_DIR:-<unset>} DATA_DIR=${DATA_DIR}"
+    if [[ -n "${VOLUME_DATA_DIR:-}" && -d "${VOLUME_DATA_DIR}" ]]; then
+        find "${VOLUME_DATA_DIR}" -maxdepth 3 -mindepth 1 -print 2>/dev/null \
+            | while IFS= read -r path; do printf '%s\n' "${path#${VOLUME_DATA_DIR}/}"; done \
+            | sort | head -200 || true
+    elif [[ -d "${DATA_DIR}" ]]; then
+        find "${DATA_DIR}" -maxdepth 2 -mindepth 1 -print 2>/dev/null \
+            | while IFS= read -r path; do printf '%s\n' "${path#${DATA_DIR}/}"; done \
+            | sort | head -200 || true
+    fi
+}
+
+function assert_no_pgdata_at_volume_root() {
+    if [[ -z "${VOLUME_DATA_DIR:-}" || "${VOLUME_DATA_DIR}" == "${DATA_DIR}" || ! -d "${VOLUME_DATA_DIR}" ]]; then
+        return
+    fi
+
+    local misplaced=()
+    for path in PG_VERSION base global pg_wal; do
+        if [[ -e "${VOLUME_DATA_DIR}/${path}" ]]; then
+            misplaced+=("${path}")
+        fi
+    done
+
+    if [[ ${#misplaced[@]} -gt 0 ]]; then
+        echo "ERROR: PostgreSQL data files were found at volume root ${VOLUME_DATA_DIR}: ${misplaced[*]}" >&2
+        echo "ERROR: restore payload must live under ${DATA_DIR}" >&2
+        log_restore_layout >&2
+        exit 1
+    fi
+}
+
+function assert_pgdata_restored() {
+    local missing=()
+    for path in PG_VERSION base global pg_wal; do
+        if [[ ! -e "${DATA_DIR}/${path}" ]]; then
+            missing+=("${path}")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: invalid PostgreSQL data directory after pg-basebackup restore: ${DATA_DIR}" >&2
+        echo "ERROR: missing required entries: ${missing[*]}" >&2
+        log_restore_layout >&2
+        exit 1
+    fi
+
+    assert_no_pgdata_at_volume_root
 }
 
 function save_backup_end_lsn() {
@@ -54,33 +124,46 @@ function save_backup_end_lsn() {
     fi
 }
 
-mkdir -p ${DATA_DIR};
+function finish_restore() {
+    assert_pgdata_restored
+    save_backup_end_lsn
+    echo "done!";
+    exit 0
+}
+
+validate_data_dir_contract
+mkdir -p "${DATA_DIR}";
 
 if [ $(remote_file_exists "${DP_BACKUP_NAME}.tar.zst") == "true" ]; then
   datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.tar.zst" - | tar -xvf - -C "${DATA_DIR}/"
-  save_backup_end_lsn
-  echo "done!";
-  exit 0
+  finish_restore
 fi
 
 # for compatibility
 if [ $(remote_file_exists "${DP_BACKUP_NAME}.tar.gz") == "true" ]; then
   datasafed pull "${DP_BACKUP_NAME}.tar.gz" - | gunzip | tar -xvf - -C "${DATA_DIR}/"
-  save_backup_end_lsn
-  echo "done!";
-  exit 0
+  finish_restore
 fi
 
 # NOTE: restore from an old version backup, will be removed in 0.8
+restored_base_archive=false
 if [ $(remote_file_exists "base.tar.gz") == "true" ]; then
   datasafed pull "base.tar.gz" - | tar -xzvf - -C "${DATA_DIR}/"
+  restored_base_archive=true
 elif [ $(remote_file_exists "base.tar") == "true" ]; then
   datasafed pull "base.tar" - | tar -xvf - -C "${DATA_DIR}/"
+  restored_base_archive=true
 fi
 if [ $(remote_file_exists "pg_wal.tar.gz") == "true" ]; then
+  mkdir -p "${DATA_DIR}/pg_wal"
   datasafed pull "pg_wal.tar.gz" - | tar -xzvf - -C "${DATA_DIR}/pg_wal/"
 elif [ $(remote_file_exists "pg_wal.tar") == "true" ]; then
+  mkdir -p "${DATA_DIR}/pg_wal"
   datasafed pull "pg_wal.tar" - | tar -xvf - -C "${DATA_DIR}/pg_wal/"
 fi
-save_backup_end_lsn
-echo "done!";
+if [[ "${restored_base_archive}" != "true" ]]; then
+  echo "ERROR: no supported pg-basebackup artifact found for ${DP_BACKUP_NAME}" >&2
+  echo "ERROR: expected ${DP_BACKUP_NAME}.tar.zst, ${DP_BACKUP_NAME}.tar.gz, base.tar.gz, or base.tar" >&2
+  exit 1
+fi
+finish_restore

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -164,32 +164,45 @@ done
 
 if [[ "\${IS_REPLICA}" == "true" ]]; then
     echo "Replica creation detected. Patroni will use basebackup from primary."
+    rm -rf "\${DATA_DIR}.old"
     rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
+    exit 1
+fi
+
+if [[ ! -d "\${DATA_DIR}.old" ]]; then
+    echo "ERROR: restored PostgreSQL data handoff directory is missing: \${DATA_DIR}.old" >&2
+    exit 1
+fi
+
+if [[ -d "\${DATA_DIR}" ]] && [[ -n "\$(find "\${DATA_DIR}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    echo "ERROR: PostgreSQL data directory is not empty before restore handoff: \${DATA_DIR}" >&2
     exit 1
 fi
 
 missing=()
 for path in PG_VERSION base global pg_wal; do
-    if [[ ! -e "\${DATA_DIR}/\${path}" ]]; then
+    if [[ ! -e "\${DATA_DIR}.old/\${path}" ]]; then
         missing+=("\${path}")
     fi
 done
 
 if [[ \${#missing[@]} -gt 0 ]]; then
-    echo "ERROR: restored PostgreSQL data directory is incomplete: \${DATA_DIR}" >&2
+    echo "ERROR: restored PostgreSQL data directory is incomplete: \${DATA_DIR}.old" >&2
     echo "ERROR: missing required entries: \${missing[*]}" >&2
     exit 1
 fi
 
-rm -f "\${DATA_DIR}/standby.signal" "\${DATA_DIR}/recovery.signal"
+rm -f "\${DATA_DIR}.old/standby.signal" "\${DATA_DIR}.old/recovery.signal"
 
 if [[ "\$(id -u)" == "0" ]]; then
-    chown -R postgres:postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
-        || chown -R postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}"
+    chown -R postgres:postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
+        || chown -R postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}"
 fi
 
 sync
 echo "Basebackup restored data accepted at \${DATA_DIR}"
+rm -rf "\${DATA_DIR}"
+mv "\${DATA_DIR}.old" "\${DATA_DIR}"
 rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
 EOF
     chmod +x "${RESTORE_SCRIPT_DIR}/kb_restore.sh"
@@ -199,6 +212,10 @@ function finish_restore() {
     assert_pgdata_restored
     save_backup_end_lsn
     write_restore_hook
+    rm -rf "${DATA_DIR}.old"
+    mv "${DATA_DIR}" "${DATA_DIR}.old"
+    mkdir -p "${DATA_DIR}"
+    sync
     echo "done!";
     exit 0
 }

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -234,6 +234,18 @@ EOF
 function finish_restore() {
     assert_pgdata_restored
     save_backup_end_lsn
+    # PITR chain hand-off: when a restore timestamp is set, the archive-wal
+    # Continuous prepareData (postgresql-pitr-restore.sh) runs next and
+    # expects the base data to still live in DATA_DIR. Staging into
+    # DATA_DIR.old and arming the kb_restore hook/signal here would make
+    # that script fail on an empty pg_wal and leak a signal its legacy hook
+    # cannot clear. Mirror wal-g-restore.sh: leave the data in place and
+    # let the Continuous stage own recovery configuration.
+    if [[ -n "${DP_RESTORE_TIMESTAMP:-}${DP_RESTORE_TIME:-}" ]]; then
+        sync
+        echo "done!";
+        exit 0
+    fi
     write_restore_hook
     rm -rf "${DATA_DIR}.old"
     mv "${DATA_DIR}" "${DATA_DIR}.old"

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -148,6 +148,23 @@ set -o pipefail
 
 DATA_DIR="${DATA_DIR}"
 RESTORE_SCRIPT_DIR="${RESTORE_SCRIPT_DIR}"
+HANDOFF_MARKER=".kb_restore_handoff"
+
+function verify_pgdata_complete() {
+    local root_dir="\$1"
+    missing=()
+    for path in PG_VERSION base global pg_wal; do
+        if [[ ! -e "\${root_dir}/\${path}" ]]; then
+            missing+=("\${path}")
+        fi
+    done
+
+    if [[ \${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: restored PostgreSQL data directory is incomplete: \${root_dir}" >&2
+        echo "ERROR: missing required entries: \${missing[*]}" >&2
+        exit 1
+    fi
+}
 
 IS_REPLICA=false
 while [[ \$# -gt 0 ]]; do
@@ -170,6 +187,20 @@ if [[ "\${IS_REPLICA}" == "true" ]]; then
 fi
 
 if [[ ! -d "\${DATA_DIR}.old" ]]; then
+    if [[ -f "\${DATA_DIR}/\${HANDOFF_MARKER}" ]]; then
+        verify_pgdata_complete "\${DATA_DIR}"
+        sync
+        echo "Basebackup restore handoff already committed at \${DATA_DIR}"
+        rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
+        rm -f "\${DATA_DIR}/\${HANDOFF_MARKER}" || true
+        exit 0
+    fi
+
+    if [[ -d "\${DATA_DIR}" ]] && [[ -n "\$(find "\${DATA_DIR}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+        echo "ERROR: PostgreSQL data directory is non-empty but restore handoff marker is absent: \${DATA_DIR}" >&2
+        exit 1
+    fi
+
     echo "ERROR: restored PostgreSQL data handoff directory is missing: \${DATA_DIR}.old" >&2
     exit 1
 fi
@@ -179,20 +210,10 @@ if [[ -d "\${DATA_DIR}" ]] && [[ -n "\$(find "\${DATA_DIR}" -mindepth 1 -maxdept
     exit 1
 fi
 
-missing=()
-for path in PG_VERSION base global pg_wal; do
-    if [[ ! -e "\${DATA_DIR}.old/\${path}" ]]; then
-        missing+=("\${path}")
-    fi
-done
-
-if [[ \${#missing[@]} -gt 0 ]]; then
-    echo "ERROR: restored PostgreSQL data directory is incomplete: \${DATA_DIR}.old" >&2
-    echo "ERROR: missing required entries: \${missing[*]}" >&2
-    exit 1
-fi
+verify_pgdata_complete "\${DATA_DIR}.old"
 
 rm -f "\${DATA_DIR}.old/standby.signal" "\${DATA_DIR}.old/recovery.signal"
+touch "\${DATA_DIR}.old/\${HANDOFF_MARKER}"
 
 if [[ "\$(id -u)" == "0" ]]; then
     chown -R postgres:postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
@@ -203,7 +224,9 @@ sync
 echo "Basebackup restored data accepted at \${DATA_DIR}"
 rm -rf "\${DATA_DIR}"
 mv "\${DATA_DIR}.old" "\${DATA_DIR}"
+sync
 rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
+rm -f "\${DATA_DIR}/\${HANDOFF_MARKER}" || true
 EOF
     chmod +x "${RESTORE_SCRIPT_DIR}/kb_restore.sh"
 }

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -181,6 +181,8 @@ if [[ \${#missing[@]} -gt 0 ]]; then
     exit 1
 fi
 
+rm -f "\${DATA_DIR}/standby.signal" "\${DATA_DIR}/recovery.signal"
+
 if [[ "\$(id -u)" == "0" ]]; then
     chown -R postgres:postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
         || chown -R postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}"

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -219,6 +219,7 @@ if [[ "\$(id -u)" == "0" ]]; then
     chown -R postgres:postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
         || chown -R postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}"
 fi
+chmod 0700 "\${DATA_DIR}.old"
 
 sync
 echo "Basebackup restored data accepted at \${DATA_DIR}"

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -124,9 +124,79 @@ function save_backup_end_lsn() {
     fi
 }
 
+function configure_restore_script_dir() {
+    if [[ -z "${RESTORE_SCRIPT_DIR:-}" ]]; then
+        if [[ -n "${VOLUME_DATA_DIR:-}" ]]; then
+            RESTORE_SCRIPT_DIR="${VOLUME_DATA_DIR}/kb_restore"
+        else
+            RESTORE_SCRIPT_DIR="$(dirname "$(dirname "${DATA_DIR}")")/kb_restore"
+        fi
+    fi
+    RESTORE_SCRIPT_DIR="${RESTORE_SCRIPT_DIR%/}"
+}
+
+function write_restore_hook() {
+    configure_restore_script_dir
+    mkdir -p "${RESTORE_SCRIPT_DIR}"
+    chmod 777 "${RESTORE_SCRIPT_DIR}"
+    touch "${RESTORE_SCRIPT_DIR}/kb_restore.signal"
+
+    cat > "${RESTORE_SCRIPT_DIR}/kb_restore.sh" <<EOF
+#!/bin/bash
+set -e
+set -o pipefail
+
+DATA_DIR="${DATA_DIR}"
+RESTORE_SCRIPT_DIR="${RESTORE_SCRIPT_DIR}"
+
+IS_REPLICA=false
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        --replica)
+            IS_REPLICA=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ "\${IS_REPLICA}" == "true" ]]; then
+    echo "Replica creation detected. Patroni will use basebackup from primary."
+    rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
+    exit 1
+fi
+
+missing=()
+for path in PG_VERSION base global pg_wal; do
+    if [[ ! -e "\${DATA_DIR}/\${path}" ]]; then
+        missing+=("\${path}")
+    fi
+done
+
+if [[ \${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: restored PostgreSQL data directory is incomplete: \${DATA_DIR}" >&2
+    echo "ERROR: missing required entries: \${missing[*]}" >&2
+    exit 1
+fi
+
+if [[ "\$(id -u)" == "0" ]]; then
+    chown -R postgres:postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
+        || chown -R postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}"
+fi
+
+rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
+sync
+echo "Basebackup restored data accepted at \${DATA_DIR}"
+EOF
+    chmod +x "${RESTORE_SCRIPT_DIR}/kb_restore.sh"
+}
+
 function finish_restore() {
     assert_pgdata_restored
     save_backup_end_lsn
+    write_restore_hook
     echo "done!";
     exit 0
 }

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -219,7 +219,7 @@ if [[ "\$(id -u)" == "0" ]]; then
     chown -R postgres:postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}" 2>/dev/null \
         || chown -R postgres "\${DATA_DIR}.old" "\${RESTORE_SCRIPT_DIR}"
 fi
-chmod 0700 "\${DATA_DIR}.old"
+chmod 00700 "\${DATA_DIR}.old"
 
 sync
 echo "Basebackup restored data accepted at \${DATA_DIR}"

--- a/addons/postgresql/dataprotection/pg-basebackup-restore.sh
+++ b/addons/postgresql/dataprotection/pg-basebackup-restore.sh
@@ -188,9 +188,9 @@ if [[ "\$(id -u)" == "0" ]]; then
         || chown -R postgres "\${DATA_DIR}" "\${RESTORE_SCRIPT_DIR}"
 fi
 
-rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
 sync
 echo "Basebackup restored data accepted at \${DATA_DIR}"
+rm -f "\${RESTORE_SCRIPT_DIR}/kb_restore.signal"
 EOF
     chmod +x "${RESTORE_SCRIPT_DIR}/kb_restore.sh"
 }

--- a/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
@@ -46,6 +46,18 @@ postgresql: {}'
     unset POSTGRES_CONF_DIR POSTGRES_PGDATA_DIR RESTORE_DATA_DIR SPILO_CONFIGURATION
   }
 
+  ordinary_restore_has_no_recovery_conf() {
+    python3 - "${out}" <<'PY'
+import sys
+import yaml
+
+with open(sys.argv[1], 'r') as stream:
+    config = yaml.safe_load(stream)
+sys.exit(0 if 'recovery_conf' not in config['bootstrap']['kb_restore'] else 1)
+PY
+    printf "%s" "$?"
+  }
+
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -58,6 +70,7 @@ postgresql: {}'
     The contents of file "${out}" should include "kb_restore:"
     The contents of file "${out}" should include "command: bash ${restore_dir}/kb_restore.sh"
     The contents of file "${out}" should include "keep_existing_recovery_conf: false"
+    The result of function ordinary_restore_has_no_recovery_conf should eq 0
     The contents of file "${out}" should include "create_replica_methods:"
     The contents of file "${out}" should include "restore_data"
     The contents of file "${out}" should include "kb_restore.sh --replica"
@@ -68,5 +81,18 @@ postgresql: {}'
     The status should eq 0
     The contents of file "${out}" should not include "method: kb_restore"
     The contents of file "${out}" should not include "create_replica_methods:"
+  End
+
+  It "keeps the recovery configuration for point-in-time restore"
+    touch "${restore_dir}/kb_restore.signal"
+    cat > "${pgdata_dir}/conf/recovery.conf" <<'EOF'
+restore_command = 'cp /archive/%f %p'
+recovery_target_time = '2026-07-12 06:00:00+00'
+EOF
+    When run python3 ../scripts/generate_patroni_yaml.py "${out}"
+    The status should eq 0
+    The contents of file "${out}" should include "method: kb_restore_from_time"
+    The contents of file "${out}" should include "recovery_conf:"
+    The contents of file "${out}" should include "restore_command: cp /archive/%f %p"
   End
 End

--- a/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash
+
+Describe "scripts/generate_patroni_yaml.py"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-generate-patroni-XXXXXX)
+    conf_dir="${tmpdir}/conf"
+    pgdata_dir="${tmpdir}/pgdata"
+    restore_dir="${pgdata_dir}/kb_restore"
+    out="${tmpdir}/patroni.yaml"
+    mkdir -p "${conf_dir}" "${pgdata_dir}/conf" "${restore_dir}"
+
+    cat > "${conf_dir}/pg_hba.conf" <<'EOF'
+host all all 0.0.0.0/0 md5
+EOF
+    cat > "${conf_dir}/replica_restore.conf" <<'EOF'
+create_replica_methods:
+- restore_data
+- basebackup
+restore_data:
+  command: bash /home/postgres/pgdata/kb_restore/kb_restore.sh --replica
+EOF
+    cat > "${conf_dir}/patroni.yaml" <<'EOF'
+postgresql:
+  use_pg_rewind: true
+EOF
+    cat > "${conf_dir}/kb_pitr.conf" <<'EOF'
+method: kb_restore_from_time
+kb_restore_from_time:
+  command: bash /home/postgres/pgdata/kb_restore/kb_restore.sh
+  keep_existing_recovery_conf: false
+  recovery_conf: {}
+EOF
+
+    export POSTGRES_CONF_DIR="${conf_dir}"
+    export POSTGRES_PGDATA_DIR="${pgdata_dir}"
+    export RESTORE_DATA_DIR="${restore_dir}"
+    export SPILO_CONFIGURATION='bootstrap:
+  initdb:
+  - auth-host: md5
+postgresql: {}'
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+    unset POSTGRES_CONF_DIR POSTGRES_PGDATA_DIR RESTORE_DATA_DIR SPILO_CONFIGURATION
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It "adds primary bootstrap and follower replica restore methods when restore signal exists"
+    touch "${restore_dir}/kb_restore.signal"
+    When run python3 ../scripts/generate_patroni_yaml.py "${out}"
+    The status should eq 0
+    The path "${out}" should be exist
+    The contents of file "${out}" should include "method: kb_restore"
+    The contents of file "${out}" should include "kb_restore:"
+    The contents of file "${out}" should include "command: bash ${restore_dir}/kb_restore.sh"
+    The contents of file "${out}" should include "keep_existing_recovery_conf: false"
+    The contents of file "${out}" should include "create_replica_methods:"
+    The contents of file "${out}" should include "restore_data"
+    The contents of file "${out}" should include "kb_restore.sh --replica"
+  End
+
+  It "does not add restore bootstrap when the restore signal is absent"
+    When run python3 ../scripts/generate_patroni_yaml.py "${out}"
+    The status should eq 0
+    The contents of file "${out}" should not include "method: kb_restore"
+    The contents of file "${out}" should not include "create_replica_methods:"
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -16,10 +16,11 @@ Describe "dataprotection/pg-basebackup-restore.sh"
 
     VOLUME_DATA_DIR="${tmpdir}/pgdata"
     DATA_DIR="${VOLUME_DATA_DIR}/pgroot/data"
+    RESTORE_SCRIPT_DIR="${VOLUME_DATA_DIR}/kb_restore"
     DP_DATASAFED_BIN_PATH="${bindir}"
     DP_BACKUP_BASE_PATH="/backup"
     DP_BACKUP_NAME="backup-test"
-    export PATH CALL_LOG VOLUME_DATA_DIR DATA_DIR DP_DATASAFED_BIN_PATH \
+    export PATH CALL_LOG VOLUME_DATA_DIR DATA_DIR RESTORE_SCRIPT_DIR DP_DATASAFED_BIN_PATH \
       DP_BACKUP_BASE_PATH DP_BACKUP_NAME
     unset DATASAFED_LIST_OUT TAR_CREATE_PGDATA 2>/dev/null || true
     write_stubs
@@ -83,6 +84,16 @@ EOF
     cat "${CALL_LOG}"
   }
 
+  restore_hook_syntax_status() {
+    bash -n "${RESTORE_SCRIPT_DIR}/kb_restore.sh" >/dev/null 2>&1
+    printf "%s" "$?"
+  }
+
+  restore_hook_primary_status() {
+    bash "${RESTORE_SCRIPT_DIR}/kb_restore.sh" >/dev/null 2>&1
+    printf "%s" "$?"
+  }
+
   It "restores the modern zstd archive into pgroot/data and leaves the volume root clean"
     export DATASAFED_LIST_OUT="backup-test.tar.zst"
     When run bash "$(script_path)"
@@ -95,6 +106,15 @@ EOF
     The path "${DATA_DIR}/pg_wal" should be directory
     The path "${VOLUME_DATA_DIR}/PG_VERSION" should not be exist
     The path "${VOLUME_DATA_DIR}/base" should not be exist
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should be executable
+    The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "DATA_DIR=\"${DATA_DIR}\""
+    The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "PG_VERSION base global pg_wal"
+    The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "--replica"
+    The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include 'rm -f "${RESTORE_SCRIPT_DIR}/kb_restore.signal"'
+    The result of function restore_hook_syntax_status should eq 0
+    The result of function restore_hook_primary_status should eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
   End
 
   It "fails when DATA_DIR does not match the PostgreSQL volume data subdirectory"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -100,7 +100,7 @@ EOF
   }
 
   mode_of_data_dir() {
-    stat -f "%Lp" "${DATA_DIR}" 2>/dev/null || stat -c "%a" "${DATA_DIR}"
+    stat -c "%a" "${DATA_DIR}" 2>/dev/null || stat -f "%Lp" "${DATA_DIR}"
   }
 
   It "stages the modern zstd archive for Patroni bootstrap and leaves the volume root clean"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -22,7 +22,7 @@ Describe "dataprotection/pg-basebackup-restore.sh"
     DP_BACKUP_NAME="backup-test"
     export PATH CALL_LOG VOLUME_DATA_DIR DATA_DIR RESTORE_SCRIPT_DIR DP_DATASAFED_BIN_PATH \
       DP_BACKUP_BASE_PATH DP_BACKUP_NAME
-    unset DATASAFED_LIST_OUT TAR_CREATE_PGDATA 2>/dev/null || true
+    unset DATASAFED_LIST_OUT TAR_CREATE_PGDATA DP_RESTORE_TIMESTAMP DP_RESTORE_TIME 2>/dev/null || true
     write_stubs
   }
 
@@ -132,6 +132,21 @@ EOF
     The path "${DATA_DIR}/pg_wal" should be directory
     The path "${DATA_DIR}/standby.signal" should not be exist
     The path "${DATA_DIR}/recovery.signal" should not be exist
+  End
+
+  It "leaves data in DATA_DIR for the archive-wal Continuous stage when a restore timestamp is set"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    export DP_RESTORE_TIMESTAMP="1783500000"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "done!"
+    # PITR hand-off contract: postgresql-pitr-restore.sh reads ${DATA_DIR}/pg_wal
+    # next, so the base payload must stay unstaged and no hook/signal may arm.
+    The path "${DATA_DIR}/PG_VERSION" should be exist
+    The path "${DATA_DIR}/pg_wal" should be directory
+    The path "${DATA_DIR}.old" should not be exist
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should not be exist
   End
 
   It "keeps the restore signal when the primary hook fails before commit"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -111,10 +111,14 @@ EOF
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "DATA_DIR=\"${DATA_DIR}\""
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "PG_VERSION base global pg_wal"
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "--replica"
+    The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "standby.signal"
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include 'rm -f "${RESTORE_SCRIPT_DIR}/kb_restore.signal"'
     The result of function restore_hook_syntax_status should eq 0
+    touch "${DATA_DIR}/standby.signal" "${DATA_DIR}/recovery.signal"
     The result of function restore_hook_primary_status should eq 0
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
+    The path "${DATA_DIR}/standby.signal" should not be exist
+    The path "${DATA_DIR}/recovery.signal" should not be exist
   End
 
   It "fails when DATA_DIR does not match the PostgreSQL volume data subdirectory"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -94,29 +94,37 @@ EOF
     printf "%s" "$?"
   }
 
-  It "restores the modern zstd archive into pgroot/data and leaves the volume root clean"
+  It "stages the modern zstd archive for Patroni bootstrap and leaves the volume root clean"
     export DATASAFED_LIST_OUT="backup-test.tar.zst"
     When run bash "$(script_path)"
     The status should eq 0
     The output should include "done!"
     The result of function call_log should include "tar -xvf - -C ${DATA_DIR}/"
-    The path "${DATA_DIR}/PG_VERSION" should be exist
-    The path "${DATA_DIR}/base" should be directory
-    The path "${DATA_DIR}/global" should be directory
-    The path "${DATA_DIR}/pg_wal" should be directory
+    The path "${DATA_DIR}/PG_VERSION" should not be exist
+    The path "${DATA_DIR}/base" should not be exist
+    The path "${DATA_DIR}.old/PG_VERSION" should be exist
+    The path "${DATA_DIR}.old/base" should be directory
+    The path "${DATA_DIR}.old/global" should be directory
+    The path "${DATA_DIR}.old/pg_wal" should be directory
     The path "${VOLUME_DATA_DIR}/PG_VERSION" should not be exist
     The path "${VOLUME_DATA_DIR}/base" should not be exist
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should be executable
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "DATA_DIR=\"${DATA_DIR}\""
+    The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include '${DATA_DIR}.old'
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "PG_VERSION base global pg_wal"
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "--replica"
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include "standby.signal"
     The contents of file "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should include 'rm -f "${RESTORE_SCRIPT_DIR}/kb_restore.signal"'
     The result of function restore_hook_syntax_status should eq 0
-    touch "${DATA_DIR}/standby.signal" "${DATA_DIR}/recovery.signal"
+    touch "${DATA_DIR}.old/standby.signal" "${DATA_DIR}.old/recovery.signal"
     The result of function restore_hook_primary_status should eq 0
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
+    The path "${DATA_DIR}.old" should not be exist
+    The path "${DATA_DIR}/PG_VERSION" should be exist
+    The path "${DATA_DIR}/base" should be directory
+    The path "${DATA_DIR}/global" should be directory
+    The path "${DATA_DIR}/pg_wal" should be directory
     The path "${DATA_DIR}/standby.signal" should not be exist
     The path "${DATA_DIR}/recovery.signal" should not be exist
   End
@@ -132,6 +140,8 @@ EOF
     chmod +x "${bindir}/sync"
     The result of function restore_hook_primary_status should not eq 0
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+    The path "${DATA_DIR}.old/PG_VERSION" should be exist
+    The path "${DATA_DIR}/PG_VERSION" should not be exist
   End
 
   It "fails when DATA_DIR does not match the PostgreSQL volume data subdirectory"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -99,6 +99,10 @@ EOF
     printf "%s" "$?"
   }
 
+  mode_of_data_dir() {
+    stat -f "%Lp" "${DATA_DIR}" 2>/dev/null || stat -c "%a" "${DATA_DIR}"
+  }
+
   It "stages the modern zstd archive for Patroni bootstrap and leaves the volume root clean"
     export DATASAFED_LIST_OUT="backup-test.tar.zst"
     When run bash "$(script_path)"
@@ -147,6 +151,26 @@ EOF
     The path "${DATA_DIR}.old" should not be exist
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should not be exist
+  End
+
+  It "normalizes group-writable restored PGDATA permissions before primary handoff"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    chmod 0775 "${DATA_DIR}.old"
+    The result of function restore_hook_primary_status should eq 0
+    The result of function mode_of_data_dir should eq 700
+    The path "${DATA_DIR}/PG_VERSION" should be exist
+  End
+
+  It "normalizes setgid group-writable restored PGDATA permissions before primary handoff"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    chmod 2775 "${DATA_DIR}.old"
+    The result of function restore_hook_primary_status should eq 0
+    The result of function mode_of_data_dir should eq 700
+    The path "${DATA_DIR}/PG_VERSION" should be exist
   End
 
   It "keeps the restore signal when the primary hook fails before commit"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -1,0 +1,137 @@
+# shellcheck shell=bash
+
+Describe "dataprotection/pg-basebackup-restore.sh"
+
+  script_path() {
+    printf "%s" "../dataprotection/pg-basebackup-restore.sh"
+  }
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-basebackup-restore-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+
+    VOLUME_DATA_DIR="${tmpdir}/pgdata"
+    DATA_DIR="${VOLUME_DATA_DIR}/pgroot/data"
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/backup"
+    DP_BACKUP_NAME="backup-test"
+    export PATH CALL_LOG VOLUME_DATA_DIR DATA_DIR DP_DATASAFED_BIN_PATH \
+      DP_BACKUP_BASE_PATH DP_BACKUP_NAME
+    unset DATASAFED_LIST_OUT TAR_CREATE_PGDATA 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+case "$1" in
+  list)
+    for item in ${DATASAFED_LIST_OUT:-}; do
+      if [ "$item" = "$2" ]; then
+        printf '%s\n' "$item"
+      fi
+    done
+    ;;
+  pull)
+    printf '%s\n' "archive bytes"
+    ;;
+esac
+EOF
+    cat > "${bindir}/tar" <<'EOF'
+#!/bin/sh
+printf 'tar %s\n' "$*" >> "${CALL_LOG}"
+dest=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    shift
+    dest=$1
+  fi
+  shift || break
+done
+[ -n "$dest" ] || exit 1
+if [ "${TAR_CREATE_PGDATA:-1}" = "1" ]; then
+  mkdir -p "$dest/base" "$dest/global" "$dest/pg_wal"
+  printf '18\n' > "$dest/PG_VERSION"
+  printf '{"WAL-Ranges":[{"End-LSN":"0/5000028"}]}\n' > "$dest/backup_manifest"
+fi
+cat > /dev/null
+EOF
+    cat > "${bindir}/gunzip" <<'EOF'
+#!/bin/sh
+cat
+EOF
+    cat > "${bindir}/pg_waldump" <<'EOF'
+#!/bin/sh
+echo "rmgr: Transaction len (rec/tot): 0/0, tx: 1, lsn: 0/5000028, prev 0/0"
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/tar" "${bindir}/gunzip" "${bindir}/pg_waldump"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "restores the modern zstd archive into pgroot/data and leaves the volume root clean"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The output should include "done!"
+    The result of function call_log should include "tar -xvf - -C ${DATA_DIR}/"
+    The path "${DATA_DIR}/PG_VERSION" should be exist
+    The path "${DATA_DIR}/base" should be directory
+    The path "${DATA_DIR}/global" should be directory
+    The path "${DATA_DIR}/pg_wal" should be directory
+    The path "${VOLUME_DATA_DIR}/PG_VERSION" should not be exist
+    The path "${VOLUME_DATA_DIR}/base" should not be exist
+  End
+
+  It "fails when DATA_DIR does not match the PostgreSQL volume data subdirectory"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    DATA_DIR="${VOLUME_DATA_DIR}"
+    export DATA_DIR
+    When run bash "$(script_path)"
+    The status should be failure
+    The error should include "DATA_DIR must be ${VOLUME_DATA_DIR}/pgroot/data"
+    The result of function call_log should not include "datasafed pull"
+  End
+
+  It "fails when no supported basebackup artifact exists"
+    export DATASAFED_LIST_OUT=""
+    When run bash "$(script_path)"
+    The status should be failure
+    The error should include "no supported pg-basebackup artifact found"
+    The output should not include "done!"
+  End
+
+  It "fails when the restored payload is not a PostgreSQL data directory"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    export TAR_CREATE_PGDATA=0
+    When run bash "$(script_path)"
+    The status should be failure
+    The error should include "invalid PostgreSQL data directory"
+    The error should include "PG_VERSION"
+    The output should not include "done!"
+  End
+
+  It "fails when PostgreSQL data files are present at the volume root"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    mkdir -p "${VOLUME_DATA_DIR}/base"
+    printf '18\n' > "${VOLUME_DATA_DIR}/PG_VERSION"
+    When run bash "$(script_path)"
+    The status should be failure
+    The error should include "PostgreSQL data files were found at volume root"
+    The output should not include "done!"
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -94,6 +94,11 @@ EOF
     printf "%s" "$?"
   }
 
+  restore_hook_replica_status() {
+    bash "${RESTORE_SCRIPT_DIR}/kb_restore.sh" --replica >/dev/null 2>&1
+    printf "%s" "$?"
+  }
+
   It "stages the modern zstd archive for Patroni bootstrap and leaves the volume root clean"
     export DATASAFED_LIST_OUT="backup-test.tar.zst"
     When run bash "$(script_path)"
@@ -142,6 +147,79 @@ EOF
     The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
     The path "${DATA_DIR}.old/PG_VERSION" should be exist
     The path "${DATA_DIR}/PG_VERSION" should not be exist
+  End
+
+  It "keeps the restore signal when the handoff directory is missing before commit"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    /bin/rm -rf "${DATA_DIR}.old"
+    The result of function restore_hook_primary_status should not eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+    The path "${DATA_DIR}.old" should not be exist
+    The path "${DATA_DIR}/PG_VERSION" should not be exist
+  End
+
+  It "keeps the restore signal and staged data when DATA_DIR is not empty before commit"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    mkdir -p "${DATA_DIR}/unexpected"
+    The result of function restore_hook_primary_status should not eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+    The path "${DATA_DIR}.old/PG_VERSION" should be exist
+    The path "${DATA_DIR}/unexpected" should be directory
+  End
+
+  It "cleans the restore signal and staged handoff on replica fallback"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The result of function restore_hook_replica_status should not eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
+    The path "${DATA_DIR}.old" should not be exist
+    The path "${DATA_DIR}/PG_VERSION" should not be exist
+  End
+
+  It "converges when the primary hook moved data before clearing the signal"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    cat > "${bindir}/rm" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *kb_restore.signal*) exit 7 ;;
+esac
+exec /bin/rm "$@"
+EOF
+    chmod +x "${bindir}/rm"
+    The result of function restore_hook_primary_status should not eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+    The path "${DATA_DIR}.old" should not be exist
+    The path "${DATA_DIR}/.kb_restore_handoff" should be exist
+    The path "${DATA_DIR}/PG_VERSION" should be exist
+
+    /bin/rm -f "${bindir}/rm"
+    The result of function restore_hook_primary_status should eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should not be exist
+    The path "${DATA_DIR}/.kb_restore_handoff" should not be exist
+    The path "${DATA_DIR}/PG_VERSION" should be exist
+    The path "${DATA_DIR}/base" should be directory
+    The path "${DATA_DIR}/global" should be directory
+    The path "${DATA_DIR}/pg_wal" should be directory
+  End
+
+  It "fails when the handoff directory is missing and DATA_DIR lacks the restore marker"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    /bin/rm -rf "${DATA_DIR}.old"
+    mkdir -p "${DATA_DIR}/base"
+    printf '18\n' > "${DATA_DIR}/PG_VERSION"
+    The result of function restore_hook_primary_status should not eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+    The path "${DATA_DIR}/.kb_restore_handoff" should not be exist
+    The path "${DATA_DIR}/PG_VERSION" should be exist
   End
 
   It "fails when DATA_DIR does not match the PostgreSQL volume data subdirectory"

--- a/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh
@@ -121,6 +121,19 @@ EOF
     The path "${DATA_DIR}/recovery.signal" should not be exist
   End
 
+  It "keeps the restore signal when the primary hook fails before commit"
+    export DATASAFED_LIST_OUT="backup-test.tar.zst"
+    When run bash "$(script_path)"
+    The status should eq 0
+    cat > "${bindir}/sync" <<'EOF'
+#!/bin/sh
+exit 7
+EOF
+    chmod +x "${bindir}/sync"
+    The result of function restore_hook_primary_status should not eq 0
+    The path "${RESTORE_SCRIPT_DIR}/kb_restore.signal" should be exist
+  End
+
   It "fails when DATA_DIR does not match the PostgreSQL volume data subdirectory"
     export DATASAFED_LIST_OUT="backup-test.tar.zst"
     DATA_DIR="${VOLUME_DATA_DIR}"

--- a/addons/postgresql/scripts-ut-spec/postgres_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/postgres_setup_spec.sh
@@ -115,6 +115,33 @@ Describe "PostgreSQL Initialization Script Tests"
       The variable SPILO_CONFIGURATION should include "bootstrap:"
       The variable SPILO_CONFIGURATION should include "auth-host: md5"
     End
+
+    It "propagates restore replica configuration when the restore signal exists"
+      RESTORE_DATA_DIR="$(mktemp -d -t pg-restore-data-XXXXXX)"
+      touch "${RESTORE_DATA_DIR}/kb_restore.signal"
+      export RESTORE_DATA_DIR
+      python3() {
+        echo "postgresql:
+                create_replica_methods:
+                - restore_data
+                - basebackup
+                restore_data:
+                  command: bash /home/postgres/pgdata/kb_restore/kb_restore.sh --replica" > "$tmp_patroni_yaml"
+      }
+      chown() {
+        :
+      }
+      exec() {
+        :
+      }
+      When call regenerate_spilo_configuration_and_start_postgres
+      The stderr should include "/home/postgres/.kb_set_up.log: No such file or directory"
+      The status should be success
+      The variable SPILO_CONFIGURATION should include "create_replica_methods:"
+      The variable SPILO_CONFIGURATION should include "restore_data"
+      The variable SPILO_CONFIGURATION should include "kb_restore.sh --replica"
+      rm -rf "${RESTORE_DATA_DIR}"
+    End
   End
 
   Describe "need_restart_for_pending()"

--- a/addons/postgresql/scripts/generate_patroni_yaml.py
+++ b/addons/postgresql/scripts/generate_patroni_yaml.py
@@ -39,6 +39,8 @@ def postgresql_conf_to_dict(file_path):
 
 def main(filename):
     restore_dir = os.environ.get('RESTORE_DATA_DIR', '')
+    conf_dir = os.environ.get('POSTGRES_CONF_DIR', '/home/postgres/conf')
+    pgdata_dir = os.environ.get('POSTGRES_PGDATA_DIR', '/home/postgres/pgdata')
     local_config = yaml.safe_load(
         os.environ.get('SPILO_CONFIGURATION',
                        os.environ.get('PATRONI_CONFIGURATION', ''))) or {}
@@ -51,23 +53,29 @@ def main(filename):
     postgresql['custom_conf'] = '/home/postgres/conf/postgresql.conf'
 
     # add pg_hba.conf
-    with open('/home/postgres/conf/pg_hba.conf', 'r') as f:
+    with open(os.path.join(conf_dir, 'pg_hba.conf'), 'r') as f:
         lines = read_file_lines(f)
         if lines:
             postgresql['pg_hba'] = lines
     if restore_dir and os.path.isfile(
             os.path.join(restore_dir, 'kb_restore.signal')):
-        if 'postgresql' not in local_config:
-            local_config['postgresql'] = {}
-        with open('/home/postgres/conf/replica_restore.conf', 'r') as f:
+        with open(os.path.join(conf_dir, 'replica_restore.conf'), 'r') as f:
             replica_restore_conf = yaml.safe_load(f)
             local_config['postgresql'].update(replica_restore_conf)
+        if 'bootstrap' not in local_config:
+            local_config['bootstrap'] = {}
+        local_config['bootstrap']['method'] = 'kb_restore'
+        local_config['bootstrap']['kb_restore'] = {
+            'command': 'bash {}'.format(os.path.join(restore_dir, 'kb_restore.sh')),
+            'keep_existing_recovery_conf': False,
+            'recovery_conf': {},
+        }
 
     # point in time recovery(PITR)
-    if os.path.isfile("/home/postgres/pgdata/conf/recovery.conf"):
-        with open('/home/postgres/conf/kb_pitr.conf', 'r') as f:
+    if os.path.isfile(os.path.join(pgdata_dir, "conf/recovery.conf")):
+        with open(os.path.join(conf_dir, 'kb_pitr.conf'), 'r') as f:
             pitr_config = yaml.safe_load(f)
-            re_config = postgresql_conf_to_dict("/home/postgres/pgdata/conf/recovery.conf")
+            re_config = postgresql_conf_to_dict(os.path.join(pgdata_dir, "conf/recovery.conf"))
             pitr_config[pitr_config['method']]['recovery_conf'].update(re_config)
             local_config['bootstrap'].update(pitr_config)
 
@@ -76,8 +84,8 @@ def main(filename):
         local_config['bootstrap'] = {}
     if 'dcs' not in local_config['bootstrap']:
         local_config['bootstrap']['dcs'] = {}
-    if os.path.exists('/home/postgres/conf/patroni.yaml'):
-        with open('/home/postgres/conf/patroni.yaml', 'r') as f:
+    if os.path.exists(os.path.join(conf_dir, 'patroni.yaml')):
+        with open(os.path.join(conf_dir, 'patroni.yaml'), 'r') as f:
             local_config['bootstrap']['dcs'].update(yaml.safe_load(f))
     else:
         print('patroni.yaml not found')

--- a/addons/postgresql/scripts/generate_patroni_yaml.py
+++ b/addons/postgresql/scripts/generate_patroni_yaml.py
@@ -68,7 +68,6 @@ def main(filename):
         local_config['bootstrap']['kb_restore'] = {
             'command': 'bash {}'.format(os.path.join(restore_dir, 'kb_restore.sh')),
             'keep_existing_recovery_conf': False,
-            'recovery_conf': {},
         }
 
     # point in time recovery(PITR)

--- a/addons/postgresql/templates/actionset-pgbasebackup.yaml
+++ b/addons/postgresql/templates/actionset-pgbasebackup.yaml
@@ -12,6 +12,8 @@ spec:
       value: {{ .Values.dataMountPath }}
     - name: DATA_DIR
       value: "$(VOLUME_DATA_DIR)/pgroot/data"
+    - name: RESTORE_SCRIPT_DIR
+      value: "$(VOLUME_DATA_DIR)/kb_restore"
   backup:
     preBackup: []
     postBackup: []

--- a/addons/postgresql/templates/actionset-pgbasebackup.yaml
+++ b/addons/postgresql/templates/actionset-pgbasebackup.yaml
@@ -8,8 +8,10 @@ metadata:
 spec:
   backupType: Full
   env:
+    - name: VOLUME_DATA_DIR
+      value: {{ .Values.dataMountPath }}
     - name: DATA_DIR
-      value: {{ .Values.dataMountPath }}/pgroot/data
+      value: "$(VOLUME_DATA_DIR)/pgroot/data"
   backup:
     preBackup: []
     postBackup: []


### PR DESCRIPTION
## Summary

Fixes #3111.

This PR tightens PostgreSQL `pg-basebackup` restore prepareData so it cannot silently succeed with an empty, misplaced, or incomplete payload:

- `postgresql-basebackup` ActionSet now declares `VOLUME_DATA_DIR=/home/postgres/pgdata` and derives `DATA_DIR=$(VOLUME_DATA_DIR)/pgroot/data`.
- `pg-basebackup-restore.sh` now fails before pulling when `DATA_DIR` does not match the PostgreSQL runtime data subdirectory.
- After extraction, the script requires `PG_VERSION`, `base/`, `global/`, and `pg_wal/` under `pgroot/data`, and rejects PostgreSQL data files at the volume root.
- The old compatibility fallback now fails if neither `base.tar.gz` nor `base.tar` exists instead of printing `done!`.
- Added focused ShellSpec coverage for the success path and fail-fast cases.

## Evidence

Local checks on branch `easton/pg-restore-path-fix` commit `d586e60fa`:

- `shellspec --load-path ./shellspec --default-path addons/postgresql/scripts-ut-spec/pg_basebackup_restore_spec.sh --shell bash` -> 5 examples, 0 failures.
- `find addons/postgresql/dataprotection addons/postgresql/scripts addons/postgresql/scripts-ut-spec -type f \( -name '*.sh' -o -name '*.bash' \) -print0 | xargs -0 -n1 bash -n && git diff --check` -> pass.
- `helm dependency build addons/postgresql` then `helm template pg addons/postgresql` -> rendered `postgresql-basebackup` has `VOLUME_DATA_DIR=/home/postgres/pgdata` and `DATA_DIR=$(VOLUME_DATA_DIR)/pgroot/data`.

Full PostgreSQL shellspec suite was also attempted locally, but the existing `pitr_restore_spec` fails on this macOS host because the local environment lacks GNU `ls -I` compatibility under Bash 3.2. The new pg-basebackup spec is independent and passes.

## Runtime boundary

Draft until target-side restore validation runs on the fixed vcluster. This PR only proves the script/data-dir contract locally; it does not claim PostgreSQL restore PASS, full backup-restore acceptance, or release readiness.
