### PR TITLE
fix(mysql): myloader restore uses DP-injected credentials, not component-only admin creds

### DIFF
--- a/addons/mysql/dataprotection/mysql-myloader.sh
+++ b/addons/mysql/dataprotection/mysql-myloader.sh
@@ -37,5 +37,5 @@ fi
 echo "parameters: $params"
 
 datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.mydumper.zst" - | myloader --stream  \
-  -h ${DP_DB_HOST} -u ${MYSQL_ADMIN_USER} -p ${MYSQL_ADMIN_PASSWORD} -P ${DP_DB_PORT} --regex '^(?!(kubeblocks\.kb_health_check$))' \
+  -h ${DP_DB_HOST} -u ${DP_DB_USER} -p ${DP_DB_PASSWORD} -P ${DP_DB_PORT} --regex '^(?!(kubeblocks\.kb_health_check$))' \
   ${params}

--- a/addons/mysql/scripts-ut-spec/mysql_myloader_spec.sh
+++ b/addons/mysql/scripts-ut-spec/mysql_myloader_spec.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "mysql-myloader.sh restore credential wiring"
+
+    restore_env() {
+        export DP_DATASAFED_BIN_PATH="/tmp"
+        export DP_BACKUP_BASE_PATH="/tmp"
+        export DP_BACKUP_NAME="restore-bk"
+        export DP_BACKUP_INFO_FILE="/tmp/mysql-myloader-info-$$"
+        # DP injects these connection vars into the restore job; the script
+        # already relies on DP_DB_HOST / DP_DB_PORT on the same myloader line.
+        export DP_DB_HOST="db-host"
+        export DP_DB_PORT="3306"
+        export DP_DB_USER="dp_user"
+        export DP_DB_PASSWORD="dp_pass"
+        # component-container-only creds that are NOT injected into the DP job.
+        export MYSQL_ADMIN_USER="admin_user"
+        export MYSQL_ADMIN_PASSWORD="admin_pass"
+        export threads="2"
+    }
+    BeforeEach "restore_env"
+
+    cleanup() {
+        rm -f "${DP_BACKUP_INFO_FILE}" "${DP_BACKUP_INFO_FILE}.exit"
+    }
+    AfterEach "cleanup"
+
+    It "connects with DP_DB_USER/DP_DB_PASSWORD (matching mysql-mydumper.sh), not MYSQL_ADMIN_*"
+        datasafed() { return 0; }
+        myloader() { echo "MYLOADER_INVOKED $*"; cat >/dev/null; }
+        When run source ../dataprotection/mysql-myloader.sh
+        The status should be success
+        The stdout should include "MYLOADER_INVOKED"
+        The stdout should include "-u dp_user"
+        The stdout should include "-p dp_pass"
+        The stdout should not include "admin_user"
+        The stdout should not include "admin_pass"
+    End
+
+    It "does not reference component-only MYSQL_ADMIN_* creds (restore-job asymmetry regression guard)"
+        When run grep -F "MYSQL_ADMIN" ../dataprotection/mysql-myloader.sh
+        The status should be failure
+        The output should equal ""
+    End
+
+End


### PR DESCRIPTION
## Problem

`addons/mysql/dataprotection/mysql-myloader.sh:40` (the mydumper/myloader logical **restore**) connects with `${MYSQL_ADMIN_USER}` / `${MYSQL_ADMIN_PASSWORD}`. Those are **component-container** env (`credentialVarRef` in `templates/_helpers.tpl:177`) and are **not** injected into the DataProtection restore job. `templates/actionset-mydumper.yaml` declares no `env:` for the restore action, so in the restore job these two vars are empty → myloader fails authentication → the mydumper/myloader restore fails.

Two independent signals that DP connection env is the correct source:
- The **backup** side `mysql-mydumper.sh:37` already uses `${DP_DB_USER}` / `${DP_DB_PASSWORD}`.
- The **same** myloader line already relies on the DP-injected `${DP_DB_HOST}` / `${DP_DB_PORT}`, so user/password belong to the same DP connection env.

## Fix

Restore connects with `${DP_DB_USER}` / `${DP_DB_PASSWORD}`, matching the backup side and the host/port already on that line. No other behavior changed.

## Test

New `scripts-ut-spec/mysql_myloader_spec.sh`:
- behavioral: sources the script with mocked `datasafed`/`myloader`, asserts myloader is invoked with `-u dp_user -p dp_pass` and **not** the admin creds;
- regression guard: script no longer references `MYSQL_ADMIN_*`.

`make scripts-test` equivalent (shellspec, bash 5.3): mysql suite **8 examples, 0 failures**. `bash -n` clean. `helm template addons/mysql` renders.

## Evidence boundary

Static + unit-level (credential wiring + shellspec). This is a **draft** — a live mydumper→myloader restore run is still needed to confirm end-to-end restore PASS in the acceptance env. Filed as one of the round-2 review findings; sibling PR handles the proxysql SIGTERM issue separately. `nopick`.

Head: see branch. Base: main @554fd848.