### PR TITLE
fix(postgresql): remove reload-applicable parameters from restart-parameter.yaml

### DIFF
--- a/addons/postgresql/reloader/restart-parameter.yaml
+++ b/addons/postgresql/reloader/restart-parameter.yaml
@@ -1,6 +1,9 @@
 #parameters:
 - archive_mode
 - autovacuum_freeze_max_age
+# autovacuum_max_workers is sighup (reload-applicable) since PG17; kept in the
+# restart list because this file is shared across majors and PG12-16 still
+# require a restart. Cost on PG17+: one unnecessary restart, never a wrong value.
 - autovacuum_max_workers
 - autovacuum_multixact_freeze_max_age
 - bg_mon.history_buckets
@@ -57,7 +60,6 @@
 - recovery_target_time
 - recovery_target_timeline
 - recovery_target_xid
-- session_preload_libraries
 - shared_buffers
 - shared_memory_type
 - shared_preload_libraries
@@ -70,9 +72,6 @@
 - unix_socket_group
 - unix_socket_permissions
 - wal_buffers
-- wal_compression
 - wal_decode_buffer_size
 - wal_level
 - wal_log_hints
-- wal_keep_segments
-- wal_keep_size


### PR DESCRIPTION
Addresses the restart-misrouting item of #3149 (independent of the update-parameter.sh items, which land after #3025 merges to avoid same-file conflicts).

Removes `wal_keep_size`, `wal_keep_segments` (sighup), `wal_compression`, `session_preload_libraries` (superuser) from the restart routing — PostgreSQL applies all four via reload in every supported major, and the forced primary restart was pure downtime. `autovacuum_max_workers` stays with an explanatory comment (sighup only since PG17; shared file; PG17+ cost is an unnecessary restart, never a wrong value).

YAML validated; 4 removals confirmed programmatically. Draft until a reconfigure of one of these params is runtime-verified to reload without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)