### PR TITLE
fix(etcd): honor inject image pull policy

### DIFF
--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -13,7 +13,7 @@ spec:
   runtime:
     initContainers:
       - name: inject-bash
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         volumeMounts:
           - name: scripts
             mountPath: /scripts


### PR DESCRIPTION
## Summary

Fix the Helm `default` argument order so the etcd `inject-bash` init container honors `images.pullPolicy` while retaining `IfNotPresent` as the default.

Fixes #3125.

## Validation

```text
default policies:
  inject-bash: IfNotPresent
  etcd:        IfNotPresent

images.pullPolicy=Never,image.pullPolicy=Never:
  inject-bash: Never
  etcd:        Never
```

- `helm template addons/etcd --dependency-update` for default and explicit Never values
- `helm lint addons/etcd`: 1 chart linted, 0 failed

## Scope

One template expression only. No image reference, runtime command, lifecycle action, or backup/restore behavior changes.
