### PR TITLE
fix(mysql): fail closed on orchestrator API ambiguity

### DIFF
--- a/addons/mysql/orc-tools/orchestrator-client.sh
+++ b/addons/mysql/orc-tools/orchestrator-client.sh
@@ -275,7 +275,7 @@ function api {
   api_call_result=0
   if [[ ${curl_auth_params} != "401 Unauthorized" ]]; then
     for sleep_time in 0.1 0.2 0.5 1 2 2.5 5 0 ; do
-      api_response=$(curl ${curl_auth_params} -s "$uri" | jq '.')
+      api_response=$(curl ${curl_auth_params} -fsS "$uri" | jq -ce 'select(. != null)')
       api_call_result=$?
       [ $api_call_result -eq 0 ] && break
       sleep $sleep_time
@@ -1048,4 +1048,5 @@ function main {
   run_command
 }
 
+${__SOURCED__:+false} : || return 0
 main

--- a/addons/mysql/orc-tools/orchestrator-client.sh
+++ b/addons/mysql/orc-tools/orchestrator-client.sh
@@ -145,7 +145,7 @@ function universal_sed {
 }
 
 function fail {
-  message="$myname[$$]: $1"
+  message="${myname}[$$]: $1"
   >&2 echo "$message"
   exit 1
 }

--- a/addons/mysql/scripts-ut-spec/orc_api_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_api_contract_spec.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+
+Describe "Orchestrator API contract"
+  Describe "init alias endpoint"
+    Include ../scripts/init-mysql-instance-for-orc.sh
+
+    It "normalizes a host endpoint with the API port"
+      ORCHESTRATOR_API=""
+      ORC_ENDPOINTS="mysql-orchestrator"
+      ORC_PORTS="3000"
+      When call orchestrator_api_base
+      The output should equal "http://mysql-orchestrator:3000"
+      The status should be success
+    End
+
+    It "does not double-prefix a configured URL"
+      ORCHESTRATOR_API="http://mysql-orchestrator:3000/api"
+      When call orchestrator_api_base
+      The output should equal "http://mysql-orchestrator:3000"
+      The status should be success
+    End
+
+    It "uses the normalized API endpoint for alias registration"
+      ORCHESTRATOR_API=""
+      ORC_ENDPOINTS="mysql-orchestrator:9999"
+      ORC_PORTS="3000"
+      curl() { printf '%s\n' "$*"; }
+      When call set_cluster_alias "mysql-0:3306" "mysql"
+      The output should include "--max-time 4"
+      The output should include "http://mysql-orchestrator:3000/api/set-cluster-alias/mysql-0:3306?alias=mysql"
+      The status should be success
+    End
+  End
+
+  Describe "client HTTP response"
+    setup_client() {
+      export __SOURCED__=1
+      export ORCHESTRATOR_API="http://orchestrator:3000/api"
+    }
+    Before "setup_client"
+    Include ../scripts/orchestrator-client.sh
+
+    It "rejects an HTTP error even when the body is JSON"
+      curl() { printf '%s\n' '{"Code":"OK"}'; return 22; }
+      sleep() { :; }
+      When run api "clusters-info"
+      The status should be failure
+      The stderr should include "Cannot access orchestrator"
+    End
+
+    It "rejects a JSON null response"
+      curl() { printf '%s\n' 'null'; }
+      sleep() { :; }
+      When run api "clusters-info"
+      The status should be failure
+      The stderr should include "Cannot access orchestrator"
+    End
+  End
+End

--- a/addons/mysql/scripts-ut-spec/orc_preterminate_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_preterminate_spec.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+
+Describe "Orchestrator preTerminate contract"
+  setup() {
+    export __SOURCED__=1
+    export CLUSTER_NAME="mysql-cluster"
+  }
+  Before "setup"
+  Include ../scripts/orc-preterminate.sh
+
+  It "fails closed when Orchestrator is unreachable"
+    run_orchestrator_client() { return 124; }
+    When run forget_cluster
+    The status should be failure
+    The stderr should include "Orchestrator unreachable"
+  End
+
+  It "forgets by cluster alias and verifies absence"
+    run_orchestrator_client() {
+      case "$*" in
+        "-c clusters-alias") printf '%s\n' "other,other" ;;
+        "-c forget-cluster -alias mysql-cluster") return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+    sleep() { :; }
+    When run forget_cluster
+    The status should be success
+    The output should include "successfully removed"
+  End
+
+  It "fails when the alias remains registered"
+    run_orchestrator_client() {
+      case "$*" in
+        "-c clusters-alias") printf '%s\n' "mysql-cluster,mysql-cluster" ;;
+        "-c forget-cluster -alias mysql-cluster") return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+    sleep() { :; }
+    When run forget_cluster
+    The status should be failure
+    The stderr should include "still exists"
+  End
+End

--- a/addons/mysql/scripts/init-mysql-instance-for-orc.sh
+++ b/addons/mysql/scripts/init-mysql-instance-for-orc.sh
@@ -20,6 +20,27 @@ mysql_error() {
 	exit 1
 }
 
+orchestrator_api_base() {
+  local endpoint="${ORCHESTRATOR_API:-${ORC_ENDPOINTS%% *}}"
+
+  if [[ "$endpoint" != http://* && "$endpoint" != https://* ]]; then
+    endpoint="${endpoint%%:*}"
+    endpoint="http://${endpoint}:${ORC_PORTS}"
+  fi
+  endpoint="${endpoint%/}"
+  printf '%s\n' "${endpoint%/api}"
+}
+
+set_cluster_alias() {
+  local cluster_info="$1"
+  local cluster_alias="$2"
+  local api_base
+
+  api_base=$(orchestrator_api_base)
+  curl --fail --silent --show-error --max-time 4 -X GET \
+    "${api_base}/api/set-cluster-alias/${cluster_info}?alias=${cluster_alias}"
+}
+
 # create orchestrator user in mysql
 create_mysql_user() {
   mysql_note "Create MySQL User and Grant Permissions..."
@@ -48,8 +69,6 @@ EOF
 
   local instance="${POD_NAME}"
   local cluster_alias="${CLUSTER_NAME}"
-  local orchestrator_url="${ORC_ENDPOINTS}" # for example, http://orchestrator:3000
-
   mysql_note "Registering cluster in Orchestrator"
   mysql_note "  Instance: $instance"
   mysql_note "  Alias: $cluster_alias"
@@ -90,7 +109,7 @@ EOF
   fi
 
   # Set alias via API
-  curl --silent -X GET "http://${orchestrator_url}/api/set-cluster-alias/${cluster_info}?alias=${cluster_alias}"
+  set_cluster_alias "$cluster_info" "$cluster_alias"
   sleep 5
   result=""
   attempt=0
@@ -102,7 +121,7 @@ EOF
     fi
     mysql_note "Cluster alias not set yet, waiting... (attempt $((attempt + 1))/$max_attempts)"
     attempt=$((attempt + 1))
-    curl --silent -X GET "http://${orchestrator_url}/api/set-cluster-alias/${cluster_info}?alias=${cluster_alias}"
+    set_cluster_alias "$cluster_info" "$cluster_alias"
     sleep 5
   done
   if [ $attempt -eq $max_attempts ]; then

--- a/addons/mysql/scripts/orc-preterminate.sh
+++ b/addons/mysql/scripts/orc-preterminate.sh
@@ -16,27 +16,30 @@ mysql_error() {
   exit 1
 }
 
-# Forget cluster
-if /kubeblocks/orchestrator-client -c forget-cluster -i "${KB_AGENT_POD_NAME}" 2>&1; then
-  mysql_note "Forget cluster command executed"
-else
-  mysql_note "Forget cluster command failed, continuing anyway"
-fi
+run_orchestrator_client() {
+  local budget="${ORC_PRETERMINATE_CLIENT_TIMEOUT_SECONDS:-8}"
+  timeout "${budget}s" /kubeblocks/orchestrator-client "$@"
+}
 
-if /kubeblocks/orchestrator-client -c forget-cluster -alias "${CLUSTER_NAME}" 2>&1; then
-  mysql_note "Forget cluster command executed"
-else
-  mysql_note "Forget cluster command failed, continuing anyway"
-fi
+forget_cluster() {
+  local clusters
 
+  if ! run_orchestrator_client -c clusters-alias >/dev/null; then
+    mysql_error "Orchestrator unreachable; refusing to report cluster removal"
+  fi
+  if ! run_orchestrator_client -c forget-cluster -alias "${CLUSTER_NAME}"; then
+    mysql_error "Failed to forget cluster alias ${CLUSTER_NAME}"
+  fi
 
-sleep 3
+  sleep 3
+  if ! clusters=$(run_orchestrator_client -c clusters-alias); then
+    mysql_error "Orchestrator unreachable; cannot verify removal of ${CLUSTER_NAME}"
+  fi
+  if printf '%s\n' "$clusters" | awk -F, -v name="$CLUSTER_NAME" '$1 == name || $2 == name { found=1 } END { exit !found }'; then
+    mysql_error "Cluster ${CLUSTER_NAME} still exists in Orchestrator"
+  fi
+  mysql_note "Cluster ${CLUSTER_NAME} successfully removed from Orchestrator"
+}
 
-# Check if cluster still exists
-cluster_name=$(/kubeblocks/orchestrator-client -c which-cluster -i "${KB_AGENT_POD_NAME}" 2>/dev/null || echo "")
-if [ -z "$cluster_name" ]; then
-  mysql_note "Cluster successfully forgotten from Orchestrator"
-  exit 0
-fi
-
-mysql_error "Cluster still exists in Orchestrator: ${cluster_name}"
+${__SOURCED__:+false} : || return 0
+forget_cluster

--- a/addons/mysql/scripts/orchestrator-client.sh
+++ b/addons/mysql/scripts/orchestrator-client.sh
@@ -145,7 +145,7 @@ function universal_sed {
 }
 
 function fail {
-  message="$myname[$$]: $1"
+  message="${myname}[$$]: $1"
   >&2 echo "$message"
   exit 1
 }
@@ -237,7 +237,7 @@ function detect_leader_api {
     leader_api="$(normalize_orchestrator_api $orchestrator_api)"
     return
   fi
-  for api in ${apis[@]} ; do
+  for api in "${apis[@]}" ; do
     api=$(normalize_orchestrator_api $api)
     leader_check=$(curl ${curl_auth_params} -m 1 -s -o /dev/null -w "%{http_code}" "${api}/leader-check")
     if [ "$leader_check" == "200" ] ; then
@@ -246,7 +246,7 @@ function detect_leader_api {
     fi
   done
   # Cannot find leader directly. Maybe our config is wrong. But, perhaps one of the nodes can route us?
-  for api in ${apis[@]} ; do
+  for api in "${apis[@]}" ; do
     api=$(normalize_orchestrator_api $api)
     leader_check=$(curl ${curl_auth_params} -m 1 -s -o /dev/null -w "%{http_code}" "${api}/routed-leader-check")
     if [ "$leader_check" == "200" ] ; then

--- a/addons/mysql/scripts/orchestrator-client.sh
+++ b/addons/mysql/scripts/orchestrator-client.sh
@@ -275,7 +275,7 @@ function api {
   api_call_result=0
   if [[ ${curl_auth_params} != "401 Unauthorized" ]]; then
     for sleep_time in 0.1 0.2 0.5 1 2 2.5 5 0 ; do
-      api_response=$(curl ${curl_auth_params} -s "$uri" | jq '.')
+      api_response=$(curl ${curl_auth_params} -fsS "$uri" | jq -ce 'select(. != null)')
       api_call_result=$?
       [ $api_call_result -eq 0 ] && break
       sleep $sleep_time
@@ -1048,4 +1048,5 @@ function main {
   run_command
 }
 
+${__SOURCED__:+false} : || return 0
 main


### PR DESCRIPTION
## Problem

Static review found fail-open and contract defects in the MySQL Orchestrator integration:

- direct cluster-alias registration constructed `http://${ORC_ENDPOINTS}` although the API port is supplied separately;
- orchestrator-client accepted HTTP 4xx/5xx and JSON `null` as successful responses;
- preTerminate forgot by a short Pod name, continued after Orchestrator errors, and could report success from an empty or unreachable readback.

## Changes

- normalize the Orchestrator API base and use bounded fail-on-HTTP-error alias requests;
- require curl HTTP success plus non-null JSON in both packaged orchestrator-client copies;
- make preTerminate bounded and alias-based, prove Orchestrator reachability, and verify the cluster name/alias is absent before success;
- add focused ShellSpec negative and positive cases.

## Validation

- ShellSpec: 8 examples, 0 failures
- `bash -n` on touched scripts: PASS
- `git diff --check`: PASS
- `helm lint addons/mysql`: PASS
- full chart render: PASS
- exact rebased-head PR CI: terminal green

## Evidence Boundary

The branch is rebased onto current `main` at exact head `64b9be0c6abe270b125de0a9055ae4f9956165dd`. This is source, unit, syntax, and render evidence. Runtime N=0; it does not establish MySQL acceptance, full-suite PASS, or release readiness.
