### PR TITLE
fix(redis): fail closed on sentinel restart without primary

### DIFF
--- a/addons/redis/scripts-ut-spec/redis5_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis5_start_spec.sh
@@ -531,5 +531,83 @@ Describe "Redis5 Start Bash Script Tests"
         The stdout should include "Error: Required environment variable SENTINEL_POD_FQDN_LIST is not set."
       End
     End
+
+    Context "when sentinel is configured but no sentinel returns primary info"
+      setup() {
+        export REDIS_DATA_DIR="./redis5-data"
+        export SENTINEL_COMPONENT_NAME="redis-sentinel"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.redis-sentinel-headless,sentinel-1.redis-sentinel-headless"
+        mkdir -p "$REDIS_DATA_DIR"
+        echo "persisted" > "$REDIS_DATA_DIR/dump.rdb"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset SENTINEL_COMPONENT_NAME
+        unset SENTINEL_POD_FQDN_LIST
+        unset REDIS_DATA_DIR
+        rm -rf ./redis5-data
+      }
+      After "un_setup"
+
+      It "fails closed instead of falling back to default primary when Redis data exists"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        getent() {
+          echo "10.0.0.1 $2"
+        }
+        retry_get_master_addr_by_name_from_sentinel() {
+          return 1
+        }
+        get_default_initialize_primary_node() {
+          echo "SHOULD_NOT_FALLBACK"
+        }
+        When run init_or_get_primary_from_redis_sentinel
+        The status should be failure
+        The stdout should include "Failed to retrieve primary info from sentinel: sentinel-0.redis-sentinel-headless"
+        The stdout should include "Failed to retrieve primary info from sentinel: sentinel-1.redis-sentinel-headless"
+        The stdout should include "Error: no primary node found from all redis sentinels and Redis data already exists; refusing to use default primary while sentinel is configured."
+        The stdout should not include "SHOULD_NOT_FALLBACK"
+      End
+    End
+
+    Context "when no sentinel returns primary info before first bootstrap"
+      setup() {
+        service_port="6379"
+        export REDIS_POD_NAME_LIST="redis-1,redis-0"
+        export REDIS_POD_FQDN_LIST="redis-1.redis-headless.default,redis-0.redis-headless.default"
+        export REDIS_DATA_DIR="./redis5-data-empty"
+        export SENTINEL_COMPONENT_NAME="redis-sentinel"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.redis-sentinel-headless"
+        mkdir -p "$REDIS_DATA_DIR"
+        echo "placeholder" > "$REDIS_DATA_DIR/users.acl"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset REDIS_POD_NAME_LIST
+        unset REDIS_POD_FQDN_LIST
+        unset REDIS_DATA_DIR
+        unset SENTINEL_COMPONENT_NAME
+        unset SENTINEL_POD_FQDN_LIST
+        unset service_port
+        rm -rf ./redis5-data-empty
+      }
+      After "un_setup"
+
+      It "allows default primary fallback for first bootstrap"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        getent() {
+          echo "10.0.0.1 $2"
+        }
+        retry_get_master_addr_by_name_from_sentinel() {
+          return 1
+        }
+        When call init_or_get_primary_from_redis_sentinel
+        The status should be success
+        The stdout should include "no primary node found from all redis sentinels and Redis data dir is empty, use default primary node for first bootstrap."
+        The variable primary should eq "redis-0.redis-headless.default"
+        The variable primary_port should eq "6379"
+      End
+    End
   End
 End

--- a/addons/redis/scripts-ut-spec/redis_start_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_start_spec.sh
@@ -586,36 +586,76 @@ Describe "Redis Start Bash Script Tests"
         # shellcheck disable=SC2034
         retry_delay_second=1
         export REDIS_POD_NAME_LIST="redis-1,redis-0"
+        export REDIS_POD_FQDN_LIST="redis-1.redis-headless.default,redis-0.redis-headless.default"
+        export REDIS_DATA_DIR="./redis-data"
         export SENTINEL_COMPONENT_NAME="redis-sentinel"
         export SENTINEL_POD_FQDN_LIST="sentinel-0.redis-sentinel-headless,sentinel-1.redis-sentinel-headless"
+        mkdir -p "$REDIS_DATA_DIR"
+        echo "persisted" > "$REDIS_DATA_DIR/dump.rdb"
       }
       Before "setup"
 
       un_setup() {
         unset SENTINEL_COMPONENT_NAME
         unset SENTINEL_POD_FQDN_LIST
+        unset REDIS_POD_NAME_LIST
+        unset REDIS_POD_FQDN_LIST
+        unset REDIS_DATA_DIR
+        rm -rf ./redis-data
       }
       After "un_setup"
 
-      It "handles empty primary info retrieved from sentinel"
+      It "fails closed instead of falling back to default primary when Redis data exists"
         Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
         build_sentinel_get_master_addr_by_name_command() {
           echo "echo ''"
         }
         get_default_initialize_primary_node() {
-          # shellcheck disable=SC2034
-          primary="fake-primary1"
-          # shellcheck disable=SC2034
-          primary_port="fake-primary-port1"
+          echo "SHOULD_NOT_FALLBACK"
+        }
+        When run init_or_get_primary_from_redis_sentinel
+        The status should be failure
+        The stdout should include "Empty primary info retrieved from sentinel"
+        The stdout should include "Failed to retrieve primary info from sentinel: sentinel-1.redis-sentinel-headless"
+        The stdout should include "Error: no primary node found from all redis sentinels and Redis data already exists; refusing to use default primary while sentinel is configured."
+        The stdout should not include "SHOULD_NOT_FALLBACK"
+        The stderr should include "Function 'get_master_addr_by_name_from_sentinel' failed after 1 retries"
+      End
+    End
+
+    Context "when no sentinel returns primary info before first bootstrap"
+      setup() {
+        export REDIS_POD_NAME_LIST="redis-1,redis-0"
+        export REDIS_POD_FQDN_LIST="redis-1.redis-headless.default,redis-0.redis-headless.default"
+        export REDIS_DATA_DIR="./redis-data-empty"
+        export SENTINEL_COMPONENT_NAME="redis-sentinel"
+        export SENTINEL_POD_FQDN_LIST="sentinel-0.redis-sentinel-headless"
+        mkdir -p "$REDIS_DATA_DIR"
+        echo "user default on" > "$REDIS_DATA_DIR/users.acl"
+      }
+      Before "setup"
+
+      un_setup() {
+        unset SENTINEL_COMPONENT_NAME
+        unset SENTINEL_POD_FQDN_LIST
+        unset REDIS_POD_NAME_LIST
+        unset REDIS_POD_FQDN_LIST
+        unset REDIS_DATA_DIR
+        rm -rf ./redis-data-empty
+      }
+      After "un_setup"
+
+      It "allows default primary fallback for first bootstrap"
+        Skip if "shell type and version unmatch, please check!" should_skip_when_shell_type_and_version_invalid
+        build_sentinel_get_master_addr_by_name_command() {
+          echo "echo ''"
         }
         When call init_or_get_primary_from_redis_sentinel
         The status should be success
-        The stdout should include "Empty primary info retrieved from sentinel"
-        The stdout should include "Failed to retrieve primary info from sentinel: sentinel-1.redis-sentinel-headless"
-        The stdout should include "no primary node found from all redis sentinels, use default primary node."
-        The stderr should include "Function 'get_master_addr_by_name_from_sentinel' failed after 1 retries"
-        The variable primary should eq "fake-primary1"
-        The variable primary_port should eq "fake-primary-port1"
+        The stdout should include "no primary node found from all redis sentinels and Redis data dir is empty, use default primary node for first bootstrap."
+        The stderr should include "Function 'get_master_addr_by_name_from_sentinel' failed after 3 retries"
+        The variable primary should eq "redis-0.redis-headless.default"
+        The variable primary_port should eq "6379"
       End
     End
   End

--- a/addons/redis/scripts/redis-start.sh
+++ b/addons/redis/scripts/redis-start.sh
@@ -190,10 +190,15 @@ init_or_get_primary_from_redis_sentinel() {
     fi
   done
 
-  # if there is no primary node found, use the default primary node
+  # if sentinel is configured but no sentinel can provide primary info, only
+  # allow default-primary fallback before Redis has persisted data.
   echo "get all primary info from redis sentinel master_count_map: ${master_count_map[*]}"
   if [ ${#master_count_map[@]} -eq 0 ]; then
-    echo "no primary node found from all redis sentinels, use default primary node."
+    if redis_data_dir_has_existing_data; then
+      echo "Error: no primary node found from all redis sentinels and Redis data already exists; refusing to use default primary while sentinel is configured."
+      exit 1
+    fi
+    echo "no primary node found from all redis sentinels and Redis data dir is empty, use default primary node for first bootstrap."
     get_default_initialize_primary_node
     return
   fi
@@ -207,6 +212,20 @@ init_or_get_primary_from_redis_sentinel() {
       primary_port=$(echo $host_port | cut -d: -f2)
     fi
   done
+}
+
+redis_data_dir_has_existing_data() {
+  local data_dir="${REDIS_DATA_DIR:-/data}"
+  local existing_data
+
+  [ -d "$data_dir" ] || return 1
+  existing_data=$(find "$data_dir" -mindepth 1 -maxdepth 1 \
+    ! -name "users.acl" \
+    ! -name "users.acl.bak" \
+    ! -name ".fixed_pod_ip_enabled" \
+    ! -name ".kb_redis_start_initialized" \
+    -print -quit 2>/dev/null)
+  [ -n "$existing_data" ]
 }
 
 build_sentinel_get_master_addr_by_name_command() {

--- a/addons/redis/scripts/redis5-start.sh
+++ b/addons/redis/scripts/redis5-start.sh
@@ -156,10 +156,15 @@ init_or_get_primary_from_redis_sentinel() {
     fi
   done
 
-  # if there is no primary node found, use the default primary node
+  # if sentinel is configured but no sentinel can provide primary info, only
+  # allow default-primary fallback before Redis has persisted data.
   echo "get all primary info from redis sentinel master_count_map: ${master_count_map[*]}"
   if [ ${#master_count_map[@]} -eq 0 ]; then
-    echo "no primary node found from all redis sentinels, use default primary node."
+    if redis_data_dir_has_existing_data; then
+      echo "Error: no primary node found from all redis sentinels and Redis data already exists; refusing to use default primary while sentinel is configured."
+      exit 1
+    fi
+    echo "no primary node found from all redis sentinels and Redis data dir is empty, use default primary node for first bootstrap."
     get_default_initialize_primary_node
     return
   fi
@@ -173,6 +178,20 @@ init_or_get_primary_from_redis_sentinel() {
       primary_port=$(echo $host_port | cut -d: -f2)
     fi
   done
+}
+
+redis_data_dir_has_existing_data() {
+  local data_dir="${REDIS_DATA_DIR:-/data}"
+  local existing_data
+
+  [ -d "$data_dir" ] || return 1
+  existing_data=$(find "$data_dir" -mindepth 1 -maxdepth 1 \
+    ! -name "users.acl" \
+    ! -name "users.acl.bak" \
+    ! -name ".fixed_pod_ip_enabled" \
+    ! -name ".kb_redis_start_initialized" \
+    -print -quit 2>/dev/null)
+  [ -n "$existing_data" ]
 }
 
 build_sentinel_get_master_addr_by_name_command() {


### PR DESCRIPTION
## Summary

Fixes #3133.

This patch closes the Redis sentinel fallback blocker while preserving first-bootstrap behavior:

- when Sentinel is configured but no Sentinel returns primary info, startup now checks whether Redis already has persisted data;
- if persisted Redis data exists, startup exits non-zero instead of falling back to the default/min-lexicographical primary;
- if the Redis data directory has no persisted Redis data, startup may still use the default primary for first bootstrap;
- applies the same contract to Redis 6/7 `redis-start.sh` and Redis 5 `redis5-start.sh`;
- adds focused ShellSpec coverage for restart/data-present fail-closed and first-bootstrap/data-empty fallback cases.

## Verification

Local checks:

```bash
bash -n addons/redis/scripts/redis-start.sh addons/redis/scripts/redis5-start.sh addons/redis/scripts-ut-spec/redis_start_spec.sh addons/redis/scripts-ut-spec/redis5_start_spec.sh
shellspec --load-path ./shellspec --shell /opt/homebrew/bin/bash addons/redis/scripts-ut-spec/redis_start_spec.sh addons/redis/scripts-ut-spec/redis5_start_spec.sh
shellspec --load-path ./shellspec --shell bash addons/redis/scripts-ut-spec/redis_start_spec.sh addons/redis/scripts-ut-spec/redis5_start_spec.sh
git diff --check
```

Results:

- Bash 5 focused ShellSpec: 72 examples, 0 failures
- macOS Bash 3 default path: 72 examples, 0 failures, 11 guarded skips
- `bash -n`: PASS
- `git diff --check`: PASS

Not run locally:

- `shellcheck`: unavailable on this machine (`shellcheck: command not found`)
- live sentinel restart runtime: not run yet; this PR remains draft pending CI and runtime acceptance

## Boundary

This PR only covers the sentinel fallback/split-brain blocker. The PITR backup/restore fail-fast blocker is handled separately in #3132.

Testing handoff boundary per #all direction: Redis dev side specifies the contract and focused test scenario here; Redis test owner should execute runtime validation and collect pod/log/evidence artifacts against this exact head.
