### PR TITLE
fix(mysql): make xtrabackup restore retries explicit

### DIFF
--- a/addons/mysql/dataprotection/restore.sh
+++ b/addons/mysql/dataprotection/restore.sh
@@ -3,6 +3,28 @@ set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
+
+restore_preflight() {
+  local residue
+
+  mkdir -p "${DATA_DIR}"
+  if [ -f "${DATA_DIR}/.xtrabackup_restore" ]; then
+    echo "Restore already completed; keeping existing data"
+    return 10
+  fi
+  residue=$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name lost+found -print -quit)
+  if [ -n "$residue" ]; then
+    echo "Restore target is non-empty without completion marker: ${residue}" >&2
+    return 1
+  fi
+}
+
+${__SOURCED__:+false} : || return 0
+restore_preflight_rc=0
+restore_preflight || restore_preflight_rc=$?
+[ "$restore_preflight_rc" -eq 10 ] && exit 0
+[ "$restore_preflight_rc" -ne 0 ] && exit "$restore_preflight_rc"
+
 mkdir -p ${DATA_DIR}
 TMP_DIR=${MYSQL_DIR}/temp
 mkdir -p ${TMP_DIR} && cd ${TMP_DIR}

--- a/addons/mysql/dataprotection/xtrabackup-incremental-restore.sh
+++ b/addons/mysql/dataprotection/xtrabackup-incremental-restore.sh
@@ -3,6 +3,27 @@ set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 
+restore_preflight() {
+  local residue
+
+  mkdir -p "${DATA_DIR}"
+  if [ -f "${DATA_DIR}/.xtrabackup_restore" ]; then
+    echo "Restore already completed; keeping existing data"
+    return 10
+  fi
+  residue=$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name lost+found -print -quit)
+  if [ -n "$residue" ]; then
+    echo "Restore target is non-empty without completion marker: ${residue}" >&2
+    return 1
+  fi
+}
+
+${__SOURCED__:+false} : || return 0
+restore_preflight_rc=0
+restore_preflight || restore_preflight_rc=$?
+[ "$restore_preflight_rc" -eq 10 ] && exit 0
+[ "$restore_preflight_rc" -ne 0 ] && exit "$restore_preflight_rc"
+
 # function change_backend_path changes the DATASAFED_BACKEND_BASE_PATH by backup name
 function change_backend_path() {
   backup_name=$1

--- a/addons/mysql/scripts-ut-spec/incremental_restore_preflight_spec.sh
+++ b/addons/mysql/scripts-ut-spec/incremental_restore_preflight_spec.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+
+Describe "incremental xtrabackup restore preflight"
+  setup() {
+    export __SOURCED__=1
+    export DATA_DIR="${SHELLSPEC_TMPBASE}/mysql-incremental-data"
+    rm -rf "$DATA_DIR"
+  }
+  Before "setup"
+  Include ../dataprotection/xtrabackup-incremental-restore.sh
+
+  It "allows an empty target"
+    When call restore_preflight
+    The status should be success
+  End
+
+  It "treats a completion marker as an idempotent retry"
+    mkdir -p "$DATA_DIR"
+    touch "$DATA_DIR/.xtrabackup_restore"
+    When call restore_preflight
+    The status should equal 10
+    The output should include "already completed"
+  End
+
+  It "fails closed on partial restored data"
+    mkdir -p "$DATA_DIR/mysql"
+    When call restore_preflight
+    The status should be failure
+    The stderr should include "non-empty without completion marker"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/restore_preflight_spec.sh
+++ b/addons/mysql/scripts-ut-spec/restore_preflight_spec.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+
+Describe "xtrabackup restore preflight"
+  setup() {
+    export __SOURCED__=1
+    export DATA_DIR="${SHELLSPEC_TMPBASE}/mysql-data"
+    rm -rf "$DATA_DIR"
+  }
+  Before "setup"
+
+  Describe "full restore"
+    Include ../dataprotection/restore.sh
+
+    It "allows an empty target"
+      When call restore_preflight
+      The status should be success
+    End
+
+    It "treats a completion marker as an idempotent retry"
+      mkdir -p "$DATA_DIR"
+      touch "$DATA_DIR/.xtrabackup_restore"
+      When call restore_preflight
+      The status should equal 10
+      The output should include "already completed"
+    End
+
+    It "fails closed on partial restored data"
+      mkdir -p "$DATA_DIR/mysql"
+      When call restore_preflight
+      The status should be failure
+      The stderr should include "non-empty without completion marker"
+    End
+
+    It "ignores a filesystem lost+found directory"
+      mkdir -p "$DATA_DIR/lost+found"
+      When call restore_preflight
+      The status should be success
+    End
+  End
+End


### PR DESCRIPTION
## Problem

Both full and incremental xtrabackup restore scripts always enter download/prepare/`--move-back`, even when a DataProtection action is retried. A retry after success fails unnecessarily; a retry after a partial move-back can operate on a non-empty target without classifying the interrupted state.

## Contract

- completion marker present: idempotent success, keep existing data;
- empty target (ignoring filesystem `lost+found`): proceed;
- non-empty target without marker: fail closed and preserve the partial-restored evidence.

The guard runs before download/prepare/move-back in both scripts.

## Validation

- ShellSpec: 7 examples, 0 failures (full + incremental; empty/completed/partial/lost+found)
- `bash -n` touched scripts: PASS
- `git diff --check`: PASS
- `helm dependency build addons/mysql`: PASS
- `helm lint addons/mysql`: PASS
- `helm template mysql addons/mysql`: PASS

## Evidence boundary

Static/unit/render evidence only; restore runtime N=0. This does not establish restore PASS, fullsuite PASS, or release readiness.
