### PR TITLE
fix(postgresql): accept wal_init_zero as boolean

### DIFF
--- a/addons/postgresql/config/pg12-config-constraint.cue
+++ b/addons/postgresql/config/pg12-config-constraint.cue
@@ -1037,7 +1037,7 @@
 	wal_writer_flush_after?: int & >=0 & <=2147483647 @storeResource(8KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & "on" | "off"
+	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
 
 	// (kB) Sets the maximum memory to be used for query workspaces.
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)

--- a/addons/postgresql/config/pg12-config-constraint.cue
+++ b/addons/postgresql/config/pg12-config-constraint.cue
@@ -1037,7 +1037,7 @@
 	wal_writer_flush_after?: int & >=0 & <=2147483647 @storeResource(8KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & ("on" | "off" | "true" | "false")
+	wal_init_zero?: string & "on" | "off" | "true" | "false"
 
 	// (kB) Sets the maximum memory to be used for query workspaces.
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)

--- a/addons/postgresql/config/pg12-config-constraint.cue
+++ b/addons/postgresql/config/pg12-config-constraint.cue
@@ -1037,7 +1037,7 @@
 	wal_writer_flush_after?: int & >=0 & <=2147483647 @storeResource(8KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
+	wal_init_zero?: string & ("on" | "off" | "true" | "false")
 
 	// (kB) Sets the maximum memory to be used for query workspaces.
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)

--- a/addons/postgresql/config/pg14-config-constraint.cue
+++ b/addons/postgresql/config/pg14-config-constraint.cue
@@ -1106,7 +1106,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & "on" | "off"
+	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg14-config-constraint.cue
+++ b/addons/postgresql/config/pg14-config-constraint.cue
@@ -1106,7 +1106,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & ("on" | "off" | "true" | "false")
+	wal_init_zero?: string & "on" | "off" | "true" | "false"
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg14-config-constraint.cue
+++ b/addons/postgresql/config/pg14-config-constraint.cue
@@ -1106,7 +1106,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
+	wal_init_zero?: string & ("on" | "off" | "true" | "false")
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg15-config-constraint.cue
+++ b/addons/postgresql/config/pg15-config-constraint.cue
@@ -1106,7 +1106,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & "on" | "off"
+	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg15-config-constraint.cue
+++ b/addons/postgresql/config/pg15-config-constraint.cue
@@ -1106,7 +1106,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & ("on" | "off" | "true" | "false")
+	wal_init_zero?: string & "on" | "off" | "true" | "false"
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg15-config-constraint.cue
+++ b/addons/postgresql/config/pg15-config-constraint.cue
@@ -1106,7 +1106,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
+	wal_init_zero?: string & ("on" | "off" | "true" | "false")
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg16-config-constraint.cue
+++ b/addons/postgresql/config/pg16-config-constraint.cue
@@ -1100,7 +1100,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & ("on" | "off" | "true" | "false")
+	wal_init_zero?: string & "on" | "off" | "true" | "false"
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg16-config-constraint.cue
+++ b/addons/postgresql/config/pg16-config-constraint.cue
@@ -1100,7 +1100,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & "on" | "off"
+	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg16-config-constraint.cue
+++ b/addons/postgresql/config/pg16-config-constraint.cue
@@ -1100,7 +1100,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
+	wal_init_zero?: string & ("on" | "off" | "true" | "false")
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg17-config-constraint.cue
+++ b/addons/postgresql/config/pg17-config-constraint.cue
@@ -1097,7 +1097,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
+	wal_init_zero?: string & ("on" | "off" | "true" | "false")
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg17-config-constraint.cue
+++ b/addons/postgresql/config/pg17-config-constraint.cue
@@ -1097,7 +1097,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & "on" | "off"
+	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg17-config-constraint.cue
+++ b/addons/postgresql/config/pg17-config-constraint.cue
@@ -1097,7 +1097,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & ("on" | "off" | "true" | "false")
+	wal_init_zero?: string & "on" | "off" | "true" | "false"
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg18-config-constraint.cue
+++ b/addons/postgresql/config/pg18-config-constraint.cue
@@ -1097,7 +1097,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
+	wal_init_zero?: string & ("on" | "off" | "true" | "false")
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg18-config-constraint.cue
+++ b/addons/postgresql/config/pg18-config-constraint.cue
@@ -1097,7 +1097,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & "on" | "off"
+	wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/config/pg18-config-constraint.cue
+++ b/addons/postgresql/config/pg18-config-constraint.cue
@@ -1097,7 +1097,7 @@
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
-	wal_init_zero?: string & ("on" | "off" | "true" | "false")
+	wal_init_zero?: string & "on" | "off" | "true" | "false"
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+
+Describe "PostgreSQL wal_init_zero configuration"
+  assert_wal_init_zero_contract() {
+    local major="$1"
+
+    grep -Fq 'wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))' "../config/pg${major}-config-constraint.cue"
+    grep -Fq 'wal_init_zero = off' "../config/pg${major}-config.tpl"
+  }
+
+  It "keeps pg12 wal_init_zero compatible with bool and PostgreSQL on/off values"
+    When call assert_wal_init_zero_contract 12
+    The status should be success
+  End
+
+  It "keeps pg14 wal_init_zero compatible with bool and PostgreSQL on/off values"
+    When call assert_wal_init_zero_contract 14
+    The status should be success
+  End
+
+  It "keeps pg15 wal_init_zero compatible with bool and PostgreSQL on/off values"
+    When call assert_wal_init_zero_contract 15
+    The status should be success
+  End
+
+  It "keeps pg16 wal_init_zero compatible with bool and PostgreSQL on/off values"
+    When call assert_wal_init_zero_contract 16
+    The status should be success
+  End
+
+  It "keeps pg17 wal_init_zero compatible with bool and PostgreSQL on/off values"
+    When call assert_wal_init_zero_contract 17
+    The status should be success
+  End
+
+  It "keeps pg18 wal_init_zero compatible with bool and PostgreSQL on/off values"
+    When call assert_wal_init_zero_contract 18
+    The status should be success
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh
@@ -13,7 +13,7 @@ Describe "PostgreSQL wal_init_zero configuration"
     local cue="../config/pg${major}-config-constraint.cue"
 
     # exact expected type: string enum accepting both PG and bool spellings
-    grep -Fq 'wal_init_zero?: string & ("on" | "off" | "true" | "false")' "${cue}"
+    grep -Fq 'wal_init_zero?: string & "on" | "off" | "true" | "false"' "${cue}"
     # guard against regression to any bool-kind participation for this GUC
     if grep -E 'wal_init_zero\?:.*bool' "${cue}"; then
       echo "wal_init_zero must not include a bool branch (BoolKind wins kind classification and breaks on/off)" >&2

--- a/addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh
@@ -1,39 +1,54 @@
 # shellcheck shell=bash
+# Contract: wal_init_zero must be a PURE STRING enum in CUE.
+# A bool|string disjunction is classified BoolType by the KubeBlocks CUE
+# visitor (BoolKind is checked before StringKind in IncompleteKind bitmask
+# order), which routes values through strconv.ParseBool and rejects
+# PostgreSQL's canonical on/off spelling — including the tpl default
+# `wal_init_zero = off`, which would then fail whole-rendered-file
+# validation on cluster creation and every reconfigure.
 
 Describe "PostgreSQL wal_init_zero configuration"
   assert_wal_init_zero_contract() {
     local major="$1"
+    local cue="../config/pg${major}-config-constraint.cue"
 
-    grep -Fq 'wal_init_zero?: (bool & (false | true)) | (string & ("on" | "off"))' "../config/pg${major}-config-constraint.cue"
+    # exact expected type: string enum accepting both PG and bool spellings
+    grep -Fq 'wal_init_zero?: string & ("on" | "off" | "true" | "false")' "${cue}"
+    # guard against regression to any bool-kind participation for this GUC
+    if grep -E 'wal_init_zero\?:.*bool' "${cue}"; then
+      echo "wal_init_zero must not include a bool branch (BoolKind wins kind classification and breaks on/off)" >&2
+      return 1
+    fi
+    # the tpl default uses PG spelling and must be inside the accepted enum
     grep -Fq 'wal_init_zero = off' "../config/pg${major}-config.tpl"
   }
 
-  It "keeps pg12 wal_init_zero compatible with bool and PostgreSQL on/off values"
+  It "keeps pg12 wal_init_zero a string enum accepting on/off/true/false"
     When call assert_wal_init_zero_contract 12
     The status should be success
   End
 
-  It "keeps pg14 wal_init_zero compatible with bool and PostgreSQL on/off values"
+  It "keeps pg14 wal_init_zero a string enum accepting on/off/true/false"
     When call assert_wal_init_zero_contract 14
     The status should be success
   End
 
-  It "keeps pg15 wal_init_zero compatible with bool and PostgreSQL on/off values"
+  It "keeps pg15 wal_init_zero a string enum accepting on/off/true/false"
     When call assert_wal_init_zero_contract 15
     The status should be success
   End
 
-  It "keeps pg16 wal_init_zero compatible with bool and PostgreSQL on/off values"
+  It "keeps pg16 wal_init_zero a string enum accepting on/off/true/false"
     When call assert_wal_init_zero_contract 16
     The status should be success
   End
 
-  It "keeps pg17 wal_init_zero compatible with bool and PostgreSQL on/off values"
+  It "keeps pg17 wal_init_zero a string enum accepting on/off/true/false"
     When call assert_wal_init_zero_contract 17
     The status should be success
   End
 
-  It "keeps pg18 wal_init_zero compatible with bool and PostgreSQL on/off values"
+  It "keeps pg18 wal_init_zero a string enum accepting on/off/true/false"
     When call assert_wal_init_zero_contract 18
     The status should be success
   End


### PR DESCRIPTION
## Problem

apecloud/apecloud#19428 reports that changing PostgreSQL `configuration.wal_init_zero` fails.

Dev evidence from the linked KBE issue:

- A fresh `postgresql-17` cluster accepted a direct KB OpsRequest with `wal_init_zero=on`; the ConfigMap changed to `wal_init_zero = on`, and runtime `SHOW wal_init_zero` returned `on`.
- The same cluster rejected a direct KB OpsRequest with `wal_init_zero=true` because the addon CUE constraint only allowed string `"on" | "off"`.

PostgreSQL official docs define `wal_init_zero` as a boolean parameter, and PostgreSQL boolean settings may be written as `on/off`, `true/false`, `yes/no`, or `1/0`.

## Fix

- Change `wal_init_zero` CUE constraints for PostgreSQL pg12/14/15/16/17/18 from string enum `"on" | "off"` to the existing addon boolean pattern: `bool & false | true`.
- Keep the default template value as `wal_init_zero = off`, which is a valid PostgreSQL boolean token and preserves existing rendered config behavior.
- Add a shellspec guard to keep all supported PostgreSQL majors aligned.

## Validation

- `shellspec --load-path ./shellspec --default-path addons/postgresql/scripts-ut-spec/wal_init_zero_spec.sh --shell bash`
- `shellspec --load-path ./shellspec --default-path addons/postgresql/scripts-ut-spec --shell bash`
- `helm dependency build addons/postgresql`
- `helm template pg addons/postgresql` and checked rendered ParametersDefinitions contain `wal_init_zero?: bool & false | true` while templates still render `wal_init_zero = off`.
- `git diff --check`

Related: apecloud/apecloud#19428
Replaces metadata-only attempt: apecloud/apecloud#19492
