### PR TITLE
fix(mysql): proxysql-entry forwards SIGTERM to proxysql for graceful shutdown

### DIFF
--- a/addons/mysql/scripts-ut-spec/proxysql_entry_spec.sh
+++ b/addons/mysql/scripts-ut-spec/proxysql_entry_spec.sh
@@ -33,4 +33,103 @@ Describe "ProxySQL Entry Script Tests"
         End
     End
 
+    Describe "term_handler unit contract"
+        # Include defines term_handler without running the main body, because
+        # the script's __SOURCED__ guard returns early after the function decls.
+        # term_handler ends with `exit 0`, so use `When run` (subshell) here.
+        Include ../scripts/proxysql-entry.sh
+
+        It "forwards SIGTERM to the captured proxysql pid and exits 0"
+            kill() { echo "kill $*"; }
+            wait() { echo "wait $*"; }
+            pid=12345
+            When run term_handler
+            The status should be success
+            The stdout should include "kill -TERM 12345"
+        End
+
+        It "is a no-op when no proxysql pid was captured (signal before spawn)"
+            kill() { echo "kill $*"; }
+            wait() { echo "wait $*"; }
+            pid=0
+            When run term_handler
+            The status should be success
+            The stdout should not include "kill"
+        End
+
+        It "terminates instead of falling through to a second wait (double-wait guard)"
+            # If term_handler returned instead of exiting, control would fall
+            # through to the main path's bottom `wait "$pid"`, which under set -e
+            # would exit 127 ("not a child") after the handler already reaped it.
+            kill() { :; }
+            wait() { :; }
+            pid=999
+            probe() { term_handler; echo "FELL_THROUGH"; }
+            When run probe
+            The status should be success
+            The output should not include "FELL_THROUGH"
+        End
+
+        It "installs a SIGTERM/SIGINT trap before spawning proxysql"
+            When run cat ../scripts/proxysql-entry.sh
+            The status should be success
+            The output should include "trap 'term_handler' SIGTERM SIGINT"
+            # trap line must appear before the proxysql spawn line
+            trap_ln=$(grep -n "trap 'term_handler'" ../scripts/proxysql-entry.sh | head -1 | cut -d: -f1)
+            spawn_ln=$(grep -n "^proxysql -c" ../scripts/proxysql-entry.sh | head -1 | cut -d: -f1)
+            The variable trap_ln should satisfy test "$trap_ln" -lt "$spawn_ln"
+        End
+    End
+
+    Describe "end-to-end SIGTERM forwarding to a real proxysql child"
+        run_signal_test() {
+            tmpdir=$(mktemp -d)
+            marker="${tmpdir}/term-received"
+            ready="${tmpdir}/proxysql-up"
+
+            # stub proxysql: signal readiness, record SIGTERM, exit cleanly.
+            cat > "${tmpdir}/proxysql" <<STUB
+#!/usr/bin/env bash
+trap 'echo received > "${marker}"; exit 0' TERM
+echo up > "${ready}"
+while true; do sleep 0.05; done
+STUB
+            chmod +x "${tmpdir}/proxysql"
+
+            # stub configure helper and sed: succeed immediately (sed stub avoids
+            # BSD/GNU -i differences on the test host).
+            printf '#!/usr/bin/env bash\nexit 0\n' > "${tmpdir}/configure.sh"
+            chmod +x "${tmpdir}/configure.sh"
+            printf '#!/usr/bin/env bash\nexit 0\n' > "${tmpdir}/sed"
+            chmod +x "${tmpdir}/sed"
+
+            PATH="${tmpdir}:${PATH}" \
+                PROXYSQL_CONFIGURE_SCRIPT="${tmpdir}/configure.sh" \
+                PROXYSQL_CONFIG_TPL="/dev/null" \
+                PROXYSQL_CONFIG_OUT="${tmpdir}/proxysql.cnf" \
+                FRONTEND_TLS_ENABLED=false \
+                bash ../scripts/proxysql-entry.sh >/dev/null 2>&1 &
+            wrapper_pid=$!
+
+            # deterministically wait until proxysql is up (configure is instant,
+            # so the wrapper is then parked at the bottom `wait`), then send TERM.
+            i=0
+            while [ ! -f "${ready}" ] && [ ${i} -lt 100 ]; do sleep 0.05; i=$((i + 1)); done
+            sleep 0.1
+            kill -TERM "${wrapper_pid}" 2>/dev/null
+
+            wait "${wrapper_pid}"
+            rc=$?
+
+            if [ -f "${marker}" ]; then term="yes"; else term="no"; fi
+            rm -rf "${tmpdir}"
+            echo "child_term=${term} wrapper_rc=${rc}"
+        }
+
+        It "delivers SIGTERM to the proxysql child and the wrapper exits 0"
+            When call run_signal_test
+            The output should equal "child_term=yes wrapper_rc=0"
+        End
+    End
+
 End

--- a/addons/mysql/scripts/proxysql-entry.sh
+++ b/addons/mysql/scripts/proxysql-entry.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -e
 
+# pid stores the process id of the proxysql child; 0 until proxysql is spawned
+# so a signal arriving before the spawn is a safe no-op.
+declare -i pid=0
+
+# term_handler forwards pod-termination signals to the proxysql child so it
+# shuts down cleanly instead of being SIGKILLed after the termination grace
+# period, then terminates the wrapper itself. It reaps the child exactly once
+# and exits, so the main path never runs a second `wait` (which would fail with
+# "not a child" / 127 under `set -e`). Defined before the shellspec guard so it
+# stays unit-testable.
+term_handler() {
+  if [ "${pid}" -ne 0 ]; then
+    kill -TERM "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+  fi
+  exit 0
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -11,10 +29,7 @@ ${__SOURCED__:+false} : || return 0
 # use the current scrip name while putting log
 script_name=${0##*/}
 
-# pid stores the process id of the proxysql process
-declare -i pid
-
-if [ $FRONTEND_TLS_ENABLED == "true" ]; then
+if [ "${FRONTEND_TLS_ENABLED}" == "true" ]; then
     cp /var/lib/frontend/server/ca.crt /var/lib/proxysql/proxysql-ca.pem
     cp /var/lib/frontend/server/tls.crt /var/lib/proxysql/proxysql-cert.pem
     cp /var/lib/frontend/server/tls.key /var/lib/proxysql/proxysql-key.pem
@@ -30,21 +45,33 @@ if [ "${__SOURCED__:+x}" ]; then
   return 0
 fi
 
+# Install the signal trap as the first thing in the main path (pid is still 0)
+# so any SIGTERM during startup — config rendering, spawn, or the configure
+# helper — is handled instead of killing the wrapper with the default action.
+trap 'term_handler' SIGTERM SIGINT
+
+# These paths are overridable so the signal-handling contract can be exercised
+# end-to-end in tests. They default to the in-image paths (no behavior change).
+: "${PROXYSQL_CONFIGURE_SCRIPT:=/scripts/proxysql/configure-proxysql.sh}"
+: "${PROXYSQL_CONFIG_TPL:=/config/custom-config/proxysql.tpl}"
+: "${PROXYSQL_CONFIG_OUT:=/proxysql.cnf}"
+
 function replace_config_variables() {
-  cat /config/custom-config/proxysql.tpl > /proxysql.cnf
-  sed -i "s|\${PROXYSQL_MONITOR_PASSWORD}|${PROXYSQL_MONITOR_PASSWORD}|g" /proxysql.cnf
-  sed -i "s|\${PROXYSQL_CLUSTER_PASSWORD}|${PROXYSQL_CLUSTER_PASSWORD}|g" /proxysql.cnf
-  sed -i "s|\${PROXYSQL_ADMIN_PASSWORD}|${PROXYSQL_ADMIN_PASSWORD}|g" /proxysql.cnf
+  cat "${PROXYSQL_CONFIG_TPL}" > "${PROXYSQL_CONFIG_OUT}"
+  sed -i "s|\${PROXYSQL_MONITOR_PASSWORD}|${PROXYSQL_MONITOR_PASSWORD}|g" "${PROXYSQL_CONFIG_OUT}"
+  sed -i "s|\${PROXYSQL_CLUSTER_PASSWORD}|${PROXYSQL_CLUSTER_PASSWORD}|g" "${PROXYSQL_CONFIG_OUT}"
+  sed -i "s|\${PROXYSQL_ADMIN_PASSWORD}|${PROXYSQL_ADMIN_PASSWORD}|g" "${PROXYSQL_CONFIG_OUT}"
 }
 
 echo "Configuring proxysql ..."
 replace_config_variables
-# Start ProxySQL with PID 1
-exec proxysql -c /proxysql.cnf -f $CMDARG &
+
+# Run proxysql as a child (not exec) so this wrapper stays alive as the
+# container init process and can forward signals to it via the trap above.
+proxysql -c /proxysql.cnf -f $CMDARG &
 pid=$!
 
-/scripts/proxysql/configure-proxysql.sh
+"${PROXYSQL_CONFIGURE_SCRIPT}"
 
 echo "Waiting for proxysql ..."
-wait $pid
-
+wait "${pid}"


### PR DESCRIPTION
## Problem

`addons/mysql/scripts/proxysql-entry.sh` is the proxysql container command (`templates/cmpd-proxysql.yaml:140`). It backgrounded proxysql with `exec proxysql ... &` then `wait`, with **no signal trap**. On pod termination the wrapper (the container init process) receives SIGTERM but never forwards it to proxysql, so proxysql keeps running until the termination grace period elapses and is then SIGKILLed. This slows down / flaps scale-in, rolling-update, and delete tests. The mysql container already traps and forwards; proxysql should too — same class as the #3090 exec/signal fix.

## Fix

- Install a `term_handler` trap on `SIGTERM`/`SIGINT` as the **first** thing in the main path (`pid` initialized to `0`) so a signal during startup — config rendering, spawn, or the configure helper — is handled instead of the default kill.
- The handler forwards `TERM` to the proxysql pid, reaps it **exactly once**, and `exit`s, so the main path never runs a second `wait` (which would exit 127 "not a child" under `set -e`).
- Drop the misleading `exec ... &` (exec cannot replace the shell for a backgrounded job) and the false "PID 1" comment; run proxysql as a child so the wrapper stays alive to forward signals.
- Quote the `FRONTEND_TLS_ENABLED` test so an unset value is not a `set -e` syntax error.
- Make the configure-helper / config-template / config-output paths overridable (in-image defaults unchanged) so the signal contract can be exercised end-to-end.

## Tests (`scripts-ut-spec/proxysql_entry_spec.sh`)

- **end-to-end**: a real proxysql-stub child receives SIGTERM and the wrapper exits 0 — deterministic: waits until the child signals readiness (so the wrapper is parked at the bottom `wait`) before sending TERM.
- **double-wait guard**: `term_handler` exits rather than falling through to a second `wait`; verified to **fail** against a return-instead-of-exit handler.
- **trap ordering**: the trap is installed before the proxysql spawn line.
- **unit**: `term_handler` forwards `kill -TERM <pid>` and is a no-op when no pid was captured.

mysql suite (shellspec, bash 5.3): **11 examples, 0 failures**. `bash -n` clean; `helm template addons/mysql` renders. The three shellcheck warnings on the file (`script_name` unused, `CMDARG` array-to-string / unquoted split) are pre-existing and unchanged by this diff.

## Evidence boundary

Static + unit-level (including a real-subprocess signal test). This is a **draft** — a live pod-delete / rolling-update timing check in the acceptance env is still needed to confirm the graceful-shutdown improvement end-to-end. Round-2 review finding; sibling PR #3154 handles the myloader restore-credential issue separately. `nopick`.

Base: main @554fd848.
