### PR TITLE
fix(postgresql): PITR restore retry re-stages and re-runs instead of un-staging a completed restore

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -4,9 +4,13 @@ export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 if [[ -d ${DATA_DIR}.old ]] && [[ ! -d ${DATA_DIR} ]]; then
-  # if dataDir.old exists but dataDir not exits, retry it
+  # A previous run already completed the final staging mv. Un-staging and
+  # exiting 0 here (the old behavior) left a populated DATA_DIR carrying
+  # recovery.signal but no bootstrap: Patroni adopted the directory and
+  # postgres crash-looped on a missing restore_command. Move the data back
+  # and RE-RUN the whole preparation instead — the WAL re-fetch and config
+  # rewrite below are idempotent and the script ends by staging again.
   mv ${DATA_DIR}.old ${DATA_DIR}
-  exit 0;
 fi
 
 mkdir -p ${PITR_DIR};

--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # use datasafed and default config
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"


### PR DESCRIPTION
Fixes #3119.

The retry branch moved a completed restore's data back out of `.old` and exited 0, leaving a populated `DATA_DIR` with `recovery.signal` but no bootstrap — Patroni adopted the directory and postgres crash-looped on a missing `restore_command`. The branch now moves the data back and lets the whole preparation re-run (WAL re-fetch and config rewrite are idempotent), ending staged again.

Sandbox verification (stubbed fetch-wal-log/DP_log): from the completed state (.old populated, DATA_DIR absent) the script re-runs end-to-end and finishes re-staged (.old populated, recovery.conf + kb_restore.sh regenerated), rc=0.

Draft until runtime-tested per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)