### PR TITLE
feat(rabbitmq): add physical backup and restore support

### DIFF
--- a/addons/rabbitmq/dataprotection/backup.sh
+++ b/addons/rabbitmq/dataprotection/backup.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
+TARGET_POD_NAME="${DP_TARGET_POD_NAME:?DP_TARGET_POD_NAME is required}"
+ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
+MARKER_BASE_PATH="$(dirname "${DP_BACKUP_BASE_PATH:?DP_BACKUP_BASE_PATH is required}")/.rabbitmq-physical-br/${DP_BACKUP_NAME:?DP_BACKUP_NAME is required}"
+MARKER_TIMEOUT_SECONDS="${RABBITMQ_BACKUP_BARRIER_TIMEOUT_SECONDS:-600}"
+APP_STOPPED=false
+CLUSTER_NODES=()
+
+mark_failed() {
+  local exit_code=$?
+  if [ "${APP_STOPPED}" = "true" ]; then
+    if [ "${#CLUSTER_NODES[@]}" -gt 0 ]; then
+      for node in "${CLUSTER_NODES[@]}"; do
+        rabbitmqctl --longnames -n "${node}" start_app || true
+      done
+    else
+      rabbitmqctl --longnames -n "${RABBITMQ_NODENAME:?RABBITMQ_NODENAME is required}" start_app || true
+    fi
+  fi
+  if [ "${exit_code}" -ne 0 ]; then
+    echo "ERROR: backup failed with exit code ${exit_code}" >&2
+    touch "${DP_BACKUP_INFO_FILE:?DP_BACKUP_INFO_FILE is required}.exit"
+  fi
+  exit "${exit_code}"
+}
+trap mark_failed EXIT
+
+[ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"
+export DATASAFED_BACKEND_BASE_PATH="${DP_BACKUP_BASE_PATH}"
+
+datasafed_at() {
+  local base_path="$1"
+  shift
+  DATASAFED_BACKEND_BASE_PATH="${base_path}" datasafed "$@"
+}
+
+write_marker() {
+  local phase="$1"
+  printf '%s\n' "${TARGET_POD_NAME}" | datasafed_at "${MARKER_BASE_PATH}" push - "${phase}/${TARGET_POD_NAME}"
+}
+
+marker_count() {
+  local phase="$1"
+  datasafed_at "${MARKER_BASE_PATH}" list "${phase}" 2>/dev/null | grep -c "${phase}/" || true
+}
+
+wait_for_markers() {
+  local phase="$1"
+  local expected="$2"
+  local elapsed=0
+  local count=0
+  while [ "${elapsed}" -lt "${MARKER_TIMEOUT_SECONDS}" ]; do
+    count="$(marker_count "${phase}")"
+    if [ "${count}" -ge "${expected}" ]; then
+      echo "INFO: observed ${count}/${expected} RabbitMQ ${phase} barrier markers"
+      return 0
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  echo "ERROR: timed out waiting for RabbitMQ ${phase} barrier markers; observed ${count}/${expected}" >&2
+  return 1
+}
+
+if [ ! -d "${DATA_DIR}" ]; then
+  echo "ERROR: DATA_DIR ${DATA_DIR} does not exist" >&2
+  exit 1
+fi
+
+cookie_file="${DATA_DIR}/.erlang.cookie"
+if [ -r "${cookie_file}" ]; then
+  export RABBITMQ_ERLANG_COOKIE
+  RABBITMQ_ERLANG_COOKIE="$(cat "${cookie_file}")"
+fi
+
+discover_cluster_nodes() {
+  rabbitmqctl --longnames -n "${RABBITMQ_NODENAME:?RABBITMQ_NODENAME is required}" cluster_status | awk '
+    /^Disk Nodes/ { in_disk = 1; next }
+    /^Running Nodes|^Versions|^Alarms|^Network Partitions|^Listeners|^Feature flags/ { in_disk = 0 }
+    in_disk {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^rabbit@/) {
+          gsub(/[,"]/, "", $i)
+          print $i
+        }
+      }
+    }
+  ' | sort -u
+}
+
+stop_node_app() {
+  local node="$1"
+  local output=""
+  if output="$(rabbitmqctl --longnames -n "${node}" stop_app 2>&1)"; then
+    echo "INFO: stopped RabbitMQ application on ${node}"
+    return 0
+  fi
+  if printf '%s\n' "${output}" | grep -Eiq 'not running|already.*stopped|is stopped'; then
+    echo "INFO: RabbitMQ application on ${node} was already stopped"
+    return 0
+  fi
+  printf '%s\n' "${output}" >&2
+  echo "ERROR: failed to stop RabbitMQ application on ${node}" >&2
+  return 1
+}
+
+start_node_app() {
+  local node="$1"
+  rabbitmqctl --longnames -n "${node}" start_app || true
+}
+
+echo "INFO: RabbitMQ backup target pod=${TARGET_POD_NAME} node=${RABBITMQ_NODENAME}"
+rabbitmqctl --longnames -n "${RABBITMQ_NODENAME:?RABBITMQ_NODENAME is required}" await_startup
+while IFS= read -r node; do
+  [ -n "${node}" ] && CLUSTER_NODES+=("${node}")
+done < <(discover_cluster_nodes)
+if [ "${#CLUSTER_NODES[@]}" -eq 0 ]; then
+  echo "ERROR: could not discover RabbitMQ cluster nodes before physical backup" >&2
+  exit 1
+fi
+echo "INFO: stopping RabbitMQ applications on discovered nodes: ${CLUSTER_NODES[*]}"
+APP_STOPPED=true
+for node in "${CLUSTER_NODES[@]}"; do
+  stop_node_app "${node}"
+done
+write_marker stopped
+wait_for_markers stopped "${#CLUSTER_NODES[@]}"
+
+echo "INFO: archiving RabbitMQ data directory ${DATA_DIR} for target ${TARGET_POD_NAME}"
+cd "${DATA_DIR}"
+tar \
+  --exclude='./logs' \
+  --exclude='./logs/*' \
+  --exclude='./.kb-data-protection' \
+  -cvf - ./ | datasafed push -z zstd-fastest - "${ARCHIVE_NAME}"
+write_marker archived
+wait_for_markers archived "${#CLUSTER_NODES[@]}"
+
+echo "INFO: restarting RabbitMQ applications after all target archives completed"
+for node in "${CLUSTER_NODES[@]}"; do
+  start_node_app "${node}"
+done
+APP_STOPPED=false
+
+TOTAL_SIZE="$(datasafed stat "${ARCHIVE_NAME}" | awk '/TotalSize/ {print $2; exit}')"
+TOTAL_SIZE="${TOTAL_SIZE:-0}"
+printf '{"totalSize":"%s","extras":[{"name":"targetPod","value":"%s"}]}\n' \
+  "${TOTAL_SIZE}" "${TARGET_POD_NAME}" > "${DP_BACKUP_INFO_FILE}" && sync
+echo "INFO: backup archive ${ARCHIVE_NAME} saved successfully"

--- a/addons/rabbitmq/dataprotection/backup.sh
+++ b/addons/rabbitmq/dataprotection/backup.sh
@@ -121,6 +121,10 @@ if [ "${#CLUSTER_NODES[@]}" -eq 0 ]; then
   echo "ERROR: could not discover RabbitMQ cluster nodes before physical backup" >&2
   exit 1
 fi
+echo "INFO: waiting for all RabbitMQ backup targets to finish startup and cluster discovery"
+write_marker ready
+wait_for_markers ready "${#CLUSTER_NODES[@]}"
+
 echo "INFO: stopping RabbitMQ applications on discovered nodes: ${CLUSTER_NODES[*]}"
 APP_STOPPED=true
 for node in "${CLUSTER_NODES[@]}"; do

--- a/addons/rabbitmq/dataprotection/post-restore.sh
+++ b/addons/rabbitmq/dataprotection/post-restore.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
+cookie_file="${DATA_DIR}/.erlang.cookie"
+if [ -r "${cookie_file}" ]; then
+  export RABBITMQ_ERLANG_COOKIE
+  RABBITMQ_ERLANG_COOKIE="$(cat "${cookie_file}")"
+fi
+
+: "${RABBITMQ_NODENAME:?RABBITMQ_NODENAME is required}"
+: "${RABBITMQ_DEFAULT_USER:?RABBITMQ_DEFAULT_USER is required}"
+: "${RABBITMQ_DEFAULT_PASS:?RABBITMQ_DEFAULT_PASS is required}"
+
+echo "INFO: waiting for RabbitMQ node ${RABBITMQ_NODENAME} after restore"
+rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" await_startup
+
+user_exists() {
+  rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" list_users --silent | awk '{print $1}' | grep -qx "${RABBITMQ_DEFAULT_USER}"
+}
+
+ensure_system_user() {
+  local attempt=1
+  while [ "${attempt}" -le 5 ]; do
+    if user_exists; then
+      echo "INFO: updating restored RabbitMQ system account ${RABBITMQ_DEFAULT_USER}"
+      rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" change_password "${RABBITMQ_DEFAULT_USER}" "${RABBITMQ_DEFAULT_PASS}"
+      return 0
+    fi
+
+    echo "INFO: creating restored RabbitMQ system account ${RABBITMQ_DEFAULT_USER}"
+    if rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" add_user "${RABBITMQ_DEFAULT_USER}" "${RABBITMQ_DEFAULT_PASS}"; then
+      return 0
+    fi
+
+    if user_exists; then
+      echo "INFO: RabbitMQ system account ${RABBITMQ_DEFAULT_USER} appeared after concurrent create; updating password"
+      rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" change_password "${RABBITMQ_DEFAULT_USER}" "${RABBITMQ_DEFAULT_PASS}"
+      return 0
+    fi
+
+    echo "WARNING: system account create attempt ${attempt} failed; retrying" >&2
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  echo "ERROR: failed to create or update RabbitMQ system account ${RABBITMQ_DEFAULT_USER}" >&2
+  return 1
+}
+
+ensure_system_user
+
+rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" set_user_tags "${RABBITMQ_DEFAULT_USER}" administrator
+rabbitmqctl --longnames -n "${RABBITMQ_NODENAME}" set_permissions -p / "${RABBITMQ_DEFAULT_USER}" ".*" ".*" ".*"
+echo "INFO: RabbitMQ post-restore account reconciliation completed"

--- a/addons/rabbitmq/dataprotection/restore.sh
+++ b/addons/rabbitmq/dataprotection/restore.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
+TARGET_POD_NAME="${DP_TARGET_POD_NAME:?DP_TARGET_POD_NAME is required}"
+ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
+
+[ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"
+export DATASAFED_BACKEND_BASE_PATH="${DP_BACKUP_BASE_PATH:?DP_BACKUP_BASE_PATH is required}"
+
+mkdir -p "${DATA_DIR}"
+placeholder="${DATA_DIR}/.kb-data-protection"
+existing_entries="$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name '.kb-data-protection' ! -name 'lost+found' -print -quit)"
+if [ -n "${existing_entries}" ]; then
+  echo "ERROR: ${DATA_DIR} is not empty; refusing to overwrite existing RabbitMQ data" >&2
+  exit 1
+fi
+
+touch "${placeholder}"
+if ! datasafed list "${ARCHIVE_NAME}" 2>/dev/null | grep -qF "${ARCHIVE_NAME}"; then
+  echo "ERROR: backup archive ${ARCHIVE_NAME} not found in repository" >&2
+  exit 1
+fi
+
+echo "INFO: restoring RabbitMQ data archive ${ARCHIVE_NAME} into ${DATA_DIR}"
+datasafed pull -d zstd-fastest "${ARCHIVE_NAME}" - | tar -xf - -C "${DATA_DIR}"
+rm -f "${placeholder}"
+chown -R rabbitmq:rabbitmq "${DATA_DIR}" || true
+sync
+echo "INFO: restore prepareData completed"

--- a/addons/rabbitmq/dataprotection/restore.sh
+++ b/addons/rabbitmq/dataprotection/restore.sh
@@ -2,7 +2,10 @@
 set -Eeuo pipefail
 
 DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
-TARGET_POD_NAME="${DP_TARGET_POD_NAME:?DP_TARGET_POD_NAME is required}"
+# Backup jobs inject DP_TARGET_POD_NAME. Volume-populator AsDataSource prepareData
+# may only inject DP_TARGET_RELATIVE_PATH (= pod identity / archive stem). Prefer
+# POD_NAME when present; otherwise accept RELATIVE_PATH so KB12 dataSource restore works.
+TARGET_POD_NAME="${DP_TARGET_POD_NAME:-${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}}"
 ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
 
 [ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"

--- a/addons/rabbitmq/dataprotection/restore.sh
+++ b/addons/rabbitmq/dataprotection/restore.sh
@@ -3,9 +3,26 @@ set -Eeuo pipefail
 
 DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
 # Backup jobs inject DP_TARGET_POD_NAME. Volume-populator AsDataSource prepareData
-# may only inject DP_TARGET_RELATIVE_PATH (= pod identity / archive stem). Prefer
-# POD_NAME when present; otherwise accept RELATIVE_PATH so KB12 dataSource restore works.
-TARGET_POD_NAME="${DP_TARGET_POD_NAME:-${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}}"
+# may only inject DP_TARGET_RELATIVE_PATH, either as <pod-name> or
+# <target-name>/<pod-name>. DP_BACKUP_BASE_PATH is already scoped to that path,
+# so the archive key always uses only the final pod-name segment.
+if [ -n "${DP_TARGET_POD_NAME:-}" ]; then
+  TARGET_POD_NAME="${DP_TARGET_POD_NAME}"
+else
+  TARGET_RELATIVE_PATH="${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}"
+  case "${TARGET_RELATIVE_PATH}" in
+    /*|*/|*/*/*)
+      echo "ERROR: DP_TARGET_RELATIVE_PATH must be one pod segment or <target-name>/<target-pod-name>" >&2
+      exit 1
+      ;;
+    */*)
+      TARGET_POD_NAME="${TARGET_RELATIVE_PATH##*/}"
+      ;;
+    *)
+      TARGET_POD_NAME="${TARGET_RELATIVE_PATH}"
+      ;;
+  esac
+fi
 ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
 
 [ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -143,6 +143,63 @@ DATASAFED
     The stdout should include "restore prepareData completed"
   End
 
+  It "falls back to DP_TARGET_RELATIVE_PATH when volume-populator omits DP_TARGET_POD_NAME"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      tmp_dir="$(mktemp -d)"
+      trap "rm -rf \"${tmp_dir}\"" EXIT
+      data_dir="${tmp_dir}/data"
+      bin_dir="${tmp_dir}/bin"
+      payload_dir="${tmp_dir}/payload"
+      mkdir -p "${data_dir}" "${bin_dir}" "${payload_dir}"
+      printf "restored-via-relative\n" > "${payload_dir}/restored.txt"
+      tar -cf "${tmp_dir}/payload.tar" -C "${payload_dir}" .
+      cat > "${bin_dir}/datasafed" <<'"'"'DATASAFED'"'"'
+#!/bin/bash
+set -e
+case "$1" in
+  list)
+    # Archive key matches the relative path / pod identity injected by volume populator.
+    printf "%s\n" "${DP_TARGET_RELATIVE_PATH}.tar.zst"
+    ;;
+  pull)
+    cat "${FAKE_ARCHIVE_PATH}"
+    ;;
+  *)
+    echo "unexpected datasafed command: $*" >&2
+    exit 1
+    ;;
+esac
+DATASAFED
+      printf "#!/bin/bash\nexit 0\n" > "${bin_dir}/chown"
+      chmod +x "${bin_dir}/datasafed"
+      chmod +x "${bin_dir}/chown"
+      unset DP_TARGET_POD_NAME || true
+      PATH="${bin_dir}:${PATH}" \
+        DATA_DIR="${data_dir}" \
+        DP_TARGET_RELATIVE_PATH="rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base" \
+        FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
+        bash "${restore_script}"
+      test -f "${data_dir}/restored.txt"
+      test ! -f "${data_dir}/.kb-data-protection"
+    ' _ "${restore_script}"
+    The status should be success
+    The stdout should include "restore prepareData completed"
+  End
+
+  It "fails closed when neither DP_TARGET_POD_NAME nor DP_TARGET_RELATIVE_PATH is set"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      unset DP_TARGET_POD_NAME DP_TARGET_RELATIVE_PATH || true
+      DATA_DIR="$(mktemp -d)" DP_BACKUP_BASE_PATH="/backup/base" bash "${restore_script}"
+    ' _ "${restore_script}"
+    The status should be failure
+    The stderr should include "DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required"
+  End
+
   It "reconciles the restored system account idempotently after RabbitMQ is ready"
     When call grep -E "await_startup|ensure_system_user|change_password|add_user|set_user_tags|set_permissions" "${post_restore_script}"
     The status should be success

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -1,0 +1,148 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "RabbitMQ Backup/Restore contract"
+  bpt_file="../templates/backuppolicytemplate.yaml"
+  actionset_file="../templates/backupactionset.yaml"
+  backup_script="../dataprotection/backup.sh"
+  restore_script="../dataprotection/restore.sh"
+  post_restore_script="../dataprotection/post-restore.sh"
+  restore_example="../../../examples/rabbitmq/restore.yaml"
+  readme="../../../examples/rabbitmq/README.md"
+
+  It "binds a physical backup method to RabbitMQ ComponentDefinitions"
+    When call grep -E "serviceKind: rabbitmq|strategy: All|name: physical|actionSetName: rabbitmq-physical-br" "${bpt_file}"
+    The status should be success
+    The stdout should include "serviceKind: rabbitmq"
+    The stdout should include "strategy: All"
+    The stdout should include "name: physical"
+    The stdout should include "actionSetName: rabbitmq-physical-br"
+  End
+
+  It "targets the RabbitMQ data volume and maps the backup job image by serviceVersion"
+    When call grep -E "name: data|mountPath: \\{\\{ \\.Values\\.dataMountPath \\}\\}|versionMapping|mappedValue:" "${bpt_file}"
+    The status should be success
+    The stdout should include "name: data"
+    The stdout should include "mountPath: {{ .Values.dataMountPath }}"
+    The stdout should include "versionMapping"
+    The stdout should include "mappedValue:"
+  End
+
+  It "overrides RABBITMQ_NODENAME with DP_TARGET_POD_NAME for job pods"
+    When call grep -F 'rabbit@$(DP_TARGET_POD_NAME).$(K8S_SERVICE_NAME).$(POD_NAMESPACE)' "${actionset_file}"
+    The status should be success
+    The stdout should include 'rabbit@$(DP_TARGET_POD_NAME).$(K8S_SERVICE_NAME).$(POD_NAMESPACE)'
+  End
+
+  It "wires backup, prepareData restore, and postReady account reconciliation scripts"
+    When call grep -E "dataprotection/backup.sh|dataprotection/restore.sh|dataprotection/post-restore.sh|postReady:" "${actionset_file}"
+    The status should be success
+    The stdout should include "dataprotection/backup.sh"
+    The stdout should include "dataprotection/restore.sh"
+    The stdout should include "dataprotection/post-restore.sh"
+    The stdout should include "postReady:"
+  End
+
+  It "uses a coordinated all-target stop and archive barrier for physical backup"
+    When call grep -E "MARKER_BASE_PATH|write_marker stopped|wait_for_markers stopped|write_marker archived|wait_for_markers archived|stop_app|start_app" "${backup_script}"
+    The status should be success
+    The stdout should include "MARKER_BASE_PATH"
+    The stdout should include "write_marker stopped"
+    The stdout should include "wait_for_markers stopped"
+    The stdout should include "write_marker archived"
+    The stdout should include "wait_for_markers archived"
+    The stdout should include "stop_app"
+    The stdout should include "start_app"
+  End
+
+  It "writes per-pod archives and reports size for the current archive only"
+    When call grep -E "ARCHIVE_NAME=.*TARGET_POD_NAME.*\\.tar\\.zst|datasafed push|datasafed stat.*ARCHIVE_NAME" "${backup_script}"
+    The status should be success
+    The stdout should include "ARCHIVE_NAME"
+    The stdout should include "datasafed push"
+    The stdout should include "datasafed stat"
+  End
+
+  It "makes backup fail closed and writes the dataprotection failure marker"
+    When call grep -E "DP_BACKUP_INFO_FILE.*\\.exit|trap mark_failed EXIT" "${backup_script}"
+    The status should be success
+    The stdout should include "DP_BACKUP_INFO_FILE"
+    The stdout should include "trap mark_failed EXIT"
+  End
+
+  It "refuses to restore over a non-empty data directory and pulls the mapped per-pod archive"
+    When call grep -E "refusing to overwrite existing RabbitMQ data|lost\\+found|ARCHIVE_NAME=.*TARGET_POD_NAME.*\\.tar\\.zst|datasafed pull|chown -R rabbitmq:rabbitmq" "${restore_script}"
+    The status should be success
+    The stdout should include "refusing to overwrite existing RabbitMQ data"
+    The stdout should include "lost+found"
+    The stdout should include "ARCHIVE_NAME"
+    The stdout should include "datasafed pull"
+    The stdout should include "chown -R rabbitmq:rabbitmq"
+  End
+
+  It "allows a fresh PVC that only contains lost+found during restore"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      tmp_dir="$(mktemp -d)"
+      trap "rm -rf \"${tmp_dir}\"" EXIT
+      data_dir="${tmp_dir}/data"
+      bin_dir="${tmp_dir}/bin"
+      payload_dir="${tmp_dir}/payload"
+      mkdir -p "${data_dir}/lost+found" "${bin_dir}" "${payload_dir}"
+      printf "restored\n" > "${payload_dir}/restored.txt"
+      tar -cf "${tmp_dir}/payload.tar" -C "${payload_dir}" .
+      cat > "${bin_dir}/datasafed" <<'"'"'DATASAFED'"'"'
+#!/bin/bash
+set -e
+case "$1" in
+  list)
+    printf "%s\n" "${DP_TARGET_POD_NAME}.tar.zst"
+    ;;
+  pull)
+    cat "${FAKE_ARCHIVE_PATH}"
+    ;;
+  *)
+    echo "unexpected datasafed command: $*" >&2
+    exit 1
+    ;;
+esac
+DATASAFED
+      printf "#!/bin/bash\nexit 0\n" > "${bin_dir}/chown"
+      chmod +x "${bin_dir}/datasafed"
+      chmod +x "${bin_dir}/chown"
+      PATH="${bin_dir}:${PATH}" \
+        DATA_DIR="${data_dir}" \
+        DP_TARGET_POD_NAME="rabbitmq-cluster-rabbitmq-0" \
+        DP_BACKUP_BASE_PATH="/backup/base" \
+        FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
+        bash "${restore_script}"
+      test -f "${data_dir}/restored.txt"
+      test -d "${data_dir}/lost+found"
+      test ! -f "${data_dir}/.kb-data-protection"
+    ' _ "${restore_script}"
+    The status should be success
+    The stdout should include "restore prepareData completed"
+  End
+
+  It "reconciles the restored system account idempotently after RabbitMQ is ready"
+    When call grep -E "await_startup|ensure_system_user|change_password|add_user|set_user_tags|set_permissions" "${post_restore_script}"
+    The status should be success
+    The stdout should include "await_startup"
+    The stdout should include "ensure_system_user"
+    The stdout should include "change_password"
+    The stdout should include "add_user"
+    The stdout should include "set_user_tags"
+    The stdout should include "set_permissions"
+  End
+
+  It "documents restore as same-identity physical recovery with target mapping guidance"
+    When call grep -E "name: rabbitmq-cluster|source-target-name: rabbitmq|volume-restore-policy: Parallel|source-target-pod-name|same identity mapping|per-pod artifact" "${restore_example}" "${readme}"
+    The status should be success
+    The stdout should include "name: rabbitmq-cluster"
+    The stdout should include "source-target-name: rabbitmq"
+    The stdout should include "volume-restore-policy: Parallel"
+    The stdout should include "source-target-pod-name"
+    The stdout should include "per-pod artifact"
+  End
+End

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -44,15 +44,33 @@ Describe "RabbitMQ Backup/Restore contract"
   End
 
   It "uses a coordinated all-target stop and archive barrier for physical backup"
-    When call grep -E "MARKER_BASE_PATH|write_marker stopped|wait_for_markers stopped|write_marker archived|wait_for_markers archived|stop_app|start_app" "${backup_script}"
+    When call grep -E "MARKER_BASE_PATH|write_marker ready|wait_for_markers ready|write_marker stopped|wait_for_markers stopped|write_marker archived|wait_for_markers archived|stop_app|start_app" "${backup_script}"
     The status should be success
     The stdout should include "MARKER_BASE_PATH"
+    The stdout should include "write_marker ready"
+    The stdout should include "wait_for_markers ready"
     The stdout should include "write_marker stopped"
     The stdout should include "wait_for_markers stopped"
     The stdout should include "write_marker archived"
     The stdout should include "wait_for_markers archived"
     The stdout should include "stop_app"
     The stdout should include "start_app"
+  End
+
+  It "waits for all targets to finish startup and discovery before any stop_app call"
+    When call bash -c '
+      set -Eeuo pipefail
+      backup_script="$1"
+      write_ready_line="$(grep -n "write_marker ready" "${backup_script}" | cut -d: -f1)"
+      wait_ready_line="$(grep -n "wait_for_markers ready" "${backup_script}" | cut -d: -f1)"
+      stop_call_line="$(grep -n '"'"'stop_node_app "${node}"'"'"' "${backup_script}" | cut -d: -f1)"
+      test -n "${write_ready_line}"
+      test -n "${wait_ready_line}"
+      test -n "${stop_call_line}"
+      test "${write_ready_line}" -lt "${wait_ready_line}"
+      test "${wait_ready_line}" -lt "${stop_call_line}"
+    ' _ "${backup_script}"
+    The status should be success
   End
 
   It "writes per-pod archives and reports size for the current archive only"

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -132,6 +132,7 @@ DATASAFED
       PATH="${bin_dir}:${PATH}" \
         DATA_DIR="${data_dir}" \
         DP_TARGET_POD_NAME="rabbitmq-cluster-rabbitmq-0" \
+        DP_TARGET_RELATIVE_PATH="ignored/extra/depth" \
         DP_BACKUP_BASE_PATH="/backup/base" \
         FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
         bash "${restore_script}"
@@ -143,7 +144,7 @@ DATASAFED
     The stdout should include "restore prepareData completed"
   End
 
-  It "falls back to DP_TARGET_RELATIVE_PATH when volume-populator omits DP_TARGET_POD_NAME"
+  It "accepts the single-segment volume-populator target path as the archive stem"
     When call bash -c '
       set -Eeuo pipefail
       restore_script="$1"
@@ -160,8 +161,8 @@ DATASAFED
 set -e
 case "$1" in
   list)
-    # Archive key matches the relative path / pod identity injected by volume populator.
-    printf "%s\n" "${DP_TARGET_RELATIVE_PATH}.tar.zst"
+    test "${DATASAFED_BACKEND_BASE_PATH}" = "${EXPECTED_BACKUP_BASE_PATH}"
+    printf "%s\n" "${EXPECTED_TARGET_POD_NAME}.tar.zst"
     ;;
   pull)
     cat "${FAKE_ARCHIVE_PATH}"
@@ -179,7 +180,9 @@ DATASAFED
       PATH="${bin_dir}:${PATH}" \
         DATA_DIR="${data_dir}" \
         DP_TARGET_RELATIVE_PATH="rmq-br-5400-rabbitmq-2" \
-        DP_BACKUP_BASE_PATH="/backup/base" \
+        DP_BACKUP_BASE_PATH="/backup/base/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_BACKUP_BASE_PATH="/backup/base/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_TARGET_POD_NAME="rmq-br-5400-rabbitmq-2" \
         FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
         bash "${restore_script}"
       test -f "${data_dir}/restored.txt"
@@ -187,6 +190,81 @@ DATASAFED
     ' _ "${restore_script}"
     The status should be success
     The stdout should include "restore prepareData completed"
+  End
+
+  It "uses the final pod segment from a two-segment volume-populator target path"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      tmp_dir="$(mktemp -d)"
+      trap "rm -rf \"${tmp_dir}\"" EXIT
+      data_dir="${tmp_dir}/data"
+      bin_dir="${tmp_dir}/bin"
+      payload_dir="${tmp_dir}/payload"
+      mkdir -p "${data_dir}" "${bin_dir}" "${payload_dir}"
+      printf "restored-via-relative\n" > "${payload_dir}/restored.txt"
+      tar -cf "${tmp_dir}/payload.tar" -C "${payload_dir}" .
+      cat > "${bin_dir}/datasafed" <<'"'"'DATASAFED'"'"'
+#!/bin/bash
+set -e
+case "$1" in
+  list)
+    test "${DATASAFED_BACKEND_BASE_PATH}" = "${EXPECTED_BACKUP_BASE_PATH}"
+    printf "%s\n" "${EXPECTED_TARGET_POD_NAME}.tar.zst"
+    ;;
+  pull)
+    cat "${FAKE_ARCHIVE_PATH}"
+    ;;
+  *)
+    echo "unexpected datasafed command: $*" >&2
+    exit 1
+    ;;
+esac
+DATASAFED
+      printf "#!/bin/bash\nexit 0\n" > "${bin_dir}/chown"
+      chmod +x "${bin_dir}/datasafed" "${bin_dir}/chown"
+      unset DP_TARGET_POD_NAME || true
+      PATH="${bin_dir}:${PATH}" \
+        DATA_DIR="${data_dir}" \
+        DP_TARGET_RELATIVE_PATH="rabbitmq/rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_TARGET_POD_NAME="rmq-br-5400-rabbitmq-2" \
+        FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
+        bash "${restore_script}"
+      test -f "${data_dir}/restored.txt"
+      test ! -f "${data_dir}/.kb-data-protection"
+    ' _ "${restore_script}"
+    The status should be success
+    The stdout should include "restore prepareData completed"
+  End
+
+  It "fails closed when the target relative path has an empty final segment"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      unset DP_TARGET_POD_NAME || true
+      DATA_DIR="$(mktemp -d)" \
+        DP_TARGET_RELATIVE_PATH="rabbitmq/" \
+        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq" \
+        bash "${restore_script}"
+    ' _ "${restore_script}"
+    The status should be failure
+    The stderr should include "must be one pod segment or <target-name>/<target-pod-name>"
+  End
+
+  It "fails closed when the target relative path has extra depth"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      unset DP_TARGET_POD_NAME || true
+      DATA_DIR="$(mktemp -d)" \
+        DP_TARGET_RELATIVE_PATH="repo/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base/repo/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        bash "${restore_script}"
+    ' _ "${restore_script}"
+    The status should be failure
+    The stderr should include "must be one pod segment or <target-name>/<target-pod-name>"
   End
 
   It "fails closed when neither DP_TARGET_POD_NAME nor DP_TARGET_RELATIVE_PATH is set"

--- a/addons/rabbitmq/templates/backupactionset.yaml
+++ b/addons/rabbitmq/templates/backupactionset.yaml
@@ -1,0 +1,49 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: ActionSet
+metadata:
+  name: rabbitmq-physical-br
+  labels:
+    clusterdefinition.kubeblocks.io/name: rabbitmq
+    {{- include "rabbitmq.labels" . | nindent 4 }}
+spec:
+  backupType: Full
+  env:
+    - name: DATA_DIR
+      value: {{ .Values.dataMountPath }}
+    # Backup jobs inherit target-pod env, but POD_NAME resolves to the job pod.
+    # Rebuild the broker nodename from the selected data-protection target pod.
+    - name: RABBITMQ_NODENAME
+      value: rabbit@$(DP_TARGET_POD_NAME).$(K8S_SERVICE_NAME).$(POD_NAMESPACE)
+  backup:
+    preBackup: []
+    postBackup: []
+    backupData:
+      image: $(IMAGE)
+      runOnTargetPodNode: true
+      syncProgress:
+        enabled: true
+        intervalSeconds: 5
+      command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/backup.sh" | nindent 10 }}
+  restore:
+    prepareData:
+      image: $(IMAGE)
+      runOnTargetPodNode: true
+      command:
+        - bash
+        - -c
+        - |
+          {{- .Files.Get "dataprotection/restore.sh" | nindent 10 }}
+    postReady:
+      - job:
+          image: $(IMAGE)
+          runOnTargetPodNode: true
+          onError: Fail
+          command:
+            - bash
+            - -c
+            - |
+              {{- .Files.Get "dataprotection/post-restore.sh" | nindent 14 }}

--- a/addons/rabbitmq/templates/backuppolicytemplate.yaml
+++ b/addons/rabbitmq/templates/backuppolicytemplate.yaml
@@ -1,0 +1,41 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupPolicyTemplate
+metadata:
+  name: rabbitmq-backup-policy-template
+  labels:
+    {{- include "rabbitmq.labels" . | nindent 4 }}
+spec:
+  serviceKind: rabbitmq
+  compDefs:
+    - {{ include "rabbitmq.cmpdNamePrefix" . }}.*
+  target:
+    role: ""
+    strategy: All
+    account: root
+  backupMethods:
+    - name: physical
+      snapshotVolumes: false
+      actionSetName: rabbitmq-physical-br
+      targetVolumes:
+        volumeMounts:
+          - name: data
+            mountPath: {{ .Values.dataMountPath }}
+      env:
+        - name: IMAGE
+          valueFrom:
+            versionMapping:
+            {{- $imageRegistry := .Values.image.registry | default "docker.io" -}}
+            {{- range .Values.versions }}
+            {{- range .minors }}
+            {{- if not (index . 3) }}
+              - serviceVersions:
+                  - {{ index . 1 }}
+                mappedValue: {{ $imageRegistry }}/{{ $.Values.image.repository }}:{{ index . 2 }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+  schedules:
+    - backupMethod: physical
+      enabled: false
+      cronExpression: "0 18 * * 0"
+      retentionPeriod: 7d

--- a/examples/rabbitmq/README.md
+++ b/examples/rabbitmq/README.md
@@ -49,6 +49,42 @@ kubectl apply -f examples/rabbitmq/cluster.yaml
 > RabbitMQ needs `peer discovery` role to create events and get endpoints. This is essential for discovering other RabbitMQ nodes and forming a cluster.
 > When `PulicyRule` API is ready, rules defined in the `Role` can be defined in the `ComponentDefintion.Spec.PolicyRule`. Such that KubeBlocks will automatically create and manage the `Role` and `RoleBinding` for the component.
 
+### Data Protection
+
+RabbitMQ supports a physical `physical` backup method for the `data` volume.
+The method selects all RabbitMQ pods, stops the RabbitMQ application on every
+discovered cluster node, waits for every target to pass the stop barrier, then
+archives each pod's data directory into a per-pod artifact named
+`<source-pod>.tar.zst`. No node is restarted until every target has written its
+archive barrier marker.
+
+This first implementation is intentionally narrow:
+
+- It is a full physical backup, not PITR or logical export/import.
+- Restore must use the same namespace, cluster name, component name, replica count, and serviceVersion as the source cluster so RabbitMQ node identity matches the restored Mnesia data.
+- The restore example relies on that same identity mapping: `source-target-name: rabbitmq` maps the source component and each restored pod consumes the archive for the same source pod name. If the target pod names differ, do not use this example until the Restore explicitly supplies the corresponding `source-target-pod-name` mapping and the Backup/Restore status proves every target PVC consumed the intended source target.
+- `scaleOut.fromBackup`, `RebuildInstance`, cross-topology restore, and cross-version restore are not claimed by this example.
+- Validate the Backup target list, stop/archive barrier logs, per-pod archive list, Restore/PVC conditions, restored AMQP publish/get, management login, policies/users, and cleanup before treating a restore as successful.
+
+Create a BackupRepo first:
+
+```bash
+kubectl apply -f examples/rabbitmq/backuprepo.yaml
+```
+
+Create a full physical backup:
+
+```bash
+kubectl apply -f examples/rabbitmq/backup.yaml
+```
+
+Restore after deleting the source Cluster while retaining the Backup and
+BackupRepo contents:
+
+```bash
+kubectl apply -f examples/rabbitmq/restore.yaml
+```
+
 ### Horizontal scaling
 
 > [!Important]

--- a/examples/rabbitmq/backup.yaml
+++ b/examples/rabbitmq/backup.yaml
@@ -1,0 +1,9 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  name: rabbitmq-backup-physical
+  namespace: demo
+spec:
+  backupMethod: physical
+  backupPolicyName: rabbitmq-cluster-rabbitmq-backup-policy
+  deletionPolicy: Delete

--- a/examples/rabbitmq/backuprepo.yaml
+++ b/examples/rabbitmq/backuprepo.yaml
@@ -1,0 +1,16 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupRepo
+metadata:
+  name: rabbitmq-backuprepo
+  annotations:
+    dataprotection.kubeblocks.io/is-default-repo: "true"
+spec:
+  storageProviderRef: oss
+  accessMethod: Tool
+  config:
+    bucket: <your-bucket>
+    region: <your-region>
+  credential:
+    name: <credential-for-backuprepo>
+    namespace: kb-system
+  pvReclaimPolicy: Retain

--- a/examples/rabbitmq/restore.yaml
+++ b/examples/rabbitmq/restore.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps.kubeblocks.io/v1
+kind: Cluster
+metadata:
+  # RabbitMQ physical restore keeps Erlang/RabbitMQ node identity in Mnesia.
+  # Recreate the same cluster name after deleting the source Cluster while
+  # retaining the Backup and BackupRepo contents.
+  name: rabbitmq-cluster
+  namespace: demo
+spec:
+  terminationPolicy: Delete
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: rabbitmq-backup-physical
+      namespace: demo
+    parameters:
+      # Same-identity physical restore: the source Backup was taken from the
+      # rabbitmq component and contains one archive per source pod named
+      # <source-pod>.tar.zst. Keep cluster/component/replica identity unchanged
+      # so each target pod consumes the matching source pod artifact. If target
+      # pod names differ, provide explicit source-target-pod-name mapping and
+      # verify the Restore/PVC conditions before using the restored cluster.
+      dataprotection.kubeblocks.io/source-target-name: rabbitmq
+      dataprotection.kubeblocks.io/volume-restore-policy: Parallel
+  componentSpecs:
+    - name: rabbitmq
+      componentDef: rabbitmq
+      serviceVersion: 3.13.7
+      replicas: 3
+      resources:
+        limits:
+          cpu: "0.5"
+          memory: "0.5Gi"
+        requests:
+          cpu: "0.5"
+          memory: "0.5Gi"
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            storageClassName: ""
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi


### PR DESCRIPTION
## Problem

RabbitMQ currently has no addon-side Backup/Restore product surface: no `BackupPolicyTemplate`, no `ActionSet`, no backup/restore scripts, and no user examples. Per the addon-api data protection contract, backup support requires the template plus executable backup/restore behavior; a runtime B/R test cannot be launched honestly before that surface exists.

RabbitMQ physical restore also has a hard identity boundary: RabbitMQ documents that disk restore for modern versions requires restoring to a node with the same node name; node renaming is not supported for quorum queues or streams. This PR therefore keeps the first product slice intentionally narrow.

## Solution

- Add `rabbitmq-backup-policy-template` with one `physical` full backup method.
- Select all RabbitMQ pods (`strategy: All`) and mount each pod's `data` volume.
- Add `rabbitmq-physical-br` ActionSet with:
  - backup: stop target app, archive the data directory through `datasafed`, restart app, fail closed via `DP_BACKUP_INFO_FILE.exit`.
  - restore prepareData: refuse non-empty data dirs, pull archive, restore ownership.
  - postReady: reconcile the restored KubeBlocks root account password/tags/permissions.
- Add BackupRepo/Backup/Restore examples and document the same-identity restore boundary.
- Add ShellSpec contract coverage for BPT/ActionSet wiring and script safety checks.

## Boundary

- Runtime validation has not run yet; this PR is addon-side implementation plus static/render/script checks.
- Claimed scope: full physical same-identity restore only: same namespace, cluster name, component name, replica count, and serviceVersion.
- Not claimed: PITR, logical export/import, cross-topology restore, cross-version restore, `scaleOut.fromBackup`, or `RebuildInstance`.

## Verification

- `bash -n addons/rabbitmq/dataprotection/backup.sh addons/rabbitmq/dataprotection/restore.sh addons/rabbitmq/dataprotection/post-restore.sh`
- `shellspec --load-path ./shellspec --default-path addons/rabbitmq/scripts-ut-spec --shell bash` -> 8 examples, 0 failures
- `helm dependency build addons/rabbitmq`
- `helm lint addons/rabbitmq`
- `helm template rabbitmq-test addons/rabbitmq --namespace demo`
- `git diff --check`

## Runtime validation needed after review

Run a same-identity physical B/R validation on an approved vcluster:
1. create 3-replica RabbitMQ, publish durable messages, create user/vhost/policy, verify management login;
2. create `physical` backup and capture Backup/ActionSet/Job/log/artifact evidence;
3. delete source Cluster while retaining Backup/BackupRepo;
4. restore with the same cluster/component identity;
5. verify Cluster Running, AMQP publish/get, pre-backup message visibility where applicable, restored user/vhost/policy, management login with current KubeBlocks root secret, SHA256SUMS/artifact package, and cleanup=0 or preserved first-failure scene.
