### PR TITLE
fix(postgresql): pgdumpall restore fails on non-conflict SQL errors instead of reporting success

### DIFF
--- a/addons/postgresql/dataprotection/pgdumpall-restore.sh
+++ b/addons/postgresql/dataprotection/pgdumpall-restore.sh
@@ -15,7 +15,24 @@ function remote_file_exists() {
 }
 
 if [ $(remote_file_exists "${DP_BACKUP_NAME}.sql.zst") == "true" ]; then
-  datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.sql.zst" - | psql -U ${DP_DB_USER} -h ${DP_DB_HOST} -p ${DP_DB_PORT}
+  # psql exits 0 even when individual statements fail (so set -e/pipefail
+  # never fire), and a restore that silently skipped databases or roles was
+  # reported Succeeded. Plain ON_ERROR_STOP=1 is not usable either: a
+  # pg_dumpall script legitimately conflicts with pre-provisioned objects
+  # (e.g. `role "postgres" already exists`). Capture stderr and fail on any
+  # SQL error that is not a benign already-exists conflict.
+  errlog="$(mktemp)"
+  if ! datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.sql.zst" - \
+      | psql -U ${DP_DB_USER} -h ${DP_DB_HOST} -p ${DP_DB_PORT} 2>"${errlog}"; then
+    cat "${errlog}" >&2
+    echo "ERROR: pgdumpall restore pipeline failed" >&2
+    exit 1
+  fi
+  cat "${errlog}" >&2
+  if grep "^ERROR:" "${errlog}" | grep -vE "already exists" | grep -q .; then
+    echo "ERROR: pgdumpall restore hit non-conflict SQL errors (see above); data may be partially restored" >&2
+    exit 1
+  fi
   echo "restore complete!";
   exit 0
 fi


### PR DESCRIPTION
Fixes #3122.

psql exits 0 even when individual statements fail, so a restore that silently skipped databases or roles was marked Succeeded. Plain `ON_ERROR_STOP=1` is not usable here: a pg_dumpall script legitimately conflicts with pre-provisioned objects (e.g. `role "postgres" already exists` — KB provisions system accounts before restore). The restore now captures psql stderr, replays it to the job log, and fails when any `ERROR:` line is not a benign already-exists conflict; a hard pipeline failure also fails the job with the log attached.

Sandbox verification (stubbed datasafed/psql): benign-conflict-only stderr → rc 0; mixed with a real error (`relation does not exist`) → rc 1 with the classification message.

Draft until runtime-tested per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)