### PR TITLE
fix(redis): fail fast on PITR archive errors

### DIFF
--- a/addons/redis/dataprotection/pitr-backup.sh
+++ b/addons/redis/dataprotection/pitr-backup.sh
@@ -1,4 +1,6 @@
 # shellcheck shell=bash
+set -e -o pipefail
+
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
@@ -161,7 +163,7 @@ function purge_expired_files() {
   local current_unix=$(date +%s)
   info=$(DP_purge_expired_files ${current_unix} ${global_last_purge_time} / 600)
   if [ ! -z "${info}" ]; then
-    global_last_purge_time=${currentUnix}
+    global_last_purge_time=${current_unix}
     DP_log "Cleanup expired aof files: ${info}"
     local total_size=$(datasafed stat / | grep TotalSize | awk '{print $2}')
     DP_save_backup_status_info "${total_size}"

--- a/addons/redis/dataprotection/pitr-restore.sh
+++ b/addons/redis/dataprotection/pitr-restore.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=bash
+set -e -o pipefail
+
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
@@ -31,8 +34,8 @@ function get_files_to_restore() {
 
   local filename=$(datasafed list / | sort -Vr | awk -v rt="$restore_time" -F '.' '$1 <= rt {print; exit}')
   if [ -z "$filename" ]; then
-    DP_log "No backup found for the given restore time: $DP_RESTORE_TIME"
-    exit 0
+    DP_error_log "No backup found for the given restore time: $DP_RESTORE_TIME"
+    exit 1
   fi
 
   case "$filename" in
@@ -45,7 +48,8 @@ function get_files_to_restore() {
     datasafed pull -d zstd-fastest "${filename}" - | tar -xvf - -C "${DATA_DIR}/"
     ;;
   *)
-    DP_log "Unknown aof_file type: $filename"
+    DP_error_log "Unknown aof_file type: $filename"
+    exit 1
     ;;
   esac
 }

--- a/addons/redis/scripts-ut-spec/pitr_dataprotection_spec.sh
+++ b/addons/redis/scripts-ut-spec/pitr_dataprotection_spec.sh
@@ -1,0 +1,176 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "pitr_dataprotection_spec.sh skip all cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis PITR dataprotection scripts"
+  setup_pitr_env() {
+    PITR_REPO_ROOT=$(git rev-parse --show-toplevel)
+    PITR_TMP=$(mktemp -d)
+    PITR_WORKDIR="$PITR_TMP/work"
+    PITR_BIN="$PITR_TMP/bin"
+    PITR_DATASAFED_LOG="$PITR_TMP/datasafed.log"
+    PITR_RM_MARKER="$PITR_TMP/datasafed-rm.marker"
+
+    mkdir -p "$PITR_WORKDIR" "$PITR_BIN" "$PITR_TMP/data/appendonlydir"
+    export PATH="$PITR_BIN:$PATH"
+    export DATA_DIR="$PITR_TMP/data"
+    export DP_DATASAFED_BIN_PATH="$PITR_BIN"
+    export DP_BACKUP_BASE_PATH="/"
+    export DP_DB_HOST="127.0.0.1"
+    export DP_DB_PORT="6379"
+    export DP_DB_PASSWORD=""
+    export REDIS_CLI_TLS_CMD=""
+    export DP_BACKUP_INFO_FILE="$PITR_TMP/backup-info.json"
+    export LOG_ARCHIVE_SECONDS="600"
+    export DP_RESTORE_TIME="1970-01-01T00:20:00Z"
+    export PITR_DATASAFED_LOG PITR_RM_MARKER
+
+    cat >"$PITR_BIN/date" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-d" ]; then
+  case "$2" in
+    *00:20:00*) echo 1200 ;;
+    *) echo 2000 ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "+%s" ]; then
+  echo 2000
+  exit 0
+fi
+if [ "$1" = "-u" ]; then
+  echo "1970-01-01 00:00:00"
+  exit 0
+fi
+echo 2000
+EOF
+
+    cat >"$PITR_BIN/redis-cli" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *"CONFIG GET appenddirname"*) printf 'appenddirname\nappendonlydir\n' ;;
+  *"CONFIG GET appendfilename"*) printf 'appendfilename\nappendonly.aof\n' ;;
+  *"CONFIG GET aof-use-rdb-preamble"*) printf 'aof-use-rdb-preamble\nyes\n' ;;
+  *"CONFIG GET aof-timestamp-enabled"*) printf 'aof-timestamp-enabled\nyes\n' ;;
+  *"CONFIG GET aof-disable-auto-gc"*) printf 'aof-disable-auto-gc\nyes\n' ;;
+  *) echo "OK" ;;
+esac
+EOF
+
+    cat >"$PITR_BIN/redis-check-rdb" <<'EOF'
+#!/bin/sh
+echo "ctime '1000'"
+EOF
+
+    cat >"$PITR_BIN/datasafed" <<'EOF'
+#!/bin/sh
+case "$1" in
+  list)
+    case "$PITR_DATASAFED_LIST_MODE" in
+      tar) echo "1000.1.tar.zst" ;;
+      unknown) echo "1000.1.bad" ;;
+      *) : ;;
+    esac
+    ;;
+  push)
+    echo "push $*" >> "$PITR_DATASAFED_LOG"
+    exit "${PITR_PUSH_STATUS:-0}"
+    ;;
+  pull)
+    echo "pull $*" >> "$PITR_DATASAFED_LOG"
+    printf 'not-a-tar'
+    exit "${PITR_PULL_STATUS:-0}"
+    ;;
+  rm)
+    echo "rm $*" >> "$PITR_DATASAFED_LOG"
+    touch "$PITR_RM_MARKER"
+    ;;
+  stat)
+    echo "TotalSize 0"
+    ;;
+esac
+EOF
+
+    chmod +x "$PITR_BIN/date" "$PITR_BIN/redis-cli" "$PITR_BIN/redis-check-rdb" "$PITR_BIN/datasafed"
+  }
+
+  cleanup_pitr_env() {
+    rm -rf "$PITR_TMP"
+  }
+
+  BeforeEach "setup_pitr_env"
+  AfterEach "cleanup_pitr_env"
+
+  run_pitr_backup() {
+    (
+      cd "$PITR_WORKDIR" || exit 1
+      . "$PITR_REPO_ROOT/addons/redis/dataprotection/common-scripts.sh"
+      . "$PITR_REPO_ROOT/addons/redis/dataprotection/pitr-backup.sh"
+    )
+  }
+
+  run_pitr_restore() {
+    (
+      cd "$PITR_WORKDIR" || exit 1
+      . "$PITR_REPO_ROOT/addons/redis/dataprotection/common-scripts.sh"
+      . "$PITR_REPO_ROOT/addons/redis/dataprotection/pitr-restore.sh"
+    )
+  }
+
+  prepare_archive_pair() {
+    echo "file appendonly.aof.2.incr.aof seq 2 type i" > "$DATA_DIR/appendonlydir/appendonly.aof.manifest"
+    echo "base" > "$DATA_DIR/appendonlydir/appendonly.aof.1.base.rdb"
+    echo "incr" > "$DATA_DIR/appendonlydir/appendonly.aof.1.incr.aof"
+    echo "user default on nopass ~* +@all" > "$DATA_DIR/users.acl"
+    BACKUP_BASE_FILE="$DATA_DIR/appendonlydir/appendonly.aof.1.base.rdb"
+    BACKUP_INCR_FILE="$DATA_DIR/appendonlydir/appendonly.aof.1.incr.aof"
+    export PITR_DATASAFED_LIST_MODE="empty"
+    export PITR_PUSH_STATUS="42"
+  }
+
+  It "does not delete tracked PITR files when archive upload fails"
+    prepare_archive_pair
+
+    When run run_pitr_backup
+    The status should be failure
+    The stdout should include "INFO: start to backup"
+    The stderr should include "appendonly.aof.1.incr.aof"
+    The path "$BACKUP_BASE_FILE" should be exist
+    The path "$BACKUP_INCR_FILE" should be exist
+    The path "$PITR_RM_MARKER" should not be exist
+  End
+
+  It "fails restore when no PITR archive matches the requested restore time"
+    export PITR_DATASAFED_LIST_MODE="empty"
+
+    When run run_pitr_restore
+    The status should be failure
+    The output should include "ERROR: No backup found for the given restore time"
+    The path "$DATA_DIR/.kb-data-protection" should be exist
+    The output should not include "Restore complete."
+  End
+
+  It "fails restore when archive pull or extraction fails"
+    export PITR_DATASAFED_LIST_MODE="tar"
+    export PITR_PULL_STATUS="42"
+
+    When run run_pitr_restore
+    The status should be failure
+    The stderr should include "tar:"
+    The path "$DATA_DIR/.kb-data-protection" should be exist
+    The output should not include "Restore complete."
+  End
+
+  It "fails restore when the selected PITR object has an unknown type"
+    export PITR_DATASAFED_LIST_MODE="unknown"
+
+    When run run_pitr_restore
+    The status should be failure
+    The output should include "ERROR: Unknown aof_file type: 1000.1.bad"
+    The output should not include "Restore complete."
+  End
+End


### PR DESCRIPTION
## Summary

Fixes #3131.

This patch closes the Redis PITR fail-open paths reported in the static review:

- enable `set -e -o pipefail` in `pitr-backup.sh`, so failed `datasafed push` / archive pipelines stop before remote cleanup or local AOF/base-file deletion;
- enable `set -e -o pipefail` in `pitr-restore.sh`, so failed archive pull/extract exits non-zero;
- make restore return non-zero when no archive matches the requested restore time;
- make restore return non-zero for unknown PITR object types;
- fix the backup purge timestamp typo `currentUnix` -> `current_unix`;
- add focused Redis ShellSpec coverage for these failure contracts with stubbed `datasafed`/`redis-cli`/`redis-check-rdb`.

## Verification

Local checks:

```bash
bash -n addons/redis/dataprotection/pitr-backup.sh addons/redis/dataprotection/pitr-restore.sh addons/redis/scripts-ut-spec/pitr_dataprotection_spec.sh
shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/pitr_dataprotection_spec.sh
shellspec --load-path ./shellspec --shell bash addons/redis/scripts-ut-spec/pitr_dataprotection_spec.sh
git diff --check
```

Results:

- Bash 5 focused ShellSpec: 4 examples, 0 failures
- macOS Bash 3 default path: guarded skip, 0 examples, 0 failures
- `bash -n`: PASS
- `git diff --check`: PASS

Not run locally:

- `shellcheck`: unavailable on this machine (`shellcheck: command not found`)
- live Redis PITR runtime: not run yet; this PR remains draft pending CI and runtime acceptance

## Boundary

This PR only covers the PITR backup/restore fail-fast blocker. It does not address the separate sentinel fallback/split-brain blocker from the same review; that should be handled in a separate P0 PR.
