### PR TITLE
fix(redis): capture redis-cli exit code before the xtrace helper (cluster)

### DIFF
--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -125,8 +125,8 @@ check_redis_server_ready() {
   fi
   logging_check_ready_cmd=${check_ready_cmd/$REDIS_DEFAULT_PASSWORD/********}
   output=$($check_ready_cmd)
-  set_xtrace_when_ut_mode_false
   status=$?
+  set_xtrace_when_ut_mode_false
   if [ $status -ne 0 ] || [ "$output" != "PONG" ] ; then
     echo "Failed to execute the check ready command: $logging_check_ready_cmd" >&2
     return 1
@@ -219,8 +219,8 @@ get_cluster_info() {
     command="redis-cli $REDIS_CLI_TLS_CMD -h $cluster_node -p $cluster_node_port -a $REDIS_DEFAULT_PASSWORD cluster info"
   fi
   cluster_info=$($command)
-  set_xtrace_when_ut_mode_false
   status=$?
+  set_xtrace_when_ut_mode_false
   if [ $status -ne 0 ]; then
     echo "Failed to execute the get cluster info command" >&2
     return 1
@@ -238,8 +238,8 @@ get_cluster_nodes_info() {
     command="redis-cli $REDIS_CLI_TLS_CMD -h $cluster_node -p $cluster_node_port -a $REDIS_DEFAULT_PASSWORD cluster nodes"
   fi
   cluster_nodes_info=$($command)
-  set_xtrace_when_ut_mode_false
   status=$?
+  set_xtrace_when_ut_mode_false
   if [ $status -ne 0 ]; then
     echo "Failed to execute the get cluster nodes info command" >&2
     return 1

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1528,6 +1528,14 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 0
       }
 
+      # Isolate the scale-out failure path from the redis-cli-dependent ACL
+      # prerequisite (mirrors the sibling Context above). Previously this ran
+      # unmocked and only "passed" because get_cluster_info masked its exit
+      # code; with the masking fixed, sync_acl correctly fails without redis-cli.
+      sync_acl_for_redis_cluster_shard() {
+        return 0
+      }
+
       scale_out_redis_cluster_shard() {
         return 1
       }


### PR DESCRIPTION
## Problem (from Helios redis master-head review — blocker-class)

In `redis-cluster-scripts/redis-cluster-common.sh`, `get_redis_cluster_ping` / `get_cluster_info` / `get_cluster_nodes_info` do:
```sh
cluster_nodes_info=$($command)
set_xtrace_when_ut_mode_false   # a plain helper that always returns 0
status=$?                       # <- captures the helper's rc, not redis-cli's
if [ $status -ne 0 ]; then ...
```
So on any redis-cli failure (connection refused, LOADING, auth error) these functions return **rc=0 with empty stdout**, defeating every `*_with_retry` wrapper. Most dangerous cascade: in `redis-cluster-replica-member-leave.sh`, empty cluster-nodes output is read as "only one line, nothing to remove" → **memberLeave exits 0 without issuing `CLUSTER FORGET`**, leaving a permanent `fail` entry in every node's table (and a later pod-name reuse collides with it).

## Fix

Move `status=$?` to immediately after each command substitution, before the xtrace helper, so the real exit code drives the checks. 3 sites, 3-line reorder.

## Validation

`bash -n` PASS. The change only makes the existing `if [ $status -ne 0 ]` guards actually fire on failure; success-path behavior is unchanged. Local note: this checkout's ShellSpec harness (`spec_helper`) isn't set up, so I did not run the unit specs locally — **CI should run `redis_cluster_common_spec.sh` + the member-leave spec** to confirm.

Draft — pending redis team regression on master + this PR (a focused case: make cluster-info/nodes fail and assert the retry wrappers now retry / member-leave fails closed instead of silently exiting 0). Filed at @westonnnn's direction as part of the redis review handoff.