### PR TITLE
fix(oceanbase-ce): raise log archive destination timeout

### DIFF
--- a/addons/oceanbase-ce/dataprotection/backup.sh
+++ b/addons/oceanbase-ce/dataprotection/backup.sh
@@ -80,7 +80,8 @@ function prepareTenantLogArchive() {
   save_defer_archivelog_tenants "${tenant_id}"
   destUrl=$(getDestURL archive ${tenant_name} ${tenant_id})
   echo "INFO: prepare log archive dest for tenant ${tenant_name}"
-  result=`${mysql_cmd} "ALTER SYSTEM SET LOG_ARCHIVE_DEST=\"LOCATION=${destUrl}\" TENANT=${tenant_name};"`
+  # Allow remote storage validation to outlive the default 10s session timeout.
+  result=`${mysql_cmd} "SET SESSION ob_query_timeout=1000000000; ALTER SYSTEM SET LOG_ARCHIVE_DEST=\"LOCATION=${destUrl}\" TENANT=${tenant_name};"`
   if [[ $? -ne 0 ]];then
      echo "ERROR: alert log_archive_dest for tenant ${tenant_name} failed: ${result}"
      exit 1

--- a/addons/oceanbase-ce/scripts-ut-spec/backup_spec.sh
+++ b/addons/oceanbase-ce/scripts-ut-spec/backup_spec.sh
@@ -1,0 +1,25 @@
+# shellcheck shell=bash
+
+Describe "OceanBase CE backup SQL timeout scope"
+  backup_script="../dataprotection/backup.sh"
+
+  count_timeout_prefixed_sql() {
+    local statement="$1"
+    grep -Ec "SET SESSION ob_query_timeout=1000000000;[[:space:]]*ALTER SYSTEM SET ${statement}" "$backup_script" || true
+  }
+
+  It "raises the session timeout for LOG_ARCHIVE_DEST"
+    When call count_timeout_prefixed_sql 'LOG_ARCHIVE_DEST='
+    The output should eq "1"
+  End
+
+  It "does not broaden the timeout change to LOG_ARCHIVE_DEST_STATE"
+    When call count_timeout_prefixed_sql "LOG_ARCHIVE_DEST_STATE='ENABLE'"
+    The output should eq "0"
+  End
+
+  It "does not broaden the timeout change to DATA_BACKUP_DEST"
+    When call count_timeout_prefixed_sql 'DATA_BACKUP_DEST='
+    The output should eq "0"
+  End
+End


### PR DESCRIPTION
Closes #3127.

## Problem

In one isolated diagnostic scene, `ALTER SYSTEM SET LOG_ARCHIVE_DEST` returned OceanBase error 4012 under the default session `ob_query_timeout=10000000`. Repeating the same ALTER with the same redacted S3 URL after setting `ob_query_timeout=1000000000` succeeded once.

This is N=1 evidence for a narrowly scoped addon-script fix candidate. It does not establish a product-wide root cause.

## Change

- Set `ob_query_timeout=1000000000` in the same `obclient -e` session immediately before `ALTER SYSTEM SET LOG_ARCHIVE_DEST`.
- Do not change `LOG_ARCHIVE_DEST_STATE` or `DATA_BACKUP_DEST`.
- Add ShellSpec contract tests for the positive and two negative scope boundaries.

## Validation

- TDD red on the previous implementation: `3 examples, 1 failure`.
- Patched ShellSpec: `3 examples, 0 failures`.
- `bash -n`: PASS.
- `shellcheck --severity=error`: PASS.
- diff-check: PASS.
- `helm dependency build`, `helm lint`, and `helm template`: PASS.
- Focused peer review: ACCEPT; XP design-contract classes 1-8 checked with no blocker.
- Owner-side package reproducibility: two independent temporary package directories produced the same chart SHA; packaged `backup.sh` matched the source script SHA.

## Runtime boundary

No fixed-candidate runtime is counted yet. The prior diagnostic scene is control evidence only. After the exact packaged chart is deployed and the mounted script identity is verified, validation requires at least two fresh clean-cluster B02 success scenes.
