### PR TITLE
fix(mysql): fail close ORC prechecks within action budgets

### DIFF
--- a/addons/mysql/scripts-ut-spec/orc_member_leave_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_member_leave_spec.sh
@@ -1,0 +1,106 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2329
+
+Describe "ORC memberLeave script tests"
+  Include ../scripts/orc-member-leave.sh
+
+  setup_member_leave() {
+    export KB_LEAVE_MEMBER_POD_NAME="mysql-2"
+    export MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS=10
+    export MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS=0
+  }
+
+  cleanup_member_leave() {
+    unset KB_LEAVE_MEMBER_POD_NAME
+    unset KB_AGENT_POD_NAME
+    unset MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS
+    unset MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS
+  }
+
+  Before 'setup_member_leave'
+  After 'cleanup_member_leave'
+
+  It "closes only after all bounded calls prove the instance is absent"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget|clusters) return 0 ;;
+        all-instances) printf '%s\n' 'mysql-0:3306' 'mysql-1:3306' ; return 0 ;;
+      esac
+      return 1
+    }
+
+    When call run_member_leave
+    The status should be success
+    The output should include "successfully removed"
+  End
+
+  It "fails when the bounded forget call times out"
+    run_orchestrator_client_with_budget() {
+      [ "$3" = "forget" ] && return 124
+      return 0
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The error should include "phase: forget-command-failed"
+    The error should include "rc: 124"
+  End
+
+  It "fails when the bounded reachability call times out"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget) return 0 ;;
+        clusters) return 124 ;;
+      esac
+      return 0
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The output should include "Forget command executed"
+    The error should include "phase: orchestrator-unreachable"
+    The error should include "rc: 124"
+  End
+
+  It "fails when the bounded instance verification call times out"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget|clusters) return 0 ;;
+        all-instances) return 124 ;;
+      esac
+      return 1
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The output should include "Forget command executed"
+    The error should include "phase: instance-verification-failed"
+    The error should include "rc: 124"
+  End
+
+  It "fails while the instance remains present"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget|clusters) return 0 ;;
+        all-instances) printf '%s\n' 'mysql-0:3306' 'mysql-2:3306' ; return 0 ;;
+      esac
+      return 1
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The output should include "Forget command executed"
+    The error should include "phase: instance-still-present"
+    The error should include "next-retry-safe: yes"
+  End
+
+  It "rejects a missing leaving-member identity"
+    unset KB_LEAVE_MEMBER_POD_NAME
+    unset KB_AGENT_POD_NAME
+
+    When call run_member_leave
+    The status should be failure
+    The error should include "phase: leaving-member-missing"
+    The error should include "next-retry-safe: no"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
@@ -28,13 +28,23 @@ Describe "ORC switchover script tests"
       The variable ORC_PRECHECK_STDERR should include "transient response parse failed"
     End
 
-    It "selects the last valid host-port token from stdout"
+    It "rejects colon-shaped jq noise without a Kubernetes hostname"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' 'jq:error:42'
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be failure
+      The variable ORC_PRECHECK_MASTER should equal ""
+      The variable ORC_PRECHECK_STDOUT should equal "jq:error:42"
+    End
+
+    It "selects the valid host-port token around colon-shaped noise"
       run_orchestrator_client_with_budget() {
         printf '%s\n' \
-          'retrying request' \
-          'mysql-stale:3306' \
-          'not a master token' \
-          'mysql-current:3306'
+          'jq:error:42' \
+          'mysql-current:3306' \
+          'curl:error:7'
       }
 
       When call resolve_orchestrator_master_with_budget 3 mysql-0

--- a/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
@@ -4,6 +4,45 @@
 Describe "ORC switchover script tests"
   Include ../scripts/orc-switchover.sh
 
+  Describe "Orchestrator master precheck parsing"
+    It "keeps retry stderr out of a final successful master token"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' 'mysql-1:3306'
+        printf '%s\n' 'jq: error: transient response parse failed' >&2
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be success
+      The variable ORC_PRECHECK_MASTER should equal "mysql-1:3306"
+      The variable ORC_PRECHECK_STDERR should include "transient response parse failed"
+    End
+
+    It "fails closed when the client emits only stderr noise"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' 'jq: error: transient response parse failed' >&2
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be failure
+      The variable ORC_PRECHECK_MASTER should equal ""
+      The variable ORC_PRECHECK_STDERR should include "transient response parse failed"
+    End
+
+    It "selects the last valid host-port token from stdout"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' \
+          'retrying request' \
+          'mysql-stale:3306' \
+          'not a master token' \
+          'mysql-current:3306'
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be success
+      The variable ORC_PRECHECK_MASTER should equal "mysql-current:3306"
+    End
+  End
+
   Describe "MySQL read flag parsing"
     It "recognizes writable flags after mysql client stderr noise"
       output=$(printf '%s\n%s\n' \

--- a/addons/mysql/scripts/orc-member-leave.sh
+++ b/addons/mysql/scripts/orc-member-leave.sh
@@ -1,49 +1,120 @@
 #!/bin/bash
 
-# Logging functions
 mysql_log() {
   local text="$*"; if [ "$#" -eq 0 ]; then text="$(cat)"; fi
-  printf '%s\n'  "$text"
+  printf '%s\n' "$text"
 }
 mysql_note() {
   mysql_log "$@"
 }
-mysql_warn() {
-  mysql_log "$@" >&2
-}
-mysql_error() {
-  mysql_log "$@" >&2
-  exit 1
+
+member_leave_diagnose_not_ready() {
+  local phase="$1"
+  local ctx="$2"
+  local retry_safe="$3"
+  {
+    echo "orc memberLeave diagnosis:"
+    echo "  action: memberLeave"
+    echo "  phase: ${phase}"
+    echo "  leaving-member: ${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME:-<unset>}}"
+    echo "${ctx}"
+    echo "  next-retry-safe: ${retry_safe}"
+  } >&2
 }
 
-# memberLeave contract: KubeBlocks injects the LEAVING member's identity as
-# KB_LEAVE_MEMBER_POD_NAME; the action may execute on a different pod, so
-# KB_AGENT_POD_NAME (the execution pod) is only a fallback for older runtimes.
-leave_member="${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME}}"
-if [ -z "$leave_member" ]; then
-  mysql_error "Neither KB_LEAVE_MEMBER_POD_NAME nor KB_AGENT_POD_NAME is set"
-fi
+run_command_with_budget() {
+  local budget="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 1s "${budget}s" "$@"
+    return $?
+  fi
 
-# Forget instance from Orchestrator
-if /kubeblocks/orchestrator-client -c forget -i "${leave_member}" 2>&1; then
+  local temp_dir output_file error_file timeout_file pid timer_pid rc
+  temp_dir=$(mktemp -d /tmp/orc-member-leave.XXXXXX) || return 1
+  output_file="${temp_dir}/output"
+  error_file="${temp_dir}/error"
+  timeout_file="${temp_dir}/timeout"
+  "$@" > "${output_file}" 2> "${error_file}" &
+  pid=$!
+  (
+    sleep "${budget}"
+    if kill -0 "${pid}" 2>/dev/null; then
+      printf 'timeout\n' > "${timeout_file}"
+      kill "${pid}" 2>/dev/null || true
+      sleep 1
+      kill -9 "${pid}" 2>/dev/null || true
+    fi
+  ) &
+  timer_pid=$!
+
+  wait "${pid}" 2>/dev/null
+  rc=$?
+  kill "${timer_pid}" 2>/dev/null || true
+  wait "${timer_pid}" 2>/dev/null || true
+  cat "${output_file}"
+  cat "${error_file}" >&2
+  if [ -s "${timeout_file}" ]; then
+    rc=124
+  fi
+  rm -rf "${temp_dir}"
+  return "$rc"
+}
+
+run_orchestrator_client_with_budget() {
+  local budget="$1"
+  shift
+  run_command_with_budget "${budget}" /kubeblocks/orchestrator-client "$@"
+}
+
+run_member_leave() {
+  local leave_member budget settle_seconds output rc
+  leave_member="${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME:-}}"
+  budget="${MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS:-10}"
+  settle_seconds="${MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS:-3}"
+  if [ -z "$leave_member" ]; then
+    member_leave_diagnose_not_ready "leaving-member-missing" \
+      "  required-env: KB_LEAVE_MEMBER_POD_NAME or KB_AGENT_POD_NAME" "no"
+    return 1
+  fi
+
+  output=$(run_orchestrator_client_with_budget "${budget}" -c forget -i "${leave_member}" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    member_leave_diagnose_not_ready "forget-command-failed" \
+      "$(printf '  rc: %s\n  output: %s' "$rc" "${output:-<empty>}")" "yes"
+    return 1
+  fi
   mysql_note "Forget command executed"
-else
-  mysql_note "Forget command failed, continuing anyway"
-fi
 
-sleep 3
+  sleep "${settle_seconds}"
+  mysql_note "Verifying instance was forgotten..."
+  output=$(run_orchestrator_client_with_budget "${budget}" -c clusters 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    member_leave_diagnose_not_ready "orchestrator-unreachable" \
+      "$(printf '  rc: %s\n  output: %s' "$rc" "${output:-<empty>}")" "yes"
+    return 1
+  fi
 
-# Verify instance was forgotten. "Instance not found" and "Orchestrator is
-# down" both yield an empty query result, so prove Orchestrator is reachable
-# first - otherwise an outage would be reported as a successful removal.
-mysql_note "Verifying instance was forgotten..."
-if ! /kubeblocks/orchestrator-client -c clusters >/dev/null 2>&1; then
-  mysql_error "Orchestrator unreachable; cannot verify removal of ${leave_member}"
-fi
-instance_info=$(/kubeblocks/orchestrator-client -c instance -i "${leave_member}" 2>/dev/null || true)
+  output=$(run_orchestrator_client_with_budget "${budget}" -c all-instances 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    member_leave_diagnose_not_ready "instance-verification-failed" \
+      "$(printf '  rc: %s\n  output: %s' "$rc" "${output:-<empty>}")" "yes"
+    return 1
+  fi
+  if ! printf '%s\n' "$output" | awk -F: -v target="$leave_member" '$1 == target { found = 1 } END { exit found ? 0 : 1 }'; then
+    mysql_note "Instance ${leave_member} successfully removed from Orchestrator"
+    return 0
+  fi
 
-if [ -z "$instance_info" ]; then
-  mysql_note "Instance ${leave_member} successfully removed from Orchestrator"
-  exit 0
-fi
-mysql_error "Instance ${leave_member} still exists in Orchestrator"
+  member_leave_diagnose_not_ready "instance-still-present" \
+    "  observed: ${output}" "yes"
+  return 1
+}
+
+# ShellSpec includes this file to test functions without executing the action.
+${__SOURCED__:+false} : || return 0
+
+run_member_leave

--- a/addons/mysql/scripts/orc-switchover.sh
+++ b/addons/mysql/scripts/orc-switchover.sh
@@ -82,7 +82,7 @@ ORC_PRECHECK_MASTER=""
 
 extract_last_orchestrator_instance() {
   awk '
-    /^[^[:space:]]+:[0-9]+$/ {
+    /^[^[:space:]:]+:[0-9]+$/ {
       last = $0
       found = 1
     }

--- a/addons/mysql/scripts/orc-switchover.sh
+++ b/addons/mysql/scripts/orc-switchover.sh
@@ -38,11 +38,12 @@ run_command_with_budget() {
     return $?
   fi
 
-  local temp_dir output_file timeout_file pid timer_pid rc
+  local temp_dir output_file error_file timeout_file pid timer_pid rc
   temp_dir=$(mktemp -d /tmp/orc-switchover.XXXXXX) || return 1
   output_file="${temp_dir}/output"
+  error_file="${temp_dir}/error"
   timeout_file="${temp_dir}/timeout"
-  "$@" > "${output_file}" 2>&1 &
+  "$@" > "${output_file}" 2> "${error_file}" &
   pid=$!
   (
     sleep "${budget}"
@@ -60,6 +61,7 @@ run_command_with_budget() {
   kill "${timer_pid}" 2>/dev/null || true
   wait "${timer_pid}" 2>/dev/null || true
   cat "${output_file}"
+  cat "${error_file}" >&2
   if [ -s "${timeout_file}" ]; then
     rc=124
   fi
@@ -71,6 +73,55 @@ run_orchestrator_client_with_budget() {
   local budget="$1"
   shift
   run_command_with_budget "${budget}" /kubeblocks/orchestrator-client "$@"
+}
+
+ORC_PRECHECK_RC=""
+ORC_PRECHECK_STDOUT=""
+ORC_PRECHECK_STDERR=""
+ORC_PRECHECK_MASTER=""
+
+extract_last_orchestrator_instance() {
+  awk '
+    /^[^[:space:]]+:[0-9]+$/ {
+      last = $0
+      found = 1
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+      print last
+    }
+  '
+}
+
+resolve_orchestrator_master_with_budget() {
+  local budget="$1"
+  local instance="$2"
+  local stderr_file
+
+  ORC_PRECHECK_RC=""
+  ORC_PRECHECK_STDOUT=""
+  ORC_PRECHECK_STDERR=""
+  ORC_PRECHECK_MASTER=""
+  if ! stderr_file=$(mktemp /tmp/orc-master-precheck.XXXXXX); then
+    ORC_PRECHECK_RC=1
+    ORC_PRECHECK_STDERR="failed to create master precheck stderr file"
+    return 1
+  fi
+
+  ORC_PRECHECK_STDOUT=$(run_orchestrator_client_with_budget "${budget}" \
+    -c which-cluster-master -i "${instance}" 2> "${stderr_file}")
+  ORC_PRECHECK_RC=$?
+  ORC_PRECHECK_STDERR=$(cat "${stderr_file}" 2>/dev/null || true)
+  rm -f "${stderr_file}"
+  if [ "${ORC_PRECHECK_RC}" -ne 0 ]; then
+    return 1
+  fi
+
+  ORC_PRECHECK_MASTER=$(printf '%s\n' "${ORC_PRECHECK_STDOUT}" | extract_last_orchestrator_instance) \
+    || return 1
+  [ -n "${ORC_PRECHECK_MASTER}" ]
 }
 
 ORC_SWITCHOVER_CLIENT_PID=""
@@ -245,18 +296,16 @@ append_switchover_verify_history() {
 
 verify_switchover_closed_once() {
   local candidate="${KB_SWITCHOVER_CANDIDATE_NAME:-}"
-  local master_from_orc precheck_budget rc
+  local precheck_budget
   precheck_budget="${MYSQL_ORC_SWITCHOVER_PRECHECK_TIMEOUT_SECONDS:-3}"
 
   if [ -z "$candidate" ]; then
-    master_from_orc=$(run_orchestrator_client_with_budget "${precheck_budget}" -c which-cluster-master -i "${KB_SWITCHOVER_CURRENT_NAME}" 2>&1)
-    rc=$?
-    if [ $rc -ne 0 ]; then
-      SWITCHOVER_VERIFY_CANDIDATE_FLAGS="candidate lookup rc=${rc} output=${master_from_orc}"
+    if ! resolve_orchestrator_master_with_budget "${precheck_budget}" "${KB_SWITCHOVER_CURRENT_NAME}"; then
+      SWITCHOVER_VERIFY_CANDIDATE_FLAGS="candidate lookup rc=${ORC_PRECHECK_RC:-1} stdout=${ORC_PRECHECK_STDOUT:-<empty>} stderr=${ORC_PRECHECK_STDERR:-<empty>}"
       SWITCHOVER_VERIFY_CURRENT_FLAGS="<not checked>"
       return 1
     fi
-    candidate="${master_from_orc%%:*}"
+    candidate="${ORC_PRECHECK_MASTER%%:*}"
   fi
   SWITCHOVER_VERIFY_CANDIDATE="${candidate:-<empty>}"
 
@@ -388,11 +437,10 @@ fi
 # not be mistaken for a master name (that previously made this guard exit 0).
 precheck_budget="${MYSQL_ORC_SWITCHOVER_PRECHECK_TIMEOUT_SECONDS:-3}"
 
-master_from_orc=$(run_orchestrator_client_with_budget "${precheck_budget}" -c which-cluster-master -i "${KB_SWITCHOVER_CURRENT_NAME}" 2>&1)
-rc=$?
-if [ $rc -ne 0 ] || [ -z "$master_from_orc" ]; then
-  mysql_error "Could not determine current master from Orchestrator (rc=${rc}): ${master_from_orc}"
+if ! resolve_orchestrator_master_with_budget "${precheck_budget}" "${KB_SWITCHOVER_CURRENT_NAME}"; then
+  mysql_error "Could not determine current master from Orchestrator (rc=${ORC_PRECHECK_RC:-1}, stdout=${ORC_PRECHECK_STDOUT:-<empty>}, stderr=${ORC_PRECHECK_STDERR:-<empty>})"
 fi
+master_from_orc="${ORC_PRECHECK_MASTER}"
 
 if [ "${KB_SWITCHOVER_CURRENT_NAME}" != "${master_from_orc%%:*}" ]; then
   mysql_note "Current instance is not the master, skipping."

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -198,15 +198,24 @@ roleProbe:
       - |
         exec /orc-scripts/role-probe.sh
 memberLeave:
+  # Three sequential client calls at 10s plus a 1s kill grace and a 3s settle
+  # window fit in 36s, leaving 14s for diagnostics under the 50s action limit.
+  timeoutSeconds: {{ .Values.memberLeave.timeoutSeconds }}
   exec:
+    env:
+      - name: MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS
+        value: "{{ .Values.memberLeave.clientTimeoutSeconds }}"
+      - name: MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS
+        value: "{{ .Values.memberLeave.settleSeconds }}"
     command:
       - /bin/bash
       - -c
       - |
-        /orc-scripts/member-leave.sh 2>> /tmp/member-leave.log
-        if [ $? -ne 0 ]; then
-          echo "ERROR: Failed to member leave"
-          exit 1
+        /orc-scripts/member-leave.sh 2> >(tee -a /tmp/member-leave.log >&2)
+        rc=$?
+        if [ $rc -ne 0 ]; then
+          echo "ERROR: Failed to member leave (rc=${rc})" >&2
+          exit $rc
         fi
 switchover:
   timeoutSeconds: {{ .Values.switchover.timeoutSeconds }}

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -122,6 +122,11 @@ roleProbe:
     timeoutSeconds: 5
     clientTimeoutSeconds: 4
 
+memberLeave:
+  timeoutSeconds: 50
+  clientTimeoutSeconds: 10
+  settleSeconds: 3
+
 switchover:
   # kbagent caps positive action timeouts at 60s; keep a buffer for diagnostics.
   # Worst-case budget: 2*3s prechecks + max(40s ORC CLI, 20*(parallel 1s SQL probes) + 19*1s intervals) = 46s.


### PR DESCRIPTION
## Problem

Two ORC lifecycle paths can report success without trustworthy evidence or exceed the kbagent action window:

1. The switchover master precheck merges orchestrator-client retry stderr into stdout. A transient curl/jq error can become the parsed master token and make the script exit 0 as "not the master" without attempting switchover.
2. memberLeave runs three unbounded orchestrator-client calls. A hung client can be killed by the 60s clamp mid-action, and the old `instance ... || true` verification cannot distinguish a genuinely absent instance from a failed query.

## Change

### M1: fail closed on noisy master prechecks

- preserve stdout/stderr separately in the timeout fallback
- extract only the last non-empty `host:port` token from stdout
- use the same resolver in the initial master guard and post-switchover candidate discovery
- retain raw stdout/stderr/rc diagnostics when resolution fails

### M2: bound memberLeave and prove absence

- bound each orchestrator-client call to 10s with a 1s kill grace
- set memberLeave action timeout to 50s; worst case is 3 x 11s + 3s settle = 36s, leaving 14s for diagnostics
- fail rc=1 on forget, reachability, or verification timeout/error
- replace ambiguous `instance ... || true` with a successful bounded `all-instances` read and exact hostname absence check
- emit per-action phase and retry-safe diagnostics to action stderr and `/tmp/member-leave.log`

## Tests

- M1: retry stderr + final successful stdout; stderr-only noise; last valid stdout token
- M2: positive absent closure; forget timeout; reachability timeout; list verification timeout; instance still present; missing leaving-member identity

Local gates:

- MySQL ShellSpec: 46 examples, 0 failures (bash 3.2.57)
- focused M1+M2 ShellSpec: 19 examples, 0 failures
- bash-n: PASS
- shellcheck `--severity=warning`: PASS
- `helm dependency build addons/mysql`: PASS
- `helm lint addons/mysql`: PASS
- render: memberLeave `timeoutSeconds=50`, client timeout `10`, settle `3`, stderr mirrored
- `git diff --check`: PASS
- merge-tree: PASS, tree `6d86e28f3cb01fd7ca23f7f13251d6ae59aa6afd`

## Boundary

This PR is a draft child of #3117 and changes only M1/M2. It does not include PITR cleanup, ORC client/init/preTerminate, M3, or M4 work owned elsewhere. Evidence is code/static only; runtime N=0 and no acceptance or release-readiness claim is made.
