### PR TITLE
fix(mysql): harden PITR binlog cleanup state

### DIFF
--- a/addons/mysql/dataprotection/mysql-pitr-backup.sh
+++ b/addons/mysql/dataprotection/mysql-pitr-backup.sh
@@ -193,6 +193,10 @@ cleanup_mysql_binlogs() {
 
     # Get synced binlog files from all replicas
     function get_synced_binlogs() {
+        # Reset per call: this is invoked repeatedly in the long-lived archiver
+        # process, and a leaked value from a previous call would let a purge
+        # proceed on a stale synced position when replica discovery fails.
+        local min_synced_file=""
 
         readarray -t all_binlogs < <(ls -1 "$LOG_DIR"/*-bin.[0-9]* | sort -V)
 
@@ -344,9 +348,12 @@ cleanup_mysql_binlogs() {
     # `if [ $? -ne 0 ]` below reflects get_synced_binlogs' exit code and not
     # the always-zero exit of `local` -- this is what keeps the fail-closed
     # "don't purge when replica sync is unknown" guard actually closed.
+    # Use `if ! ...` so a non-zero get_synced_binlogs does not trip the
+    # actionset-wide `set -e` before this fail-closed guard runs (a plain
+    # `synced_binlogs=$(...)` assignment aborts the whole archiver under set -e;
+    # the `if !` context suppresses that and still catches the failure).
     local synced_binlogs
-    synced_binlogs=$(get_synced_binlogs)
-    if [ $? -ne 0 ] || [ -z "$synced_binlogs" ]; then
+    if ! synced_binlogs=$(get_synced_binlogs) || [ -z "$synced_binlogs" ]; then
         echo "No synced binlog files found"
         return 0
     fi

--- a/addons/mysql/dataprotection/mysql-pitr-backup.sh
+++ b/addons/mysql/dataprotection/mysql-pitr-backup.sh
@@ -246,10 +246,12 @@ cleanup_mysql_binlogs() {
 
     # Get the list of binlog files that have been uploaded to backup storage
     function get_uploaded_binlogs() {
+        # Match the actual log basename. DP_TARGET_POD_NAME can remain on the
+        # original primary after switchover and would hide every uploaded file.
         datasafed list -f --recursive / -o json \
             | jq -s -r ".[] | sort_by(.mtime) | .[] | .path" \
             | grep "\.zst$" \
-            | grep "${DP_TARGET_POD_NAME}" \
+            | grep -F "${LOG_PREFIX}." \
             | xargs -I {} basename {} .zst \
             | paste -sd ' ' -
     }


### PR DESCRIPTION
## Problem

The MySQL PITR cleanup integration contains three safety/availability defects:

1. under actionset-wide `set -e`, a standalone `synced_binlogs=$(get_synced_binlogs)` exits the archiver before the intended fail-closed guard can skip purge;
2. `min_synced_file` leaks across repeated cleanup calls, allowing a later empty replica discovery to reuse stale state;
3. uploaded-file detection filters by `DP_TARGET_POD_NAME`, which can remain on the old primary after switchover, hiding all uploaded files and disabling cleanup.

## Changes

- place the failing assignment in an `if ! ...` condition;
- reset `min_synced_file` locally on every invocation;
- filter uploaded files by the live `LOG_PREFIX` derived from MySQL `log_bin_basename`.

Commits are separate for focused review and rollback:
- `d315627b` set-e and stale-state guard
- `591594e2` live-prefix matching

## Validation

- `bash -n addons/mysql/dataprotection/mysql-pitr-backup.sh`: PASS
- set-e regression harness: emits `guarded` then `alive`
- uploaded-prefix harness: old-primary path excluded, `actual-writer-bin.000002` selected
- `git diff --check`: PASS
- `helm dependency build addons/mysql`: PASS
- `helm lint addons/mysql`: PASS
- `helm template mysql addons/mysql`: PASS

## Evidence boundary

Static/render evidence only; focused runtime N=0. This does not establish PITR runtime PASS, fullsuite PASS, or release readiness.
