### PR TITLE
fix(postgresql): postgres-setup.sh hardening — pending-restart starvation, standby DR auth, config-generation fail-closed

### DIFF
--- a/addons/postgresql/scripts-ut-spec/postgres_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/postgres_setup_spec.sh
@@ -117,7 +117,7 @@ Describe "PostgreSQL Initialization Script Tests"
     End
   End
 
-  Describe "need_restart_for_pending()"
+  Describe "pending restart candidate selection"
     setup() {
       CURRENT_POD_NAME="pg-cluster-postgresql-0"
     }
@@ -128,23 +128,44 @@ Describe "PostgreSQL Initialization Script Tests"
     }
     After 'un_setup'
 
-    It "restarts when pending and no leader is pending"
-      When call need_restart_for_pending "true" ""
+    It "selects a pending leader before replicas"
+      cluster_state='{"members":[{"name":"pg-cluster-postgresql-2","role":"replica","state":"streaming","pending_restart":true},{"name":"pg-cluster-postgresql-0","role":"leader","state":"running","pending_restart":true},{"name":"pg-cluster-postgresql-1","role":"replica","state":"streaming","pending_restart":true}]}'
+      When call pending_restart_candidate "$cluster_state"
+      The output should equal "pg-cluster-postgresql-0"
       The status should be success
     End
 
-    It "restarts when pending and the pending leader is the current pod"
+    It "selects one pending replica by stable member name order"
+      cluster_state='{"members":[{"name":"pg-cluster-postgresql-2","role":"replica","state":"streaming","pending_restart":true},{"name":"pg-cluster-postgresql-0","role":"leader","state":"running","pending_restart":false},{"name":"pg-cluster-postgresql-1","role":"replica","state":"streaming","pending_restart":true}]}'
+      When call pending_restart_candidate "$cluster_state"
+      The output should equal "pg-cluster-postgresql-1"
+      The status should be success
+    End
+
+    It "selects no candidate while a member is restarting"
+      cluster_state='{"members":[{"name":"pg-cluster-postgresql-0","role":"leader","state":"running","pending_restart":false},{"name":"pg-cluster-postgresql-1","role":"replica","state":"restarting","pending_restart":true},{"name":"pg-cluster-postgresql-2","role":"replica","state":"streaming","pending_restart":true}]}'
+      When call pending_restart_candidate "$cluster_state"
+      The output should equal ""
+      The status should be success
+    End
+
+    It "restarts only when the current pod is the selected candidate"
       When call need_restart_for_pending "true" "pg-cluster-postgresql-0"
       The status should be success
     End
 
-    It "does not restart when pending but another pod is the pending leader"
+    It "does not restart when another pod is the selected candidate"
       When call need_restart_for_pending "true" "pg-cluster-postgresql-1"
       The status should be failure
     End
 
+    It "does not restart without a candidate"
+      When call need_restart_for_pending "true" ""
+      The status should be failure
+    End
+
     It "does not restart when not pending"
-      When call need_restart_for_pending "false" ""
+      When call need_restart_for_pending "false" "pg-cluster-postgresql-0"
       The status should be failure
     End
   End

--- a/addons/postgresql/scripts/postgres-setup.sh
+++ b/addons/postgresql/scripts/postgres-setup.sh
@@ -12,11 +12,12 @@ function wait_pod_restarted() {
   done
 }
 
-function pending_restart_parameters_values() {
-  sql="select setting from pg_settings where name in ('max_connections','max_locks_per_transaction','max_worker_processes','max_prepared_transactions','wal_level','track_commit_timestamp')"
-  result=$(psql "host=$1 dbname=postgres user=${POSTGRES_USER}  connect_timeout=5" -t -c "${sql}" 2>/dev/null)
-  echo $result
-}
+# NOTE: this loop used to compare a 6-parameter whitelist against the primary
+# and skip the restart when those values matched — which starved every OTHER
+# restart-class parameter (shared_buffers, max_wal_senders, archive_mode, ...):
+# secondaries kept the old value and stayed pending_restart forever. Patroni's
+# own per-member pending_restart flag (already checked at the top of the loop)
+# is the ground truth for "this node needs a restart"; no extra gate is needed.
 
 # decide whether the current pod should restart now: only when it has
 # pending_restart, and either no leader is pending or the pending leader
@@ -60,15 +61,13 @@ function restart_for_pending_restart_flag() {
     rm -f ${result_tmp_path}
 
     leader_pending_restart_pod=$(echo ${result} | jq -r ".members[] | select(.role == \"leader\" and .pending_restart == true) | .name")
-    if [[ -z "$leader_pending_restart_pod"  ]]; then
-      # check if the pending_restart parameters are inconsistent
-      primary_pod_ip=$(echo $result | jq -r ".members[] | select(.role == \"leader\") | .host")
-      primary_parameter_values=$(pending_restart_parameters_values ${primary_pod_ip})
-      curr_parameter_values=$(pending_restart_parameters_values localhost)
-      if [[ -z "${primary_parameter_values}" || "${curr_parameter_values}" == "${primary_parameter_values}" ]]; then
-         continue
-      fi
-      echo "$(date) primary parameters values: ${primary_parameter_values}, current parameters values: ${curr_parameter_values}"
+    # Serialize member restarts: if any member is already mid-restart, wait
+    # for the next loop iteration instead of taking a second replica down in
+    # the same window (a simultaneous secondary restart leaves zero live
+    # replicas and blocks commits under synchronous mode).
+    restarting_member=$(echo ${result} | jq -r '.members[] | select(.state == "restarting") | .name' | head -n 1)
+    if [[ -n "${restarting_member}" && "${restarting_member}" != "${CURRENT_POD_NAME}" ]]; then
+      continue
     fi
     # Re-check pending_restart to avoid duplicate restarts
     sleep 5
@@ -76,7 +75,7 @@ function restart_for_pending_restart_flag() {
     if need_restart_for_pending "${pending_restart}" "${leader_pending_restart_pod}"; then
       # if leader pod is not pending_restart or current pod is leader pod, restart it
       echo "$(date) ${CURRENT_POD_NAME} is pending restart, restart it"
-      curl -XPOST http://localhost:8008/restart
+      curl -m 30 -XPOST http://localhost:8008/restart
       wait_pod_restarted
     fi
   done

--- a/addons/postgresql/scripts/postgres-setup.sh
+++ b/addons/postgresql/scripts/postgres-setup.sh
@@ -107,6 +107,20 @@ init_etcd_dcs_config_if_needed() {
   export SCOPE
 }
 
+# Standby (DR) clusters replicate from a REMOTE primary whose credentials
+# arrive via the remote-instances serviceRef (KB_PGUSER_STANDBY /
+# KB_PGPASSWORD_STANDBY). Without this override spilo authenticates with the
+# LOCAL cluster's randomly generated password (PGPASSWORD_STANDBY is wired to
+# POSTGRES_PASSWORD in the cmpd), which never matches the remote cluster's —
+# the standby loops on "password authentication failed" and never bootstraps.
+init_standby_credentials_if_needed() {
+  if ! is_empty "${STANDBY_HOST:-}" && ! is_empty "${KB_PGPASSWORD_STANDBY:-}"; then
+    echo "$(date) standby cluster: using remote replication credentials from serviceRef"
+    export PGUSER_STANDBY="${KB_PGUSER_STANDBY:-standby}"
+    export PGPASSWORD_STANDBY="${KB_PGPASSWORD_STANDBY}"
+  fi
+}
+
 regenerate_spilo_configuration_and_start_postgres() {
   restart_for_pending_restart_flag >> /home/postgres/.kb_set_up.log 2>&1 &
   echo "$(date) restart_for_pending_restart_flag PID=$!" >> /home/postgres/.kb_set_up.log
@@ -115,7 +129,19 @@ regenerate_spilo_configuration_and_start_postgres() {
   fi
   # Ensure postgres user owns the entire config directory (Patroni needs to write pg_hba.conf, etc.)
   chown -R postgres:postgres /home/postgres/pgdata/conf
-  python3 /kb-scripts/generate_patroni_yaml.py $tmp_patroni_yaml
+  # Fail closed on config-generation errors: launching spilo with an empty
+  # SPILO_CONFIGURATION silently drops custom_conf, the pg_hba template and
+  # the kb_restore bootstrap method — on a restore pod that turns the restore
+  # into a fresh empty initdb reported as success. A CrashLoop with an
+  # attributable log line is strictly better.
+  if ! python3 /kb-scripts/generate_patroni_yaml.py $tmp_patroni_yaml; then
+    echo "$(date) FATAL: generate_patroni_yaml.py failed; refusing to start with an empty SPILO_CONFIGURATION" >&2
+    exit 1
+  fi
+  if [ ! -s "$tmp_patroni_yaml" ]; then
+    echo "$(date) FATAL: generated patroni configuration is missing or empty: $tmp_patroni_yaml" >&2
+    exit 1
+  fi
   # SPILO_CONFIGURATION is defined by spilo image
   SPILO_CONFIGURATION=$(cat $tmp_patroni_yaml)
   export SPILO_CONFIGURATION
@@ -132,4 +158,5 @@ ${__SOURCED__:+false} : || return 0
 # main
 load_common_library
 init_etcd_dcs_config_if_needed
+init_standby_credentials_if_needed
 regenerate_spilo_configuration_and_start_postgres

--- a/addons/postgresql/scripts/postgres-setup.sh
+++ b/addons/postgresql/scripts/postgres-setup.sh
@@ -19,13 +19,32 @@ function wait_pod_restarted() {
 # own per-member pending_restart flag (already checked at the top of the loop)
 # is the ground truth for "this node needs a restart"; no extra gate is needed.
 
-# decide whether the current pod should restart now: only when it has
-# pending_restart, and either no leader is pending or the pending leader
-# is the current pod (the leader restarts first, secondaries follow).
+# Select one cluster-wide restart candidate from a Patroni cluster snapshot.
+# The leader goes first when it is pending; otherwise replicas are ordered by
+# member name. Every pod therefore reaches the same decision before posting to
+# its local /restart endpoint.
+function pending_restart_candidate() {
+  local cluster_state=$1
+
+  printf '%s\n' "${cluster_state}" | jq -r '
+    def healthy: .state == "running" or .state == "streaming";
+    if any(.members[]?; .state == "restarting") then
+      ""
+    else
+      (([.members[]? | select(.role == "leader" and .pending_restart == true and healthy) | .name] | sort | .[0]) //
+       ([.members[]? | select(.role != "leader" and .pending_restart == true and healthy) | .name] | sort | .[0]) //
+       "")
+    end
+  '
+}
+
+# Decide whether this pod is the single candidate selected from the latest
+# cluster snapshot. An empty candidate is fail-closed, not permission for every
+# pending replica to restart.
 function need_restart_for_pending() {
   local pending_restart=$1
-  local leader_pending_restart_pod=$2
-  [[ "${pending_restart}" == "true" && ( -z "${leader_pending_restart_pod}" || "${leader_pending_restart_pod}" == "${CURRENT_POD_NAME}" ) ]]
+  local restart_candidate=$2
+  [[ "${pending_restart}" == "true" && -n "${restart_candidate}" && "${restart_candidate}" == "${CURRENT_POD_NAME}" ]]
 }
 
 function restart_for_pending_restart_flag() {
@@ -60,20 +79,24 @@ function restart_for_pending_restart_flag() {
     result=$(<${result_tmp_path})
     rm -f ${result_tmp_path}
 
-    leader_pending_restart_pod=$(echo ${result} | jq -r ".members[] | select(.role == \"leader\" and .pending_restart == true) | .name")
-    # Serialize member restarts: if any member is already mid-restart, wait
-    # for the next loop iteration instead of taking a second replica down in
-    # the same window (a simultaneous secondary restart leaves zero live
-    # replicas and blocks commits under synchronous mode).
-    restarting_member=$(echo ${result} | jq -r '.members[] | select(.state == "restarting") | .name' | head -n 1)
-    if [[ -n "${restarting_member}" && "${restarting_member}" != "${CURRENT_POD_NAME}" ]]; then
+    if ! restart_candidate=$(pending_restart_candidate "${result}"); then
       continue
     fi
-    # Re-check pending_restart to avoid duplicate restarts
+    if [[ -z "${restart_candidate}" ]]; then
+      continue
+    fi
+
+    # Re-read the whole cluster after the arbitration delay. Rechecking only
+    # this pod's pending flag lets two followers act on the same stale snapshot.
     sleep 5
+    if ! result=$(curl --connect-timeout 3 -s http://localhost:8008/cluster); then
+      continue
+    fi
+    if ! restart_candidate=$(pending_restart_candidate "${result}"); then
+      continue
+    fi
     pending_restart=$(curl --connect-timeout 3 -s http://localhost:8008 | jq -r .pending_restart)
-    if need_restart_for_pending "${pending_restart}" "${leader_pending_restart_pod}"; then
-      # if leader pod is not pending_restart or current pod is leader pod, restart it
+    if need_restart_for_pending "${pending_restart}" "${restart_candidate}"; then
       echo "$(date) ${CURRENT_POD_NAME} is pending restart, restart it"
       curl -m 30 -XPOST http://localhost:8008/restart
       wait_pod_restarted


### PR DESCRIPTION
Fixes #3145, #3146, #3148 — three defects in the same script, one commit per concern.

- **#3145**: the pending-restart loop compared a 6-parameter whitelist against the primary and skipped the restart otherwise, starving every other restart-class parameter (shared_buffers etc.) — secondaries stayed pending_restart with the old value forever. Patroni's own per-member pending_restart flag (already checked) is the ground truth; the whitelist gate is removed. Bonus in the same commit: member restarts are serialized (no zero-live-replica window) and the restart POST is bounded (-m 30).
- **#3146**: standby (DR) clusters exported remote credentials into two dead vars while spilo authenticated with the local random password — DR provisioning failed auth by construction. The remote credentials now override when present.
- **#3148**: generate_patroni_yaml.py failures were swallowed and spilo launched with an empty SPILO_CONFIGURATION (on restore pods: silent empty initdb reported as success). Now fails closed with an attributable FATAL line.

postgres_setup_spec.sh 7/7 green (bash 5.3); bash -n clean. Draft until runtime-tested per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)