### PR TITLE
fix(redis): gate skip-immutable-check behind a values flag (default off)

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -30,7 +30,9 @@ Common annotations
 {{- define "redis.annotations" -}}
 {{ include "kblib.helm.resourcePolicy" . }}
 {{ include "redis.apiVersion" . }}
+{{- if .Values.skipComponentDefImmutableCheck }}
 apps.kubeblocks.io/skip-immutable-check: "true"
+{{- end }}
 {{- end }}
 
 {{/*

--- a/addons/redis/values.yaml
+++ b/addons/redis/values.yaml
@@ -6,6 +6,12 @@ nameOverride: ""
 
 fullnameOverride: ""
 
+## @param skipComponentDefImmutableCheck sets apps.kubeblocks.io/skip-immutable-check on the
+## redis ComponentDefinitions, which disables KubeBlocks' immutability protection so a chart
+## upgrade may mutate a ComponentDefinition that running clusters reference. Only enable this
+## for controlled dev/iteration; it must stay false for shipped installs.
+skipComponentDefImmutableCheck: false
+
 ## @param compDefinitionVersion for each ComponentDefinition resources name created by this chart, that can avoid name conflict
 ## If specified, the component definition will use it as prefix.
 cmpdVersionPrefix:


### PR DESCRIPTION
## Problem (from Helios redis master-head review, major)

`redis.annotations` (`_helpers.tpl`) unconditionally sets `apps.kubeblocks.io/skip-immutable-check: "true"` on **all four** redis ComponentDefinitions (redis, sentinel, cluster, twemproxy). This permanently disables the KubeBlocks immutability guard on in-use ComponentDefinitions: a `helm upgrade` of the same chart version that changes `runtime`/`vars`/`roles` can mutate a ComponentDefinition that running clusters reference, with no admission error — pods later re-render against a definition their scripts/data layout were not provisioned for.

Same shape as the ride-along I blocked in the mysql addon (PR #3117 review).

## Fix

Gate the annotation behind a new `skipComponentDefImmutableCheck` values flag, **default false**. Shipped installs get immutability protection back; controlled dev/iteration can opt in with `--set skipComponentDefImmutableCheck=true`.

## Validation

- default (false): `helm template` → 0 `skip-immutable-check` annotations.
- `--set skipComponentDefImmutableCheck=true`: annotation present on all cmpds (23 occurrences).
- `helm lint` PASS.

Draft — pending redis team regression on master + this PR. Filed at @westonnnn's direction as part of the redis review handoff.