### PR TITLE
fix(mysql): close consolidated acceptance review blockers

### DIFF
--- a/addons/mysql/config/mysql8-config-constraint.cue
+++ b/addons/mysql/config/mysql8-config-constraint.cue
@@ -583,8 +583,8 @@
 	// Controls encryption of redo log data for tables encrypted using the InnoDB tablespace encryption feature.
 	innodb_redo_log_encrypt: string & "OFF" | "ON" | *"OFF"
 
-	// The total capacity in bytes of the redo log.
-	innodb_redo_log_capacity: int & >= 8388608
+	// Optional because the template only derives it when a memory limit is available.
+	innodb_redo_log_capacity?: int & >= 8388608
 
 	// The replication thread delay (in ms) on a slave server if innodb_thread_concurrency is reached.
 	innodb_replication_delay?: int & >=0 & <=4294967295

--- a/addons/mysql/dataprotection/mysql-myloader.sh
+++ b/addons/mysql/dataprotection/mysql-myloader.sh
@@ -37,5 +37,5 @@ fi
 echo "parameters: $params"
 
 datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.mydumper.zst" - | myloader --stream  \
-  -h ${DP_DB_HOST} -u ${MYSQL_ADMIN_USER} -p ${MYSQL_ADMIN_PASSWORD} -P ${DP_DB_PORT} --regex '^(?!(kubeblocks\.kb_health_check$))' \
+  -h ${DP_DB_HOST} -u ${DP_DB_USER} -p ${DP_DB_PASSWORD} -P ${DP_DB_PORT} --regex '^(?!(kubeblocks\.kb_health_check$))' \
   ${params}

--- a/addons/mysql/dataprotection/mysql-pitr-backup.sh
+++ b/addons/mysql/dataprotection/mysql-pitr-backup.sh
@@ -193,6 +193,10 @@ cleanup_mysql_binlogs() {
 
     # Get synced binlog files from all replicas
     function get_synced_binlogs() {
+        # Reset per call: this is invoked repeatedly in the long-lived archiver
+        # process, and a leaked value from a previous call would let a purge
+        # proceed on a stale synced position when replica discovery fails.
+        local min_synced_file=""
 
         readarray -t all_binlogs < <(ls -1 "$LOG_DIR"/*-bin.[0-9]* | sort -V)
 
@@ -344,9 +348,12 @@ cleanup_mysql_binlogs() {
     # `if [ $? -ne 0 ]` below reflects get_synced_binlogs' exit code and not
     # the always-zero exit of `local` -- this is what keeps the fail-closed
     # "don't purge when replica sync is unknown" guard actually closed.
+    # Use `if ! ...` so a non-zero get_synced_binlogs does not trip the
+    # actionset-wide `set -e` before this fail-closed guard runs (a plain
+    # `synced_binlogs=$(...)` assignment aborts the whole archiver under set -e;
+    # the `if !` context suppresses that and still catches the failure).
     local synced_binlogs
-    synced_binlogs=$(get_synced_binlogs)
-    if [ $? -ne 0 ] || [ -z "$synced_binlogs" ]; then
+    if ! synced_binlogs=$(get_synced_binlogs) || [ -z "$synced_binlogs" ]; then
         echo "No synced binlog files found"
         return 0
     fi

--- a/addons/mysql/dataprotection/mysql-pitr-backup.sh
+++ b/addons/mysql/dataprotection/mysql-pitr-backup.sh
@@ -246,10 +246,12 @@ cleanup_mysql_binlogs() {
 
     # Get the list of binlog files that have been uploaded to backup storage
     function get_uploaded_binlogs() {
+        # Match the actual log basename. DP_TARGET_POD_NAME can remain on the
+        # original primary after switchover and would hide every uploaded file.
         datasafed list -f --recursive / -o json \
             | jq -s -r ".[] | sort_by(.mtime) | .[] | .path" \
             | grep "\.zst$" \
-            | grep "${DP_TARGET_POD_NAME}" \
+            | grep -F "${LOG_PREFIX}." \
             | xargs -I {} basename {} .zst \
             | paste -sd ' ' -
     }

--- a/addons/mysql/dataprotection/restore.sh
+++ b/addons/mysql/dataprotection/restore.sh
@@ -3,6 +3,28 @@ set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
+
+restore_preflight() {
+  local residue
+
+  mkdir -p "${DATA_DIR}"
+  if [ -f "${DATA_DIR}/.xtrabackup_restore" ]; then
+    echo "Restore already completed; keeping existing data"
+    return 10
+  fi
+  residue=$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name lost+found -print -quit)
+  if [ -n "$residue" ]; then
+    echo "Restore target is non-empty without completion marker: ${residue}" >&2
+    return 1
+  fi
+}
+
+${__SOURCED__:+false} : || return 0
+restore_preflight_rc=0
+restore_preflight || restore_preflight_rc=$?
+[ "$restore_preflight_rc" -eq 10 ] && exit 0
+[ "$restore_preflight_rc" -ne 0 ] && exit "$restore_preflight_rc"
+
 mkdir -p ${DATA_DIR}
 TMP_DIR=${MYSQL_DIR}/temp
 mkdir -p ${TMP_DIR} && cd ${TMP_DIR}

--- a/addons/mysql/dataprotection/xtrabackup-incremental-restore.sh
+++ b/addons/mysql/dataprotection/xtrabackup-incremental-restore.sh
@@ -3,6 +3,27 @@ set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 
+restore_preflight() {
+  local residue
+
+  mkdir -p "${DATA_DIR}"
+  if [ -f "${DATA_DIR}/.xtrabackup_restore" ]; then
+    echo "Restore already completed; keeping existing data"
+    return 10
+  fi
+  residue=$(find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name lost+found -print -quit)
+  if [ -n "$residue" ]; then
+    echo "Restore target is non-empty without completion marker: ${residue}" >&2
+    return 1
+  fi
+}
+
+${__SOURCED__:+false} : || return 0
+restore_preflight_rc=0
+restore_preflight || restore_preflight_rc=$?
+[ "$restore_preflight_rc" -eq 10 ] && exit 0
+[ "$restore_preflight_rc" -ne 0 ] && exit "$restore_preflight_rc"
+
 # function change_backend_path changes the DATASAFED_BACKEND_BASE_PATH by backup name
 function change_backend_path() {
   backup_name=$1

--- a/addons/mysql/orc-tools/orchestrator-client.sh
+++ b/addons/mysql/orc-tools/orchestrator-client.sh
@@ -275,7 +275,7 @@ function api {
   api_call_result=0
   if [[ ${curl_auth_params} != "401 Unauthorized" ]]; then
     for sleep_time in 0.1 0.2 0.5 1 2 2.5 5 0 ; do
-      api_response=$(curl ${curl_auth_params} -s "$uri" | jq '.')
+      api_response=$(curl ${curl_auth_params} -fsS "$uri" | jq -ce 'select(. != null)')
       api_call_result=$?
       [ $api_call_result -eq 0 ] && break
       sleep $sleep_time
@@ -1048,4 +1048,5 @@ function main {
   run_command
 }
 
+${__SOURCED__:+false} : || return 0
 main

--- a/addons/mysql/orc-tools/orchestrator-client.sh
+++ b/addons/mysql/orc-tools/orchestrator-client.sh
@@ -145,7 +145,7 @@ function universal_sed {
 }
 
 function fail {
-  message="$myname[$$]: $1"
+  message="${myname}[$$]: $1"
   >&2 echo "$message"
   exit 1
 }

--- a/addons/mysql/scripts-ut-spec/incremental_restore_preflight_spec.sh
+++ b/addons/mysql/scripts-ut-spec/incremental_restore_preflight_spec.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+
+Describe "incremental xtrabackup restore preflight"
+  setup() {
+    export __SOURCED__=1
+    export DATA_DIR="${SHELLSPEC_TMPBASE}/mysql-incremental-data"
+    rm -rf "$DATA_DIR"
+  }
+  Before "setup"
+  Include ../dataprotection/xtrabackup-incremental-restore.sh
+
+  It "allows an empty target"
+    When call restore_preflight
+    The status should be success
+  End
+
+  It "treats a completion marker as an idempotent retry"
+    mkdir -p "$DATA_DIR"
+    touch "$DATA_DIR/.xtrabackup_restore"
+    When call restore_preflight
+    The status should equal 10
+    The output should include "already completed"
+  End
+
+  It "fails closed on partial restored data"
+    mkdir -p "$DATA_DIR/mysql"
+    When call restore_preflight
+    The status should be failure
+    The stderr should include "non-empty without completion marker"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/mysql_myloader_spec.sh
+++ b/addons/mysql/scripts-ut-spec/mysql_myloader_spec.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "mysql-myloader.sh restore credential wiring"
+
+    restore_env() {
+        export DP_DATASAFED_BIN_PATH="/tmp"
+        export DP_BACKUP_BASE_PATH="/tmp"
+        export DP_BACKUP_NAME="restore-bk"
+        export DP_BACKUP_INFO_FILE="/tmp/mysql-myloader-info-$$"
+        # DP injects these connection vars into the restore job; the script
+        # already relies on DP_DB_HOST / DP_DB_PORT on the same myloader line.
+        export DP_DB_HOST="db-host"
+        export DP_DB_PORT="3306"
+        export DP_DB_USER="dp_user"
+        export DP_DB_PASSWORD="dp_pass"
+        # component-container-only creds that are NOT injected into the DP job.
+        export MYSQL_ADMIN_USER="admin_user"
+        export MYSQL_ADMIN_PASSWORD="admin_pass"
+        export threads="2"
+    }
+    BeforeEach "restore_env"
+
+    cleanup() {
+        rm -f "${DP_BACKUP_INFO_FILE}" "${DP_BACKUP_INFO_FILE}.exit"
+    }
+    AfterEach "cleanup"
+
+    It "connects with DP_DB_USER/DP_DB_PASSWORD (matching mysql-mydumper.sh), not MYSQL_ADMIN_*"
+        datasafed() { return 0; }
+        myloader() { echo "MYLOADER_INVOKED $*"; cat >/dev/null; }
+        When run source ../dataprotection/mysql-myloader.sh
+        The status should be success
+        The stdout should include "MYLOADER_INVOKED"
+        The stdout should include "-u dp_user"
+        The stdout should include "-p dp_pass"
+        The stdout should not include "admin_user"
+        The stdout should not include "admin_pass"
+    End
+
+    It "does not reference component-only MYSQL_ADMIN_* creds (restore-job asymmetry regression guard)"
+        When run grep -F "MYSQL_ADMIN" ../dataprotection/mysql-myloader.sh
+        The status should be failure
+        The output should equal ""
+    End
+
+End

--- a/addons/mysql/scripts-ut-spec/orc_api_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_api_contract_spec.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+
+Describe "Orchestrator API contract"
+  Describe "init alias endpoint"
+    Include ../scripts/init-mysql-instance-for-orc.sh
+
+    It "normalizes a host endpoint with the API port"
+      ORCHESTRATOR_API=""
+      ORC_ENDPOINTS="mysql-orchestrator"
+      ORC_PORTS="3000"
+      When call orchestrator_api_base
+      The output should equal "http://mysql-orchestrator:3000"
+      The status should be success
+    End
+
+    It "does not double-prefix a configured URL"
+      ORCHESTRATOR_API="http://mysql-orchestrator:3000/api"
+      When call orchestrator_api_base
+      The output should equal "http://mysql-orchestrator:3000"
+      The status should be success
+    End
+
+    It "uses the normalized API endpoint for alias registration"
+      ORCHESTRATOR_API=""
+      ORC_ENDPOINTS="mysql-orchestrator:9999"
+      ORC_PORTS="3000"
+      curl() { printf '%s\n' "$*"; }
+      When call set_cluster_alias "mysql-0:3306" "mysql"
+      The output should include "--max-time 4"
+      The output should include "http://mysql-orchestrator:3000/api/set-cluster-alias/mysql-0:3306?alias=mysql"
+      The status should be success
+    End
+  End
+
+  Describe "client HTTP response"
+    setup_client() {
+      export __SOURCED__=1
+      export ORCHESTRATOR_API="http://orchestrator:3000/api"
+    }
+    Before "setup_client"
+    Include ../scripts/orchestrator-client.sh
+
+    It "rejects an HTTP error even when the body is JSON"
+      curl() { printf '%s\n' '{"Code":"OK"}'; return 22; }
+      sleep() { :; }
+      When run api "clusters-info"
+      The status should be failure
+      The stderr should include "Cannot access orchestrator"
+    End
+
+    It "rejects a JSON null response"
+      curl() { printf '%s\n' 'null'; }
+      sleep() { :; }
+      When run api "clusters-info"
+      The status should be failure
+      The stderr should include "Cannot access orchestrator"
+    End
+  End
+End

--- a/addons/mysql/scripts-ut-spec/orc_member_leave_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_member_leave_spec.sh
@@ -1,0 +1,106 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2329
+
+Describe "ORC memberLeave script tests"
+  Include ../scripts/orc-member-leave.sh
+
+  setup_member_leave() {
+    export KB_LEAVE_MEMBER_POD_NAME="mysql-2"
+    export MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS=10
+    export MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS=0
+  }
+
+  cleanup_member_leave() {
+    unset KB_LEAVE_MEMBER_POD_NAME
+    unset KB_AGENT_POD_NAME
+    unset MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS
+    unset MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS
+  }
+
+  Before 'setup_member_leave'
+  After 'cleanup_member_leave'
+
+  It "closes only after all bounded calls prove the instance is absent"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget|clusters) return 0 ;;
+        all-instances) printf '%s\n' 'mysql-0:3306' 'mysql-1:3306' ; return 0 ;;
+      esac
+      return 1
+    }
+
+    When call run_member_leave
+    The status should be success
+    The output should include "successfully removed"
+  End
+
+  It "fails when the bounded forget call times out"
+    run_orchestrator_client_with_budget() {
+      [ "$3" = "forget" ] && return 124
+      return 0
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The error should include "phase: forget-command-failed"
+    The error should include "rc: 124"
+  End
+
+  It "fails when the bounded reachability call times out"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget) return 0 ;;
+        clusters) return 124 ;;
+      esac
+      return 0
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The output should include "Forget command executed"
+    The error should include "phase: orchestrator-unreachable"
+    The error should include "rc: 124"
+  End
+
+  It "fails when the bounded instance verification call times out"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget|clusters) return 0 ;;
+        all-instances) return 124 ;;
+      esac
+      return 1
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The output should include "Forget command executed"
+    The error should include "phase: instance-verification-failed"
+    The error should include "rc: 124"
+  End
+
+  It "fails while the instance remains present"
+    run_orchestrator_client_with_budget() {
+      case "$3" in
+        forget|clusters) return 0 ;;
+        all-instances) printf '%s\n' 'mysql-0:3306' 'mysql-2:3306' ; return 0 ;;
+      esac
+      return 1
+    }
+
+    When call run_member_leave
+    The status should be failure
+    The output should include "Forget command executed"
+    The error should include "phase: instance-still-present"
+    The error should include "next-retry-safe: yes"
+  End
+
+  It "rejects a missing leaving-member identity"
+    unset KB_LEAVE_MEMBER_POD_NAME
+    unset KB_AGENT_POD_NAME
+
+    When call run_member_leave
+    The status should be failure
+    The error should include "phase: leaving-member-missing"
+    The error should include "next-retry-safe: no"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/orc_preterminate_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_preterminate_spec.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+
+Describe "Orchestrator preTerminate contract"
+  setup() {
+    export __SOURCED__=1
+    export CLUSTER_NAME="mysql-cluster"
+  }
+  Before "setup"
+  Include ../scripts/orc-preterminate.sh
+
+  It "fails closed when Orchestrator is unreachable"
+    run_orchestrator_client() { return 124; }
+    When run forget_cluster
+    The status should be failure
+    The stderr should include "Orchestrator unreachable"
+  End
+
+  It "forgets by cluster alias and verifies absence"
+    run_orchestrator_client() {
+      case "$*" in
+        "-c clusters-alias") printf '%s\n' "other,other" ;;
+        "-c forget-cluster -alias mysql-cluster") return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+    sleep() { :; }
+    When run forget_cluster
+    The status should be success
+    The output should include "successfully removed"
+  End
+
+  It "fails when the alias remains registered"
+    run_orchestrator_client() {
+      case "$*" in
+        "-c clusters-alias") printf '%s\n' "mysql-cluster,mysql-cluster" ;;
+        "-c forget-cluster -alias mysql-cluster") return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+    sleep() { :; }
+    When run forget_cluster
+    The status should be failure
+    The stderr should include "still exists"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
@@ -28,13 +28,23 @@ Describe "ORC switchover script tests"
       The variable ORC_PRECHECK_STDERR should include "transient response parse failed"
     End
 
-    It "selects the last valid host-port token from stdout"
+    It "rejects colon-shaped jq noise without a Kubernetes hostname"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' 'jq:error:42'
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be failure
+      The variable ORC_PRECHECK_MASTER should equal ""
+      The variable ORC_PRECHECK_STDOUT should equal "jq:error:42"
+    End
+
+    It "selects the valid host-port token around colon-shaped noise"
       run_orchestrator_client_with_budget() {
         printf '%s\n' \
-          'retrying request' \
-          'mysql-stale:3306' \
-          'not a master token' \
-          'mysql-current:3306'
+          'jq:error:42' \
+          'mysql-current:3306' \
+          'curl:error:7'
       }
 
       When call resolve_orchestrator_master_with_budget 3 mysql-0

--- a/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_switchover_spec.sh
@@ -4,6 +4,45 @@
 Describe "ORC switchover script tests"
   Include ../scripts/orc-switchover.sh
 
+  Describe "Orchestrator master precheck parsing"
+    It "keeps retry stderr out of a final successful master token"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' 'mysql-1:3306'
+        printf '%s\n' 'jq: error: transient response parse failed' >&2
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be success
+      The variable ORC_PRECHECK_MASTER should equal "mysql-1:3306"
+      The variable ORC_PRECHECK_STDERR should include "transient response parse failed"
+    End
+
+    It "fails closed when the client emits only stderr noise"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' 'jq: error: transient response parse failed' >&2
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be failure
+      The variable ORC_PRECHECK_MASTER should equal ""
+      The variable ORC_PRECHECK_STDERR should include "transient response parse failed"
+    End
+
+    It "selects the last valid host-port token from stdout"
+      run_orchestrator_client_with_budget() {
+        printf '%s\n' \
+          'retrying request' \
+          'mysql-stale:3306' \
+          'not a master token' \
+          'mysql-current:3306'
+      }
+
+      When call resolve_orchestrator_master_with_budget 3 mysql-0
+      The status should be success
+      The variable ORC_PRECHECK_MASTER should equal "mysql-current:3306"
+    End
+  End
+
   Describe "MySQL read flag parsing"
     It "recognizes writable flags after mysql client stderr noise"
       output=$(printf '%s\n%s\n' \

--- a/addons/mysql/scripts-ut-spec/proxysql_entry_spec.sh
+++ b/addons/mysql/scripts-ut-spec/proxysql_entry_spec.sh
@@ -33,4 +33,103 @@ Describe "ProxySQL Entry Script Tests"
         End
     End
 
+    Describe "term_handler unit contract"
+        # Include defines term_handler without running the main body, because
+        # the script's __SOURCED__ guard returns early after the function decls.
+        # term_handler ends with `exit 0`, so use `When run` (subshell) here.
+        Include ../scripts/proxysql-entry.sh
+
+        It "forwards SIGTERM to the captured proxysql pid and exits 0"
+            kill() { echo "kill $*"; }
+            wait() { echo "wait $*"; }
+            pid=12345
+            When run term_handler
+            The status should be success
+            The stdout should include "kill -TERM 12345"
+        End
+
+        It "is a no-op when no proxysql pid was captured (signal before spawn)"
+            kill() { echo "kill $*"; }
+            wait() { echo "wait $*"; }
+            pid=0
+            When run term_handler
+            The status should be success
+            The stdout should not include "kill"
+        End
+
+        It "terminates instead of falling through to a second wait (double-wait guard)"
+            # If term_handler returned instead of exiting, control would fall
+            # through to the main path's bottom `wait "$pid"`, which under set -e
+            # would exit 127 ("not a child") after the handler already reaped it.
+            kill() { :; }
+            wait() { :; }
+            pid=999
+            probe() { term_handler; echo "FELL_THROUGH"; }
+            When run probe
+            The status should be success
+            The output should not include "FELL_THROUGH"
+        End
+
+        It "installs a SIGTERM/SIGINT trap before spawning proxysql"
+            When run cat ../scripts/proxysql-entry.sh
+            The status should be success
+            The output should include "trap 'term_handler' SIGTERM SIGINT"
+            # trap line must appear before the proxysql spawn line
+            trap_ln=$(grep -n "trap 'term_handler'" ../scripts/proxysql-entry.sh | head -1 | cut -d: -f1)
+            spawn_ln=$(grep -n "^proxysql -c" ../scripts/proxysql-entry.sh | head -1 | cut -d: -f1)
+            The variable trap_ln should satisfy test "$trap_ln" -lt "$spawn_ln"
+        End
+    End
+
+    Describe "end-to-end SIGTERM forwarding to a real proxysql child"
+        run_signal_test() {
+            tmpdir=$(mktemp -d)
+            marker="${tmpdir}/term-received"
+            ready="${tmpdir}/proxysql-up"
+
+            # stub proxysql: signal readiness, record SIGTERM, exit cleanly.
+            cat > "${tmpdir}/proxysql" <<STUB
+#!/usr/bin/env bash
+trap 'echo received > "${marker}"; exit 0' TERM
+echo up > "${ready}"
+while true; do sleep 0.05; done
+STUB
+            chmod +x "${tmpdir}/proxysql"
+
+            # stub configure helper and sed: succeed immediately (sed stub avoids
+            # BSD/GNU -i differences on the test host).
+            printf '#!/usr/bin/env bash\nexit 0\n' > "${tmpdir}/configure.sh"
+            chmod +x "${tmpdir}/configure.sh"
+            printf '#!/usr/bin/env bash\nexit 0\n' > "${tmpdir}/sed"
+            chmod +x "${tmpdir}/sed"
+
+            PATH="${tmpdir}:${PATH}" \
+                PROXYSQL_CONFIGURE_SCRIPT="${tmpdir}/configure.sh" \
+                PROXYSQL_CONFIG_TPL="/dev/null" \
+                PROXYSQL_CONFIG_OUT="${tmpdir}/proxysql.cnf" \
+                FRONTEND_TLS_ENABLED=false \
+                bash ../scripts/proxysql-entry.sh >/dev/null 2>&1 &
+            wrapper_pid=$!
+
+            # deterministically wait until proxysql is up (configure is instant,
+            # so the wrapper is then parked at the bottom `wait`), then send TERM.
+            i=0
+            while [ ! -f "${ready}" ] && [ ${i} -lt 100 ]; do sleep 0.05; i=$((i + 1)); done
+            sleep 0.1
+            kill -TERM "${wrapper_pid}" 2>/dev/null
+
+            wait "${wrapper_pid}"
+            rc=$?
+
+            if [ -f "${marker}" ]; then term="yes"; else term="no"; fi
+            rm -rf "${tmpdir}"
+            echo "child_term=${term} wrapper_rc=${rc}"
+        }
+
+        It "delivers SIGTERM to the proxysql child and the wrapper exits 0"
+            When call run_signal_test
+            The output should equal "child_term=yes wrapper_rc=0"
+        End
+    End
+
 End

--- a/addons/mysql/scripts-ut-spec/restore_preflight_spec.sh
+++ b/addons/mysql/scripts-ut-spec/restore_preflight_spec.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+
+Describe "xtrabackup restore preflight"
+  setup() {
+    export __SOURCED__=1
+    export DATA_DIR="${SHELLSPEC_TMPBASE}/mysql-data"
+    rm -rf "$DATA_DIR"
+  }
+  Before "setup"
+
+  Describe "full restore"
+    Include ../dataprotection/restore.sh
+
+    It "allows an empty target"
+      When call restore_preflight
+      The status should be success
+    End
+
+    It "treats a completion marker as an idempotent retry"
+      mkdir -p "$DATA_DIR"
+      touch "$DATA_DIR/.xtrabackup_restore"
+      When call restore_preflight
+      The status should equal 10
+      The output should include "already completed"
+    End
+
+    It "fails closed on partial restored data"
+      mkdir -p "$DATA_DIR/mysql"
+      When call restore_preflight
+      The status should be failure
+      The stderr should include "non-empty without completion marker"
+    End
+
+    It "ignores a filesystem lost+found directory"
+      mkdir -p "$DATA_DIR/lost+found"
+      When call restore_preflight
+      The status should be success
+    End
+  End
+End

--- a/addons/mysql/scripts/init-mysql-instance-for-orc.sh
+++ b/addons/mysql/scripts/init-mysql-instance-for-orc.sh
@@ -20,6 +20,27 @@ mysql_error() {
 	exit 1
 }
 
+orchestrator_api_base() {
+  local endpoint="${ORCHESTRATOR_API:-${ORC_ENDPOINTS%% *}}"
+
+  if [[ "$endpoint" != http://* && "$endpoint" != https://* ]]; then
+    endpoint="${endpoint%%:*}"
+    endpoint="http://${endpoint}:${ORC_PORTS}"
+  fi
+  endpoint="${endpoint%/}"
+  printf '%s\n' "${endpoint%/api}"
+}
+
+set_cluster_alias() {
+  local cluster_info="$1"
+  local cluster_alias="$2"
+  local api_base
+
+  api_base=$(orchestrator_api_base)
+  curl --fail --silent --show-error --max-time 4 -X GET \
+    "${api_base}/api/set-cluster-alias/${cluster_info}?alias=${cluster_alias}"
+}
+
 # create orchestrator user in mysql
 create_mysql_user() {
   mysql_note "Create MySQL User and Grant Permissions..."
@@ -48,8 +69,6 @@ EOF
 
   local instance="${POD_NAME}"
   local cluster_alias="${CLUSTER_NAME}"
-  local orchestrator_url="${ORC_ENDPOINTS}" # for example, http://orchestrator:3000
-
   mysql_note "Registering cluster in Orchestrator"
   mysql_note "  Instance: $instance"
   mysql_note "  Alias: $cluster_alias"
@@ -90,7 +109,7 @@ EOF
   fi
 
   # Set alias via API
-  curl --silent -X GET "http://${orchestrator_url}/api/set-cluster-alias/${cluster_info}?alias=${cluster_alias}"
+  set_cluster_alias "$cluster_info" "$cluster_alias"
   sleep 5
   result=""
   attempt=0
@@ -102,7 +121,7 @@ EOF
     fi
     mysql_note "Cluster alias not set yet, waiting... (attempt $((attempt + 1))/$max_attempts)"
     attempt=$((attempt + 1))
-    curl --silent -X GET "http://${orchestrator_url}/api/set-cluster-alias/${cluster_info}?alias=${cluster_alias}"
+    set_cluster_alias "$cluster_info" "$cluster_alias"
     sleep 5
   done
   if [ $attempt -eq $max_attempts ]; then

--- a/addons/mysql/scripts/orc-member-leave.sh
+++ b/addons/mysql/scripts/orc-member-leave.sh
@@ -1,49 +1,120 @@
 #!/bin/bash
 
-# Logging functions
 mysql_log() {
   local text="$*"; if [ "$#" -eq 0 ]; then text="$(cat)"; fi
-  printf '%s\n'  "$text"
+  printf '%s\n' "$text"
 }
 mysql_note() {
   mysql_log "$@"
 }
-mysql_warn() {
-  mysql_log "$@" >&2
-}
-mysql_error() {
-  mysql_log "$@" >&2
-  exit 1
+
+member_leave_diagnose_not_ready() {
+  local phase="$1"
+  local ctx="$2"
+  local retry_safe="$3"
+  {
+    echo "orc memberLeave diagnosis:"
+    echo "  action: memberLeave"
+    echo "  phase: ${phase}"
+    echo "  leaving-member: ${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME:-<unset>}}"
+    echo "${ctx}"
+    echo "  next-retry-safe: ${retry_safe}"
+  } >&2
 }
 
-# memberLeave contract: KubeBlocks injects the LEAVING member's identity as
-# KB_LEAVE_MEMBER_POD_NAME; the action may execute on a different pod, so
-# KB_AGENT_POD_NAME (the execution pod) is only a fallback for older runtimes.
-leave_member="${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME}}"
-if [ -z "$leave_member" ]; then
-  mysql_error "Neither KB_LEAVE_MEMBER_POD_NAME nor KB_AGENT_POD_NAME is set"
-fi
+run_command_with_budget() {
+  local budget="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 1s "${budget}s" "$@"
+    return $?
+  fi
 
-# Forget instance from Orchestrator
-if /kubeblocks/orchestrator-client -c forget -i "${leave_member}" 2>&1; then
+  local temp_dir output_file error_file timeout_file pid timer_pid rc
+  temp_dir=$(mktemp -d /tmp/orc-member-leave.XXXXXX) || return 1
+  output_file="${temp_dir}/output"
+  error_file="${temp_dir}/error"
+  timeout_file="${temp_dir}/timeout"
+  "$@" > "${output_file}" 2> "${error_file}" &
+  pid=$!
+  (
+    sleep "${budget}"
+    if kill -0 "${pid}" 2>/dev/null; then
+      printf 'timeout\n' > "${timeout_file}"
+      kill "${pid}" 2>/dev/null || true
+      sleep 1
+      kill -9 "${pid}" 2>/dev/null || true
+    fi
+  ) &
+  timer_pid=$!
+
+  wait "${pid}" 2>/dev/null
+  rc=$?
+  kill "${timer_pid}" 2>/dev/null || true
+  wait "${timer_pid}" 2>/dev/null || true
+  cat "${output_file}"
+  cat "${error_file}" >&2
+  if [ -s "${timeout_file}" ]; then
+    rc=124
+  fi
+  rm -rf "${temp_dir}"
+  return "$rc"
+}
+
+run_orchestrator_client_with_budget() {
+  local budget="$1"
+  shift
+  run_command_with_budget "${budget}" /kubeblocks/orchestrator-client "$@"
+}
+
+run_member_leave() {
+  local leave_member budget settle_seconds output rc
+  leave_member="${KB_LEAVE_MEMBER_POD_NAME:-${KB_AGENT_POD_NAME:-}}"
+  budget="${MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS:-10}"
+  settle_seconds="${MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS:-3}"
+  if [ -z "$leave_member" ]; then
+    member_leave_diagnose_not_ready "leaving-member-missing" \
+      "  required-env: KB_LEAVE_MEMBER_POD_NAME or KB_AGENT_POD_NAME" "no"
+    return 1
+  fi
+
+  output=$(run_orchestrator_client_with_budget "${budget}" -c forget -i "${leave_member}" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    member_leave_diagnose_not_ready "forget-command-failed" \
+      "$(printf '  rc: %s\n  output: %s' "$rc" "${output:-<empty>}")" "yes"
+    return 1
+  fi
   mysql_note "Forget command executed"
-else
-  mysql_note "Forget command failed, continuing anyway"
-fi
 
-sleep 3
+  sleep "${settle_seconds}"
+  mysql_note "Verifying instance was forgotten..."
+  output=$(run_orchestrator_client_with_budget "${budget}" -c clusters 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    member_leave_diagnose_not_ready "orchestrator-unreachable" \
+      "$(printf '  rc: %s\n  output: %s' "$rc" "${output:-<empty>}")" "yes"
+    return 1
+  fi
 
-# Verify instance was forgotten. "Instance not found" and "Orchestrator is
-# down" both yield an empty query result, so prove Orchestrator is reachable
-# first - otherwise an outage would be reported as a successful removal.
-mysql_note "Verifying instance was forgotten..."
-if ! /kubeblocks/orchestrator-client -c clusters >/dev/null 2>&1; then
-  mysql_error "Orchestrator unreachable; cannot verify removal of ${leave_member}"
-fi
-instance_info=$(/kubeblocks/orchestrator-client -c instance -i "${leave_member}" 2>/dev/null || true)
+  output=$(run_orchestrator_client_with_budget "${budget}" -c all-instances 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    member_leave_diagnose_not_ready "instance-verification-failed" \
+      "$(printf '  rc: %s\n  output: %s' "$rc" "${output:-<empty>}")" "yes"
+    return 1
+  fi
+  if ! printf '%s\n' "$output" | awk -F: -v target="$leave_member" '$1 == target { found = 1 } END { exit found ? 0 : 1 }'; then
+    mysql_note "Instance ${leave_member} successfully removed from Orchestrator"
+    return 0
+  fi
 
-if [ -z "$instance_info" ]; then
-  mysql_note "Instance ${leave_member} successfully removed from Orchestrator"
-  exit 0
-fi
-mysql_error "Instance ${leave_member} still exists in Orchestrator"
+  member_leave_diagnose_not_ready "instance-still-present" \
+    "  observed: ${output}" "yes"
+  return 1
+}
+
+# ShellSpec includes this file to test functions without executing the action.
+${__SOURCED__:+false} : || return 0
+
+run_member_leave

--- a/addons/mysql/scripts/orc-preterminate.sh
+++ b/addons/mysql/scripts/orc-preterminate.sh
@@ -16,27 +16,30 @@ mysql_error() {
   exit 1
 }
 
-# Forget cluster
-if /kubeblocks/orchestrator-client -c forget-cluster -i "${KB_AGENT_POD_NAME}" 2>&1; then
-  mysql_note "Forget cluster command executed"
-else
-  mysql_note "Forget cluster command failed, continuing anyway"
-fi
+run_orchestrator_client() {
+  local budget="${ORC_PRETERMINATE_CLIENT_TIMEOUT_SECONDS:-8}"
+  timeout "${budget}s" /kubeblocks/orchestrator-client "$@"
+}
 
-if /kubeblocks/orchestrator-client -c forget-cluster -alias "${CLUSTER_NAME}" 2>&1; then
-  mysql_note "Forget cluster command executed"
-else
-  mysql_note "Forget cluster command failed, continuing anyway"
-fi
+forget_cluster() {
+  local clusters
 
+  if ! run_orchestrator_client -c clusters-alias >/dev/null; then
+    mysql_error "Orchestrator unreachable; refusing to report cluster removal"
+  fi
+  if ! run_orchestrator_client -c forget-cluster -alias "${CLUSTER_NAME}"; then
+    mysql_error "Failed to forget cluster alias ${CLUSTER_NAME}"
+  fi
 
-sleep 3
+  sleep 3
+  if ! clusters=$(run_orchestrator_client -c clusters-alias); then
+    mysql_error "Orchestrator unreachable; cannot verify removal of ${CLUSTER_NAME}"
+  fi
+  if printf '%s\n' "$clusters" | awk -F, -v name="$CLUSTER_NAME" '$1 == name || $2 == name { found=1 } END { exit !found }'; then
+    mysql_error "Cluster ${CLUSTER_NAME} still exists in Orchestrator"
+  fi
+  mysql_note "Cluster ${CLUSTER_NAME} successfully removed from Orchestrator"
+}
 
-# Check if cluster still exists
-cluster_name=$(/kubeblocks/orchestrator-client -c which-cluster -i "${KB_AGENT_POD_NAME}" 2>/dev/null || echo "")
-if [ -z "$cluster_name" ]; then
-  mysql_note "Cluster successfully forgotten from Orchestrator"
-  exit 0
-fi
-
-mysql_error "Cluster still exists in Orchestrator: ${cluster_name}"
+${__SOURCED__:+false} : || return 0
+forget_cluster

--- a/addons/mysql/scripts/orc-switchover.sh
+++ b/addons/mysql/scripts/orc-switchover.sh
@@ -82,7 +82,7 @@ ORC_PRECHECK_MASTER=""
 
 extract_last_orchestrator_instance() {
   awk '
-    /^[^[:space:]]+:[0-9]+$/ {
+    /^[^[:space:]:]+:[0-9]+$/ {
       last = $0
       found = 1
     }

--- a/addons/mysql/scripts/orc-switchover.sh
+++ b/addons/mysql/scripts/orc-switchover.sh
@@ -38,11 +38,12 @@ run_command_with_budget() {
     return $?
   fi
 
-  local temp_dir output_file timeout_file pid timer_pid rc
+  local temp_dir output_file error_file timeout_file pid timer_pid rc
   temp_dir=$(mktemp -d /tmp/orc-switchover.XXXXXX) || return 1
   output_file="${temp_dir}/output"
+  error_file="${temp_dir}/error"
   timeout_file="${temp_dir}/timeout"
-  "$@" > "${output_file}" 2>&1 &
+  "$@" > "${output_file}" 2> "${error_file}" &
   pid=$!
   (
     sleep "${budget}"
@@ -60,6 +61,7 @@ run_command_with_budget() {
   kill "${timer_pid}" 2>/dev/null || true
   wait "${timer_pid}" 2>/dev/null || true
   cat "${output_file}"
+  cat "${error_file}" >&2
   if [ -s "${timeout_file}" ]; then
     rc=124
   fi
@@ -71,6 +73,55 @@ run_orchestrator_client_with_budget() {
   local budget="$1"
   shift
   run_command_with_budget "${budget}" /kubeblocks/orchestrator-client "$@"
+}
+
+ORC_PRECHECK_RC=""
+ORC_PRECHECK_STDOUT=""
+ORC_PRECHECK_STDERR=""
+ORC_PRECHECK_MASTER=""
+
+extract_last_orchestrator_instance() {
+  awk '
+    /^[^[:space:]]+:[0-9]+$/ {
+      last = $0
+      found = 1
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+      print last
+    }
+  '
+}
+
+resolve_orchestrator_master_with_budget() {
+  local budget="$1"
+  local instance="$2"
+  local stderr_file
+
+  ORC_PRECHECK_RC=""
+  ORC_PRECHECK_STDOUT=""
+  ORC_PRECHECK_STDERR=""
+  ORC_PRECHECK_MASTER=""
+  if ! stderr_file=$(mktemp /tmp/orc-master-precheck.XXXXXX); then
+    ORC_PRECHECK_RC=1
+    ORC_PRECHECK_STDERR="failed to create master precheck stderr file"
+    return 1
+  fi
+
+  ORC_PRECHECK_STDOUT=$(run_orchestrator_client_with_budget "${budget}" \
+    -c which-cluster-master -i "${instance}" 2> "${stderr_file}")
+  ORC_PRECHECK_RC=$?
+  ORC_PRECHECK_STDERR=$(cat "${stderr_file}" 2>/dev/null || true)
+  rm -f "${stderr_file}"
+  if [ "${ORC_PRECHECK_RC}" -ne 0 ]; then
+    return 1
+  fi
+
+  ORC_PRECHECK_MASTER=$(printf '%s\n' "${ORC_PRECHECK_STDOUT}" | extract_last_orchestrator_instance) \
+    || return 1
+  [ -n "${ORC_PRECHECK_MASTER}" ]
 }
 
 ORC_SWITCHOVER_CLIENT_PID=""
@@ -245,18 +296,16 @@ append_switchover_verify_history() {
 
 verify_switchover_closed_once() {
   local candidate="${KB_SWITCHOVER_CANDIDATE_NAME:-}"
-  local master_from_orc precheck_budget rc
+  local precheck_budget
   precheck_budget="${MYSQL_ORC_SWITCHOVER_PRECHECK_TIMEOUT_SECONDS:-3}"
 
   if [ -z "$candidate" ]; then
-    master_from_orc=$(run_orchestrator_client_with_budget "${precheck_budget}" -c which-cluster-master -i "${KB_SWITCHOVER_CURRENT_NAME}" 2>&1)
-    rc=$?
-    if [ $rc -ne 0 ]; then
-      SWITCHOVER_VERIFY_CANDIDATE_FLAGS="candidate lookup rc=${rc} output=${master_from_orc}"
+    if ! resolve_orchestrator_master_with_budget "${precheck_budget}" "${KB_SWITCHOVER_CURRENT_NAME}"; then
+      SWITCHOVER_VERIFY_CANDIDATE_FLAGS="candidate lookup rc=${ORC_PRECHECK_RC:-1} stdout=${ORC_PRECHECK_STDOUT:-<empty>} stderr=${ORC_PRECHECK_STDERR:-<empty>}"
       SWITCHOVER_VERIFY_CURRENT_FLAGS="<not checked>"
       return 1
     fi
-    candidate="${master_from_orc%%:*}"
+    candidate="${ORC_PRECHECK_MASTER%%:*}"
   fi
   SWITCHOVER_VERIFY_CANDIDATE="${candidate:-<empty>}"
 
@@ -388,11 +437,10 @@ fi
 # not be mistaken for a master name (that previously made this guard exit 0).
 precheck_budget="${MYSQL_ORC_SWITCHOVER_PRECHECK_TIMEOUT_SECONDS:-3}"
 
-master_from_orc=$(run_orchestrator_client_with_budget "${precheck_budget}" -c which-cluster-master -i "${KB_SWITCHOVER_CURRENT_NAME}" 2>&1)
-rc=$?
-if [ $rc -ne 0 ] || [ -z "$master_from_orc" ]; then
-  mysql_error "Could not determine current master from Orchestrator (rc=${rc}): ${master_from_orc}"
+if ! resolve_orchestrator_master_with_budget "${precheck_budget}" "${KB_SWITCHOVER_CURRENT_NAME}"; then
+  mysql_error "Could not determine current master from Orchestrator (rc=${ORC_PRECHECK_RC:-1}, stdout=${ORC_PRECHECK_STDOUT:-<empty>}, stderr=${ORC_PRECHECK_STDERR:-<empty>})"
 fi
+master_from_orc="${ORC_PRECHECK_MASTER}"
 
 if [ "${KB_SWITCHOVER_CURRENT_NAME}" != "${master_from_orc%%:*}" ]; then
   mysql_note "Current instance is not the master, skipping."

--- a/addons/mysql/scripts/orchestrator-client.sh
+++ b/addons/mysql/scripts/orchestrator-client.sh
@@ -145,7 +145,7 @@ function universal_sed {
 }
 
 function fail {
-  message="$myname[$$]: $1"
+  message="${myname}[$$]: $1"
   >&2 echo "$message"
   exit 1
 }
@@ -237,7 +237,7 @@ function detect_leader_api {
     leader_api="$(normalize_orchestrator_api $orchestrator_api)"
     return
   fi
-  for api in ${apis[@]} ; do
+  for api in "${apis[@]}" ; do
     api=$(normalize_orchestrator_api $api)
     leader_check=$(curl ${curl_auth_params} -m 1 -s -o /dev/null -w "%{http_code}" "${api}/leader-check")
     if [ "$leader_check" == "200" ] ; then
@@ -246,7 +246,7 @@ function detect_leader_api {
     fi
   done
   # Cannot find leader directly. Maybe our config is wrong. But, perhaps one of the nodes can route us?
-  for api in ${apis[@]} ; do
+  for api in "${apis[@]}" ; do
     api=$(normalize_orchestrator_api $api)
     leader_check=$(curl ${curl_auth_params} -m 1 -s -o /dev/null -w "%{http_code}" "${api}/routed-leader-check")
     if [ "$leader_check" == "200" ] ; then

--- a/addons/mysql/scripts/orchestrator-client.sh
+++ b/addons/mysql/scripts/orchestrator-client.sh
@@ -275,7 +275,7 @@ function api {
   api_call_result=0
   if [[ ${curl_auth_params} != "401 Unauthorized" ]]; then
     for sleep_time in 0.1 0.2 0.5 1 2 2.5 5 0 ; do
-      api_response=$(curl ${curl_auth_params} -s "$uri" | jq '.')
+      api_response=$(curl ${curl_auth_params} -fsS "$uri" | jq -ce 'select(. != null)')
       api_call_result=$?
       [ $api_call_result -eq 0 ] && break
       sleep $sleep_time
@@ -1048,4 +1048,5 @@ function main {
   run_command
 }
 
+${__SOURCED__:+false} : || return 0
 main

--- a/addons/mysql/scripts/proxysql-entry.sh
+++ b/addons/mysql/scripts/proxysql-entry.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -e
 
+# pid stores the process id of the proxysql child; 0 until proxysql is spawned
+# so a signal arriving before the spawn is a safe no-op.
+declare -i pid=0
+
+# term_handler forwards pod-termination signals to the proxysql child so it
+# shuts down cleanly instead of being SIGKILLed after the termination grace
+# period, then terminates the wrapper itself. It reaps the child exactly once
+# and exits, so the main path never runs a second `wait` (which would fail with
+# "not a child" / 127 under `set -e`). Defined before the shellspec guard so it
+# stays unit-testable.
+term_handler() {
+  if [ "${pid}" -ne 0 ]; then
+    kill -TERM "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+  fi
+  exit 0
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -11,10 +29,7 @@ ${__SOURCED__:+false} : || return 0
 # use the current scrip name while putting log
 script_name=${0##*/}
 
-# pid stores the process id of the proxysql process
-declare -i pid
-
-if [ $FRONTEND_TLS_ENABLED == "true" ]; then
+if [ "${FRONTEND_TLS_ENABLED}" == "true" ]; then
     cp /var/lib/frontend/server/ca.crt /var/lib/proxysql/proxysql-ca.pem
     cp /var/lib/frontend/server/tls.crt /var/lib/proxysql/proxysql-cert.pem
     cp /var/lib/frontend/server/tls.key /var/lib/proxysql/proxysql-key.pem
@@ -30,21 +45,33 @@ if [ "${__SOURCED__:+x}" ]; then
   return 0
 fi
 
+# Install the signal trap as the first thing in the main path (pid is still 0)
+# so any SIGTERM during startup — config rendering, spawn, or the configure
+# helper — is handled instead of killing the wrapper with the default action.
+trap 'term_handler' SIGTERM SIGINT
+
+# These paths are overridable so the signal-handling contract can be exercised
+# end-to-end in tests. They default to the in-image paths (no behavior change).
+: "${PROXYSQL_CONFIGURE_SCRIPT:=/scripts/proxysql/configure-proxysql.sh}"
+: "${PROXYSQL_CONFIG_TPL:=/config/custom-config/proxysql.tpl}"
+: "${PROXYSQL_CONFIG_OUT:=/proxysql.cnf}"
+
 function replace_config_variables() {
-  cat /config/custom-config/proxysql.tpl > /proxysql.cnf
-  sed -i "s|\${PROXYSQL_MONITOR_PASSWORD}|${PROXYSQL_MONITOR_PASSWORD}|g" /proxysql.cnf
-  sed -i "s|\${PROXYSQL_CLUSTER_PASSWORD}|${PROXYSQL_CLUSTER_PASSWORD}|g" /proxysql.cnf
-  sed -i "s|\${PROXYSQL_ADMIN_PASSWORD}|${PROXYSQL_ADMIN_PASSWORD}|g" /proxysql.cnf
+  cat "${PROXYSQL_CONFIG_TPL}" > "${PROXYSQL_CONFIG_OUT}"
+  sed -i "s|\${PROXYSQL_MONITOR_PASSWORD}|${PROXYSQL_MONITOR_PASSWORD}|g" "${PROXYSQL_CONFIG_OUT}"
+  sed -i "s|\${PROXYSQL_CLUSTER_PASSWORD}|${PROXYSQL_CLUSTER_PASSWORD}|g" "${PROXYSQL_CONFIG_OUT}"
+  sed -i "s|\${PROXYSQL_ADMIN_PASSWORD}|${PROXYSQL_ADMIN_PASSWORD}|g" "${PROXYSQL_CONFIG_OUT}"
 }
 
 echo "Configuring proxysql ..."
 replace_config_variables
-# Start ProxySQL with PID 1
-exec proxysql -c /proxysql.cnf -f $CMDARG &
+
+# Run proxysql as a child (not exec) so this wrapper stays alive as the
+# container init process and can forward signals to it via the trap above.
+proxysql -c /proxysql.cnf -f $CMDARG &
 pid=$!
 
-/scripts/proxysql/configure-proxysql.sh
+"${PROXYSQL_CONFIGURE_SCRIPT}"
 
 echo "Waiting for proxysql ..."
-wait $pid
-
+wait "${pid}"

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -198,15 +198,24 @@ roleProbe:
       - |
         exec /orc-scripts/role-probe.sh
 memberLeave:
+  # Three sequential client calls at 10s plus a 1s kill grace and a 3s settle
+  # window fit in 36s, leaving 14s for diagnostics under the 50s action limit.
+  timeoutSeconds: {{ .Values.memberLeave.timeoutSeconds }}
   exec:
+    env:
+      - name: MYSQL_ORC_MEMBER_LEAVE_CLIENT_TIMEOUT_SECONDS
+        value: "{{ .Values.memberLeave.clientTimeoutSeconds }}"
+      - name: MYSQL_ORC_MEMBER_LEAVE_SETTLE_SECONDS
+        value: "{{ .Values.memberLeave.settleSeconds }}"
     command:
       - /bin/bash
       - -c
       - |
-        /orc-scripts/member-leave.sh 2>> /tmp/member-leave.log
-        if [ $? -ne 0 ]; then
-          echo "ERROR: Failed to member leave"
-          exit 1
+        /orc-scripts/member-leave.sh 2> >(tee -a /tmp/member-leave.log >&2)
+        rc=$?
+        if [ $rc -ne 0 ]; then
+          echo "ERROR: Failed to member leave (rc=${rc})" >&2
+          exit $rc
         fi
 switchover:
   timeoutSeconds: {{ .Values.switchover.timeoutSeconds }}

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -122,6 +122,11 @@ roleProbe:
     timeoutSeconds: 5
     clientTimeoutSeconds: 4
 
+memberLeave:
+  timeoutSeconds: 50
+  clientTimeoutSeconds: 10
+  settleSeconds: 3
+
 switchover:
   # kbagent caps positive action timeouts at 60s; keep a buffer for diagnostics.
   # Worst-case budget: 2*3s prechecks + max(40s ORC CLI, 20*(parallel 1s SQL probes) + 19*1s intervals) = 46s.


### PR DESCRIPTION
## Base and scope

Exact base: `helios/mysql-review-consolidated-20260711@f163740e` (main + 12-fix integration + #3117).

This composition preserves owner commits as separate units and closes the deep-review findings before runtime acceptance:

- myloader restore uses DP-injected credentials;
- ProxySQL forwards termination signals without spawn race or double wait;
- PITR cleanup survives `set -e`, resets per-call state, and matches uploaded files by live binlog prefix;
- `innodb_redo_log_capacity` is optional when memory is unknown;
- ORC alias/API responses fail closed on wrong endpoint, HTTP errors, JSON null, and unreachable preTerminate;
- ORC switchover rejects noisy master tokens;
- ORC memberLeave uses bounded calls and positive all-instances absence proof;
- full/incremental xtrabackup retries are idempotent after completion and fail closed on partial targets.

## Local combined gate

Exact head: `a2a8796c`.

- MySQL full ShellSpec: **69 examples, 0 failures**
- focused/changed scripts `bash -n`: PASS
- changed scripts ShellCheck severity=error: PASS
- `git diff --check f163740e..HEAD`: PASS
- `helm dependency build addons/mysql`: PASS
- `helm lint addons/mysql`: PASS
- `helm template mysql addons/mysql`: PASS
- rendered memberLeave budget: 50s action, 3x10s clients + kill grace/settle <=36s

## Runtime boundary

Runtime N=0 on this combined exact head. This PR is not MySQL acceptance PASS, fullsuite PASS, or release readiness. Test execution must use the exact head and developer-specified focused scripts after this code/static gate is independently reviewed.
