### PR TITLE
fix(redis): fail closed in sync_acl when no shard pod is a valid ACL source

### DIFF
--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -926,8 +926,19 @@ sync_acl_for_redis_cluster_shard() {
       continue
     fi
     cluster_state=$(echo "$cluster_info" | awk -F: '/cluster_state/{print $2}' | tr -d '[:space:]')
-    if is_empty "$cluster_state" || equals "$cluster_state" "ok"; then
+    # Only trust a pod whose cluster_state is explicitly "ok". An empty
+    # cluster_state means the state could not be determined (parse anomaly or
+    # an unreachable pod) and must be skipped, not accepted as a source of
+    # truth for ACL rules.
+    if equals "$cluster_state" "ok"; then
        acl_list=$($redis_base_cmd -p $pod_service_port -h "$pod_fqdn" ACL LIST)
+       # ACL LIST must succeed before this pod is treated as the sync source;
+       # a failed command (e.g. connection blip) must not be mistaken for
+       # "no ACL rules to sync".
+       if [ $? -ne 0 ]; then
+         acl_list=""
+         continue
+       fi
        is_ok=true
        break
     fi

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
@@ -921,8 +921,19 @@ sync_acl_for_redis_cluster_shard() {
       continue
     fi
     cluster_state=$(echo "$cluster_info" | awk -F: '/cluster_state/{print $2}' | tr -d '[:space:]')
-    if is_empty "$cluster_state" || equals "$cluster_state" "ok"; then
+    # Only trust a pod whose cluster_state is explicitly "ok". An empty
+    # cluster_state means the state could not be determined (parse anomaly or
+    # an unreachable pod) and must be skipped, not accepted as a source of
+    # truth for ACL rules.
+    if equals "$cluster_state" "ok"; then
        acl_list=$($redis_base_cmd -p $pod_service_port -h "$pod_fqdn" ACL LIST)
+       # ACL LIST must succeed before this pod is treated as the sync source;
+       # a failed command (e.g. connection blip) must not be mistaken for
+       # "no ACL rules to sync".
+       if [ $? -ne 0 ]; then
+         acl_list=""
+         continue
+       fi
        is_ok=true
        break
     fi

--- a/addons/redis/scripts-ut-spec/redis_cluster6_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster6_manage_spec.sh
@@ -197,4 +197,81 @@ Describe "Redis Cluster6 Manage Script Tests"
       End
     End
   End
+
+  Describe "sync_acl_for_redis_cluster_shard() (Redis 6)"
+    # Contract mirrors redis_cluster_manage_spec.sh: only a pod reporting
+    # cluster_state "ok" with a successful ACL LIST may be trusted; otherwise
+    # fail closed instead of silently skipping ACL sync (which would leave a
+    # scaled-out Redis 6 shard without the cluster's custom ACL users).
+    get_pod_service_port_by_network_mode() {
+      echo "6379"
+    }
+
+    setup_sync_acl() {
+      export KB_CLUSTER_POD_FQDN_LIST="src-0,src-1"
+      export CURRENT_SHARD_POD_FQDN_LIST="dst-0"
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD=""
+    }
+    Before "setup_sync_acl"
+
+    un_setup_sync_acl() {
+      unset KB_CLUSTER_POD_FQDN_LIST CURRENT_SHARD_POD_FQDN_LIST SERVICE_PORT REDIS_DEFAULT_PASSWORD
+    }
+    After "un_setup_sync_acl"
+
+    Context "when reachable pods never report cluster_state ok"
+      get_cluster_info_with_retry() {
+        echo ""
+        return 0
+      }
+
+      It "fails closed instead of silently skipping ACL sync"
+        When run sync_acl_for_redis_cluster_shard
+        The status should be failure
+        The stdout should include "Sync ACL rules for redis cluster shard..."
+        The stderr should include "Failed to get ACL LIST from other shard pods"
+      End
+    End
+
+    Context "when the source pod is ok but ACL LIST fails"
+      get_cluster_info_with_retry() {
+        printf 'cluster_state:ok\n'
+        return 0
+      }
+      redis-cli() {
+        case "$*" in
+          *"ACL LIST"*) return 1 ;;
+          *) echo "OK" ;;
+        esac
+      }
+
+      It "does not treat a failed ACL LIST as 'no rules'; fails closed"
+        When run sync_acl_for_redis_cluster_shard
+        The status should be failure
+        The stdout should include "Sync ACL rules for redis cluster shard..."
+        The stderr should include "Failed to get ACL LIST from other shard pods"
+      End
+    End
+
+    Context "when a source pod returns ACL rules (happy path)"
+      get_cluster_info_with_retry() {
+        printf 'cluster_state:ok\n'
+        return 0
+      }
+      redis-cli() {
+        case "$*" in
+          *"ACL LIST"*) printf 'user default on nopass ~* +@all\nuser appuser on >secret ~* +@all\n' ;;
+          *) echo "OK" ;;
+        esac
+      }
+
+      It "syncs non-default ACL users without failing"
+        When run sync_acl_for_redis_cluster_shard
+        The status should be success
+        The stdout should include "Sync ACL rules for redis cluster shard..."
+        The stderr should not include "Failed to get ACL LIST from other shard pods"
+      End
+    End
+  End
 End

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1528,6 +1528,13 @@ Describe "Redis Cluster Manage Bash Script Tests"
         return 0
       }
 
+      # Isolate the scale-out failure path from the redis-cli-dependent ACL
+      # prerequisite (mirrors the sibling Context above). sync_acl now fails
+      # closed without redis-cli, so it must be mocked to reach scale-out.
+      sync_acl_for_redis_cluster_shard() {
+        return 0
+      }
+
       scale_out_redis_cluster_shard() {
         return 1
       }
@@ -1547,6 +1554,83 @@ Describe "Redis Cluster Manage Bash Script Tests"
         The status should be failure
         The stderr should include "Failed to scale out Redis Cluster shard"
         The stdout should include "Redis Cluster already initialized, scaling out the shard..."
+      End
+    End
+  End
+
+  Describe "sync_acl_for_redis_cluster_shard()"
+    # Contract: only a pod that reports cluster_state "ok" AND returns a
+    # successful ACL LIST may be trusted as the sync source; otherwise the
+    # action must fail closed rather than silently skip ACL synchronization.
+    get_pod_service_port_by_network_mode() {
+      echo "6379"
+    }
+
+    setup_sync_acl() {
+      export KB_CLUSTER_POD_FQDN_LIST="src-0,src-1"
+      export CURRENT_SHARD_POD_FQDN_LIST="dst-0"
+      export SERVICE_PORT="6379"
+      export REDIS_DEFAULT_PASSWORD=""
+    }
+    Before "setup_sync_acl"
+
+    un_setup_sync_acl() {
+      unset KB_CLUSTER_POD_FQDN_LIST CURRENT_SHARD_POD_FQDN_LIST SERVICE_PORT REDIS_DEFAULT_PASSWORD
+    }
+    After "un_setup_sync_acl"
+
+    Context "when reachable pods never report cluster_state ok"
+      get_cluster_info_with_retry() {
+        # reachable (rc 0) but empty/undetermined state
+        echo ""
+        return 0
+      }
+
+      It "fails closed instead of silently skipping ACL sync"
+        When run sync_acl_for_redis_cluster_shard
+        The status should be failure
+        The stderr should include "Failed to get ACL LIST from other shard pods"
+        The stdout should include "Sync ACL rules for redis cluster shard..."
+      End
+    End
+
+    Context "when the source pod is ok but ACL LIST fails"
+      get_cluster_info_with_retry() {
+        printf 'cluster_state:ok\n'
+        return 0
+      }
+      redis-cli() {
+        case "$*" in
+          *"ACL LIST"*) return 1 ;;
+          *) echo "OK" ;;
+        esac
+      }
+
+      It "does not treat a failed ACL LIST as 'no rules'; fails closed"
+        When run sync_acl_for_redis_cluster_shard
+        The status should be failure
+        The stdout should include "Sync ACL rules for redis cluster shard..."
+        The stderr should include "Failed to get ACL LIST from other shard pods"
+      End
+    End
+
+    Context "when a source pod returns ACL rules (happy path)"
+      get_cluster_info_with_retry() {
+        printf 'cluster_state:ok\n'
+        return 0
+      }
+      redis-cli() {
+        case "$*" in
+          *"ACL LIST"*) printf 'user default on nopass ~* +@all\nuser appuser on >secret ~* +@all\n' ;;
+          *) echo "OK" ;;
+        esac
+      }
+
+      It "syncs non-default ACL users without failing"
+        When run sync_acl_for_redis_cluster_shard
+        The status should be success
+        The stdout should include "Sync ACL rules for redis cluster shard..."
+        The stderr should not include "Failed to get ACL LIST from other shard pods"
       End
     End
   End


### PR DESCRIPTION
Closes #3138. From the Helios redis master-head review (P1, same-source as the #3137 exit-code masking, scoped separately per @Maya).

## Problem

`sync_acl_for_redis_cluster_shard` could report success while **skipping** ACL synchronization, so a scaled-out shard ends up without the cluster's custom ACL users → apps authenticating as a non-default user hit `NOPERM`/`WRONGPASS` on the new shard's slots. Two false-success paths:
1. `redis-cluster-manage.sh:929` accepted an **empty** `cluster_state` as `ok`.
2. `:930-931` set `is_ok=true` without checking `ACL LIST`'s exit code — a failed `ACL LIST` → empty result → downstream "No ACL rules found, skip" → return 0.

## Fix

- Trust only an explicit `cluster_state == "ok"` (drop the `is_empty` acceptance).
- Check `ACL LIST` rc; only `is_ok=true` on success, else continue → the existing fail-closed `exit 1` "Failed to get ACL LIST from other shard pods" fires when no pod qualifies.

## Tests

Adds a `sync_acl_for_redis_cluster_shard()` Describe with 3 contract cases: reachable-but-not-ok fails closed; `ACL LIST` rc!=0 fails closed; happy path still syncs non-default users. Also mocks `sync_acl` in the existing "failed to scale out" Context (that case previously passed only because sync_acl silently skipped).

Local validation on bash 5.3: `redis_cluster_manage_spec.sh` **48 examples, 0 failures**; `bash -n` PASS; `helm lint` PASS.

## Overlap note

The scale-out-failure spec mock here is the same isolation as **PR #3137** (both fixes independently make `sync_acl` fail closed in that unmocked test). If #3137 lands first, that one-block change dedupes trivially on rebase.

Draft + `nopick`. Runtime not required per @Maya's guidance until code+CI green. Filed at @westonnnn's direction as part of the redis review handoff.
