### PR TITLE
fix(mysql): make redo capacity constraint optional

### DIFF
--- a/addons/mysql/config/mysql8-config-constraint.cue
+++ b/addons/mysql/config/mysql8-config-constraint.cue
@@ -583,8 +583,8 @@
 	// Controls encryption of redo log data for tables encrypted using the InnoDB tablespace encryption feature.
 	innodb_redo_log_encrypt: string & "OFF" | "ON" | *"OFF"
 
-	// The total capacity in bytes of the redo log.
-	innodb_redo_log_capacity: int & >= 8388608
+	// Optional because the template only derives it when a memory limit is available.
+	innodb_redo_log_capacity?: int & >= 8388608
 
 	// The replication thread delay (in ms) on a slave server if innodb_thread_concurrency is reached.
 	innodb_replication_delay?: int & >=0 & <=4294967295


### PR DESCRIPTION
## Problem

The integration schema requires `innodb_redo_log_capacity`, while the MySQL 8.0 template only renders it when a container memory limit is available. A no-memory-limit deployment can therefore fail configuration validation before startup.

## Change

Keep the type/range validation for user-supplied values, but make the field optional. This matches the template contract: memory-known derives a value; memory-unknown omits it.

## Validation

- machine check: exactly one optional declaration and no required declaration
- default no-memory render omits `innodb_redo_log_capacity`
- `git diff --check`: PASS
- `helm dependency build addons/mysql`: PASS
- `helm lint addons/mysql`: PASS
- `helm template mysql addons/mysql`: PASS

## Evidence boundary

Static/render evidence only; no-memory-limit runtime N=0. This does not establish cluster startup PASS, fullsuite PASS, or release readiness.
