### PR TITLE
fix(postgresql): pg17/pg18 metrics — renamed pg_stat_statements columns, removed pg_stat_wal columns

### DIFF
--- a/addons/postgresql/metrics/pg17-metrics.yaml
+++ b/addons/postgresql/metrics/pg17-metrics.yaml
@@ -201,8 +201,8 @@ pg_stat_statements_by_mean_exec_time:
     local_blks_written,
     temp_blks_read,
     temp_blks_written,
-    blk_read_time / 1000 as blk_read_time_seconds,
-    blk_write_time / 1000 as blk_write_time_seconds,
+    shared_blk_read_time / 1000 as blk_read_time_seconds,
+    shared_blk_write_time / 1000 as blk_write_time_seconds,
     wal_records,
     wal_fpi,
     wal_bytes
@@ -346,8 +346,8 @@ pg_stat_statements_by_calls:
     local_blks_written,
     temp_blks_read,
     temp_blks_written,
-    blk_read_time / 1000 as blk_read_time_seconds,
-    blk_write_time / 1000 as blk_write_time_seconds,
+    shared_blk_read_time / 1000 as blk_read_time_seconds,
+    shared_blk_write_time / 1000 as blk_write_time_seconds,
     wal_records,
     wal_fpi,
     wal_bytes

--- a/addons/postgresql/metrics/pg18-metrics.yaml
+++ b/addons/postgresql/metrics/pg18-metrics.yaml
@@ -201,8 +201,8 @@ pg_stat_statements_by_mean_exec_time:
     local_blks_written,
     temp_blks_read,
     temp_blks_written,
-    blk_read_time / 1000 as blk_read_time_seconds,
-    blk_write_time / 1000 as blk_write_time_seconds,
+    shared_blk_read_time / 1000 as blk_read_time_seconds,
+    shared_blk_write_time / 1000 as blk_write_time_seconds,
     wal_records,
     wal_fpi,
     wal_bytes
@@ -346,8 +346,8 @@ pg_stat_statements_by_calls:
     local_blks_written,
     temp_blks_read,
     temp_blks_written,
-    blk_read_time / 1000 as blk_read_time_seconds,
-    blk_write_time / 1000 as blk_write_time_seconds,
+    shared_blk_read_time / 1000 as blk_read_time_seconds,
+    shared_blk_write_time / 1000 as blk_write_time_seconds,
     wal_records,
     wal_fpi,
     wal_bytes
@@ -594,17 +594,15 @@ pg_locks_detail:
         usage: "GAUGE"
         description: "Const value of 1"
 
+# PG18 removed wal_write, wal_sync, wal_write_time and wal_sync_time from
+# pg_stat_wal (moved to pg_stat_io); only the surviving columns are queried.
 pg_stat_wal:
   query: |
     /*kb-monitor*/SELECT
       wal_records,
       wal_fpi,
       wal_bytes,
-      wal_buffers_full,
-      wal_write,
-      wal_sync,
-      wal_write_time / 1000 as wal_write_time_seconds,
-      wal_sync_time / 1000 as wal_sync_time_seconds
+      wal_buffers_full
     FROM pg_stat_wal
   master: true
   metrics:
@@ -620,15 +618,3 @@ pg_stat_wal:
     - wal_buffers_full:
         usage: "COUNTER"
         description: "Number of times WAL data was written to disk because WAL buffers became full"
-    - wal_write:
-        usage: "COUNTER"
-        description: "Number of times WAL buffers were written out to disk via XLogWrite request."
-    - wal_sync:
-        usage: "COUNTER"
-        description: "Number of times WAL files were synced to disk via issue_xlog_fsync request"
-    - wal_write_time_seconds:
-        usage: "COUNTER"
-        description: "Total amount of time spent writing WAL buffers to disk via XLogWrite request"
-    - wal_sync_time_seconds:
-        usage: "COUNTER"
-        description: "Total amount of time spent syncing WAL files to disk via issue_xlog_fsync request"


### PR DESCRIPTION
Fixes #3150.

- pg17 + pg18: `pg_stat_statements` time columns renamed in 1.11 — query now uses `shared_blk_read_time`/`shared_blk_write_time`, output aliases unchanged for dashboard stability.
- pg18: `pg_stat_wal` trimmed to the columns that survive in PG18 (write/sync counters moved to `pg_stat_io`).

Both files pass YAML validation. Draft until a PG17/PG18 lane scrape confirms zero exporter SQL errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)