### PR TITLE
fix(falkordb): reuse shard container lifecycle image

### DIFF
--- a/addons/falkordb/scripts-ut-spec/sharding_lifecycle_image_contract_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/sharding_lifecycle_image_contract_spec.sh
@@ -34,7 +34,7 @@ Describe "FalkorDB sharding lifecycle image contract"
   }
   AfterEach 'cleanup_render'
 
-  It "runs shardRemove in the target container without a custom exec image"
+  It "shares FalkorDB container resources without a custom exec image"
     When call render_sharding_definition
     The status should be success
     The output should include "container: falkordb-cluster"

--- a/addons/falkordb/scripts-ut-spec/sharding_lifecycle_image_contract_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/sharding_lifecycle_image_contract_spec.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=sh
+
+Describe "FalkorDB sharding lifecycle image contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/falkordb" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  render_sharding_definition() {
+    tmp_render=$(mktemp -t falkordb-sharding-render-XXXXXX)
+    helm template test "$(chart_path)" >"$tmp_render" || return $?
+    awk '
+      capture && /^---$/ { exit }
+      $0 == "kind: ShardingDefinition" { capture = 1 }
+      capture { print }
+    ' "$tmp_render"
+  }
+
+  render_cluster_component_version() {
+    tmp_render=$(mktemp -t falkordb-cluster-version-render-XXXXXX)
+    helm template test "$(chart_path)" \
+      --show-only templates/cmpv-falkordb-cluster.yaml >"$tmp_render" || return $?
+    cat "$tmp_render"
+  }
+
+  cleanup_render() {
+    [ -n "${tmp_render:-}" ] && rm -f "$tmp_render" 2>/dev/null || true
+  }
+  AfterEach 'cleanup_render'
+
+  It "runs shardRemove in the target container without a custom exec image"
+    When call render_sharding_definition
+    The status should be success
+    The output should include "container: falkordb-cluster"
+    The output should not include "image:"
+  End
+
+  It "keeps lifecycle action images versioned by ComponentVersion"
+    When call render_cluster_component_version
+    The status should be success
+    The output should include "serviceVersion: 4.12.5"
+    The output should include "postProvision: docker.io/falkordb/falkordb:v4.12.5"
+    The output should include "serviceVersion: 4.14.12"
+    The output should include "postProvision: docker.io/falkordb/falkordb:v4.14.12"
+  End
+End

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -21,7 +21,6 @@ spec:
     shardRemove:
       timeoutSeconds: 600
       exec:
-        image: {{ include "falkordb4.image" . }}
         container: falkordb-cluster
         command:
           - /bin/bash


### PR DESCRIPTION
Closes #3128.

## Problem

FalkorDB sharded clusters using serviceVersion `4.14.12` fail before pod creation on KubeBlocks main:

```text
build kb-agent container failed: only one exec image is allowed in lifecycle actions
```

The ComponentVersion resolves ComponentDefinition lifecycle actions to `falkordb:v4.14.12`, while `ShardingDefinition.shardRemove.exec.image` is rendered from the chart default `falkordb4.image` (`v4.12.5`). KubeBlocks correctly rejects the two non-empty action images synthesized into one kb-agent container. The 4.12.5 path hid the defect because both values were equal.

## Change

Remove the redundant `shardRemove.exec.image`. KubeBlocks then reuses the ComponentVersion-resolved lifecycle image (`v4.14.12`) for kb-agent. The existing `container: falkordb-cluster` continues to share that container's mounts/resources with kb-agent; `ExecAction.Container` does not execute the action inside the named container.

Add a render contract test that proves:

- `shardRemove` shares the FalkorDB container contract and declares no custom image
- ComponentVersion keeps distinct versioned action images for 4.12.5 and 4.14.12

## TDD evidence

Before the chart edit, the new test failed on the rendered line:

```yaml
image: docker.io/falkordb/falkordb:v4.12.5
```

After the edit:

- focused ShellSpec: 2 examples, 0 failures
- full FalkorDB ShellSpec: 38 examples, 0 failures, 4 Bash-version skips
- `helm lint addons/falkordb`: PASS
- `helm template test addons/falkordb`: PASS
- `git diff --check`: PASS

Runtime validation on the dedicated vcluster will use this exact PR head before formal acceptance resumes.
