### PR TITLE
fix(redis): remove stray spaces in redis-cluster exporter TLS address

### DIFF
--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -353,7 +353,7 @@ spec:
       expression: {{ `{{if index . "REDIS_CLUSTER_HOST_NETWORK_PORT"}}{{.REDIS_CLUSTER_HOST_NETWORK_PORT}}{{else}}{{.SERVICE_PORT}}{{end}}` | toYaml }}
     - name: REDIS_METRICS_ADDR
       value: "redis://localhost:$(SERVICE_PORT)"
-      expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}rediss://localhost: {{.SERVICE_PORT }}{{else}}redis://localhost:{{.SERVICE_PORT}}{{end}}` | toYaml }}
+      expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}rediss://localhost:{{.SERVICE_PORT}}{{else}}redis://localhost:{{.SERVICE_PORT}}{{end}}` | toYaml }}
     - name: REDIS_CLI_TLS_CMD
       value: ""
       expression: {{ `{{if eq (index . "TLS_ENABLED") "true"}}--tls --insecure{{else }}{{end}}` | toYaml }}


### PR DESCRIPTION
## Problem (from Helios redis master-head review, major)

`cmpd-redis-cluster.yaml` REDIS_METRICS_ADDR expression renders `rediss://localhost: <port>` (space after the colon, and before the closing brace) when `TLS_ENABLED=true`. The metrics container consumes it as `REDIS_ADDR`, so on **every TLS-enabled redis-cluster** the exporter fails to parse/connect and metrics silently flatline.

The replication cmpd (`cmpd-redis.yaml:255`) has the correct spacing, confirming this is a copy-edit typo, not intent.

## Fix

Remove the two stray spaces so the TLS branch matches the non-TLS branch and the replication cmpd. 1-line change.

## Validation

`helm lint addons/redis` PASS (after `helm dependency build`); `helm template` renders `rediss://localhost:{{.SERVICE_PORT}}` with no space.

Draft — pending redis team regression on master + this PR (metrics scrape on a TLS-enabled redis-cluster). Filed at @westonnnn's direction as part of the redis review handoff.