### PR TITLE
feat(valkey): restore sharded backups with source slots

### DIFF
--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -194,10 +194,21 @@ if [ "${_cluster_enabled}" = "1" ]; then
     echo "ERROR: cluster mode — invalid slot ranges '${_shard_slot_ranges}' (migration markers, overlap, malformed or out-of-domain); refusing backup metadata." >&2
     exit 1
   fi
+  _rdb_sha256=$(sha256sum ./dump.rdb 2>/dev/null | awk '{print $1}')
+  case "${_rdb_sha256}" in
+    ''|*[!0-9a-fA-F]* )
+      echo "ERROR: cluster mode — cannot compute dump.rdb SHA-256 for restore identity." >&2
+      exit 1 ;;
+  esac
+  [ "${#_rdb_sha256}" -eq 64 ] || {
+    echo "ERROR: cluster mode — invalid dump.rdb SHA-256 length." >&2
+    exit 1
+  }
   {
     printf 'source_shards=%s\n' "${_source_shards}"
     printf 'shard_master_id=%s\n' "${_shard_master_id}"
     printf 'shard_slot_ranges=%s\n' "${_shard_slot_ranges}"
+    printf 'rdb_sha256=%s\n' "${_rdb_sha256}"
   } > ./cluster-meta
   backup_files+=("./cluster-meta")
   # cluster-meta is backup metadata, not engine data: it must not remain

--- a/addons/valkey/dataprotection/backup.sh
+++ b/addons/valkey/dataprotection/backup.sh
@@ -135,13 +135,35 @@ fi
 backup_files=("./dump.rdb")
 [ -f "./users.acl" ] && backup_files+=("./users.acl")
 
+validate_cluster_slot_ranges() {
+  awk -v raw="$1" 'BEGIN {
+    if (raw == "") exit 1
+    n = split(raw, parts, ",")
+    for (i = 1; i <= n; i++) {
+      token = parts[i]
+      if (token ~ /^[0-9]+$/) {
+        start = token + 0; end = start
+      } else if (token ~ /^[0-9]+-[0-9]+$/) {
+        split(token, bounds, "-")
+        start = bounds[1] + 0; end = bounds[2] + 0
+      } else {
+        exit 1
+      }
+      if (start < 0 || end > 16383 || start > end) exit 1
+      for (slot = start; slot <= end; slot++) {
+        if (seen[slot]++) exit 1
+      }
+    }
+  }'
+}
+
 # Cluster (sharding) mode: embed the source shard count as engine truth
 # (master lines in CLUSTER NODES) so restore can verify the same-shard-count
 # v1 boundary. Sentinel/standalone targets skip this (cluster_enabled:0).
 _cluster_enabled=$("${connect_base[@]}" INFO cluster 2>/dev/null | grep "^cluster_enabled:" | tr -d "\\r" | cut -d: -f2)
 if [ "${_cluster_enabled}" = "1" ]; then
   _source_shards=$("${connect_base[@]}" CLUSTER NODES 2>/dev/null | tr -d "\r" | awk '$3 ~ /master/' | grep -c . || true)
-  if [ -z "${_source_shards}" ] || [ "${_source_shards}" -lt 1 ]; then
+  if [ -z "${_source_shards}" ] || [ "${_source_shards}" -lt 3 ] || [ "${_source_shards}" -gt 32 ]; then
     echo "ERROR: cluster mode detected but could not count source shards from CLUSTER NODES." >&2
     exit 1
   fi
@@ -166,6 +188,10 @@ if [ "${_cluster_enabled}" = "1" ]; then
   _shard_slot_ranges=$(echo "${_master_line}" | cut -d' ' -f9- | tr ' ' ',')
   if [ -z "${_shard_slot_ranges}" ]; then
     echo "ERROR: cluster mode — this shard's master ${_shard_master_id} owns no slot ranges; refusing to write empty metadata." >&2
+    exit 1
+  fi
+  if ! validate_cluster_slot_ranges "${_shard_slot_ranges}"; then
+    echo "ERROR: cluster mode — invalid slot ranges '${_shard_slot_ranges}' (migration markers, overlap, malformed or out-of-domain); refusing backup metadata." >&2
     exit 1
   fi
   {

--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -72,35 +72,83 @@ seed_multipart_aof_from_rdb() {
   echo "INFO: Seeded multipart AOF manifest from restored dump.rdb."
 }
 
-# Cluster (sharding) restore: NOT SUPPORTED in v1 — fail fast.
-#
-# Same shard count is NOT a sufficient safety condition (review, PR #3044):
-# restore re-forms the cluster (phase B) with an even slot split, but the
-# SOURCE layout may differ (any post-rebalance / scale history). Keys
-# restored onto a shard that does not own their hash slots are silently
-# unreachable, and archive->target-shard positional mapping is itself
-# unverified. Until a slot-aware restore is designed (cluster-meta already
-# records source_shards + shard_slot_ranges for exactly that), a cluster
-# archive is refused outright — refusal beats silent misplacement.
-refuse_cluster_restore() {
-  local meta="${DATA_DIR}/cluster-meta" source_shards
-  [ -f "${meta}" ] || return 0
-  source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2)
-  # Remove everything THIS run extracted before exiting: the emptiness
-  # guard proved DATA_DIR held no user data at entry, so all entries here
-  # are our own extraction output. Without this, a retried prepareData
-  # pod trips the '/data is not empty' guard over our leftovers and the
-  # TRUE refusal reason is masked on every retry (live finding, CT11
-  # focused rerun).
+# Cluster archives retain cluster-meta until postProvision has rebuilt the
+# engine membership with the archived slot ownership. prepareData validates
+# the local shard metadata here; cluster-wide overlap/gap checks happen while
+# slots are assigned by valkey-cluster-manage.sh.
+cleanup_restored_payload() {
   find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name ".kb-data-protection" ! -name "lost+found" -exec rm -rf {} +
-  echo "ERROR: this archive is a Valkey CLUSTER (sharding) backup (source_shards=${source_shards})." >&2
-  echo "  Cluster datafile restore is NOT supported in v1: restored slot layouts cannot yet be" >&2
-  echo "  guaranteed to match the source (slot-aware restore is a planned follow-up; the archive" >&2
-  echo "  already records shard_slot_ranges for it). Refusing before any pod starts." >&2
-  exit 1
 }
 
-refuse_cluster_restore
+validate_restore_slot_ranges() {
+  awk -v raw="$1" 'BEGIN {
+    if (raw == "") exit 1
+    n = split(raw, parts, ",")
+    for (i = 1; i <= n; i++) {
+      token = parts[i]
+      if (token ~ /^[0-9]+$/) {
+        start = token + 0; end = start
+      } else if (token ~ /^[0-9]+-[0-9]+$/) {
+        split(token, bounds, "-")
+        start = bounds[1] + 0; end = bounds[2] + 0
+      } else {
+        exit 1
+      }
+      if (start < 0 || end > 16383 || start > end) exit 1
+      for (slot = start; slot <= end; slot++) {
+        if (seen[slot]++) exit 1
+      }
+    }
+  }'
+}
+
+validate_cluster_restore_meta() {
+  local meta="$1" source_shards shard_master_id shard_slot_ranges
+  local source_count master_count ranges_count
+
+  source_count=$(grep -c '^source_shards=' "${meta}" || true)
+  master_count=$(grep -c '^shard_master_id=' "${meta}" || true)
+  ranges_count=$(grep -c '^shard_slot_ranges=' "${meta}" || true)
+  if [ "${source_count}" -ne 1 ]; then
+    echo "ERROR: cluster-meta must contain exactly one source_shards entry." >&2
+    return 1
+  fi
+  if [ "${master_count}" -ne 1 ]; then
+    echo "ERROR: cluster-meta missing shard_master_id or contains duplicates." >&2
+    return 1
+  fi
+  if [ "${ranges_count}" -ne 1 ]; then
+    echo "ERROR: cluster-meta missing shard_slot_ranges or contains duplicates." >&2
+    return 1
+  fi
+
+  source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2-)
+  shard_master_id=$(grep '^shard_master_id=' "${meta}" | cut -d= -f2-)
+  shard_slot_ranges=$(grep '^shard_slot_ranges=' "${meta}" | cut -d= -f2-)
+  case "${source_shards}" in ''|*[!0-9]*)
+    echo "ERROR: invalid source_shards '${source_shards}' in cluster-meta." >&2
+    return 1 ;;
+  esac
+  if [ "${source_shards}" -lt 3 ] || [ "${source_shards}" -gt 32 ]; then
+    echo "ERROR: source_shards ${source_shards} is outside supported range 3..32." >&2
+    return 1
+  fi
+  case "${shard_master_id}" in ''|*[!A-Za-z0-9]*)
+    echo "ERROR: invalid shard_master_id in cluster-meta." >&2
+    return 1 ;;
+  esac
+  if ! validate_restore_slot_ranges "${shard_slot_ranges}"; then
+    echo "ERROR: invalid shard_slot_ranges '${shard_slot_ranges}' in cluster-meta." >&2
+    return 1
+  fi
+  echo "INFO: Validated cluster restore metadata (source_shards=${source_shards}, shard_slot_ranges=${shard_slot_ranges})."
+}
+
+cluster_meta="${DATA_DIR}/cluster-meta"
+if [ -f "${cluster_meta}" ] && ! validate_cluster_restore_meta "${cluster_meta}"; then
+  cleanup_restored_payload
+  exit 1
+fi
 
 seed_multipart_aof_from_rdb
 

--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -103,12 +103,13 @@ validate_restore_slot_ranges() {
 }
 
 validate_cluster_restore_meta() {
-  local meta="$1" source_shards shard_master_id shard_slot_ranges
-  local source_count master_count ranges_count
+  local meta="$1" source_shards shard_master_id shard_slot_ranges rdb_sha256 actual_rdb_sha256
+  local source_count master_count ranges_count digest_count
 
   source_count=$(grep -c '^source_shards=' "${meta}" || true)
   master_count=$(grep -c '^shard_master_id=' "${meta}" || true)
   ranges_count=$(grep -c '^shard_slot_ranges=' "${meta}" || true)
+  digest_count=$(grep -c '^rdb_sha256=' "${meta}" || true)
   if [ "${source_count}" -ne 1 ]; then
     echo "ERROR: cluster-meta must contain exactly one source_shards entry." >&2
     return 1
@@ -121,10 +122,15 @@ validate_cluster_restore_meta() {
     echo "ERROR: cluster-meta missing shard_slot_ranges or contains duplicates." >&2
     return 1
   fi
+  if [ "${digest_count}" -ne 1 ]; then
+    echo "ERROR: cluster-meta missing rdb_sha256 or contains duplicates." >&2
+    return 1
+  fi
 
   source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2-)
   shard_master_id=$(grep '^shard_master_id=' "${meta}" | cut -d= -f2-)
   shard_slot_ranges=$(grep '^shard_slot_ranges=' "${meta}" | cut -d= -f2-)
+  rdb_sha256=$(grep '^rdb_sha256=' "${meta}" | cut -d= -f2-)
   case "${source_shards}" in ''|*[!0-9]*)
     echo "ERROR: invalid source_shards '${source_shards}' in cluster-meta." >&2
     return 1 ;;
@@ -139,6 +145,19 @@ validate_cluster_restore_meta() {
   esac
   if ! validate_restore_slot_ranges "${shard_slot_ranges}"; then
     echo "ERROR: invalid shard_slot_ranges '${shard_slot_ranges}' in cluster-meta." >&2
+    return 1
+  fi
+  case "${rdb_sha256}" in ''|*[!0-9a-fA-F]*)
+    echo "ERROR: invalid rdb_sha256 in cluster-meta." >&2
+    return 1 ;;
+  esac
+  if [ "${#rdb_sha256}" -ne 64 ]; then
+    echo "ERROR: invalid rdb_sha256 length in cluster-meta." >&2
+    return 1
+  fi
+  actual_rdb_sha256=$(sha256sum "${DATA_DIR}/dump.rdb" 2>/dev/null | awk '{print $1}')
+  if [ "${actual_rdb_sha256}" != "${rdb_sha256}" ]; then
+    echo "ERROR: restored dump.rdb does not match cluster-meta rdb_sha256." >&2
     return 1
   fi
   echo "INFO: Validated cluster restore metadata (source_shards=${source_shards}, shard_slot_ranges=${shard_slot_ranges})."

--- a/addons/valkey/dataprotection/restore.sh
+++ b/addons/valkey/dataprotection/restore.sh
@@ -11,7 +11,29 @@ set -o pipefail
 [ -n "${DP_DATASAFED_BIN_PATH}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"
 export DATASAFED_BACKEND_BASE_PATH="${DP_BACKUP_BASE_PATH}"
 
-mkdir -p "${DATA_DIR}"
+case "${DATA_DIR:-}" in
+  /*) ;;
+  *) echo "ERROR: DATA_DIR must be an existing canonical absolute directory." >&2; exit 1 ;;
+esac
+[ "${DATA_DIR}" != "/" ] && [ -d "${DATA_DIR}" ] && [ ! -L "${DATA_DIR}" ] || {
+  echo "ERROR: DATA_DIR must be an existing canonical non-root directory." >&2
+  exit 1
+}
+canonical_data_dir=$(cd -P "${DATA_DIR}" 2>/dev/null && pwd -P) || exit 1
+[ "${canonical_data_dir}" = "${DATA_DIR}" ] || {
+  echo "ERROR: DATA_DIR must not contain symlink or dot-segment aliases." >&2
+  exit 1
+}
+case "${VALKEY_APPEND_DIRNAME-appendonlydir}" in
+  ''|*/*|.|..) echo "ERROR: unsafe VALKEY_APPEND_DIRNAME for restore." >&2; exit 1 ;;
+esac
+case "${VALKEY_APPEND_FILENAME-appendonly.aof}" in
+  ''|*/*|.|..) echo "ERROR: unsafe VALKEY_APPEND_FILENAME for restore." >&2; exit 1 ;;
+esac
+
+cleanup_restored_payload() {
+  find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name ".kb-data-protection" ! -name "lost+found" -exec rm -rf {} +
+}
 
 # Safety check: refuse to restore into a non-empty data directory.
 # Use -maxdepth 1 to check for any real data entry directly inside DATA_DIR.
@@ -21,16 +43,23 @@ if [ -n "${unexpected_entries}" ]; then
   echo "ERROR: ${DATA_DIR} is not empty. Remove all data before restoring." >&2
   exit 1
 fi
-if [ -e "${placeholder}" ] && [ ! -f "${placeholder}" ]; then
-  echo "ERROR: ${placeholder} exists but is not a file." >&2
-  exit 1
+if [ -e "${placeholder}" ] || [ -L "${placeholder}" ]; then
+  [ -f "${placeholder}" ] && [ ! -L "${placeholder}" ] || {
+    echo "ERROR: ${placeholder} is not a safe regular file." >&2
+    exit 1
+  }
+else
+  touch "${placeholder}"
 fi
-touch "${placeholder}"
 
 archive="${DP_BACKUP_NAME}.tar.zst"
 if datasafed list "${archive}" 2>/dev/null | grep -qF "${archive}"; then
   echo "INFO: Restoring from ${archive}..."
-  datasafed pull -d zstd-fastest "${archive}" - | tar -xvf - -C "${DATA_DIR}"
+  if ! datasafed pull -d zstd-fastest "${archive}" - | tar -xvf - -C "${DATA_DIR}"; then
+    echo "ERROR: restore archive extraction failed; removing partial payload." >&2
+    cleanup_restored_payload
+    exit 1
+  fi
 else
   echo "ERROR: backup archive '${archive}' not found in repository." >&2
   exit 1
@@ -38,17 +67,17 @@ fi
 
 seed_multipart_aof_from_rdb() {
   local rdb="${DATA_DIR}/dump.rdb"
-  local append_dirname="${VALKEY_APPEND_DIRNAME:-appendonlydir}"
-  local append_filename="${VALKEY_APPEND_FILENAME:-appendonly.aof}"
+  local append_dirname="${VALKEY_APPEND_DIRNAME-appendonlydir}"
+  local append_filename="${VALKEY_APPEND_FILENAME-appendonly.aof}"
   local append_dir="${DATA_DIR}/${append_dirname}"
   local base_file="${append_dir}/${append_filename}.1.base.rdb"
   local incr_file="${append_dir}/${append_filename}.1.incr.aof"
   local manifest_file="${append_dir}/${append_filename}.manifest"
   local restored_aof_state=""
 
-  if [ ! -s "${rdb}" ]; then
-    echo "ERROR: restored archive must contain a non-empty dump.rdb." >&2
-    exit 1
+  if [ ! -f "${rdb}" ] || [ -L "${rdb}" ] || [ ! -s "${rdb}" ]; then
+    echo "ERROR: restored archive must contain a safe regular non-empty dump.rdb." >&2
+    return 1
   fi
 
   restored_aof_state=$(find "${DATA_DIR}" -mindepth 1 \( \
@@ -59,7 +88,7 @@ seed_multipart_aof_from_rdb() {
   \) -print -quit)
   if [ -n "${restored_aof_state}" ]; then
     echo "ERROR: restored archive already contains AOF state at ${restored_aof_state}; refusing to synthesize AOF from dump.rdb." >&2
-    exit 1
+    return 1
   fi
 
   mkdir -p "${append_dir}"
@@ -70,14 +99,6 @@ seed_multipart_aof_from_rdb() {
     printf 'file %s seq 1 type i\n' "$(basename "${incr_file}")"
   } > "${manifest_file}"
   echo "INFO: Seeded multipart AOF manifest from restored dump.rdb."
-}
-
-# Cluster archives retain cluster-meta until postProvision has rebuilt the
-# engine membership with the archived slot ownership. prepareData validates
-# the local shard metadata here; cluster-wide overlap/gap checks happen while
-# slots are assigned by valkey-cluster-manage.sh.
-cleanup_restored_payload() {
-  find "${DATA_DIR}" -mindepth 1 -maxdepth 1 ! -name ".kb-data-protection" ! -name "lost+found" -exec rm -rf {} +
 }
 
 validate_restore_slot_ranges() {
@@ -164,12 +185,40 @@ validate_cluster_restore_meta() {
 }
 
 cluster_meta="${DATA_DIR}/cluster-meta"
-if [ -f "${cluster_meta}" ] && ! validate_cluster_restore_meta "${cluster_meta}"; then
+if [ -e "${cluster_meta}" ] || [ -L "${cluster_meta}" ]; then
+  if [ ! -f "${cluster_meta}" ] || [ -L "${cluster_meta}" ]; then
+    echo "ERROR: restored cluster-meta is not a safe regular file." >&2
+    cleanup_restored_payload
+    exit 1
+  fi
+  if ! validate_cluster_restore_meta "${cluster_meta}"; then
+    cleanup_restored_payload
+    exit 1
+  fi
+fi
+
+if ! seed_multipart_aof_from_rdb; then
   cleanup_restored_payload
   exit 1
 fi
 
-seed_multipart_aof_from_rdb
+if [ -f "${cluster_meta}" ]; then
+  restore_state="${DATA_DIR}/.kb-cluster-restore-state"
+  restore_state_tmp=$(mktemp "${restore_state}.tmp.XXXXXX") || {
+    echo "ERROR: cannot allocate cluster restore intent file." >&2
+    cleanup_restored_payload
+    exit 1
+  }
+  cluster_meta_sha256=$(sha256sum "${cluster_meta}" 2>/dev/null | awk '{print $1}')
+  if [ "${#cluster_meta_sha256}" -ne 64 ] || \
+     ! printf 'phase=prepared\nmeta_sha256=%s\n' "${cluster_meta_sha256}" > "${restore_state_tmp}" || \
+     ! mv -f "${restore_state_tmp}" "${restore_state}" || ! sync; then
+    rm -f "${restore_state_tmp}"
+    echo "ERROR: cannot persist cluster restore intent." >&2
+    cleanup_restored_payload
+    exit 1
+  fi
+fi
 
 rm -f "${placeholder}" && sync
 echo "INFO: Restore complete."

--- a/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
@@ -30,7 +30,7 @@ case "${args}" in
   *BGSAVE*)             echo "Background saving started"; exit 0 ;;
   *"INFO cluster"*)     printf 'cluster_enabled:1\n'; exit 0 ;;
   *"CLUSTER NODES"*)
-    printf 'mid001 10.0.0.1:6379@16379 master - 0 0 5 connected 0-5460\n'
+    printf 'mid001 10.0.0.1:6379@16379 master - 0 0 5 connected %s\n' "${FAKE_CLUSTER_RANGE:-0-5460}"
     printf 'sid002 10.0.0.2:6379@16379 myself,slave mid001 0 0 5 connected\n'
     printf 'mid003 10.0.0.3:6379@16379 master - 0 0 6 connected 5461-10922\n'
     printf 'mid004 10.0.0.4:6379@16379 master - 0 0 7 connected 10923-16383\n'
@@ -112,5 +112,15 @@ STUB
     The contents of file "${workdir}/extracted/cluster-meta" should include "source_shards=3"
     The contents of file "${workdir}/extracted/cluster-meta" should include "shard_master_id=mid001"
     The contents of file "${workdir}/extracted/cluster-meta" should include "shard_slot_ranges=0-5460"
+  End
+
+
+  It "fails before archiving when the engine view contains migration markers"
+    export FAKE_CLUSTER_RANGE='0-5460 [123->-peer]'
+    When call run_backup
+    The status should be failure
+    The stdout should include "INFO: Archiving consistent snapshot artifacts..."
+    The stderr should include "invalid slot ranges"
+    The file "${data_dir}/cluster-meta" should not be exist
   End
 End

--- a/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
+++ b/addons/valkey/scripts-ut-spec/backup_cluster_meta_spec.sh
@@ -112,6 +112,7 @@ STUB
     The contents of file "${workdir}/extracted/cluster-meta" should include "source_shards=3"
     The contents of file "${workdir}/extracted/cluster-meta" should include "shard_master_id=mid001"
     The contents of file "${workdir}/extracted/cluster-meta" should include "shard_slot_ranges=0-5460"
+    The contents of file "${workdir}/extracted/cluster-meta" should include "rdb_sha256="
   End
 
 

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -11,7 +11,15 @@ Describe "Valkey cluster restore slot contract"
 source_shards=3
 shard_master_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 shard_slot_ranges=0-5460
+rdb_sha256=827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9
 META
+    printf 'snapshot\n' > "${restore_tmp}/dump.rdb"
+    mkdir -p "${restore_tmp}/appendonlydir"
+    cp "${restore_tmp}/dump.rdb" "${restore_tmp}/appendonlydir/appendonly.aof.1.base.rdb"
+    : > "${restore_tmp}/appendonlydir/appendonly.aof.1.incr.aof"
+    printf 'file appendonly.aof.1.base.rdb seq 1 type b\nfile appendonly.aof.1.incr.aof seq 1 type i\n' \
+      > "${restore_tmp}/appendonlydir/appendonly.aof.manifest"
+    export VALKEY_DATA_DIR="${restore_tmp}"
     export CURRENT_POD_NAME="vk-shard-abc-0"
     export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-abc"
     export CURRENT_SHARD_POD_FQDN_LIST="vk-shard-abc-0.h,vk-shard-abc-1.h"
@@ -33,7 +41,7 @@ META
   restore_cleanup() {
     rm -rf "${restore_tmp:-}"
     unset CURRENT_POD_NAME CURRENT_SHARD_COMPONENT_SHORT_NAME \
-      CURRENT_SHARD_POD_FQDN_LIST ALL_SHARDS_COMPONENT_SHORT_NAMES SERVICE_PORT
+      CURRENT_SHARD_POD_FQDN_LIST ALL_SHARDS_COMPONENT_SHORT_NAMES SERVICE_PORT VALKEY_DATA_DIR
   }
   Before "restore_env"
   After "restore_cleanup"
@@ -223,14 +231,359 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
       printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected 5461-10922\n'
       printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 10923-16383\n'
     }
+    cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    attach_all_replicas() { echo ATTACH >> "${attach_log}"; }
+    attach_all_replicas() { echo "ATTACH:$1" >> "${attach_log}"; }
     cluster_formed_from_self() { return 0; }
     When call restore_cluster_from_meta "${restore_meta}"
     The status should be success
-    The contents of file "${attach_log}" should equal "ATTACH"
+    The contents of file "${attach_log}" should equal "ATTACH:restore"
     The file "${restore_meta}" should not be exist
     The stdout should include "restored cluster formed with archived slot ownership"
+  End
+
+  It "locally clears and hard-resets only an archive-verified restored duplicate"
+    calls=$(mktemp)
+    reset_done=$(mktemp)
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h)
+          printf 'id-abc vk-shard-abc-0.h:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h)
+          if [ -s "${reset_done}" ]; then
+            printf 'id-new vk-shard-abc-1.h:6379@16379 myself,master - 0 0 0 connected\n'
+          else
+            printf 'id-old vk-shard-abc-1.h:6379@16379 myself,master - 0 0 0 connected 1 4-5\n'
+          fi ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { [ "$1" = vk-shard-abc-1.h ] && [ -s "${calls}" ] && echo 0 || echo 3; }
+    build_cli() { _cli=(mock_replica_reset "$1" "${calls}" "${reset_done}"); }
+    mock_replica_reset() {
+      host="$1" log="$2" reset="$3"; shift 3
+      case "$*" in
+        FLUSHALL) echo "FLUSHALL:${host}" >> "${log}"; echo OK ;;
+        "CLUSTER RESET HARD") echo "RESET:${host}" >> "${log}"; echo yes > "${reset}"; echo OK ;;
+      esac
+    }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be success
+    The stdout should include "prepared local restored duplicate"
+    The contents of file "${calls}" should equal "FLUSHALL:vk-shard-abc-1.h
+RESET:vk-shard-abc-1.h"
+  End
+
+  It "does zero local reset writes until every restored primary view converges"
+    calls=$(mktemp)
+    restored_primary_cluster_ready_for_replica_reset() { return 1; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "phase=restore-replica-primary"
+    The stderr should include "all restored primary views"
+    The file "${calls}" should be empty file
+  End
+
+  It "refuses to clear a restored replica when dump.rdb differs from backup metadata"
+    calls=$(mktemp)
+    printf 'different snapshot\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 3; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "phase=restore-replica-data"
+    The stderr should include "retry_safe=no"
+    The file "${calls}" should be empty file
+  End
+
+  It "refuses to clear a restored replica whose singleton slots are foreign to its shard master"
+    calls=$(mktemp)
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 6000\n' ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 3; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "phase=restore-replica-slots"
+    The stderr should include "retry_safe=no"
+    The file "${calls}" should be empty file
+  End
+
+  It "refuses to clear a restored replica with post-restore AOF writes"
+    calls=$(mktemp)
+    printf 'SET unexpected value\n' > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.1.incr.aof"
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 3; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "phase=restore-replica-data"
+    The stderr should include "multipart AOF"
+    The file "${calls}" should be empty file
+  End
+
+  It "refuses to clear a restored replica with unexpected multipart AOF files"
+    calls=$(mktemp)
+    : > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.2.incr.aof"
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 3; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "phase=restore-replica-data"
+    The stderr should include "multipart AOF"
+    The file "${calls}" should be empty file
+  End
+
+  It "resumes at hard reset when a prior restore invocation already emptied the duplicate"
+    calls=$(mktemp)
+    reset_done=$(mktemp)
+    cat > "${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized" <<'MARKER'
+rdb_sha256=827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9
+master_id=id-abc
+shard=SHARD_ABC
+pod=vk-shard-abc-1
+MARKER
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h)
+          if [ -s "${reset_done}" ]; then
+            printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n'
+          else
+            printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n'
+          fi ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 0; }
+    build_cli() { _cli=(mock_reset_only "$1" "${calls}" "${reset_done}"); }
+    mock_reset_only() {
+      host="$1" log="$2" reset="$3"; shift 3
+      case "$*" in
+        FLUSHALL) echo "UNEXPECTED-FLUSH:${host}" >> "${log}" ;;
+        "CLUSTER RESET HARD") echo "RESET:${host}" >> "${log}"; echo yes > "${reset}"; echo OK ;;
+      esac
+    }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be success
+    The stdout should include "prepared local restored duplicate"
+    The contents of file "${calls}" should equal "RESET:vk-shard-abc-1.h"
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized" should not be exist
+  End
+
+  It "does zero reset writes for an empty slot-owning target without authorization"
+    calls=$(mktemp)
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 0; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "phase=restore-replica-data"
+    The stderr should include "without reset authorization"
+    The file "${calls}" should be empty file
+  End
+
+  It "does zero reset writes when the authorization belongs to another target"
+    calls=$(mktemp)
+    printf 'rdb_sha256=%s\nmaster_id=wrong\nshard=SHARD_ABC\npod=vk-shard-abc-1\n' \
+      '827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9' \
+      > "${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized"
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
+      esac
+    }
+    known_nodes_of() { echo 1; }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    dbsize_of() { echo 0; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "authorization marker does not match"
+    The file "${calls}" should be empty file
+  End
+
+  It "never clears again after the coordinator has already bound the replica"
+    calls=$(mktemp)
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h)
+          printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n'
+          printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 1 connected\n' ;;
+        *) echo SHOULD-NOT-READ-LOCAL-NODES; return 99 ;;
+      esac
+    }
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    build_cli() { _cli=(mock_no_reset "${calls}"); }
+    mock_no_reset() { echo "$*" >> "$1"; }
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be success
+    The stdout should include "already bound to shard SHARD_ABC"
+    The file "${calls}" should be empty file
+  End
+
+  It "does not run restore reset preparation during ordinary replica attach"
+    restored_replica_ready_for_attach() { echo UNSAFE-RESTORE-RESET; return 99; }
+    build_cli() { _cli=(mock_no_member); }
+    mock_no_member() { return 0; }
+    build_cluster_cli() { _ccli=(mock_add_ok); }
+    mock_add_ok() { echo OK; }
+    When call ensure_replica_bound \
+      "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be success
+    The stdout should include "attached vk-shard-abc-1.h as replica"
+    The stdout should not include "UNSAFE-RESTORE-RESET"
+  End
+
+  It "does not issue add-node in restore mode until the replica self-prepares"
+    calls=$(mktemp)
+    build_cli() { _cli=(mock_no_member); }
+    mock_no_member() { return 0; }
+    known_nodes_of() { echo 1; }
+    cluster_nodes_of() { printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n'; }
+    dbsize_of() { echo 3; }
+    build_cluster_cli() { _ccli=(mock_forbidden_add "${calls}"); }
+    mock_forbidden_add() { echo "$*" >> "$1"; }
+    When call ensure_replica_bound \
+      "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC" "restore"
+    The status should be failure
+    The stderr should include "phase=restore-replica-wait"
+    The file "${calls}" should be empty file
+  End
+
+  It "issues restore add-node only after the replica is one empty slotless node"
+    build_cli() { _cli=(mock_no_member); }
+    mock_no_member() { return 0; }
+    known_nodes_of() { echo 1; }
+    cluster_nodes_of() { printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n'; }
+    dbsize_of() { echo 0; }
+    build_cluster_cli() { _ccli=(mock_add_ok); }
+    mock_add_ok() { echo OK; }
+    When call ensure_replica_bound \
+      "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC" "restore"
+    The status should be success
+    The stdout should include "attached vk-shard-abc-1.h as replica"
+  End
+
+  It "defers before replica reset until every restored primary view is fully converged"
+    attach_log=$(mktemp)
+    build_cli() { _cli=(mock_full_cli); }
+    mock_full_cli() { [ "$1" = PING ] && echo PONG; }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected 0-5460\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected 5461-10922\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 10923-16383\n'
+    }
+    cluster_state_of() { [ "$1" = vk-shard-def-0.h ] && echo fail || echo ok; }
+    assigned_slots_of() { echo 16384; }
+    attach_all_replicas() { echo ATTACH >> "${attach_log}"; }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-attach"
+    The stderr should include "before replica reset"
+    The file "${attach_log}" should be empty file
+  End
+
+  It "keeps the primary-view gate valid after an earlier replica has attached"
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected 0-5460\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected 5461-10922\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 10923-16383\n'
+      printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 4 connected\n'
+    }
+    When call restored_primary_cluster_ready_for_replica_reset
+    The status should be success
+  End
+
+  It "fails the primary-view gate when an attached replica is not visible everywhere"
+    cluster_state_of() { echo ok; }
+    assigned_slots_of() { echo 16384; }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected 0-5460\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected 5461-10922\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 10923-16383\n'
+      [ "$1" = "vk-shard-abc-0.h" ] && \
+        printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 4 connected\n'
+    }
+    When call restored_primary_cluster_ready_for_replica_reset
+    The status should be failure
   End
 
 
@@ -244,6 +597,20 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The status should be success
     The stdout should include "RESTORE-PATH:${restore_meta}"
     The stdout should not include "ORDINARY-CREATE-PATH"
+  End
+
+  It "routes a restored non-first pod through local replica preparation"
+    export CURRENT_POD_NAME="vk-shard-abc-1"
+    build_cli() { _cli=(mock_ping); }
+    mock_ping() { [ "$1" = PING ] && echo PONG; }
+    node_id_of() { [ "$1" = vk-shard-abc-0.h ] && echo id-abc; }
+    prepare_local_restored_replica_for_attach() {
+      echo "LOCAL-PREP:$2:$3:$4:$5"
+      return 0
+    }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stdout should include "LOCAL-PREP:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc"
   End
 
   It "removes the local restore marker only after positive cluster formation"

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -100,6 +100,59 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
 
   It "uses only the deterministic coordinator to MEET fresh restored primaries"
     meet_log=$(mktemp)
+    resolve_cluster_meet_address() {
+      case "$1" in
+        vk-shard-def-0.h) echo 10.0.0.2 ;;
+        vk-shard-ghi-0.h) echo 10.0.0.3 ;;
+      esac
+    }
+    build_cli() { _cli=(mock_restore_cli "$1" "${meet_log}"); }
+    mock_restore_cli() {
+      host="$1" log="$2"; shift 2
+      case "$1" in
+        PING) echo PONG ;;
+        CLUSTER)
+          if [ "$2" = MEET ]; then
+            case "$3" in
+              *[!0-9.]*) echo "ERR Invalid node address specified: $3:$4" ;;
+              *) printf '%s\n' "$3" >> "${log}"; echo OK ;;
+            esac
+          fi ;;
+      esac
+    }
+    cluster_nodes_of() { printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected\n'; }
+    known_nodes_of() { echo 1; }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-meet"
+    The stderr should include "retry_safe=yes"
+    The contents of file "${meet_log}" should equal "10.0.0.2
+10.0.0.3"
+  End
+
+  It "resolves a restored peer FQDN to an IPv4 address for CLUSTER MEET"
+    getent() {
+      [ "$1" = ahostsv4 ] || return 1
+      printf '10.0.0.2 STREAM %s\n' "$2"
+      printf '10.0.0.2 DGRAM %s\n' "$2"
+    }
+    When call resolve_cluster_meet_address "vk-shard-def-0.h"
+    The status should be success
+    The stdout should equal "10.0.0.2"
+  End
+
+  It "rejects DNS output that is not a numeric IPv4 address"
+    getent() { printf 'not-an-ip STREAM %s\n' "$2"; }
+    When call resolve_cluster_meet_address "vk-shard-def-0.h"
+    The status should be failure
+    The stdout should be blank
+  End
+
+  It "does zero MEET writes when any fresh restored peer cannot resolve"
+    meet_log=$(mktemp)
+    resolve_cluster_meet_address() {
+      [ "$1" = vk-shard-def-0.h ] && echo 10.0.0.2
+    }
     build_cli() { _cli=(mock_restore_cli "$1" "${meet_log}"); }
     mock_restore_cli() {
       host="$1" log="$2"; shift 2
@@ -113,10 +166,9 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     known_nodes_of() { echo 1; }
     When call restore_cluster_from_meta "${restore_meta}"
     The status should be failure
-    The stderr should include "phase=restore-meet"
+    The stderr should include "phase=restore-dns"
     The stderr should include "retry_safe=yes"
-    The contents of file "${meet_log}" should equal "vk-shard-def-0.h
-vk-shard-ghi-0.h"
+    The file "${meet_log}" should be empty file
   End
 
   It "assigns only this archive's missing ranges after all primaries are mutually visible"

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -259,7 +259,7 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The file "${write_log}" should be empty file
   End
 
-  It "attaches replicas and removes metadata only after exact full-slot proof"
+  It "closes restored primary duties without waiting for later replica actions"
     attach_log=$(mktemp)
     build_cli() { _cli=(mock_full_cli); }
     mock_full_cli() { [ "$1" = PING ] && echo PONG; }
@@ -270,14 +270,16 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     }
     cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    attach_all_replicas() { echo "ATTACH:$1" >> "${attach_log}"; }
-    cluster_formed_from_self() { return 0; }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
+    attach_all_replicas() { echo "FORBIDDEN-ATTACH:$1" >> "${attach_log}"; return 99; }
+    cluster_formed_from_self() { echo FORBIDDEN-FULL-ROSTER; return 99; }
     When call restore_cluster_from_meta "${restore_meta}"
     The status should be success
-    The contents of file "${attach_log}" should equal "ATTACH:restore"
+    The file "${attach_log}" should be empty file
     The file "${restore_meta}" should not be exist
     The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=formed"
-    The stdout should include "restored cluster formed with archived slot ownership"
+    The stdout should include "restored primary duties complete"
+    The stdout should not include "FORBIDDEN-FULL-ROSTER"
   End
 
   It "accepts only an empty slotless replica with the exact offline-prepared marker"
@@ -477,7 +479,7 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The status should be success
   End
 
-  It "defers replica attach until every restored primary view is fully converged"
+  It "defers primary completion until every restored primary view is fully converged"
     attach_log=$(mktemp)
     build_cli() { _cli=(mock_full_cli); }
     mock_full_cli() { [ "$1" = PING ] && echo PONG; }
@@ -491,8 +493,8 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     attach_all_replicas() { echo ATTACH >> "${attach_log}"; }
     When call restore_cluster_from_meta "${restore_meta}"
     The status should be failure
-    The stderr should include "phase=restore-attach"
-    The stderr should include "before replica attach"
+    The stderr should include "phase=restore-primary-converge"
+    The stderr should include "one exact id set"
     The file "${attach_log}" should be empty file
   End
 
@@ -535,7 +537,7 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The stdout should not include "ORDINARY-CREATE-PATH"
   End
 
-  It "routes a restored non-first pod through local replica preparation"
+  It "lets a restored non-first pod attach and close only its local formed state"
     export CURRENT_POD_NAME="vk-shard-abc-1"
     build_cli() { _cli=(mock_ping); }
     mock_ping() { [ "$1" = PING ] && echo PONG; }
@@ -545,14 +547,16 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
       return 0
     }
     ensure_replica_bound() {
-      echo "LOCAL-ATTACH:$1:$2:$3:$4"
+      echo "LOCAL-ATTACH:$1:$2:$3:$4:${5:-ordinary}"
       return 0
     }
     When call restore_cluster_from_meta "${restore_meta}"
-    The status should be failure
+    The status should be success
     The stdout should include "LOCAL-PREP:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc"
-    The stdout should include "LOCAL-ATTACH:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc"
-    The stderr should include "phase=restore-replica-converge"
+    The stdout should include "LOCAL-ATTACH:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc:ordinary"
+    The stdout should include "LOCAL-ATTACH:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc:restore"
+    The stdout should include "restored replica duties complete"
+    The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=formed"
   End
 
   It "removes the local restore marker only after positive cluster formation"
@@ -573,7 +577,7 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
   End
 
 
-  It "removes offline marker residue after interrupted metadata cleanup"
+  It "accepts a formed local tombstone without global convergence or new writes"
     export VALKEY_DATA_DIR="${restore_tmp}"
     meta_digest=$(sha256sum "${restore_meta}" | awk '{print $1}')
     printf 'phase=formed\nmeta_sha256=%s\n' "${meta_digest}" \
@@ -581,11 +585,28 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     rm -f "${restore_meta}"
     : > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
     validate_manage_env() { return 0; }
-    cluster_formed_from_self() { return 0; }
+    cluster_formed_from_self() { return 1; }
+    mark_local_cluster_restore_formed() { echo FORBIDDEN-MUTATION; return 99; }
     When run post_provision
     The status should be success
-    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should not be exist
-    The stdout should include "committed local cluster restore formed state"
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should be exist
+    The stdout should include "local restore duties already complete"
+    The stdout should not include "FORBIDDEN-MUTATION"
+  End
+
+  It "rejects a malformed local formed tombstone without cluster-meta"
+    export VALKEY_DATA_DIR="${restore_tmp}"
+    printf 'phase=formed\nmeta_sha256=short\n' \
+      > "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+    rm -f "${restore_meta}"
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { return 1; }
+    form_cluster() { echo ORDINARY-FORMATION; return 99; }
+
+    When run post_provision
+    The status should be failure
+    The stderr should include "invalid local formed-state metadata identity"
+    The stdout should not include "ORDINARY-FORMATION"
   End
 
   It "rejects a symlinked cluster-meta on the already-formed fast path"

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -1,0 +1,208 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "Valkey cluster restore slot contract"
+  Include ../scripts/valkey-cluster-manage.sh
+
+  restore_env() {
+    restore_tmp=$(mktemp -d "${TMPDIR:-/tmp}/valkey-cluster-restore.XXXXXX")
+    restore_meta="${restore_tmp}/cluster-meta"
+    cat > "${restore_meta}" <<'META'
+source_shards=3
+shard_master_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+shard_slot_ranges=0-5460
+META
+    export CURRENT_POD_NAME="vk-shard-abc-0"
+    export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-abc"
+    export CURRENT_SHARD_POD_FQDN_LIST="vk-shard-abc-0.h,vk-shard-abc-1.h"
+    export ALL_SHARDS_COMPONENT_SHORT_NAMES="shard-abc:shard-abc,shard-def:shard-def,shard-ghi:shard-ghi"
+    export SERVICE_PORT=6379
+    each_shard_fqdn_list() {
+      printf 'SHARD_ABC vk-shard-abc-0.h,vk-shard-abc-1.h\n'
+      printf 'SHARD_DEF vk-shard-def-0.h,vk-shard-def-1.h\n'
+      printf 'SHARD_GHI vk-shard-ghi-0.h,vk-shard-ghi-1.h\n'
+    }
+    node_id_of() {
+      case "$1" in
+        vk-shard-abc-0.h) echo id-abc ;;
+        vk-shard-def-0.h) echo id-def ;;
+        vk-shard-ghi-0.h) echo id-ghi ;;
+      esac
+    }
+  }
+  restore_cleanup() {
+    rm -rf "${restore_tmp:-}"
+    unset CURRENT_POD_NAME CURRENT_SHARD_COMPONENT_SHORT_NAME \
+      CURRENT_SHARD_POD_FQDN_LIST ALL_SHARDS_COMPONENT_SHORT_NAMES SERVICE_PORT
+  }
+  Before "restore_env"
+  After "restore_cleanup"
+
+  It "accepts a disjoint in-domain slot-range list"
+    When call validate_restore_slot_ranges "0-5460,10923-12000,12001"
+    The status should be success
+  End
+
+  It "requires an explicit data directory instead of silently assuming /data"
+    unset VALKEY_DATA_DIR
+    When call cluster_restore_meta_path
+    The status should be failure
+    The stderr should include "phase=restore-env"
+    The stderr should include "no data-path fallback"
+  End
+
+  It "rejects overlapping slot ranges"
+    When call validate_restore_slot_ranges "0-5460,5460-10922"
+    The status should be failure
+  End
+
+  It "rejects an out-of-domain slot range"
+    When call validate_restore_slot_ranges "0-16384"
+    The status should be failure
+  End
+
+  It "returns only unassigned subranges already reserved for this restored shard"
+    nodes='selfid self:6379@16379 myself,master - 0 0 1 connected 0-1
+peerid peer:6379@16379 master - 0 0 2 connected 5-6'
+    When call missing_restore_slot_ranges "${nodes}" "selfid" "0-4"
+    The status should be success
+    The stdout should equal "2-4"
+  End
+
+  It "fails closed when another master owns a desired restored slot"
+    nodes='selfid self:6379@16379 myself,master - 0 0 1 connected 0-1
+peerid peer:6379@16379 master - 0 0 2 connected 2-6'
+    When call missing_restore_slot_ranges "${nodes}" "selfid" "0-4"
+    The status should be failure
+    The stderr should include "slot 2"
+    The stderr should include "peerid"
+  End
+
+  It "fails closed when this master owns a slot outside its archived ranges"
+    nodes='selfid self:6379@16379 myself,master - 0 0 1 connected 0-5'
+    When call missing_restore_slot_ranges "${nodes}" "selfid" "0-4"
+    The status should be failure
+    The stderr should include "outside archived ranges"
+  End
+
+  It "refuses a source/target shard-count mismatch before cluster writes"
+    sed -i.bak 's/source_shards=3/source_shards=4/' "${restore_meta}"
+    build_cli() { _cli=(mock_ping); }
+    mock_ping() { [ "$1" = PING ] && echo PONG; }
+    build_cluster_cli() { _ccli=(mock_write_forbidden); }
+    mock_write_forbidden() { echo WRITE-CALLED; return 99; }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-shard-count"
+    The stderr should include "retry_safe=no"
+    The stdout should not include "WRITE-CALLED"
+  End
+
+  It "uses only the deterministic coordinator to MEET fresh restored primaries"
+    meet_log=$(mktemp)
+    build_cli() { _cli=(mock_restore_cli "$1" "${meet_log}"); }
+    mock_restore_cli() {
+      host="$1" log="$2"; shift 2
+      case "$1" in
+        PING) echo PONG ;;
+        CLUSTER)
+          [ "$2" = MEET ] && printf '%s\n' "$3" >> "${log}" && echo OK ;;
+      esac
+    }
+    cluster_nodes_of() { printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected\n'; }
+    known_nodes_of() { echo 1; }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-meet"
+    The stderr should include "retry_safe=yes"
+    The contents of file "${meet_log}" should equal "vk-shard-def-0.h
+vk-shard-ghi-0.h"
+  End
+
+  It "assigns only this archive's missing ranges after all primaries are mutually visible"
+    slot_log=$(mktemp)
+    build_cli() { _cli=(mock_slot_cli "$1" "${slot_log}"); }
+    mock_slot_cli() {
+      host="$1" log="$2"; shift 2
+      case "$1" in
+        PING) echo PONG ;;
+        CLUSTER)
+          [ "$2" = ADDSLOTSRANGE ] && printf '%s-%s\n' "$3" "$4" >> "${log}" && echo OK ;;
+      esac
+    }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected\n'
+    }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-slots"
+    The stderr should include "retry_safe=yes"
+    The contents of file "${slot_log}" should equal "0-5460"
+  End
+
+  It "does zero writes when archived ranges conflict with another restored master"
+    write_log=$(mktemp)
+    build_cli() { _cli=(mock_conflict_cli "$1" "${write_log}"); }
+    mock_conflict_cli() {
+      host="$1" log="$2"; shift 2
+      [ "$1" = PING ] && echo PONG
+      [ "$1" = CLUSTER ] && printf 'WRITE %s\n' "$*" >> "${log}"
+    }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected 0-5460\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 5461-16383\n'
+    }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-slots"
+    The stderr should include "retry_safe=no"
+    The file "${write_log}" should be empty file
+  End
+
+  It "attaches replicas and removes metadata only after exact full-slot proof"
+    attach_log=$(mktemp)
+    build_cli() { _cli=(mock_full_cli); }
+    mock_full_cli() { [ "$1" = PING ] && echo PONG; }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected 0-5460\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected 5461-10922\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 10923-16383\n'
+    }
+    assigned_slots_of() { echo 16384; }
+    attach_all_replicas() { echo ATTACH >> "${attach_log}"; }
+    cluster_formed_from_self() { return 0; }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be success
+    The contents of file "${attach_log}" should equal "ATTACH"
+    The file "${restore_meta}" should not be exist
+    The stdout should include "restored cluster formed with archived slot ownership"
+  End
+
+
+  It "routes a local restore marker to the slot-aware path and never ordinary create"
+    export VALKEY_DATA_DIR="${restore_tmp}"
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { return 1; }
+    restore_cluster_from_meta() { echo "RESTORE-PATH:$1"; return 0; }
+    form_cluster() { echo ORDINARY-CREATE-PATH; return 99; }
+    When run post_provision
+    The status should be success
+    The stdout should include "RESTORE-PATH:${restore_meta}"
+    The stdout should not include "ORDINARY-CREATE-PATH"
+  End
+
+  It "removes the local restore marker only after positive cluster formation"
+    export VALKEY_DATA_DIR="${restore_tmp}"
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { return 0; }
+    restore_cluster_from_meta() { echo RESTORE-PATH; return 99; }
+    When run post_provision
+    The status should be success
+    The file "${restore_meta}" should not be exist
+    The stdout should include "removed local cluster restore metadata after positive formation proof"
+    The stdout should not include "RESTORE-PATH"
+  End
+End

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -193,6 +193,12 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The stdout should be blank
   End
 
+  It "maps an engine node address through its announced hostname"
+    line='id-abc 10.0.0.1:6379@16379,vk-shard-abc-0.h master - 0 0 1 connected'
+    When call cluster_node_address_matches_fqdn "${line}" "vk-shard-abc-0.h"
+    The status should be success
+  End
+
   It "does zero MEET writes when any fresh restored peer cannot resolve"
     meet_log=$(mktemp)
     resolve_cluster_meet_address() {
@@ -256,6 +262,28 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The status should be failure
     The stderr should include "phase=restore-slots"
     The stderr should include "retry_safe=no"
+    The file "${write_log}" should be empty file
+  End
+
+  It "does zero slot writes when every primary sees the same foreign slotless node"
+    write_log=$(mktemp)
+    build_cli() { _cli=(mock_foreign_cli "$1" "${write_log}"); }
+    mock_foreign_cli() {
+      host="$1" log="$2"; shift 2
+      [ "$1" = PING ] && echo PONG
+      [ "$1" = CLUSTER ] && [ "$2" = ADDSLOTSRANGE ] && printf 'WRITE %s\n' "$*" >> "${log}"
+    }
+    cluster_nodes_of() {
+      printf 'id-abc vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected\n'
+      printf 'id-def vk-shard-def-0.h:6379@16379 master - 0 0 2 connected\n'
+      printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected\n'
+      printf 'id-foreign foreign-0.h:6379@16379 master - 0 0 4 connected\n'
+    }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-membership"
+    The stderr should include "retry_safe=no"
+    The stderr should include "foreign-0.h"
     The file "${write_log}" should be empty file
   End
 

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -265,6 +265,30 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The file "${write_log}" should be empty file
   End
 
+  It "does zero slot writes when restored primaries share one node identity"
+    write_log=$(mktemp)
+    node_id_of() { echo id-shared; }
+    build_cli() { _cli=(mock_duplicate_id_cli "$1" "${write_log}"); }
+    mock_duplicate_id_cli() {
+      host="$1" log="$2"; shift 2
+      [ "$1" = PING ] && echo PONG
+      [ "$1" = CLUSTER ] && [ "$2" = ADDSLOTSRANGE ] && printf 'WRITE %s\n' "$*" >> "${log}"
+    }
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h) printf 'id-shared vk-shard-abc-0.h:6379@16379 master - 0 0 1 connected\n' ;;
+        vk-shard-def-0.h) printf 'id-shared vk-shard-def-0.h:6379@16379 master - 0 0 1 connected\n' ;;
+        vk-shard-ghi-0.h) printf 'id-shared vk-shard-ghi-0.h:6379@16379 master - 0 0 1 connected\n' ;;
+      esac
+    }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-membership"
+    The stderr should include "retry_safe=no"
+    The stderr should include "unique CLUSTER MYID"
+    The file "${write_log}" should be empty file
+  End
+
   It "does zero slot writes when every primary sees the same foreign slotless node"
     write_log=$(mktemp)
     build_cli() { _cli=(mock_foreign_cli "$1" "${write_log}"); }

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -6,6 +6,7 @@ Describe "Valkey cluster restore slot contract"
 
   restore_env() {
     restore_tmp=$(mktemp -d "${TMPDIR:-/tmp}/valkey-cluster-restore.XXXXXX")
+    restore_tmp=$(cd -P "${restore_tmp}" && pwd -P)
     restore_meta="${restore_tmp}/cluster-meta"
     cat > "${restore_meta}" <<'META'
 source_shards=3
@@ -13,6 +14,9 @@ shard_master_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 shard_slot_ranges=0-5460
 rdb_sha256=827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9
 META
+    meta_digest=$(sha256sum "${restore_meta}" | awk '{print $1}')
+    printf 'phase=prepared\nmeta_sha256=%s\n' "${meta_digest}" \
+      > "${restore_tmp}/.kb-cluster-restore-state"
     printf 'snapshot\n' > "${restore_tmp}/dump.rdb"
     mkdir -p "${restore_tmp}/appendonlydir"
     cp "${restore_tmp}/dump.rdb" "${restore_tmp}/appendonlydir/appendonly.aof.1.base.rdb"
@@ -43,6 +47,12 @@ META
     unset CURRENT_POD_NAME CURRENT_SHARD_COMPONENT_SHORT_NAME \
       CURRENT_SHARD_POD_FQDN_LIST ALL_SHARDS_COMPONENT_SHORT_NAMES SERVICE_PORT VALKEY_DATA_DIR
   }
+  write_offline_prepared_marker() {
+    meta_digest=$(sha256sum "${restore_meta}" | awk '{print $1}')
+    printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=vk-shard-abc-1\n' \
+      '827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9' \
+      "${meta_digest}" > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+  }
   Before "restore_env"
   After "restore_cleanup"
 
@@ -57,6 +67,17 @@ META
     The status should be failure
     The stderr should include "phase=restore-env"
     The stderr should include "no data-path fallback"
+  End
+
+  It "rejects a dot-segment lifecycle data root before restore mutation"
+    export VALKEY_DATA_DIR="${restore_tmp}/.."
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { echo SHOULD-NOT-PROBE; return 0; }
+
+    When run post_provision
+    The status should be failure
+    The stderr should include "dot-segment alias"
+    The stdout should not include "SHOULD-NOT-PROBE"
   End
 
   It "rejects overlapping slot ranges"
@@ -95,6 +116,9 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
 
   It "refuses a source/target shard-count mismatch before cluster writes"
     sed -i.bak 's/source_shards=3/source_shards=4/' "${restore_meta}"
+    meta_digest=$(sha256sum "${restore_meta}" | awk '{print $1}')
+    printf 'phase=prepared\nmeta_sha256=%s\n' "${meta_digest}" \
+      > "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
     build_cli() { _cli=(mock_ping); }
     mock_ping() { [ "$1" = PING ] && echo PONG; }
     build_cluster_cli() { _ccli=(mock_write_forbidden); }
@@ -104,6 +128,19 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The stderr should include "phase=restore-shard-count"
     The stderr should include "retry_safe=no"
     The stdout should not include "WRITE-CALLED"
+  End
+
+
+  It "refuses missing restore-state before cluster writes"
+    calls=$(mktemp)
+    rm -f "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+    build_cli() { _cli=(mock_write_forbidden "${calls}"); }
+    build_cluster_cli() { _ccli=(mock_write_forbidden "${calls}"); }
+    mock_write_forbidden() { echo "$*" >> "$1"; return 99; }
+    When call restore_cluster_from_meta "${restore_meta}"
+    The status should be failure
+    The stderr should include "phase=restore-state"
+    The file "${calls}" should be empty file
   End
 
   It "uses only the deterministic coordinator to MEET fresh restored primaries"
@@ -239,61 +276,32 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The status should be success
     The contents of file "${attach_log}" should equal "ATTACH:restore"
     The file "${restore_meta}" should not be exist
+    The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=formed"
     The stdout should include "restored cluster formed with archived slot ownership"
   End
 
-  It "locally clears and hard-resets only an archive-verified restored duplicate"
-    calls=$(mktemp)
-    reset_done=$(mktemp)
+  It "accepts only an empty slotless replica with the exact offline-prepared marker"
+    write_offline_prepared_marker
     cluster_nodes_of() {
       case "$1" in
-        vk-shard-abc-0.h)
-          printf 'id-abc vk-shard-abc-0.h:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h)
-          if [ -s "${reset_done}" ]; then
-            printf 'id-new vk-shard-abc-1.h:6379@16379 myself,master - 0 0 0 connected\n'
-          else
-            printf 'id-old vk-shard-abc-1.h:6379@16379 myself,master - 0 0 0 connected 1 4-5\n'
-          fi ;;
+        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
+        vk-shard-abc-1.h) printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n' ;;
       esac
     }
     known_nodes_of() { echo 1; }
     cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
-    dbsize_of() { [ "$1" = vk-shard-abc-1.h ] && [ -s "${calls}" ] && echo 0 || echo 3; }
-    build_cli() { _cli=(mock_replica_reset "$1" "${calls}" "${reset_done}"); }
-    mock_replica_reset() {
-      host="$1" log="$2" reset="$3"; shift 3
-      case "$*" in
-        FLUSHALL) echo "FLUSHALL:${host}" >> "${log}"; echo OK ;;
-        "CLUSTER RESET HARD") echo "RESET:${host}" >> "${log}"; echo yes > "${reset}"; echo OK ;;
-      esac
-    }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
+    dbsize_of() { echo 0; }
     When call prepare_local_restored_replica_for_attach \
       "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
     The status should be success
-    The stdout should include "prepared local restored duplicate"
-    The contents of file "${calls}" should equal "FLUSHALL:vk-shard-abc-1.h
-RESET:vk-shard-abc-1.h"
+    The stdout should include "offline-prepared"
   End
 
-  It "does zero local reset writes until every restored primary view converges"
+  It "refuses online cleanup when the restored target still contains data"
     calls=$(mktemp)
-    restored_primary_cluster_ready_for_replica_reset() { return 1; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
-    When call prepare_local_restored_replica_for_attach \
-      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
-    The status should be failure
-    The stderr should include "phase=restore-replica-primary"
-    The stderr should include "all restored primary views"
-    The file "${calls}" should be empty file
-  End
-
-  It "refuses to clear a restored replica when dump.rdb differs from backup metadata"
-    calls=$(mktemp)
-    printf 'different snapshot\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+    write_offline_prepared_marker
     cluster_nodes_of() {
       case "$1" in
         vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
@@ -303,180 +311,67 @@ RESET:vk-shard-abc-1.h"
     known_nodes_of() { echo 1; }
     cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
     dbsize_of() { echo 3; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
+    build_cli() { _cli=(mock_no_write "${calls}"); }
+    mock_no_write() { echo "$*" >> "$1"; }
     When call prepare_local_restored_replica_for_attach \
       "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
     The status should be failure
-    The stderr should include "phase=restore-replica-data"
-    The stderr should include "retry_safe=no"
+    The stderr should include "refusing online cleanup"
     The file "${calls}" should be empty file
   End
 
-  It "refuses to clear a restored replica whose singleton slots are foreign to its shard master"
+  It "refuses an empty slotless target without the offline-prepared marker"
     calls=$(mktemp)
     cluster_nodes_of() {
       case "$1" in
         vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 6000\n' ;;
+        vk-shard-abc-1.h) printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n' ;;
       esac
     }
     known_nodes_of() { echo 1; }
     cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
-    dbsize_of() { echo 3; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
-    When call prepare_local_restored_replica_for_attach \
-      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
-    The status should be failure
-    The stderr should include "phase=restore-replica-slots"
-    The stderr should include "retry_safe=no"
-    The file "${calls}" should be empty file
-  End
-
-  It "refuses to clear a restored replica with post-restore AOF writes"
-    calls=$(mktemp)
-    printf 'SET unexpected value\n' > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.1.incr.aof"
-    cluster_nodes_of() {
-      case "$1" in
-        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
-      esac
-    }
-    known_nodes_of() { echo 1; }
-    cluster_state_of() { echo ok; }
-    assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
-    dbsize_of() { echo 3; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
-    When call prepare_local_restored_replica_for_attach \
-      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
-    The status should be failure
-    The stderr should include "phase=restore-replica-data"
-    The stderr should include "multipart AOF"
-    The file "${calls}" should be empty file
-  End
-
-  It "refuses to clear a restored replica with unexpected multipart AOF files"
-    calls=$(mktemp)
-    : > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.2.incr.aof"
-    cluster_nodes_of() {
-      case "$1" in
-        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
-      esac
-    }
-    known_nodes_of() { echo 1; }
-    cluster_state_of() { echo ok; }
-    assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
-    dbsize_of() { echo 3; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
-    When call prepare_local_restored_replica_for_attach \
-      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
-    The status should be failure
-    The stderr should include "phase=restore-replica-data"
-    The stderr should include "multipart AOF"
-    The file "${calls}" should be empty file
-  End
-
-  It "resumes at hard reset when a prior restore invocation already emptied the duplicate"
-    calls=$(mktemp)
-    reset_done=$(mktemp)
-    cat > "${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized" <<'MARKER'
-rdb_sha256=827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9
-master_id=id-abc
-shard=SHARD_ABC
-pod=vk-shard-abc-1
-MARKER
-    cluster_nodes_of() {
-      case "$1" in
-        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h)
-          if [ -s "${reset_done}" ]; then
-            printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n'
-          else
-            printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n'
-          fi ;;
-      esac
-    }
-    known_nodes_of() { echo 1; }
-    cluster_state_of() { echo ok; }
-    assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
     dbsize_of() { echo 0; }
-    build_cli() { _cli=(mock_reset_only "$1" "${calls}" "${reset_done}"); }
-    mock_reset_only() {
-      host="$1" log="$2" reset="$3"; shift 3
-      case "$*" in
-        FLUSHALL) echo "UNEXPECTED-FLUSH:${host}" >> "${log}" ;;
-        "CLUSTER RESET HARD") echo "RESET:${host}" >> "${log}"; echo yes > "${reset}"; echo OK ;;
-      esac
-    }
+    build_cli() { _cli=(mock_no_write "${calls}"); }
+    mock_no_write() { echo "$*" >> "$1"; }
     When call prepare_local_restored_replica_for_attach \
       "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
-    The status should be success
-    The stdout should include "prepared local restored duplicate"
-    The contents of file "${calls}" should equal "RESET:vk-shard-abc-1.h"
-    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized" should not be exist
+    The status should be failure
+    The stderr should include "lacks the exact offline-prepared marker"
+    The file "${calls}" should be empty file
   End
 
-  It "does zero reset writes for an empty slot-owning target without authorization"
+
+  It "refuses an offline marker after cluster-meta changes"
     calls=$(mktemp)
+    write_offline_prepared_marker
+    printf '# changed after offline preparation\n' >> "${restore_meta}"
     cluster_nodes_of() {
       case "$1" in
         vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
+        vk-shard-abc-1.h) printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n' ;;
       esac
     }
     known_nodes_of() { echo 1; }
     cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
     dbsize_of() { echo 0; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
+    build_cli() { _cli=(mock_no_write "${calls}"); }
+    mock_no_write() { echo "$*" >> "$1"; }
     When call prepare_local_restored_replica_for_attach \
       "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
     The status should be failure
-    The stderr should include "phase=restore-replica-data"
-    The stderr should include "without reset authorization"
+    The stderr should include "lacks the exact offline-prepared marker"
     The file "${calls}" should be empty file
   End
 
-  It "does zero reset writes when the authorization belongs to another target"
+  It "never clears or re-prepares after the coordinator has already bound the replica"
     calls=$(mktemp)
-    printf 'rdb_sha256=%s\nmaster_id=wrong\nshard=SHARD_ABC\npod=vk-shard-abc-1\n' \
-      '827eeab94f7421c651f6170d7d0e62cd4fad4594fb07faff4466acb01128ccd9' \
-      > "${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized"
-    cluster_nodes_of() {
-      case "$1" in
-        vk-shard-abc-0.h) printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n' ;;
-        vk-shard-abc-1.h) printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n' ;;
-      esac
-    }
-    known_nodes_of() { echo 1; }
-    cluster_state_of() { echo ok; }
-    assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
-    dbsize_of() { echo 0; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
-    When call prepare_local_restored_replica_for_attach \
-      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
-    The status should be failure
-    The stderr should include "authorization marker does not match"
-    The file "${calls}" should be empty file
-  End
-
-  It "never clears again after the coordinator has already bound the replica"
-    calls=$(mktemp)
+    write_offline_prepared_marker
     cluster_nodes_of() {
       case "$1" in
         vk-shard-abc-0.h)
@@ -487,9 +382,9 @@ MARKER
     }
     cluster_state_of() { echo ok; }
     assigned_slots_of() { echo 16384; }
-    restored_primary_cluster_ready_for_replica_reset() { return 0; }
-    build_cli() { _cli=(mock_no_reset "${calls}"); }
-    mock_no_reset() { echo "$*" >> "$1"; }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
+    build_cli() { _cli=(mock_no_write "${calls}"); }
+    mock_no_write() { echo "$*" >> "$1"; }
     When call prepare_local_restored_replica_for_attach \
       "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
     The status should be success
@@ -497,8 +392,57 @@ MARKER
     The file "${calls}" should be empty file
   End
 
-  It "does not run restore reset preparation during ordinary replica attach"
-    restored_replica_ready_for_attach() { echo UNSAFE-RESTORE-RESET; return 99; }
+
+  It "rejects a symlinked prepared marker even when the replica is already bound"
+    calls=$(mktemp)
+    write_offline_prepared_marker
+    outside_marker="${restore_tmp}/outside-prepared-marker"
+    mv "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" "${outside_marker}"
+    ln -s "${outside_marker}" "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h)
+          printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n'
+          printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 1 connected\n' ;;
+      esac
+    }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
+    build_cli() { _cli=(mock_no_write "${calls}"); }
+    mock_no_write() { echo "$*" >> "$1"; }
+
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "lacks the exact offline-prepared marker"
+    The file "${calls}" should be empty file
+  End
+
+  It "rejects a symlinked prepare marker beside a valid prepared marker before bound reentry"
+    calls=$(mktemp)
+    write_offline_prepared_marker
+    outside_marker="${restore_tmp}/outside-prepare-marker"
+    cp "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" "${outside_marker}"
+    ln -s "${outside_marker}" "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+    cluster_nodes_of() {
+      case "$1" in
+        vk-shard-abc-0.h)
+          printf 'id-abc primary:6379@16379 myself,master - 0 0 1 connected 0-5460\n'
+          printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 1 connected\n' ;;
+      esac
+    }
+    restored_primary_cluster_ready_for_replica_attach() { return 0; }
+    build_cli() { _cli=(mock_no_write "${calls}"); }
+    mock_no_write() { echo "$*" >> "$1"; }
+
+    When call prepare_local_restored_replica_for_attach \
+      "${restore_meta}" "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
+    The status should be failure
+    The stderr should include "lacks the exact offline-prepared marker"
+    The file "${calls}" should be empty file
+  End
+
+  It "does not run restore preparation during ordinary replica attach"
+    offline_prepared_marker_matches() { echo UNSAFE-RESTORE-PREP; return 99; }
     build_cli() { _cli=(mock_no_member); }
     mock_no_member() { return 0; }
     build_cluster_cli() { _ccli=(mock_add_ok); }
@@ -507,40 +451,33 @@ MARKER
       "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC"
     The status should be success
     The stdout should include "attached vk-shard-abc-1.h as replica"
-    The stdout should not include "UNSAFE-RESTORE-RESET"
+    The stdout should not include "UNSAFE-RESTORE-PREP"
   End
-
-  It "does not issue add-node in restore mode until the replica self-prepares"
+  It "never lets the coordinator add an unbound restore replica"
     calls=$(mktemp)
     build_cli() { _cli=(mock_no_member); }
     mock_no_member() { return 0; }
-    known_nodes_of() { echo 1; }
-    cluster_nodes_of() { printf 'id-old replica:6379@16379 myself,master - 0 0 0 connected 1-2\n'; }
-    dbsize_of() { echo 3; }
     build_cluster_cli() { _ccli=(mock_forbidden_add "${calls}"); }
     mock_forbidden_add() { echo "$*" >> "$1"; }
     When call ensure_replica_bound \
       "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC" "restore"
     The status should be failure
     The stderr should include "phase=restore-replica-wait"
+    The stderr should include "attach itself"
     The file "${calls}" should be empty file
   End
 
-  It "issues restore add-node only after the replica is one empty slotless node"
-    build_cli() { _cli=(mock_no_member); }
-    mock_no_member() { return 0; }
-    known_nodes_of() { echo 1; }
-    cluster_nodes_of() { printf 'id-new replica:6379@16379 myself,master - 0 0 0 connected\n'; }
-    dbsize_of() { echo 0; }
-    build_cluster_cli() { _ccli=(mock_add_ok); }
-    mock_add_ok() { echo OK; }
+  It "lets the coordinator observe an already self-attached restore replica"
+    build_cli() { _cli=(mock_bound_member); }
+    mock_bound_member() {
+      printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 1 connected\n'
+    }
     When call ensure_replica_bound \
       "vk-shard-abc-0.h" "vk-shard-abc-1.h" "id-abc" "SHARD_ABC" "restore"
     The status should be success
-    The stdout should include "attached vk-shard-abc-1.h as replica"
   End
 
-  It "defers before replica reset until every restored primary view is fully converged"
+  It "defers replica attach until every restored primary view is fully converged"
     attach_log=$(mktemp)
     build_cli() { _cli=(mock_full_cli); }
     mock_full_cli() { [ "$1" = PING ] && echo PONG; }
@@ -555,7 +492,7 @@ MARKER
     When call restore_cluster_from_meta "${restore_meta}"
     The status should be failure
     The stderr should include "phase=restore-attach"
-    The stderr should include "before replica reset"
+    The stderr should include "before replica attach"
     The file "${attach_log}" should be empty file
   End
 
@@ -568,7 +505,7 @@ MARKER
       printf 'id-ghi vk-shard-ghi-0.h:6379@16379 master - 0 0 3 connected 10923-16383\n'
       printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 4 connected\n'
     }
-    When call restored_primary_cluster_ready_for_replica_reset
+    When call restored_primary_cluster_ready_for_replica_attach
     The status should be success
   End
 
@@ -582,10 +519,9 @@ MARKER
       [ "$1" = "vk-shard-abc-0.h" ] && \
         printf 'id-rep vk-shard-abc-1.h:6379@16379 slave id-abc 0 0 4 connected\n'
     }
-    When call restored_primary_cluster_ready_for_replica_reset
+    When call restored_primary_cluster_ready_for_replica_attach
     The status should be failure
   End
-
 
   It "routes a local restore marker to the slot-aware path and never ordinary create"
     export VALKEY_DATA_DIR="${restore_tmp}"
@@ -608,20 +544,75 @@ MARKER
       echo "LOCAL-PREP:$2:$3:$4:$5"
       return 0
     }
+    ensure_replica_bound() {
+      echo "LOCAL-ATTACH:$1:$2:$3:$4"
+      return 0
+    }
     When call restore_cluster_from_meta "${restore_meta}"
     The status should be failure
     The stdout should include "LOCAL-PREP:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc"
+    The stdout should include "LOCAL-ATTACH:vk-shard-abc-0.h:vk-shard-abc-1.h:id-abc:shard-abc"
+    The stderr should include "phase=restore-replica-converge"
   End
 
   It "removes the local restore marker only after positive cluster formation"
     export VALKEY_DATA_DIR="${restore_tmp}"
+    : > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+    : > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
     validate_manage_env() { return 0; }
     cluster_formed_from_self() { return 0; }
     restore_cluster_from_meta() { echo RESTORE-PATH; return 99; }
     When run post_provision
     The status should be success
     The file "${restore_meta}" should not be exist
-    The stdout should include "removed local cluster restore metadata after positive formation proof"
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" should not be exist
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should not be exist
+    The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=formed"
+    The stdout should include "committed local cluster restore formed state"
     The stdout should not include "RESTORE-PATH"
+  End
+
+
+  It "removes offline marker residue after interrupted metadata cleanup"
+    export VALKEY_DATA_DIR="${restore_tmp}"
+    meta_digest=$(sha256sum "${restore_meta}" | awk '{print $1}')
+    printf 'phase=formed\nmeta_sha256=%s\n' "${meta_digest}" \
+      > "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+    rm -f "${restore_meta}"
+    : > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { return 0; }
+    When run post_provision
+    The status should be success
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should not be exist
+    The stdout should include "committed local cluster restore formed state"
+  End
+
+  It "rejects a symlinked cluster-meta on the already-formed fast path"
+    export VALKEY_DATA_DIR="${restore_tmp}"
+    outside_meta="${restore_tmp}/outside-cluster-meta"
+    mv "${restore_meta}" "${outside_meta}"
+    ln -s "${outside_meta}" "${restore_meta}"
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { return 0; }
+
+    When run post_provision
+    The status should be failure
+    The stderr should include "is a symlink"
+    The file "${outside_meta}" should be exist
+  End
+
+  It "rejects a dangling restore-state symlink instead of treating it as absent"
+    export VALKEY_DATA_DIR="${restore_tmp}"
+    rm -f "${restore_meta}" "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+    ln -s "${restore_tmp}/missing-state" "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+    validate_manage_env() { return 0; }
+    cluster_formed_from_self() { return 1; }
+    form_cluster() { echo ORDINARY-FORMATION; return 99; }
+
+    When run post_provision
+    The status should be failure
+    The stderr should include "is a symlink"
+    The stdout should not include "ORDINARY-FORMATION"
   End
 End

--- a/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/cluster_restore_slot_contract_spec.sh
@@ -611,21 +611,21 @@ peerid peer:6379@16379 master - 0 0 2 connected 2-6'
     The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=formed"
   End
 
-  It "removes the local restore marker only after positive cluster formation"
+  It "does not bypass local restore validation when the cluster is already formed"
     export VALKEY_DATA_DIR="${restore_tmp}"
     : > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
     : > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
     validate_manage_env() { return 0; }
     cluster_formed_from_self() { return 0; }
-    restore_cluster_from_meta() { echo RESTORE-PATH; return 99; }
+    restore_cluster_from_meta() { echo RESTORE-VALIDATION-REACHED; return 1; }
     When run post_provision
-    The status should be success
-    The file "${restore_meta}" should not be exist
-    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" should not be exist
-    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should not be exist
-    The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=formed"
-    The stdout should include "committed local cluster restore formed state"
-    The stdout should not include "RESTORE-PATH"
+    The status should be failure
+    The file "${restore_meta}" should be exist
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" should be exist
+    The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should be exist
+    The contents of file "${VALKEY_DATA_DIR}/.kb-cluster-restore-state" should include "phase=prepared"
+    The stdout should include "RESTORE-VALIDATION-REACHED"
+    The stdout should not include "committed local cluster restore formed state"
   End
 
 

--- a/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
@@ -5,6 +5,7 @@ Describe "Valkey restore contract"
   setup() {
     original_path="${PATH}"
     spec_tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/valkey-restore-spec.XXXXXX")
+    spec_tmp_dir=$(cd -P "${spec_tmp_dir}" && pwd -P)
     data_dir="${spec_tmp_dir}/data"
     fakebin="${spec_tmp_dir}/fakebin"
     mkdir -p "${data_dir}" "${fakebin}"
@@ -22,7 +23,10 @@ case "$1" in
     rm -rf "${tmp}"
     mkdir -p "${tmp}/src"
     printf 'restored\n' > "${tmp}/src/restored.txt"
-    if [ "${FAKE_DATASAFED_OMIT_RDB:-}" != "1" ]; then
+    if [ "${FAKE_DATASAFED_SYMLINK_RDB:-}" = "1" ]; then
+      printf 'valkey-rdb\n' > "${tmp}/src/restored-rdb-target"
+      ln -s restored-rdb-target "${tmp}/src/dump.rdb"
+    elif [ "${FAKE_DATASAFED_OMIT_RDB:-}" != "1" ]; then
       if [ "${FAKE_DATASAFED_EMPTY_RDB:-}" = "1" ]; then
         : > "${tmp}/src/dump.rdb"
       else
@@ -46,6 +50,12 @@ case "$1" in
         [ "${FAKE_DATASAFED_OMIT_RDB_SHA:-0}" = "1" ] || \
           printf 'rdb_sha256=%s\n' "${FAKE_DATASAFED_RDB_SHA:-$(sha256sum "${tmp}/src/dump.rdb" | awk '{print $1}')}"
       } > "${tmp}/src/cluster-meta"
+    fi
+    if [ "${FAKE_DATASAFED_PULL_FAIL:-}" = "1" ]; then
+      printf 'partial\n' > "${tmp}/src/partial.txt"
+      tar -cf - -C "${tmp}/src" .
+      rm -rf "${tmp}"
+      exit 1
     fi
     tar -cf - -C "${tmp}/src" .
     rm -rf "${tmp}"
@@ -88,6 +98,7 @@ SH
     unset FAKE_DATASAFED_INCLUDE_ROOT_AOF
     unset FAKE_DATASAFED_OMIT_RDB
     unset FAKE_DATASAFED_EMPTY_RDB
+    unset FAKE_DATASAFED_SYMLINK_RDB
     unset FAKE_DATASAFED_CLUSTER_META
     unset FAKE_DATASAFED_MASTER_ID
     unset FAKE_DATASAFED_SLOT_RANGES
@@ -95,7 +106,10 @@ SH
     unset FAKE_DATASAFED_OMIT_SLOT_RANGES
     unset FAKE_DATASAFED_OMIT_RDB_SHA
     unset FAKE_DATASAFED_RDB_SHA
+    unset FAKE_DATASAFED_PULL_FAIL
     unset RESTORE_TARGET_SHARDS
+    unset VALKEY_APPEND_DIRNAME
+    unset VALKEY_APPEND_FILENAME
   }
   After "cleanup"
 
@@ -108,6 +122,70 @@ SH
     The file "${data_dir}/appendonlydir/appendonly.aof.1.base.rdb" should be exist
     The file "${data_dir}/appendonlydir/appendonly.aof.1.incr.aof" should be exist
     The file "${data_dir}/.kb-data-protection" should not be exist
+  End
+
+  It "rejects a dot-segment DATA_DIR before any restore write"
+    export DATA_DIR="${data_dir}/.."
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stderr should include "dot-segment aliases"
+    The file "${spec_tmp_dir}/restored.txt" should not be exist
+  End
+
+  It "rejects an escaping append directory before any restore write"
+    export VALKEY_APPEND_DIRNAME="../outside-aof"
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stderr should include "unsafe VALKEY_APPEND_DIRNAME"
+    The dir "${spec_tmp_dir}/outside-aof" should not be exist
+  End
+
+  It "rejects an explicitly empty append directory before any restore write"
+    export VALKEY_APPEND_DIRNAME=""
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stderr should include "unsafe VALKEY_APPEND_DIRNAME"
+  End
+
+  It "rejects a slash-bearing append filename before any restore write"
+    export VALKEY_APPEND_FILENAME="nested/appendonly.aof"
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stderr should include "unsafe VALKEY_APPEND_FILENAME"
+    The dir "${data_dir}/nested" should not be exist
+  End
+
+  It "rejects an explicitly empty append filename before any restore write"
+    export VALKEY_APPEND_FILENAME=""
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stderr should include "unsafe VALKEY_APPEND_FILENAME"
+  End
+
+  It "rejects a dangling data-protection placeholder symlink before writing"
+    outside_placeholder="${spec_tmp_dir}/outside-placeholder"
+    ln -s "${outside_placeholder}" "${data_dir}/.kb-data-protection"
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stderr should include "not a safe regular file"
+    The file "${outside_placeholder}" should not be exist
+  End
+
+  It "removes partial payload when archive extraction fails"
+    export FAKE_DATASAFED_PULL_FAIL=1
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "restore archive extraction failed"
+    The file "${data_dir}/partial.txt" should not be exist
+    The file "${data_dir}/.kb-data-protection" should be exist
   End
 
   It "seeds a multipart AOF manifest from the restored RDB"
@@ -145,7 +223,7 @@ SH
     When run bash ../dataprotection/restore.sh
     The status should be failure
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
-    The stderr should include "ERROR: restored archive must contain a non-empty dump.rdb."
+    The stderr should include "ERROR: restored archive must contain a safe regular non-empty dump.rdb."
   End
 
   It "fails closed when the restored dump.rdb is empty"
@@ -154,7 +232,17 @@ SH
     When run bash ../dataprotection/restore.sh
     The status should be failure
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
-    The stderr should include "ERROR: restored archive must contain a non-empty dump.rdb."
+    The stderr should include "ERROR: restored archive must contain a safe regular non-empty dump.rdb."
+  End
+
+  It "fails closed when the restored dump.rdb is a symlink"
+    export FAKE_DATASAFED_SYMLINK_RDB=1
+
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "safe regular non-empty dump.rdb"
+    The file "${data_dir}/appendonlydir/appendonly.aof.manifest" should not be exist
   End
 
   It "fails closed when the restored archive already contains an AOF directory"
@@ -186,6 +274,8 @@ SH
     The file "${data_dir}/cluster-meta" should be exist
     The contents of file "${data_dir}/cluster-meta" should include "shard_slot_ranges=0-5460"
     The contents of file "${data_dir}/cluster-meta" should include "rdb_sha256="
+    The contents of file "${data_dir}/.kb-cluster-restore-state" should include "phase=prepared"
+    The contents of file "${data_dir}/.kb-cluster-restore-state" should include "meta_sha256="
     The file "${data_dir}/appendonlydir/appendonly.aof.manifest" should be exist
   End
 
@@ -198,6 +288,7 @@ SH
     The stderr should include "dump.rdb does not match cluster-meta rdb_sha256"
     The file "${data_dir}/dump.rdb" should not be exist
     The file "${data_dir}/cluster-meta" should not be exist
+    The file "${data_dir}/.kb-cluster-restore-state" should not be exist
   End
 
   It "rejects old cluster metadata that lacks the restored RDB identity"
@@ -209,6 +300,7 @@ SH
     The stderr should include "cluster-meta missing rdb_sha256"
     The file "${data_dir}/dump.rdb" should not be exist
     The file "${data_dir}/cluster-meta" should not be exist
+    The file "${data_dir}/.kb-cluster-restore-state" should not be exist
   End
 
   It "fails malformed cluster metadata and re-emits the true reason on retry"
@@ -240,5 +332,6 @@ SH
     When run bash ../dataprotection/restore.sh
     The status should be success
     The stdout should include "INFO: Restore complete."
+    The file "${data_dir}/.kb-cluster-restore-state" should not be exist
   End
 End

--- a/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
@@ -37,7 +37,13 @@ case "$1" in
       printf 'existing aof\n' > "${tmp}/src/appendonly.aof"
     fi
     if [ -n "${FAKE_DATASAFED_CLUSTER_META:-}" ]; then
-      printf 'source_shards=%s\n' "${FAKE_DATASAFED_CLUSTER_META}" > "${tmp}/src/cluster-meta"
+      {
+        printf 'source_shards=%s\n' "${FAKE_DATASAFED_CLUSTER_META}"
+        [ "${FAKE_DATASAFED_OMIT_MASTER_ID:-0}" = "1" ] || \
+          printf 'shard_master_id=%s\n' "${FAKE_DATASAFED_MASTER_ID:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+        [ "${FAKE_DATASAFED_OMIT_SLOT_RANGES:-0}" = "1" ] || \
+          printf 'shard_slot_ranges=%s\n' "${FAKE_DATASAFED_SLOT_RANGES:-0-5460}"
+      } > "${tmp}/src/cluster-meta"
     fi
     tar -cf - -C "${tmp}/src" .
     rm -rf "${tmp}"
@@ -81,6 +87,10 @@ SH
     unset FAKE_DATASAFED_OMIT_RDB
     unset FAKE_DATASAFED_EMPTY_RDB
     unset FAKE_DATASAFED_CLUSTER_META
+    unset FAKE_DATASAFED_MASTER_ID
+    unset FAKE_DATASAFED_SLOT_RANGES
+    unset FAKE_DATASAFED_OMIT_MASTER_ID
+    unset FAKE_DATASAFED_OMIT_SLOT_RANGES
     unset RESTORE_TARGET_SHARDS
   }
   After "cleanup"
@@ -162,40 +172,40 @@ SH
     The stderr should include "ERROR: restored archive already contains AOF state"
     The stderr should include "appendonly.aof"
   End
-  It "refuses any cluster archive outright (v1: cluster restore unsupported)"
+  It "prepares a valid cluster archive and preserves slot metadata for postProvision"
     export FAKE_DATASAFED_CLUSTER_META=3
 
     When run bash ../dataprotection/restore.sh
-    The status should be failure
+    The status should be success
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
-    The stderr should include "CLUSTER (sharding) backup (source_shards=3)"
-    The stderr should include "NOT supported in v1"
-    The file "${data_dir}/cluster-meta" should not be exist
+    The stdout should include "Validated cluster restore metadata"
+    The file "${data_dir}/cluster-meta" should be exist
+    The contents of file "${data_dir}/cluster-meta" should include "shard_slot_ranges=0-5460"
+    The file "${data_dir}/appendonlydir/appendonly.aof.manifest" should be exist
   End
 
-  It "re-emits the TRUE refusal reason on retry (cleanup leaves no extraction residue)"
-    # CT11 focused-rerun live finding: refusal used to leave its own
-    # extracted files in DATA_DIR, so every retried prepareData pod hit
-    # the '/data is not empty' guard and the real reason was masked.
+  It "fails malformed cluster metadata and re-emits the true reason on retry"
     export FAKE_DATASAFED_CLUSTER_META=3
+    export FAKE_DATASAFED_OMIT_SLOT_RANGES=1
     When run bash -c "bash ../dataprotection/restore.sh; bash ../dataprotection/restore.sh"
     The status should be failure
-    # BOTH invocations must speak the true refusal, never the guard error
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
     The stderr should not include "is not empty"
-    The stderr should include "CLUSTER (sharding) backup (source_shards=3)"
+    The stderr should include "cluster-meta missing shard_slot_ranges"
     The file "${data_dir}/dump.rdb" should not be exist
     The file "${data_dir}/cluster-meta" should not be exist
   End
 
-  It "refusal cleanup spares the placeholder and lost+found (never real pre-existing entries)"
+  It "rejects overlapping or out-of-domain slot ranges without leaving extracted data"
     export FAKE_DATASAFED_CLUSTER_META=3
+    export FAKE_DATASAFED_SLOT_RANGES="0-100,100-5460"
     mkdir -p "${data_dir}/lost+found"
     When run bash ../dataprotection/restore.sh
     The status should be failure
     The stdout should include "INFO: Restoring from restore-test.tar.zst..."
-    The stderr should include "NOT supported in v1"
+    The stderr should include "invalid shard_slot_ranges"
     The file "${data_dir}/.kb-data-protection" should be exist
+    The file "${data_dir}/dump.rdb" should not be exist
     The dir "${data_dir}/lost+found" should be exist
   End
 

--- a/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
+++ b/addons/valkey/scripts-ut-spec/restore_contract_spec.sh
@@ -43,6 +43,8 @@ case "$1" in
           printf 'shard_master_id=%s\n' "${FAKE_DATASAFED_MASTER_ID:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
         [ "${FAKE_DATASAFED_OMIT_SLOT_RANGES:-0}" = "1" ] || \
           printf 'shard_slot_ranges=%s\n' "${FAKE_DATASAFED_SLOT_RANGES:-0-5460}"
+        [ "${FAKE_DATASAFED_OMIT_RDB_SHA:-0}" = "1" ] || \
+          printf 'rdb_sha256=%s\n' "${FAKE_DATASAFED_RDB_SHA:-$(sha256sum "${tmp}/src/dump.rdb" | awk '{print $1}')}"
       } > "${tmp}/src/cluster-meta"
     fi
     tar -cf - -C "${tmp}/src" .
@@ -91,6 +93,8 @@ SH
     unset FAKE_DATASAFED_SLOT_RANGES
     unset FAKE_DATASAFED_OMIT_MASTER_ID
     unset FAKE_DATASAFED_OMIT_SLOT_RANGES
+    unset FAKE_DATASAFED_OMIT_RDB_SHA
+    unset FAKE_DATASAFED_RDB_SHA
     unset RESTORE_TARGET_SHARDS
   }
   After "cleanup"
@@ -181,7 +185,30 @@ SH
     The stdout should include "Validated cluster restore metadata"
     The file "${data_dir}/cluster-meta" should be exist
     The contents of file "${data_dir}/cluster-meta" should include "shard_slot_ranges=0-5460"
+    The contents of file "${data_dir}/cluster-meta" should include "rdb_sha256="
     The file "${data_dir}/appendonlydir/appendonly.aof.manifest" should be exist
+  End
+
+  It "rejects cluster metadata whose dump.rdb digest does not match the archive"
+    export FAKE_DATASAFED_CLUSTER_META=3
+    export FAKE_DATASAFED_RDB_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "dump.rdb does not match cluster-meta rdb_sha256"
+    The file "${data_dir}/dump.rdb" should not be exist
+    The file "${data_dir}/cluster-meta" should not be exist
+  End
+
+  It "rejects old cluster metadata that lacks the restored RDB identity"
+    export FAKE_DATASAFED_CLUSTER_META=3
+    export FAKE_DATASAFED_OMIT_RDB_SHA=1
+    When run bash ../dataprotection/restore.sh
+    The status should be failure
+    The stdout should include "INFO: Restoring from restore-test.tar.zst..."
+    The stderr should include "cluster-meta missing rdb_sha256"
+    The file "${data_dir}/dump.rdb" should not be exist
+    The file "${data_dir}/cluster-meta" should not be exist
   End
 
   It "fails malformed cluster metadata and re-emits the true reason on retry"

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
@@ -37,25 +37,31 @@ Describe "valkey-cluster-server-start.sh behavior"
   Include ../scripts/valkey-cluster-server-start.sh
 
   setup_env() {
+    start_tmp=$(mktemp -d "${TMPDIR:-/tmp}/valkey-cluster-start.XXXXXX")
+    start_tmp=$(cd -P "${start_tmp}" && pwd -P)
     export CURRENT_POD_NAME="vk-shard-a1x-0"
     export CURRENT_POD_IP="10.0.0.11"
     export CURRENT_SHARD_POD_FQDN_LIST="vk-shard-a1x-0.vk-shard-a1x-headless.ns.svc.cluster.local,vk-shard-a1x-1.vk-shard-a1x-headless.ns.svc.cluster.local"
     export SERVICE_PORT="6379"
-    unset CLUSTER_BUS_PORT VALKEY_DEFAULT_PASSWORD
+    export VALKEY_DATA_DIR="${start_tmp}/data"
+    mkdir -p "${VALKEY_DATA_DIR}"
+    unset CLUSTER_BUS_PORT VALKEY_DEFAULT_PASSWORD VALKEY_APPEND_DIRNAME VALKEY_APPEND_FILENAME
   }
   cleanup() {
-    unset CURRENT_POD_NAME CURRENT_POD_IP CURRENT_SHARD_POD_FQDN_LIST SERVICE_PORT CLUSTER_BUS_PORT VALKEY_DEFAULT_PASSWORD
+    rm -rf "${start_tmp:-}"
+    unset CURRENT_POD_NAME CURRENT_POD_IP CURRENT_SHARD_POD_FQDN_LIST SERVICE_PORT CLUSTER_BUS_PORT VALKEY_DEFAULT_PASSWORD VALKEY_DATA_DIR VALKEY_APPEND_DIRNAME VALKEY_APPEND_FILENAME
   }
   Before "setup_env"
   After "cleanup"
 
   Describe "validate_required_env()"
     It "fails fast listing every missing required variable"
-      unset CURRENT_POD_IP CURRENT_SHARD_POD_FQDN_LIST
+      unset CURRENT_POD_IP CURRENT_SHARD_POD_FQDN_LIST VALKEY_DATA_DIR
       When call validate_required_env
       The status should be failure
       The stderr should include "CURRENT_POD_IP"
       The stderr should include "CURRENT_SHARD_POD_FQDN_LIST"
+      The stderr should include "VALKEY_DATA_DIR"
       The stderr should include "refusing to start"
     End
 
@@ -69,6 +75,30 @@ Describe "valkey-cluster-server-start.sh behavior"
     It "passes with the full contract inputs"
       When call validate_required_env
       The status should be success
+    End
+
+    It "rejects a data directory that could make offline cleanup escape its volume"
+      export VALKEY_DATA_DIR="/"
+      When call validate_required_env
+      The status should be failure
+      The stderr should include "must not be the filesystem root"
+    End
+
+    It "rejects dot segments in the destructive data path"
+      mkdir -p "${start_tmp}/other"
+      export VALKEY_DATA_DIR="${start_tmp}/data/../other"
+      When call validate_required_env
+      The status should be failure
+      The stderr should include "canonical path"
+    End
+
+    It "rejects a symlinked destructive data path"
+      mkdir -p "${start_tmp}/real-data"
+      ln -s "${start_tmp}/real-data" "${start_tmp}/linked-data"
+      export VALKEY_DATA_DIR="${start_tmp}/linked-data"
+      When call validate_required_env
+      The status should be failure
+      The stderr should include "canonical path"
     End
 
     It "rejects SERVICE_PORT=0 (out of 1..65535)"
@@ -90,6 +120,247 @@ Describe "valkey-cluster-server-start.sh behavior"
       When call validate_required_env
       The status should be failure
       The stderr should include "1..65535"
+    End
+  End
+
+
+  Describe "prepare_restored_replica_offline()"
+    seed_restored_archive() {
+      printf 'snapshot\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      digest=$(sha256sum "${VALKEY_DATA_DIR}/dump.rdb" | awk '{print $1}')
+      printf 'source_shards=3\nshard_master_id=source-id\nshard_slot_ranges=0-5460\nrdb_sha256=%s\n' "${digest}" \
+        > "${VALKEY_DATA_DIR}/cluster-meta"
+      meta_digest=$(sha256sum "${VALKEY_DATA_DIR}/cluster-meta" | awk '{print $1}')
+      printf 'phase=prepared\nmeta_sha256=%s\n' "${meta_digest}" \
+        > "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+      mkdir -p "${VALKEY_DATA_DIR}/appendonlydir"
+      cp "${VALKEY_DATA_DIR}/dump.rdb" "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.1.base.rdb"
+      : > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.1.incr.aof"
+      printf 'file appendonly.aof.1.base.rdb seq 1 type b\nfile appendonly.aof.1.incr.aof seq 1 type i\n' \
+        > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.manifest"
+    }
+
+    It "preserves the restored payload on the shard first pod"
+      seed_restored_archive
+      When call prepare_restored_replica_offline
+      The status should be success
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should be exist
+      The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should not be exist
+    End
+
+    It "refuses a prepared restore when cluster-meta is missing"
+      printf 'snapshot\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      printf 'phase=prepared\nmeta_sha256=%064d\n' 0 \
+        > "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "lacks cluster-meta"
+      The stderr should include "refusing ordinary startup"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+    End
+
+    It "allows a formed restore restart without cluster-meta"
+      printf 'replicated\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      printf 'phase=formed\nmeta_sha256=%064d\n' 0 \
+        > "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+      When call prepare_restored_replica_offline
+      The status should be success
+      The contents of file "${VALKEY_DATA_DIR}/dump.rdb" should include "replicated"
+    End
+
+    It "refuses a symlinked formed restore state without cluster-meta"
+      outside_state="${SHELLSPEC_TMPBASE}/outside-restore-state"
+      printf 'phase=formed\nmeta_sha256=%064d\n' 0 > "${outside_state}"
+      ln -s "${outside_state}" "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "not a safe regular file"
+    End
+
+
+    It "does not classify an ordinary data-bearing restart as restore"
+      printf 'ordinary\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      When call prepare_restored_replica_offline
+      The status should be success
+      The contents of file "${VALKEY_DATA_DIR}/dump.rdb" should include "ordinary"
+    End
+
+    It "discards a verified non-first payload before server start"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      When call prepare_restored_replica_offline
+      The status should be success
+      The stdout should include "Prepared restored replica"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should not be exist
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should not be exist
+      The file "${VALKEY_DATA_DIR}/cluster-meta" should be exist
+      The contents of file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should include "pod=vk-shard-a1x-1"
+      The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" should not be exist
+    End
+
+    It "fails closed before deletion when the archive digest differs"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      printf 'tampered\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "does not match cluster-meta"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should be exist
+    End
+
+    It "refuses a symlinked dump.rdb before destructive cleanup"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      mv "${VALKEY_DATA_DIR}/dump.rdb" "${start_tmp}/outside-rdb"
+      ln -s "${start_tmp}/outside-rdb" "${VALKEY_DATA_DIR}/dump.rdb"
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "dump.rdb is not a safe regular file"
+      The file "${start_tmp}/outside-rdb" should be exist
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should be exist
+    End
+
+    It "rejects an unsafe AOF directory contract before deletion"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      export VALKEY_APPEND_DIRNAME=".."
+      seed_restored_archive
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "unsafe restored replica AOF directory"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should be exist
+    End
+
+    It "rejects an explicitly empty AOF directory contract before deletion"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      export VALKEY_APPEND_DIRNAME=""
+      seed_restored_archive
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "unsafe restored replica AOF directory"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+    End
+
+    It "rejects an explicitly empty AOF filename contract before deletion"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      export VALKEY_APPEND_FILENAME=""
+      seed_restored_archive
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "unsafe restored replica AOF path contract"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+    End
+
+
+    It "refuses a symlinked AOF directory without touching its target"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      mv "${VALKEY_DATA_DIR}/appendonlydir" "${start_tmp}/outside-aof"
+      ln -s "${start_tmp}/outside-aof" "${VALKEY_DATA_DIR}/appendonlydir"
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "multipart AOF is not the pristine restore seed"
+      The file "${start_tmp}/outside-aof/appendonly.aof.1.base.rdb" should be exist
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+    End
+
+    It "resumes an authorized deletion interrupted before the prepared marker"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" \
+        > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+      rm -f "${VALKEY_DATA_DIR}/dump.rdb"
+      When call prepare_restored_replica_offline
+      The status should be success
+      The stdout should include "Prepared restored replica"
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should not be exist
+      The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" should be exist
+      The file "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" should not be exist
+    End
+
+    It "refuses a symlinked prepare marker before destructive cleanup"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      outside_marker="${start_tmp}/outside-prepare-marker"
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" > "${outside_marker}"
+      ln -s "${outside_marker}" \
+        "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "not a safe regular file"
+      The file "${VALKEY_DATA_DIR}/dump.rdb" should be exist
+      The dir "${VALKEY_DATA_DIR}/appendonlydir" should be exist
+    End
+
+    It "never clears replicated data after the prepared marker exists"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" \
+        > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+      printf 'replicated-later\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      printf 'replicated-aof\n' > "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.1.incr.aof"
+      When call prepare_restored_replica_offline
+      The status should be success
+      The contents of file "${VALKEY_DATA_DIR}/dump.rdb" should include "replicated-later"
+      The contents of file "${VALKEY_DATA_DIR}/appendonlydir/appendonly.aof.1.incr.aof" should include "replicated-aof"
+    End
+
+    It "refuses a symlinked prepared marker without clearing replicated data"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      outside_marker="${start_tmp}/outside-prepared-marker"
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" > "${outside_marker}"
+      ln -s "${outside_marker}" \
+        "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+      printf 'replicated-later\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "not a safe regular file"
+      The contents of file "${VALKEY_DATA_DIR}/dump.rdb" should include "replicated-later"
+    End
+
+    It "refuses a valid prepared marker that coexists with a symlinked prepare marker"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" \
+        > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+      outside_marker="${start_tmp}/outside-prepare-marker"
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" > "${outside_marker}"
+      ln -s "${outside_marker}" \
+        "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "offline prepare marker is not a safe regular file"
+    End
+
+
+    It "fails closed when the restore metadata changes after offline authorization"
+      export CURRENT_POD_NAME="vk-shard-a1x-1"
+      seed_restored_archive
+      printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s\n' \
+        "${digest}" "${meta_digest}" "${CURRENT_POD_NAME}" \
+        > "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+      printf '# changed after authorization\n' >> "${VALKEY_DATA_DIR}/cluster-meta"
+      printf 'replicated-later\n' > "${VALKEY_DATA_DIR}/dump.rdb"
+      When call prepare_restored_replica_offline
+      The status should be failure
+      The stderr should include "restore state does not match cluster-meta"
+      The contents of file "${VALKEY_DATA_DIR}/dump.rdb" should include "replicated-later"
     End
   End
 
@@ -183,6 +454,31 @@ Describe "Valkey cluster template contracts"
     # Ports must come from SERVICE_PORT / CLUSTER_BUS_PORT vars.
     When call grep -E "(^|[^0-9])(6379|16379)([^0-9]|$)" "${start_script}"
     The status should be failure
+  End
+
+  It "provides the persistent data directory required by offline restore preparation"
+    When call grep -c "name: VALKEY_DATA_DIR" "${cmpd}"
+    The status should be success
+    The stdout should equal "1"
+  End
+
+  It "uses same-directory mktemp files instead of predictable PID temp paths"
+    When call grep -E '\.tmp\.\$\$' "${start_script}" ../dataprotection/restore.sh ../scripts/valkey-cluster-manage.sh
+    The status should be failure
+  End
+
+  restored_prepare_precedes_server_start() {
+    awk '
+      /^prepare_restored_replica_offline \|\| exit 1$/ { prepare = NR }
+      /^conf_file=\$\(build_cluster_conf / { config = NR }
+      /^start_cluster_server / { start = NR }
+      END { exit !(prepare > 0 && prepare < config && config < start) }
+    ' "$1"
+  }
+
+  It "prepares restored replicas before config rendering and server exec"
+    When call restored_prepare_precedes_server_start "${start_script}"
+    The status should be success
   End
 
   It "wires postProvision preCondition at the action level (KB Action API shape)"

--- a/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
+++ b/addons/valkey/scripts-ut-spec/valkey_cluster_start_spec.sh
@@ -511,6 +511,17 @@ Describe "Valkey cluster template contracts"
     The stdout should equal "1"
   End
 
+  post_provision_targets_all_pods() {
+    awk '/^    postProvision:/,/^      retryPolicy:/' "$1" \
+      | grep -c '^        targetPodSelector: All$'
+  }
+
+  It "requires postProvision success on every pod before Component completion"
+    When call post_provision_targets_all_pods "${cmpd}"
+    The status should be success
+    The stdout should equal "1"
+  End
+
   It "pins CURRENT_POD_NAME on the shardRemove ACTION env (not just runtime)"
     When call action_env_has_pod_name "${shardingdef}" "shardRemove"
     The status should be success

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -462,6 +462,30 @@ local_cluster_restore_state_matches_meta() {
   }
 }
 
+local_cluster_restore_formed_without_meta() {
+  local state actual meta_sha256 expected_formed
+  state=$(cluster_restore_state_path) || return 1
+  [ -f "${state}" ] && [ ! -L "${state}" ] || {
+    classify restore-state no "local formed-state tombstone is missing or unsafe"
+    return 1
+  }
+  actual=$(cat "${state}" 2>/dev/null) || return 1
+  case "${actual}" in phase=formed$'\n'meta_sha256=*) ;;
+    *) classify restore-state no "invalid local formed-state tombstone"; return 1 ;;
+  esac
+  meta_sha256=${actual#*$'\n'meta_sha256=}
+  case "${meta_sha256}" in ''|*[!0-9a-fA-F]*) meta_sha256="" ;; esac
+  [ "${#meta_sha256}" -eq 64 ] || {
+    classify restore-state no "invalid local formed-state metadata identity"
+    return 1
+  }
+  expected_formed=$(printf 'phase=formed\nmeta_sha256=%s' "${meta_sha256}")
+  [ "${actual}" = "${expected_formed}" ] || {
+    classify restore-state no "invalid local formed-state tombstone"
+    return 1
+  }
+}
+
 mark_local_cluster_restore_formed() {
   local meta="${1}" state actual meta_sha256 tmp expected_prepared expected_formed
   state=$(cluster_restore_state_path) || return 1
@@ -636,8 +660,10 @@ restore_cluster_from_meta() {
     }
     prepare_local_restored_replica_for_attach "${meta}" "${self_first}" "${host}" "${other_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" || return 1
     ensure_replica_bound "${self_first}" "${host}" "${other_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" || return 1
-    classify restore-replica-converge yes "offline-prepared replica ${host} attached; waiting for complete restored membership"
-    return 1
+    ensure_replica_bound "${self_first}" "${host}" "${other_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" restore || return 1
+    mark_local_cluster_restore_formed "${meta}" || return 1
+    echo "restored replica duties complete for ${host}; local binding is committed."
+    return 0
   fi
 
   coord=$(coordinator_shard) || return 1
@@ -783,23 +809,13 @@ restore_cluster_from_meta() {
     classify restore-coverage yes "local archived ranges restored; cluster coverage ${total}/16384"
     return 1
   fi
-  if ! self_is_coordinator_pod "${coord}"; then
-    classify restore-attach yes "slot coverage complete; waiting for coordinator ${coord} to attach replicas"
-    return 1
-  fi
-
   restored_primary_cluster_ready_for_replica_attach || {
-    classify restore-attach yes "restored primary views have not all converged to state=ok, 16384 slots and one exact id set before replica attach"
+    classify restore-primary-converge yes "restored primary views have not all converged to state=ok, 16384 slots and one exact id set"
     return 1
   }
 
-  attach_all_replicas restore || return 1
-  cluster_formed_from_self || {
-    classify restore-converge yes "archived slots assigned but restored membership not complete"
-    return 1
-  }
   mark_local_cluster_restore_formed "${meta}" || return 1
-  echo "restored cluster formed with archived slot ownership and complete membership."
+  echo "restored primary duties complete with archived slot ownership and converged primary views."
 }
 
 # ── formation ────────────────────────────────────────────────────────────────
@@ -1376,8 +1392,8 @@ offline_prepared_marker_matches() {
 
 # A restored non-first pod must already have discarded its redundant archive
 # in the server entrypoint, before valkey-server accepted any client. The
-# lifecycle action never clears online data; it only proves the empty,
-# slotless singleton and waits for the coordinator to attach it.
+# lifecycle action never clears online data; it proves the empty, slotless
+# singleton, attaches only this pod, and commits only this pod's formed state.
 prepare_local_restored_replica_for_attach() {
   local meta="${1}" via="${2}" fqdn="${3}" master_id="${4}" shard="${5}"
   local primary_nodes target_nodes primary_line target_line target_count
@@ -1463,6 +1479,14 @@ post_provision() {
       exit 1
     fi
   done
+  # A formed state is a durable per-pod completion tombstone. With selector=All,
+  # an earlier pod can be invoked again while later pods are still converging.
+  if [ ! -e "${restore_meta}" ] && [ -f "${restore_state}" ] && \
+     grep -qx 'phase=formed' "${restore_state}"; then
+    local_cluster_restore_formed_without_meta || exit 1
+    echo "local restore duties already complete — allowing the next pod action to proceed."
+    exit 0
+  fi
   if cluster_formed_from_self; then
     if [ -e "${restore_state}" ] || [ -e "${restore_meta}" ] || \
        [ -e "${restore_prepare}" ] || [ -e "${restore_prepared}" ]; then

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -684,7 +684,7 @@ restore_cluster_from_meta() {
   local meta="$1" roster shard_line shard fqdns first self_first
   local coord primary_count=0 coord_host="" current_nodes current_ids
   local host other_known other_nodes other_ids other_id meet_address met=0
-  local self_id missing range out total i
+  local self_id missing range out total i unique_primary_count
   local primary_hosts=() primary_ids=() meet_hosts=() meet_addresses=()
 
   load_cluster_restore_meta "${meta}" || return 1
@@ -749,6 +749,12 @@ restore_cluster_from_meta() {
     classify restore-roster no "coordinator ${coord} missing from restored roster"
     return 1
   }
+  unique_primary_count=$(printf '%s\n' "${primary_ids[@]}" | LC_ALL=C sort -u |
+    awk 'NF {n++} END {print n+0}')
+  if [ "${unique_primary_count}" -ne "${primary_count}" ]; then
+    classify restore-membership no "restored primaries must have unique CLUSTER MYID values"
+    return 1
+  fi
 
   current_nodes=$(cluster_nodes_of "${coord_host}") || {
     classify restore-meet yes "cannot read coordinator CLUSTER NODES from ${coord_host}"

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -156,6 +156,69 @@ node_id_sets_overlap() {
   return 1
 }
 
+cluster_node_address_matches_fqdn() {
+  local line="${1}" fqdn="${2}" address primary token
+  local -a _cluster_address_parts
+  address=$(printf '%s\n' "${line}" | awk '{print $2}')
+  [ -n "${address}" ] || return 1
+  primary="${address%%:*}"
+  [ "${primary}" = "${fqdn}" ] && return 0
+  IFS=',' read -ra _cluster_address_parts <<< "${address}"
+  for token in "${_cluster_address_parts[@]:1}"; do
+    token="${token#hostname=}"
+    [ "${token}" = "${fqdn}" ] && return 0
+  done
+  return 1
+}
+
+# A restore view may contain any already-attached configured replica, but it
+# must not contain a node outside the KubeBlocks roster. Identical views alone
+# are insufficient: every primary could agree on the same stale foreign node.
+cluster_view_contains_only_configured_members() {
+  local nodes="${1}" roster="${2}" shard_line fqdns fqdn configured=""
+  local line matched address seen=""
+
+  while IFS= read -r shard_line; do
+    fqdns="${shard_line#* }"
+    for fqdn in $(printf '%s\n' "${fqdns}" | tr ',' '\n' | grep -v '^$'); do
+      if printf '%s\n' "${configured}" | grep -Fqx "${fqdn}"; then
+        echo "duplicate configured restore member ${fqdn}" >&2
+        return 1
+      fi
+      configured="${configured}${configured:+$'\n'}${fqdn}"
+    done
+  done <<< "${roster}"
+  [ -n "${configured}" ] || {
+    echo "configured restore roster is empty" >&2
+    return 1
+  }
+
+  printf '%s\n' "${nodes}" | cluster_node_id_set >/dev/null || return 1
+  while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    matched=""
+    while IFS= read -r fqdn; do
+      [ -n "${fqdn}" ] || continue
+      cluster_node_address_matches_fqdn "${line}" "${fqdn}" || continue
+      [ -z "${matched}" ] || {
+        echo "cluster node address matches multiple configured members: ${line}" >&2
+        return 1
+      }
+      matched="${fqdn}"
+    done <<< "${configured}"
+    if [ -z "${matched}" ]; then
+      address=$(printf '%s\n' "${line}" | awk '{print $2}')
+      echo "cluster view contains foreign node ${address:-unknown}" >&2
+      return 1
+    fi
+    if printf '%s\n' "${seen}" | grep -Fqx "${matched}"; then
+      echo "cluster view contains duplicate configured member ${matched}" >&2
+      return 1
+    fi
+    seen="${seen}${seen:+$'\n'}${matched}"
+  done <<< "${nodes}"
+}
+
 # Slot count currently owned by the master whose id is $2, read from $1's
 # view of CLUSTER NODES. Prints the count of slot ranges' total slots.
 slots_owned_by() {
@@ -599,6 +662,7 @@ restored_primary_cluster_ready_for_replica_attach() {
   for host in "${primary_hosts[@]}"; do
     [ "$(cluster_state_of "${host}")" = "ok" ] && [ "$(assigned_slots_of "${host}")" = "16384" ] || return 1
     nodes=$(cluster_nodes_of "${host}") || return 1
+    cluster_view_contains_only_configured_members "${nodes}" "${roster}" || return 1
     observed=$(printf '%s\n' "${nodes}" | cluster_node_id_set) || return 1
     if [ -z "${expected}" ]; then
       expected="${observed}"
@@ -694,6 +758,10 @@ restore_cluster_from_meta() {
     classify restore-meet yes "malformed coordinator CLUSTER NODES from ${coord_host}"
     return 1
   }
+  if ! cluster_view_contains_only_configured_members "${current_nodes}" "${roster}"; then
+    classify restore-membership no "coordinator ${coord_host} sees a node outside the configured restore roster"
+    return 1
+  fi
 
   # Only the deterministic coordinator writes MEET. Materialize and validate
   # every pending peer address before the first mutation, so a DNS gap cannot
@@ -759,6 +827,10 @@ restore_cluster_from_meta() {
       classify restore-membership yes "malformed CLUSTER NODES from ${host}"
       return 1
     }
+    if ! cluster_view_contains_only_configured_members "${other_nodes}" "${roster}"; then
+      classify restore-membership no "${host} sees a node outside the configured restore roster"
+      return 1
+    fi
     for other_id in "${primary_ids[@]}"; do
       if ! printf '%s\n' "${other_ids}" | grep -Fqx "${other_id}"; then
         classify restore-membership yes "${host} does not yet see restored primary ${other_id}"

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -1565,20 +1565,23 @@ post_provision() {
     echo "local restore duties already complete — allowing the next pod action to proceed."
     exit 0
   fi
-  if cluster_formed_from_self; then
-    if [ -e "${restore_state}" ] || [ -e "${restore_meta}" ] || \
-       [ -e "${restore_prepare}" ] || [ -e "${restore_prepared}" ]; then
-      mark_local_cluster_restore_formed "${restore_meta}" || exit 1
-    fi
-    echo "cluster already formed (state ok, 16384 slots) — nothing to do."
-    exit 0
-  fi
+  # A live cluster can be globally formed while this pod still has uncommitted
+  # restore duties. Validate its archived ownership or replica preparation
+  # before the generic formed fast path is allowed to remove cluster-meta.
   if [ -e "${restore_meta}" ]; then
     [ -f "${restore_meta}" ] || {
       classify restore-state no "cluster-meta is not a safe regular file"
       exit 1
     }
     restore_cluster_from_meta "${restore_meta}" || exit 1
+    exit 0
+  fi
+  if cluster_formed_from_self; then
+    if [ -e "${restore_state}" ] || [ -e "${restore_meta}" ] || \
+       [ -e "${restore_prepare}" ] || [ -e "${restore_prepared}" ]; then
+      mark_local_cluster_restore_formed "${restore_meta}" || exit 1
+    fi
+    echo "cluster already formed (state ok, 16384 slots) — nothing to do."
     exit 0
   fi
   if [ -e "${restore_state}" ] || [ -e "${restore_prepare}" ] || [ -e "${restore_prepared}" ]; then

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -57,6 +57,23 @@ validate_manage_env() {
   return 0
 }
 
+validate_restore_data_dir() {
+  local canonical_data_dir
+  case "${VALKEY_DATA_DIR:-}" in
+    /*) ;;
+    *) classify restore-env no "VALKEY_DATA_DIR must be an existing canonical absolute directory"; return 1 ;;
+  esac
+  [ "${VALKEY_DATA_DIR}" != "/" ] && [ -d "${VALKEY_DATA_DIR}" ] && [ ! -L "${VALKEY_DATA_DIR}" ] || {
+    classify restore-env no "VALKEY_DATA_DIR must be an existing canonical non-root directory"
+    return 1
+  }
+  canonical_data_dir=$(cd -P "${VALKEY_DATA_DIR}" 2>/dev/null && pwd -P) || return 1
+  [ "${canonical_data_dir}" = "${VALKEY_DATA_DIR}" ] || {
+    classify restore-env no "VALKEY_DATA_DIR contains a symlink or dot-segment alias"
+    return 1
+  }
+}
+
 # ── cli helpers ──────────────────────────────────────────────────────────────
 
 build_cli() {
@@ -420,6 +437,88 @@ cluster_restore_meta_path() {
   echo "${VALKEY_DATA_DIR}/cluster-meta"
 }
 
+cluster_restore_state_path() {
+  echo "${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+}
+
+local_cluster_restore_state_matches_meta() {
+  local meta="${1}" state actual meta_sha256 expected_prepared expected_formed
+  state=$(cluster_restore_state_path) || return 1
+  [ -f "${meta}" ] && [ -f "${state}" ] && [ ! -L "${state}" ] || {
+    classify restore-state no "cluster-meta lacks its exact local restore-state contract"
+    return 1
+  }
+  meta_sha256=$(sha256sum "${meta}" 2>/dev/null | awk '{print $1}')
+  [ "${#meta_sha256}" -eq 64 ] || {
+    classify restore-state no "cannot identify local cluster-meta"
+    return 1
+  }
+  actual=$(cat "${state}" 2>/dev/null) || return 1
+  expected_prepared=$(printf 'phase=prepared\nmeta_sha256=%s' "${meta_sha256}")
+  expected_formed=$(printf 'phase=formed\nmeta_sha256=%s' "${meta_sha256}")
+  [ "${actual}" = "${expected_prepared}" ] || [ "${actual}" = "${expected_formed}" ] || {
+    classify restore-state no "local cluster restore state does not match cluster-meta"
+    return 1
+  }
+}
+
+mark_local_cluster_restore_formed() {
+  local meta="${1}" state actual meta_sha256 tmp expected_prepared expected_formed
+  state=$(cluster_restore_state_path) || return 1
+  [ ! -L "${meta}" ] || {
+    classify restore-state no "cluster-meta is not a safe regular file"
+    return 1
+  }
+  [ -f "${state}" ] && [ ! -L "${state}" ] || {
+    classify restore-state no "local cluster restore state is missing or unsafe"
+    return 1
+  }
+  actual=$(cat "${state}" 2>/dev/null) || return 1
+  if [ -f "${meta}" ]; then
+    meta_sha256=$(sha256sum "${meta}" 2>/dev/null | awk '{print $1}')
+    [ "${#meta_sha256}" -eq 64 ] || {
+      classify restore-state no "cannot identify local cluster-meta before formed commit"
+      return 1
+    }
+    expected_prepared=$(printf 'phase=prepared\nmeta_sha256=%s' "${meta_sha256}")
+    expected_formed=$(printf 'phase=formed\nmeta_sha256=%s' "${meta_sha256}")
+    [ "${actual}" = "${expected_prepared}" ] || [ "${actual}" = "${expected_formed}" ] || {
+      classify restore-state no "local cluster restore state does not match cluster-meta"
+      return 1
+    }
+  else
+    case "${actual}" in phase=formed$'\n'meta_sha256=*) ;;
+      *) classify restore-state no "cluster-meta disappeared before the local formed-state commit"; return 1 ;;
+    esac
+    meta_sha256=${actual#*$'\n'meta_sha256=}
+    case "${meta_sha256}" in ''|*[!0-9a-fA-F]*) meta_sha256="" ;; esac
+    [ "${#meta_sha256}" -eq 64 ] || {
+      classify restore-state no "invalid local formed-state metadata identity"
+      return 1
+    }
+    expected_formed=$(printf 'phase=formed\nmeta_sha256=%s' "${meta_sha256}")
+    [ "${actual}" = "${expected_formed}" ] || return 1
+  fi
+  if [ "${actual}" != "${expected_formed}" ]; then
+    tmp=$(mktemp "${state}.tmp.XXXXXX") || {
+      classify restore-state yes "cannot allocate local formed-state commit"
+      return 1
+    }
+    printf '%s\n' "${expected_formed}" > "${tmp}" && mv -f "${tmp}" "${state}" && sync || {
+      rm -f "${tmp}"
+      classify restore-state yes "cannot persist local formed-state commit"
+      return 1
+    }
+  fi
+  rm -f "${meta}" \
+    "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" \
+    "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" && sync || {
+      classify restore-state yes "cannot remove local restore preparation residue"
+      return 1
+    }
+  echo "committed local cluster restore formed state and removed preparation residue."
+}
+
 load_cluster_restore_meta() {
   local meta="$1" source_count master_count ranges_count digest_count
   source_count=$(grep -c '^source_shards=' "${meta}" || true)
@@ -460,7 +559,7 @@ load_cluster_restore_meta() {
   fi
 }
 
-restored_primary_cluster_ready_for_replica_reset() {
+restored_primary_cluster_ready_for_replica_attach() {
   local roster shard_line fqdns host id nodes observed expected="" primary_id
   local primary_hosts=() primary_ids=()
   roster=$(each_shard_fqdn_list) || return 1
@@ -501,6 +600,7 @@ restore_cluster_from_meta() {
   local primary_hosts=() primary_ids=() meet_hosts=() meet_addresses=()
 
   load_cluster_restore_meta "${meta}" || return 1
+  local_cluster_restore_state_matches_meta "${meta}" || return 1
   roster=$(each_shard_fqdn_list) || return 1
   while read -r shard_line; do
     shard="${shard_line%% *}"
@@ -535,6 +635,8 @@ restore_cluster_from_meta() {
       return 1
     }
     prepare_local_restored_replica_for_attach "${meta}" "${self_first}" "${host}" "${other_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" || return 1
+    ensure_replica_bound "${self_first}" "${host}" "${other_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" || return 1
+    classify restore-replica-converge yes "offline-prepared replica ${host} attached; waiting for complete restored membership"
     return 1
   fi
 
@@ -686,8 +788,8 @@ restore_cluster_from_meta() {
     return 1
   fi
 
-  restored_primary_cluster_ready_for_replica_reset || {
-    classify restore-attach yes "restored primary views have not all converged to state=ok, 16384 slots and one exact id set before replica reset"
+  restored_primary_cluster_ready_for_replica_attach || {
+    classify restore-attach yes "restored primary views have not all converged to state=ok, 16384 slots and one exact id set before replica attach"
     return 1
   }
 
@@ -696,7 +798,7 @@ restore_cluster_from_meta() {
     classify restore-converge yes "archived slots assigned but restored membership not complete"
     return 1
   }
-  rm -f "${meta}"
+  mark_local_cluster_restore_formed "${meta}" || return 1
   echo "restored cluster formed with archived slot ownership and complete membership."
 }
 
@@ -995,8 +1097,9 @@ form_cluster() {
   echo "cluster formed: state ok, 16384/16384 slots assigned."
 }
 
-# Attach every non-first pod of every shard as a replica of that shard's
-# master (identified by engine node id, resolved fresh each invocation).
+# In ordinary formation, attach every non-first pod to its shard master. In
+# restore mode, this coordinator path is observation-only: each non-first pod
+# must validate its PVC-local offline marker and attach itself.
 attach_all_replicas() {
   local mode="${1:-ordinary}"
   local shard_line shard fqdns first rest fqdn master_id add_out roster
@@ -1219,10 +1322,18 @@ ensure_replica_bound() {
   local line flags parent out
   build_cli "${via}"
   line=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -F "${fqdn}" | head -1)
-  if [ -z "${line}" ]; then
-    if [ "${mode}" = "restore" ]; then
-      restored_replica_ready_for_attach "${fqdn}" "${shard}" || return 1
+  if [ "${mode}" = "restore" ]; then
+    if [ -n "${line}" ]; then
+      flags=$(echo "${line}" | awk '{print $3}')
+      parent=$(echo "${line}" | awk '{print $4}')
+      if echo "${flags}" | grep -q slave && [ "${parent}" = "${master_id}" ]; then
+        return 0
+      fi
     fi
+    classify restore-replica-wait yes "restored replica ${fqdn} must validate its local offline marker and attach itself to shard ${shard}"
+    return 1
+  fi
+  if [ -z "${line}" ]; then
     build_cluster_cli
     out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${via}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
       classify attach-add-node yes "add replica ${fqdn} to shard ${shard} failed (re-entry re-drives): ${out}"
@@ -1245,77 +1356,45 @@ ensure_replica_bound() {
   echo "repaired ${fqdn}: now replicating shard ${shard} master ${master_id}."
 }
 
-# The coordinator never clears a remote pod. It only attaches a restored
-# replica after that pod's own postProvision action has positively reduced it
-# to one empty, slotless node.
-restored_replica_ready_for_attach() {
-  local fqdn="${1}" shard="${2}" nodes line flags parent ranges size
-  nodes=$(cluster_nodes_of "${fqdn}") || return 1
-  [ "$(printf '%s\n' "${nodes}" | awk 'NF {n++} END {print n+0}')" -eq 1 ] && \
-    [ "$(known_nodes_of "${fqdn}")" = "1" ] || {
-      classify restore-replica-wait yes "restored replica ${fqdn} has not prepared one isolated node for shard ${shard}"
-      return 1
-    }
-  line=$(printf '%s\n' "${nodes}" | awk 'NF {print; exit}')
-  flags=$(printf '%s\n' "${line}" | awk '{print $3}')
-  parent=$(printf '%s\n' "${line}" | awk '{print $4}')
-  ranges=$(printf '%s\n' "${line}" | cut -d' ' -f9-)
-  size=$(dbsize_of "${fqdn}") || true
-  case "${flags}:${parent}:${ranges}:${size}" in
-    *myself*master*:-::0) return 0 ;;
-  esac
-  classify restore-replica-wait yes "restored replica ${fqdn} is not yet empty and slotless for shard ${shard}"
-  return 1
+offline_prepared_marker_matches() {
+  local fqdn="${1}" expected_rdb_sha256="${2}" meta="${3}" marker prepare_marker actual expected meta_sha256
+  marker="${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+  prepare_marker="${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+  [ -f "${marker}" ] && [ ! -L "${marker}" ] || return 1
+  meta_sha256=$(sha256sum "${meta}" 2>/dev/null | awk '{print $1}')
+  [ "${#meta_sha256}" -eq 64 ] || return 1
+  expected=$(printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s' \
+    "${expected_rdb_sha256}" "${meta_sha256}" "${fqdn%%.*}")
+  actual=$(cat "${marker}" 2>/dev/null) || return 1
+  [ "${actual}" = "${expected}" ] || return 1
+  if [ -e "${prepare_marker}" ] || [ -L "${prepare_marker}" ]; then
+    [ -f "${prepare_marker}" ] && [ ! -L "${prepare_marker}" ] || return 1
+    actual=$(cat "${prepare_marker}" 2>/dev/null) || return 1
+    [ "${actual}" = "${expected}" ] || return 1
+  fi
 }
 
-local_restored_aof_is_pristine() {
-  local expected_rdb_sha256="${1}"
-  local append_dirname="${VALKEY_APPEND_DIRNAME:-appendonlydir}"
-  local append_filename="${VALKEY_APPEND_FILENAME:-appendonly.aof}"
-  local append_dir="${VALKEY_DATA_DIR}/${append_dirname}"
-  local base="${append_dir}/${append_filename}.1.base.rdb"
-  local incr="${append_dir}/${append_filename}.1.incr.aof"
-  local manifest="${append_dir}/${append_filename}.manifest"
-  local expected_manifest actual_manifest unexpected base_sha256
-
-  [ -f "${base}" ] && [ -f "${incr}" ] && [ -f "${manifest}" ] || return 1
-  [ ! -s "${incr}" ] || return 1
-  base_sha256=$(sha256sum "${base}" 2>/dev/null | awk '{print $1}')
-  [ "${base_sha256}" = "${expected_rdb_sha256}" ] || return 1
-  expected_manifest=$(printf 'file %s seq 1 type b\nfile %s seq 1 type i' \
-    "$(basename "${base}")" "$(basename "${incr}")")
-  actual_manifest=$(cat "${manifest}" 2>/dev/null) || return 1
-  [ "${actual_manifest}" = "${expected_manifest}" ] || return 1
-  unexpected=$(find "${append_dir}" -mindepth 1 -maxdepth 1 \
-    ! -name "$(basename "${base}")" \
-    ! -name "$(basename "${incr}")" \
-    ! -name "$(basename "${manifest}")" -print) || return 1
-  [ -z "${unexpected}" ]
-}
-
-# prepareData restores the same per-shard archive onto every PVC. Each
-# ordinal>0 action clears only its own redundant copy, and only after proving:
-# the ordinal-0 primary is authoritative, local slots are a subset of that
-# master, dump.rdb matches backup-recorded restore metadata, and no post-restore AOF
-# writes exist. Before FLUSHALL it persists an exact local authorization
-# marker; an empty DB with shadow slots is a valid re-entry state only when
-# that marker still matches this archive, pod, shard and intended master.
+# A restored non-first pod must already have discarded its redundant archive
+# in the server entrypoint, before valkey-server accepted any client. The
+# lifecycle action never clears online data; it only proves the empty,
+# slotless singleton and waits for the coordinator to attach it.
 prepare_local_restored_replica_for_attach() {
   local meta="${1}" via="${2}" fqdn="${3}" master_id="${4}" shard="${5}"
   local primary_nodes target_nodes primary_line target_line target_count
-  local flags parent primary_ranges target_ranges target_size actual_rdb_sha256
-  local bound_line bound_flags bound_parent out reset_nodes reset_line reset_ranges
-  local reset_marker expected_marker actual_marker marker_tmp
+  local flags parent primary_ranges target_ranges target_size
+  local bound_line bound_flags bound_parent
 
   load_cluster_restore_meta "${meta}" || return 1
-
-  restored_primary_cluster_ready_for_replica_reset || {
-    classify restore-replica-primary yes "all restored primary views are not fully converged before clearing ${fqdn}"
+  offline_prepared_marker_matches "${fqdn}" "${_restore_rdb_sha256}" "${meta}" || {
+    classify restore-replica-data no "restored replica ${fqdn} lacks the exact offline-prepared marker"
     return 1
   }
-
+  restored_primary_cluster_ready_for_replica_attach || {
+    classify restore-replica-primary yes "all restored primary views are not fully converged before attaching ${fqdn}"
+    return 1
+  }
   if [ "$(cluster_state_of "${via}")" != "ok" ] || [ "$(assigned_slots_of "${via}")" != "16384" ]; then
-    classify restore-replica-primary yes "primary ${via} is not state=ok with 16384 slots before clearing ${fqdn}"
+    classify restore-replica-primary yes "primary ${via} is not state=ok with 16384 slots before attaching ${fqdn}"
     return 1
   fi
   primary_nodes=$(cluster_nodes_of "${via}") || return 1
@@ -1329,9 +1408,6 @@ prepare_local_restored_replica_for_attach() {
     *) classify restore-replica-primary no "intended node ${master_id} is not a master in ${via} view"; return 1 ;;
   esac
 
-  # The coordinator can attach this pod between local retries. Once the
-  # primary view proves the intended binding, local cleanup must never run
-  # again; the next positive full-formation observation removes the marker.
   bound_line=$(printf '%s\n' "${primary_nodes}" | grep -F "${fqdn}" | head -1)
   if [ -n "${bound_line}" ]; then
     bound_flags=$(printf '%s\n' "${bound_line}" | awk '{print $3}')
@@ -1357,116 +1433,55 @@ prepare_local_restored_replica_for_attach() {
     *myself*master*:-) ;;
     *) classify restore-replica-shape no "restore target ${fqdn} is not a singleton myself,master"; return 1 ;;
   esac
-
   primary_ranges=$(printf '%s\n' "${primary_line}" | cut -d' ' -f9-)
   target_ranges=$(printf '%s\n' "${target_line}" | cut -d' ' -f9-)
   if ! slot_ranges_are_subset "${target_ranges}" "${primary_ranges}"; then
     classify restore-replica-slots no "restore target ${fqdn} claims slots outside shard ${shard} master ${master_id}"
     return 1
   fi
-
   target_size=$(dbsize_of "${fqdn}") || true
   case "${target_size}" in
-    ''|*[!0-9]*) classify restore-replica-data yes "cannot read numeric DBSIZE from restored duplicate ${fqdn}"; return 1 ;;
+    ''|*[!0-9]*) classify restore-replica-data yes "cannot read numeric DBSIZE from restored replica ${fqdn}"; return 1 ;;
   esac
-
-  reset_marker="${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized"
-  expected_marker=$(printf 'rdb_sha256=%s\nmaster_id=%s\nshard=%s\npod=%s' \
-    "${_restore_rdb_sha256}" "${master_id}" "${shard}" "${fqdn%%.*}")
-  actual_marker=""
-  if [ -e "${reset_marker}" ]; then
-    [ -f "${reset_marker}" ] || {
-      classify restore-replica-data no "local reset authorization marker is not a regular file"
-      return 1
-    }
-    actual_marker=$(cat "${reset_marker}" 2>/dev/null) || {
-      classify restore-replica-data no "cannot read local reset authorization marker"
-      return 1
-    }
-    [ "${actual_marker}" = "${expected_marker}" ] || {
-      classify restore-replica-data no "local reset authorization marker does not match this restore target"
-      return 1
-    }
-  fi
-
-  if [ "${target_size}" -eq 0 ] && [ -z "${target_ranges}" ]; then
-    rm -f "${reset_marker}" && sync
-    echo "restored duplicate ${fqdn} is already empty and slotless for shard ${shard}."
-    return 0
-  fi
-  if [ "${target_size}" -eq 0 ] && [ "${actual_marker}" != "${expected_marker}" ]; then
-    classify restore-replica-data no "empty restored duplicate ${fqdn} still owns slots without reset authorization"
-    return 1
-  fi
-  if [ "${target_size}" -gt 0 ]; then
-    actual_rdb_sha256=$(sha256sum "${VALKEY_DATA_DIR}/dump.rdb" 2>/dev/null | awk '{print $1}')
-    [ "${actual_rdb_sha256}" = "${_restore_rdb_sha256}" ] || {
-      classify restore-replica-data no "local dump.rdb on ${fqdn} does not match restore metadata"
-      return 1
-    }
-    local_restored_aof_is_pristine "${_restore_rdb_sha256}" || {
-      classify restore-replica-data no "local multipart AOF is not the pristine restore seed; refusing to clear ${fqdn}"
-      return 1
-    }
-    if [ -z "${actual_marker}" ]; then
-      marker_tmp="${reset_marker}.tmp.$$"
-      if ! printf '%s\n' "${expected_marker}" > "${marker_tmp}" || \
-         ! mv -f "${marker_tmp}" "${reset_marker}" || ! sync; then
-        rm -f "${marker_tmp}"
-        classify restore-replica-data yes "cannot persist local reset authorization marker for ${fqdn}"
-        return 1
-      fi
-    fi
-    build_cli "${fqdn}"
-    out=$("${_cli[@]}" FLUSHALL 2>&1) || {
-      classify restore-replica-flush yes "FLUSHALL on verified duplicate ${fqdn} failed: ${out}"
-      return 1
-    }
-    case "${out}" in '(error)'*|'ERR '*) classify restore-replica-flush yes "FLUSHALL on ${fqdn} returned protocol error: ${out}"; return 1 ;; esac
-    [ "$(dbsize_of "${fqdn}")" = "0" ] || {
-      classify restore-replica-flush yes "verified duplicate ${fqdn} is not empty after FLUSHALL"
-      return 1
-    }
-  fi
-
-  build_cli "${fqdn}"
-  out=$("${_cli[@]}" CLUSTER RESET HARD 2>&1) || {
-    classify restore-replica-reset yes "CLUSTER RESET HARD on ${fqdn} failed: ${out}"
+  [ "${target_size}" -eq 0 ] && [ -z "${target_ranges}" ] || {
+    classify restore-replica-data no "restored replica ${fqdn} was not prepared offline; refusing online cleanup"
     return 1
   }
-  case "${out}" in '(error)'*|'ERR '*) classify restore-replica-reset yes "CLUSTER RESET HARD on ${fqdn} returned protocol error: ${out}"; return 1 ;; esac
-
-  reset_nodes=$(cluster_nodes_of "${fqdn}") || return 1
-  [ "$(printf '%s\n' "${reset_nodes}" | awk 'NF {n++} END {print n+0}')" -eq 1 ] && \
-    [ "$(known_nodes_of "${fqdn}")" = "1" ] && [ "$(dbsize_of "${fqdn}")" = "0" ] || {
-      classify restore-replica-reset yes "${fqdn} did not converge to one empty node after hard reset"
-      return 1
-    }
-  reset_line=$(printf '%s\n' "${reset_nodes}" | awk 'NF {print; exit}')
-  reset_ranges=$(printf '%s\n' "${reset_line}" | cut -d' ' -f9-)
-  [ -z "${reset_ranges}" ] || {
-    classify restore-replica-reset yes "${fqdn} still claims slots after hard reset"
-    return 1
-  }
-  rm -f "${reset_marker}" && sync
-  echo "prepared local restored duplicate ${fqdn} for replica attach to shard ${shard}."
+  echo "restored replica ${fqdn} is empty, slotless and offline-prepared for shard ${shard}."
 }
-
 post_provision() {
   validate_manage_env || exit 1
-  local restore_meta
+  validate_restore_data_dir || exit 1
+  local restore_meta restore_state restore_prepare restore_prepared path
   restore_meta=$(cluster_restore_meta_path) || exit 1
+  restore_state=$(cluster_restore_state_path) || exit 1
+  restore_prepare="${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+  restore_prepared="${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+  for path in "${restore_meta}" "${restore_state}" "${restore_prepare}" "${restore_prepared}"; do
+    if [ -L "${path}" ]; then
+      classify restore-state no "local restore artifact ${path} is a symlink"
+      exit 1
+    fi
+  done
   if cluster_formed_from_self; then
-    if [ -f "${restore_meta}" ]; then
-      rm -f "${restore_meta}"
-      echo "removed local cluster restore metadata after positive formation proof."
+    if [ -e "${restore_state}" ] || [ -e "${restore_meta}" ] || \
+       [ -e "${restore_prepare}" ] || [ -e "${restore_prepared}" ]; then
+      mark_local_cluster_restore_formed "${restore_meta}" || exit 1
     fi
     echo "cluster already formed (state ok, 16384 slots) — nothing to do."
     exit 0
   fi
-  if [ -f "${restore_meta}" ]; then
+  if [ -e "${restore_meta}" ]; then
+    [ -f "${restore_meta}" ] || {
+      classify restore-state no "cluster-meta is not a safe regular file"
+      exit 1
+    }
     restore_cluster_from_meta "${restore_meta}" || exit 1
     exit 0
+  fi
+  if [ -e "${restore_state}" ] || [ -e "${restore_prepare}" ] || [ -e "${restore_prepared}" ]; then
+    classify restore-state no "local restore state exists without cluster-meta before formation"
+    exit 1
   fi
   local coord
   coord=$(coordinator_shard) || exit 1

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -176,6 +176,114 @@ slots_owned_in_node_line() {
   echo "${total}"
 }
 
+# Restore metadata uses comma-separated slots/ranges (for example
+# 0-5460,6000). The parser is deliberately strict: overlap, malformed tokens,
+# or values outside the engine domain must fail before any slot mutation.
+validate_restore_slot_ranges() {
+  awk -v raw="$1" 'BEGIN {
+    if (raw == "") exit 1
+    n = split(raw, parts, ",")
+    for (i = 1; i <= n; i++) {
+      token = parts[i]
+      if (token ~ /^[0-9]+$/) {
+        start = token + 0; end = start
+      } else if (token ~ /^[0-9]+-[0-9]+$/) {
+        split(token, bounds, "-")
+        start = bounds[1] + 0; end = bounds[2] + 0
+      } else {
+        exit 1
+      }
+      if (start < 0 || end > 16383 || start > end) exit 1
+      for (slot = start; slot <= end; slot++) {
+        if (seen[slot]++) exit 1
+      }
+    }
+  }'
+}
+
+# Prints the comma-separated portions of $3 that are still unassigned.
+# Existing ownership by this node is idempotent. Ownership by another node,
+# or this node owning anything outside its archived ranges, is a hard conflict.
+missing_restore_slot_ranges() {
+  local nodes="$1" self_id="$2" desired="$3"
+  printf '%s\n' "${nodes}" | awk -v self="${self_id}" -v desired="${desired}" '
+    function mark_range(token, owner,    b, start, end, slot) {
+      if (token ~ /^\[/) {
+        print "open migrating/importing slot marker present: " token > "/dev/stderr"
+        bad = 1; return
+      }
+      if (token ~ /^[0-9]+$/) {
+        start = token + 0; end = start
+      } else if (token ~ /^[0-9]+-[0-9]+$/) {
+        split(token, b, "-"); start = b[1] + 0; end = b[2] + 0
+      } else {
+        print "invalid CLUSTER NODES slot token: " token > "/dev/stderr"
+        bad = 1; return
+      }
+      if (start < 0 || end > 16383 || start > end) {
+        print "invalid CLUSTER NODES slot range: " token > "/dev/stderr"
+        bad = 1; return
+      }
+      for (slot = start; slot <= end; slot++) {
+        if (owner_of[slot] != "" && owner_of[slot] != owner) {
+          print "slot " slot " has multiple owners" > "/dev/stderr"
+          bad = 1
+        }
+        owner_of[slot] = owner
+      }
+    }
+    BEGIN {
+      n = split(desired, parts, ",")
+      for (i = 1; i <= n; i++) {
+        token = parts[i]
+        if (token ~ /^[0-9]+$/) {
+          start = token + 0; end = start
+        } else if (token ~ /^[0-9]+-[0-9]+$/) {
+          split(token, b, "-"); start = b[1] + 0; end = b[2] + 0
+        } else {
+          bad = 1; start = 1; end = 0
+        }
+        if (start < 0 || end > 16383 || start > end) {
+          bad = 1
+        } else {
+          for (slot = start; slot <= end; slot++) {
+            if (wanted[slot]++) bad = 1
+          }
+        }
+      }
+    }
+    NF > 0 {
+      owner = $1
+      for (i = 9; i <= NF; i++) mark_range($i, owner)
+    }
+    END {
+      if (bad) exit 1
+      for (slot = 0; slot <= 16383; slot++) {
+        if (owner_of[slot] == self && !wanted[slot]) {
+          print "self node owns slot " slot " outside archived ranges" > "/dev/stderr"
+          bad = 1
+        }
+        if (wanted[slot] && owner_of[slot] != "" && owner_of[slot] != self) {
+          print "slot " slot " is already owned by " owner_of[slot] ", not " self > "/dev/stderr"
+          bad = 1
+        }
+      }
+      if (bad) exit 1
+      output = ""; start = -1
+      for (slot = 0; slot <= 16384; slot++) {
+        missing = (slot < 16384 && wanted[slot] && owner_of[slot] == "")
+        if (missing && start < 0) start = slot
+        if (!missing && start >= 0) {
+          end = slot - 1
+          range = (start == end ? start : start "-" end)
+          output = output (output == "" ? "" : ",") range
+          start = -1
+        }
+      }
+      print output
+    }'
+}
+
 # ── deterministic coordinator ────────────────────────────────────────────────
 
 # Prints the coordinator shard short name. Hard-fails on empty/duplicate
@@ -234,6 +342,231 @@ self_is_coordinator_pod() {
   local my_shard_first
   my_shard_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
   [ "${my_shard_first%%.*}" = "${CURRENT_POD_NAME}" ]
+}
+
+cluster_restore_meta_path() {
+  if [ -z "${VALKEY_DATA_DIR:-}" ]; then
+    classify restore-env no "VALKEY_DATA_DIR is required; no data-path fallback"
+    return 1
+  fi
+  echo "${VALKEY_DATA_DIR}/cluster-meta"
+}
+
+load_cluster_restore_meta() {
+  local meta="$1" source_count master_count ranges_count
+  source_count=$(grep -c '^source_shards=' "${meta}" || true)
+  master_count=$(grep -c '^shard_master_id=' "${meta}" || true)
+  ranges_count=$(grep -c '^shard_slot_ranges=' "${meta}" || true)
+  if [ "${source_count}" -ne 1 ] || [ "${master_count}" -ne 1 ] || [ "${ranges_count}" -ne 1 ]; then
+    classify restore-meta no "cluster-meta requires exactly one source_shards, shard_master_id and shard_slot_ranges entry"
+    return 1
+  fi
+  _restore_source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2-)
+  _restore_source_master_id=$(grep '^shard_master_id=' "${meta}" | cut -d= -f2-)
+  _restore_slot_ranges=$(grep '^shard_slot_ranges=' "${meta}" | cut -d= -f2-)
+  case "${_restore_source_shards}" in ''|*[!0-9]*)
+    classify restore-meta no "invalid source_shards '${_restore_source_shards}'"
+    return 1 ;;
+  esac
+  if [ "${_restore_source_shards}" -lt 3 ] || [ "${_restore_source_shards}" -gt 32 ]; then
+    classify restore-meta no "source_shards ${_restore_source_shards} outside 3..32"
+    return 1
+  fi
+  case "${_restore_source_master_id}" in ''|*[!A-Za-z0-9]*)
+    classify restore-meta no "invalid shard_master_id in cluster-meta"
+    return 1 ;;
+  esac
+  if ! validate_restore_slot_ranges "${_restore_slot_ranges}"; then
+    classify restore-meta no "invalid shard_slot_ranges '${_restore_slot_ranges}'"
+    return 1
+  fi
+}
+
+# Same-shard-count cluster restore. Each restored shard's ordinal-0 PVC carries
+# its own archived slot ranges. The deterministic coordinator first connects
+# the fresh masters with CLUSTER MEET; then every shard independently claims
+# only still-unassigned ranges from its own metadata. Engine ownership rejects
+# overlap, and the global 16384 positive gate rejects gaps before replicas bind.
+restore_cluster_from_meta() {
+  local meta="$1" roster shard_line shard fqdns first self_first
+  local coord primary_count=0 coord_host="" current_nodes current_ids
+  local host other_known other_nodes other_ids other_id met=0
+  local self_id missing range out total i
+  local primary_hosts=() primary_ids=()
+
+  load_cluster_restore_meta "${meta}" || return 1
+  roster=$(each_shard_fqdn_list) || return 1
+  while read -r shard_line; do
+    shard="${shard_line%% *}"
+    fqdns="${shard_line#* }"
+    first=$(first_fqdn_of_list "${fqdns}")
+    [ -n "${first}" ] || {
+      classify restore-roster no "shard ${shard} has no designated primary"
+      return 1
+    }
+    if ! build_cli "${first}" || ! "${_cli[@]}" PING 2>/dev/null | grep -q PONG; then
+      classify restore-wait-primaries yes "restored shard ${shard} primary ${first} not answering yet"
+      return 1
+    fi
+    primary_hosts+=("${first}")
+    primary_count=$((primary_count + 1))
+  done <<< "${roster}"
+
+  if [ "${primary_count}" -ne "${_restore_source_shards}" ]; then
+    classify restore-shard-count no "source_shards=${_restore_source_shards} target_shards=${primary_count}; cross-shard-count restore is unsupported"
+    return 1
+  fi
+
+  self_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
+  if [ "${self_first%%.*}" != "${CURRENT_POD_NAME}" ]; then
+    classify restore-target yes "cluster-meta is handled only by restored shard first pod ${self_first%%.*}; current=${CURRENT_POD_NAME}"
+    return 1
+  fi
+
+  coord=$(coordinator_shard) || return 1
+  while read -r shard_line; do
+    shard="${shard_line%% *}"
+    fqdns="${shard_line#* }"
+    first=$(first_fqdn_of_list "${fqdns}")
+    if [ "${shard}" = "$(echo "${coord}" | tr '[:lower:]-' '[:upper:]_')" ]; then
+      coord_host="${first}"
+    fi
+    other_id=$(node_id_of "${first}") || true
+    [ -n "${other_id}" ] || {
+      classify restore-myid yes "cannot read CLUSTER MYID from restored primary ${first}"
+      return 1
+    }
+    primary_ids+=("${other_id}")
+  done <<< "${roster}"
+  [ -n "${coord_host}" ] || {
+    classify restore-roster no "coordinator ${coord} missing from restored roster"
+    return 1
+  }
+
+  current_nodes=$(cluster_nodes_of "${coord_host}") || {
+    classify restore-meet yes "cannot read coordinator CLUSTER NODES from ${coord_host}"
+    return 1
+  }
+  current_ids=$(printf '%s\n' "${current_nodes}" | cluster_node_id_set) || {
+    classify restore-meet yes "malformed coordinator CLUSTER NODES from ${coord_host}"
+    return 1
+  }
+
+  # Only the deterministic coordinator writes MEET. A fresh node (known=1)
+  # may be introduced; an independently configured disjoint node is refused.
+  if self_is_coordinator_pod "${coord}"; then
+    for ((i=0; i<${#primary_hosts[@]}; i++)); do
+      host="${primary_hosts[$i]}"; other_id="${primary_ids[$i]}"
+      [ "${host}" = "${coord_host}" ] && continue
+      printf '%s\n' "${current_ids}" | grep -Fqx "${other_id}" && continue
+      other_known=$(known_nodes_of "${host}") || {
+        classify restore-meet yes "cannot read known-node count from ${host}"
+        return 1
+      }
+      case "${other_known}" in ''|*[!0-9]*)
+        classify restore-meet yes "invalid known-node count '${other_known}' from ${host}"
+        return 1 ;;
+      esac
+      if [ "${other_known}" -ne 1 ]; then
+        other_nodes=$(cluster_nodes_of "${host}") || return 1
+        other_ids=$(printf '%s\n' "${other_nodes}" | cluster_node_id_set) || return 1
+        if ! node_id_sets_overlap "${current_ids}" "${other_ids}"; then
+          classify restore-meet no "restored primary ${host} belongs to a disjoint configured cluster"
+          return 1
+        fi
+        classify restore-meet yes "membership gossip with ${host} is incomplete; deferring before mutation"
+        return 1
+      fi
+      build_cli "${coord_host}"
+      out=$("${_cli[@]}" CLUSTER MEET "${host}" "${SERVICE_PORT}" 2>&1) || {
+        classify restore-meet yes "CLUSTER MEET ${host} failed: ${out}"
+        return 1
+      }
+      case "${out}" in '(error)'*|'ERR '*)
+        classify restore-meet yes "CLUSTER MEET ${host} returned protocol error: ${out}"
+        return 1 ;;
+      esac
+      met=$((met + 1))
+    done
+    if [ "${met}" -gt 0 ]; then
+      classify restore-meet yes "introduced ${met} restored primary node(s); deferring for mutual visibility"
+      return 1
+    fi
+  fi
+
+  # Every primary must see every designated primary before any slot write.
+  for ((i=0; i<${#primary_hosts[@]}; i++)); do
+    host="${primary_hosts[$i]}"
+    other_nodes=$(cluster_nodes_of "${host}") || {
+      classify restore-membership yes "cannot read CLUSTER NODES from ${host}"
+      return 1
+    }
+    other_ids=$(printf '%s\n' "${other_nodes}" | cluster_node_id_set) || {
+      classify restore-membership yes "malformed CLUSTER NODES from ${host}"
+      return 1
+    }
+    for other_id in "${primary_ids[@]}"; do
+      if ! printf '%s\n' "${other_ids}" | grep -Fqx "${other_id}"; then
+        classify restore-membership yes "${host} does not yet see restored primary ${other_id}"
+        return 1
+      fi
+    done
+  done
+
+  self_id=$(node_id_of "${self_first}") || true
+  [ -n "${self_id}" ] || {
+    classify restore-myid yes "cannot read local restored primary id from ${self_first}"
+    return 1
+  }
+  current_nodes=$(cluster_nodes_of "${self_first}") || return 1
+  if ! missing=$(missing_restore_slot_ranges "${current_nodes}" "${self_id}" "${_restore_slot_ranges}"); then
+    classify restore-slots no "archived slot ownership conflicts with current cluster view for ${self_first}"
+    return 1
+  fi
+  if [ -n "${missing}" ]; then
+    build_cli "${self_first}"
+    for range in $(echo "${missing}" | tr ',' ' '); do
+      if echo "${range}" | grep -q -- '-'; then
+        out=$("${_cli[@]}" CLUSTER ADDSLOTSRANGE "${range%-*}" "${range#*-}" 2>&1) || {
+          classify restore-slots yes "ADDSLOTSRANGE ${range} failed: ${out}"
+          return 1
+        }
+      else
+        out=$("${_cli[@]}" CLUSTER ADDSLOTS "${range}" 2>&1) || {
+          classify restore-slots yes "ADDSLOTS ${range} failed: ${out}"
+          return 1
+        }
+      fi
+      case "${out}" in '(error)'*|'ERR '*)
+        classify restore-slots yes "slot assignment ${range} returned protocol error: ${out}"
+        return 1 ;;
+      esac
+    done
+    classify restore-slots yes "assigned archived ranges ${missing} to ${self_first}; deferring for cluster-wide coverage"
+    return 1
+  fi
+
+  total=$(assigned_slots_of "${self_first}")
+  case "${total}" in ''|*[!0-9]*)
+    classify restore-coverage yes "invalid assigned-slot total '${total}'"
+    return 1 ;;
+  esac
+  if [ "${total}" -ne 16384 ]; then
+    classify restore-coverage yes "local archived ranges restored; cluster coverage ${total}/16384"
+    return 1
+  fi
+  if ! self_is_coordinator_pod "${coord}"; then
+    classify restore-attach yes "slot coverage complete; waiting for coordinator ${coord} to attach replicas"
+    return 1
+  fi
+
+  attach_all_replicas || return 1
+  cluster_formed_from_self || {
+    classify restore-converge yes "archived slots assigned but restored membership not complete"
+    return 1
+  }
+  rm -f "${meta}"
+  echo "restored cluster formed with archived slot ownership and complete membership."
 }
 
 # ── formation ────────────────────────────────────────────────────────────────
@@ -778,8 +1111,18 @@ ensure_replica_bound() {
 
 post_provision() {
   validate_manage_env || exit 1
+  local restore_meta
+  restore_meta=$(cluster_restore_meta_path) || exit 1
   if cluster_formed_from_self; then
+    if [ -f "${restore_meta}" ]; then
+      rm -f "${restore_meta}"
+      echo "removed local cluster restore metadata after positive formation proof."
+    fi
     echo "cluster already formed (state ok, 16384 slots) — nothing to do."
+    exit 0
+  fi
+  if [ -f "${restore_meta}" ]; then
+    restore_cluster_from_meta "${restore_meta}" || exit 1
     exit 0
   fi
   local coord

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -113,6 +113,12 @@ cluster_nodes_of() {
   "${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r'
 }
 
+dbsize_of() {
+  local host="${1}"
+  build_cli "${host}"
+  "${_cli[@]}" DBSIZE 2>/dev/null | tr -d '\r\n'
+}
+
 cluster_node_id_set() {
   local nodes
   nodes=$(cat)
@@ -174,6 +180,37 @@ slots_owned_in_node_line() {
     esac
   done
   echo "${total}"
+}
+
+# Every slot claimed by the restored replica must already be owned by its
+# intended primary. This makes the replica's local claims provably redundant
+# before any destructive reset.
+slot_ranges_are_subset() {
+  local child="${1}" parent="${2}"
+  awk -v child="${child}" -v parent="${parent}" 'BEGIN {
+    n = split(parent, pt, /[[:space:]]+/)
+    for (i = 1; i <= n; i++) {
+      token = pt[i]
+      if (token == "") continue
+      if (token ~ /^[0-9]+$/) {start = token + 0; end = start}
+      else if (token ~ /^[0-9]+-[0-9]+$/) {
+        split(token, b, "-"); start = b[1] + 0; end = b[2] + 0
+      } else exit 1
+      if (start < 0 || start > end || end > 16383) exit 1
+      for (s = start; s <= end; s++) parent_seen[s] = 1
+    }
+    n = split(child, ct, /[[:space:]]+/)
+    for (i = 1; i <= n; i++) {
+      token = ct[i]
+      if (token == "") continue
+      if (token ~ /^[0-9]+$/) {start = token + 0; end = start}
+      else if (token ~ /^[0-9]+-[0-9]+$/) {
+        split(token, b, "-"); start = b[1] + 0; end = b[2] + 0
+      } else exit 1
+      if (start < 0 || start > end || end > 16383) exit 1
+      for (s = start; s <= end; s++) if (!parent_seen[s]) exit 1
+    }
+  }'
 }
 
 # Restore metadata uses comma-separated slots/ranges (for example
@@ -332,6 +369,17 @@ first_fqdn_of_list() {
   echo "${1}" | tr ',' '\n' | grep -v '^$' | sort | head -1
 }
 
+current_pod_fqdn_of_list() {
+  local list="${1}" fqdn found=""
+  for fqdn in $(echo "${list}" | tr ',' '\n' | grep -v '^$'); do
+    [ "${fqdn%%.*}" = "${CURRENT_POD_NAME}" ] || continue
+    [ -z "${found}" ] || return 1
+    found="${fqdn}"
+  done
+  [ -n "${found}" ] || return 1
+  printf '%s\n' "${found}"
+}
+
 self_is_coordinator_pod() {
   local coord_shard="${1}"
   local self_short_upper coord_upper
@@ -373,17 +421,19 @@ cluster_restore_meta_path() {
 }
 
 load_cluster_restore_meta() {
-  local meta="$1" source_count master_count ranges_count
+  local meta="$1" source_count master_count ranges_count digest_count
   source_count=$(grep -c '^source_shards=' "${meta}" || true)
   master_count=$(grep -c '^shard_master_id=' "${meta}" || true)
   ranges_count=$(grep -c '^shard_slot_ranges=' "${meta}" || true)
-  if [ "${source_count}" -ne 1 ] || [ "${master_count}" -ne 1 ] || [ "${ranges_count}" -ne 1 ]; then
-    classify restore-meta no "cluster-meta requires exactly one source_shards, shard_master_id and shard_slot_ranges entry"
+  digest_count=$(grep -c '^rdb_sha256=' "${meta}" || true)
+  if [ "${source_count}" -ne 1 ] || [ "${master_count}" -ne 1 ] || [ "${ranges_count}" -ne 1 ] || [ "${digest_count}" -ne 1 ]; then
+    classify restore-meta no "cluster-meta requires exactly one source_shards, shard_master_id, shard_slot_ranges and rdb_sha256 entry"
     return 1
   fi
   _restore_source_shards=$(grep '^source_shards=' "${meta}" | cut -d= -f2-)
   _restore_source_master_id=$(grep '^shard_master_id=' "${meta}" | cut -d= -f2-)
   _restore_slot_ranges=$(grep '^shard_slot_ranges=' "${meta}" | cut -d= -f2-)
+  _restore_rdb_sha256=$(grep '^rdb_sha256=' "${meta}" | cut -d= -f2-)
   case "${_restore_source_shards}" in ''|*[!0-9]*)
     classify restore-meta no "invalid source_shards '${_restore_source_shards}'"
     return 1 ;;
@@ -400,6 +450,42 @@ load_cluster_restore_meta() {
     classify restore-meta no "invalid shard_slot_ranges '${_restore_slot_ranges}'"
     return 1
   fi
+  case "${_restore_rdb_sha256}" in ''|*[!0-9a-fA-F]*)
+    classify restore-meta no "invalid rdb_sha256 in cluster-meta"
+    return 1 ;;
+  esac
+  if [ "${#_restore_rdb_sha256}" -ne 64 ]; then
+    classify restore-meta no "invalid rdb_sha256 length in cluster-meta"
+    return 1
+  fi
+}
+
+restored_primary_cluster_ready_for_replica_reset() {
+  local roster shard_line fqdns host id nodes observed expected="" primary_id
+  local primary_hosts=() primary_ids=()
+  roster=$(each_shard_fqdn_list) || return 1
+  while read -r shard_line; do
+    fqdns="${shard_line#* }"
+    host=$(first_fqdn_of_list "${fqdns}")
+    id=$(node_id_of "${host}") || true
+    [ -n "${id}" ] || return 1
+    primary_hosts+=("${host}")
+    primary_ids+=("${id}")
+  done <<< "${roster}"
+  [ "$(printf '%s\n' "${primary_ids[@]}" | LC_ALL=C sort -u | awk 'NF {n++} END {print n+0}')" -eq "${#primary_hosts[@]}" ] || return 1
+  for host in "${primary_hosts[@]}"; do
+    [ "$(cluster_state_of "${host}")" = "ok" ] && [ "$(assigned_slots_of "${host}")" = "16384" ] || return 1
+    nodes=$(cluster_nodes_of "${host}") || return 1
+    observed=$(printf '%s\n' "${nodes}" | cluster_node_id_set) || return 1
+    if [ -z "${expected}" ]; then
+      expected="${observed}"
+    else
+      [ "${observed}" = "${expected}" ] || return 1
+    fi
+    for primary_id in "${primary_ids[@]}"; do
+      printf '%s\n' "${observed}" | grep -Fxq "${primary_id}" || return 1
+    done
+  done
 }
 
 # Same-shard-count cluster restore. Each restored shard's ordinal-0 PVC carries
@@ -439,7 +525,16 @@ restore_cluster_from_meta() {
 
   self_first=$(first_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}")
   if [ "${self_first%%.*}" != "${CURRENT_POD_NAME}" ]; then
-    classify restore-target yes "cluster-meta is handled only by restored shard first pod ${self_first%%.*}; current=${CURRENT_POD_NAME}"
+    host=$(current_pod_fqdn_of_list "${CURRENT_SHARD_POD_FQDN_LIST}") || {
+      classify restore-target no "current pod ${CURRENT_POD_NAME} is not uniquely present in its shard roster"
+      return 1
+    }
+    other_id=$(node_id_of "${self_first}") || true
+    [ -n "${other_id}" ] || {
+      classify restore-replica-primary yes "cannot read intended restored primary id from ${self_first}"
+      return 1
+    }
+    prepare_local_restored_replica_for_attach "${meta}" "${self_first}" "${host}" "${other_id}" "${CURRENT_SHARD_COMPONENT_SHORT_NAME}" || return 1
     return 1
   fi
 
@@ -591,7 +686,12 @@ restore_cluster_from_meta() {
     return 1
   fi
 
-  attach_all_replicas || return 1
+  restored_primary_cluster_ready_for_replica_reset || {
+    classify restore-attach yes "restored primary views have not all converged to state=ok, 16384 slots and one exact id set before replica reset"
+    return 1
+  }
+
+  attach_all_replicas restore || return 1
   cluster_formed_from_self || {
     classify restore-converge yes "archived slots assigned but restored membership not complete"
     return 1
@@ -898,6 +998,7 @@ form_cluster() {
 # Attach every non-first pod of every shard as a replica of that shard's
 # master (identified by engine node id, resolved fresh each invocation).
 attach_all_replicas() {
+  local mode="${1:-ordinary}"
   local shard_line shard fqdns first rest fqdn master_id add_out roster
   roster=$(each_shard_fqdn_list) || return 1
   while read -r shard_line; do
@@ -911,7 +1012,7 @@ attach_all_replicas() {
     fi
     for fqdn in $(echo "${fqdns}" | tr ',' '\n' | grep -v '^$' | sort); do
       [ "${fqdn}" = "${first}" ] && continue
-      ensure_replica_bound "${first}" "${fqdn}" "${master_id}" "${shard}" || return 1
+      ensure_replica_bound "${first}" "${fqdn}" "${master_id}" "${shard}" "${mode}" || return 1
     done
   done <<< "${roster}"
 }
@@ -1114,10 +1215,14 @@ attach_shard_replicas_to() {
 # the engine if it did). Present and bound -> done.
 ensure_replica_bound() {
   local via="${1}" fqdn="${2}" master_id="${3}" shard="${4}"
+  local mode="${5:-ordinary}"
   local line flags parent out
   build_cli "${via}"
   line=$("${_cli[@]}" CLUSTER NODES 2>/dev/null | tr -d '\r' | grep -F "${fqdn}" | head -1)
   if [ -z "${line}" ]; then
+    if [ "${mode}" = "restore" ]; then
+      restored_replica_ready_for_attach "${fqdn}" "${shard}" || return 1
+    fi
     build_cluster_cli
     out=$("${_ccli[@]}" --cluster add-node "${fqdn}:${SERVICE_PORT}" "${via}:${SERVICE_PORT}" --cluster-slave --cluster-master-id "${master_id}" 2>&1) || {
       classify attach-add-node yes "add replica ${fqdn} to shard ${shard} failed (re-entry re-drives): ${out}"
@@ -1138,6 +1243,213 @@ ensure_replica_bound() {
     return 1
   }
   echo "repaired ${fqdn}: now replicating shard ${shard} master ${master_id}."
+}
+
+# The coordinator never clears a remote pod. It only attaches a restored
+# replica after that pod's own postProvision action has positively reduced it
+# to one empty, slotless node.
+restored_replica_ready_for_attach() {
+  local fqdn="${1}" shard="${2}" nodes line flags parent ranges size
+  nodes=$(cluster_nodes_of "${fqdn}") || return 1
+  [ "$(printf '%s\n' "${nodes}" | awk 'NF {n++} END {print n+0}')" -eq 1 ] && \
+    [ "$(known_nodes_of "${fqdn}")" = "1" ] || {
+      classify restore-replica-wait yes "restored replica ${fqdn} has not prepared one isolated node for shard ${shard}"
+      return 1
+    }
+  line=$(printf '%s\n' "${nodes}" | awk 'NF {print; exit}')
+  flags=$(printf '%s\n' "${line}" | awk '{print $3}')
+  parent=$(printf '%s\n' "${line}" | awk '{print $4}')
+  ranges=$(printf '%s\n' "${line}" | cut -d' ' -f9-)
+  size=$(dbsize_of "${fqdn}") || true
+  case "${flags}:${parent}:${ranges}:${size}" in
+    *myself*master*:-::0) return 0 ;;
+  esac
+  classify restore-replica-wait yes "restored replica ${fqdn} is not yet empty and slotless for shard ${shard}"
+  return 1
+}
+
+local_restored_aof_is_pristine() {
+  local expected_rdb_sha256="${1}"
+  local append_dirname="${VALKEY_APPEND_DIRNAME:-appendonlydir}"
+  local append_filename="${VALKEY_APPEND_FILENAME:-appendonly.aof}"
+  local append_dir="${VALKEY_DATA_DIR}/${append_dirname}"
+  local base="${append_dir}/${append_filename}.1.base.rdb"
+  local incr="${append_dir}/${append_filename}.1.incr.aof"
+  local manifest="${append_dir}/${append_filename}.manifest"
+  local expected_manifest actual_manifest unexpected base_sha256
+
+  [ -f "${base}" ] && [ -f "${incr}" ] && [ -f "${manifest}" ] || return 1
+  [ ! -s "${incr}" ] || return 1
+  base_sha256=$(sha256sum "${base}" 2>/dev/null | awk '{print $1}')
+  [ "${base_sha256}" = "${expected_rdb_sha256}" ] || return 1
+  expected_manifest=$(printf 'file %s seq 1 type b\nfile %s seq 1 type i' \
+    "$(basename "${base}")" "$(basename "${incr}")")
+  actual_manifest=$(cat "${manifest}" 2>/dev/null) || return 1
+  [ "${actual_manifest}" = "${expected_manifest}" ] || return 1
+  unexpected=$(find "${append_dir}" -mindepth 1 -maxdepth 1 \
+    ! -name "$(basename "${base}")" \
+    ! -name "$(basename "${incr}")" \
+    ! -name "$(basename "${manifest}")" -print) || return 1
+  [ -z "${unexpected}" ]
+}
+
+# prepareData restores the same per-shard archive onto every PVC. Each
+# ordinal>0 action clears only its own redundant copy, and only after proving:
+# the ordinal-0 primary is authoritative, local slots are a subset of that
+# master, dump.rdb matches backup-recorded restore metadata, and no post-restore AOF
+# writes exist. Before FLUSHALL it persists an exact local authorization
+# marker; an empty DB with shadow slots is a valid re-entry state only when
+# that marker still matches this archive, pod, shard and intended master.
+prepare_local_restored_replica_for_attach() {
+  local meta="${1}" via="${2}" fqdn="${3}" master_id="${4}" shard="${5}"
+  local primary_nodes target_nodes primary_line target_line target_count
+  local flags parent primary_ranges target_ranges target_size actual_rdb_sha256
+  local bound_line bound_flags bound_parent out reset_nodes reset_line reset_ranges
+  local reset_marker expected_marker actual_marker marker_tmp
+
+  load_cluster_restore_meta "${meta}" || return 1
+
+  restored_primary_cluster_ready_for_replica_reset || {
+    classify restore-replica-primary yes "all restored primary views are not fully converged before clearing ${fqdn}"
+    return 1
+  }
+
+  if [ "$(cluster_state_of "${via}")" != "ok" ] || [ "$(assigned_slots_of "${via}")" != "16384" ]; then
+    classify restore-replica-primary yes "primary ${via} is not state=ok with 16384 slots before clearing ${fqdn}"
+    return 1
+  fi
+  primary_nodes=$(cluster_nodes_of "${via}") || return 1
+  primary_line=$(printf '%s\n' "${primary_nodes}" | awk -v id="${master_id}" '$1 == id')
+  [ "$(printf '%s\n' "${primary_line}" | awk 'NF {n++} END {print n+0}')" -eq 1 ] || {
+    classify restore-replica-primary no "intended master ${master_id} is not unique in ${via} view"
+    return 1
+  }
+  case "$(printf '%s\n' "${primary_line}" | awk '{print $3}')" in
+    *master*) ;;
+    *) classify restore-replica-primary no "intended node ${master_id} is not a master in ${via} view"; return 1 ;;
+  esac
+
+  # The coordinator can attach this pod between local retries. Once the
+  # primary view proves the intended binding, local cleanup must never run
+  # again; the next positive full-formation observation removes the marker.
+  bound_line=$(printf '%s\n' "${primary_nodes}" | grep -F "${fqdn}" | head -1)
+  if [ -n "${bound_line}" ]; then
+    bound_flags=$(printf '%s\n' "${bound_line}" | awk '{print $3}')
+    bound_parent=$(printf '%s\n' "${bound_line}" | awk '{print $4}')
+    if echo "${bound_flags}" | grep -q slave && [ "${bound_parent}" = "${master_id}" ]; then
+      echo "restored replica ${fqdn} is already bound to shard ${shard} master ${master_id}."
+      return 0
+    fi
+    classify restore-replica-wait yes "primary ${via} sees ${fqdn}, but its replica binding has not converged"
+    return 1
+  fi
+
+  target_nodes=$(cluster_nodes_of "${fqdn}") || return 1
+  target_count=$(printf '%s\n' "${target_nodes}" | awk 'NF {n++} END {print n+0}')
+  [ "${target_count}" -eq 1 ] && [ "$(known_nodes_of "${fqdn}")" = "1" ] || {
+    classify restore-replica-shape no "restore target ${fqdn} is not an isolated single-node cluster"
+    return 1
+  }
+  target_line=$(printf '%s\n' "${target_nodes}" | awk 'NF {print; exit}')
+  flags=$(printf '%s\n' "${target_line}" | awk '{print $3}')
+  parent=$(printf '%s\n' "${target_line}" | awk '{print $4}')
+  case "${flags}:${parent}" in
+    *myself*master*:-) ;;
+    *) classify restore-replica-shape no "restore target ${fqdn} is not a singleton myself,master"; return 1 ;;
+  esac
+
+  primary_ranges=$(printf '%s\n' "${primary_line}" | cut -d' ' -f9-)
+  target_ranges=$(printf '%s\n' "${target_line}" | cut -d' ' -f9-)
+  if ! slot_ranges_are_subset "${target_ranges}" "${primary_ranges}"; then
+    classify restore-replica-slots no "restore target ${fqdn} claims slots outside shard ${shard} master ${master_id}"
+    return 1
+  fi
+
+  target_size=$(dbsize_of "${fqdn}") || true
+  case "${target_size}" in
+    ''|*[!0-9]*) classify restore-replica-data yes "cannot read numeric DBSIZE from restored duplicate ${fqdn}"; return 1 ;;
+  esac
+
+  reset_marker="${VALKEY_DATA_DIR}/.kb-restored-replica-reset-authorized"
+  expected_marker=$(printf 'rdb_sha256=%s\nmaster_id=%s\nshard=%s\npod=%s' \
+    "${_restore_rdb_sha256}" "${master_id}" "${shard}" "${fqdn%%.*}")
+  actual_marker=""
+  if [ -e "${reset_marker}" ]; then
+    [ -f "${reset_marker}" ] || {
+      classify restore-replica-data no "local reset authorization marker is not a regular file"
+      return 1
+    }
+    actual_marker=$(cat "${reset_marker}" 2>/dev/null) || {
+      classify restore-replica-data no "cannot read local reset authorization marker"
+      return 1
+    }
+    [ "${actual_marker}" = "${expected_marker}" ] || {
+      classify restore-replica-data no "local reset authorization marker does not match this restore target"
+      return 1
+    }
+  fi
+
+  if [ "${target_size}" -eq 0 ] && [ -z "${target_ranges}" ]; then
+    rm -f "${reset_marker}" && sync
+    echo "restored duplicate ${fqdn} is already empty and slotless for shard ${shard}."
+    return 0
+  fi
+  if [ "${target_size}" -eq 0 ] && [ "${actual_marker}" != "${expected_marker}" ]; then
+    classify restore-replica-data no "empty restored duplicate ${fqdn} still owns slots without reset authorization"
+    return 1
+  fi
+  if [ "${target_size}" -gt 0 ]; then
+    actual_rdb_sha256=$(sha256sum "${VALKEY_DATA_DIR}/dump.rdb" 2>/dev/null | awk '{print $1}')
+    [ "${actual_rdb_sha256}" = "${_restore_rdb_sha256}" ] || {
+      classify restore-replica-data no "local dump.rdb on ${fqdn} does not match restore metadata"
+      return 1
+    }
+    local_restored_aof_is_pristine "${_restore_rdb_sha256}" || {
+      classify restore-replica-data no "local multipart AOF is not the pristine restore seed; refusing to clear ${fqdn}"
+      return 1
+    }
+    if [ -z "${actual_marker}" ]; then
+      marker_tmp="${reset_marker}.tmp.$$"
+      if ! printf '%s\n' "${expected_marker}" > "${marker_tmp}" || \
+         ! mv -f "${marker_tmp}" "${reset_marker}" || ! sync; then
+        rm -f "${marker_tmp}"
+        classify restore-replica-data yes "cannot persist local reset authorization marker for ${fqdn}"
+        return 1
+      fi
+    fi
+    build_cli "${fqdn}"
+    out=$("${_cli[@]}" FLUSHALL 2>&1) || {
+      classify restore-replica-flush yes "FLUSHALL on verified duplicate ${fqdn} failed: ${out}"
+      return 1
+    }
+    case "${out}" in '(error)'*|'ERR '*) classify restore-replica-flush yes "FLUSHALL on ${fqdn} returned protocol error: ${out}"; return 1 ;; esac
+    [ "$(dbsize_of "${fqdn}")" = "0" ] || {
+      classify restore-replica-flush yes "verified duplicate ${fqdn} is not empty after FLUSHALL"
+      return 1
+    }
+  fi
+
+  build_cli "${fqdn}"
+  out=$("${_cli[@]}" CLUSTER RESET HARD 2>&1) || {
+    classify restore-replica-reset yes "CLUSTER RESET HARD on ${fqdn} failed: ${out}"
+    return 1
+  }
+  case "${out}" in '(error)'*|'ERR '*) classify restore-replica-reset yes "CLUSTER RESET HARD on ${fqdn} returned protocol error: ${out}"; return 1 ;; esac
+
+  reset_nodes=$(cluster_nodes_of "${fqdn}") || return 1
+  [ "$(printf '%s\n' "${reset_nodes}" | awk 'NF {n++} END {print n+0}')" -eq 1 ] && \
+    [ "$(known_nodes_of "${fqdn}")" = "1" ] && [ "$(dbsize_of "${fqdn}")" = "0" ] || {
+      classify restore-replica-reset yes "${fqdn} did not converge to one empty node after hard reset"
+      return 1
+    }
+  reset_line=$(printf '%s\n' "${reset_nodes}" | awk 'NF {print; exit}')
+  reset_ranges=$(printf '%s\n' "${reset_line}" | cut -d' ' -f9-)
+  [ -z "${reset_ranges}" ] || {
+    classify restore-replica-reset yes "${fqdn} still claims slots after hard reset"
+    return 1
+  }
+  rm -f "${reset_marker}" && sync
+  echo "prepared local restored duplicate ${fqdn} for replica attach to shard ${shard}."
 }
 
 post_provision() {

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -344,6 +344,26 @@ self_is_coordinator_pod() {
   [ "${my_shard_first%%.*}" = "${CURRENT_POD_NAME}" ]
 }
 
+# Valkey CLUSTER MEET requires a numeric address; regular client connections
+# may use pod FQDNs, but MEET rejects them. Accept only a resolved IPv4 address.
+resolve_cluster_meet_address() {
+  local host="$1" address
+  command -v getent >/dev/null 2>&1 || return 1
+  address=$(getent ahostsv4 "${host}" 2>/dev/null | awk 'NF > 0 {print $1; exit}') || true
+  if [ -z "${address}" ]; then
+    address=$(getent hosts "${host}" 2>/dev/null | awk 'NF > 0 {print $1; exit}') || true
+  fi
+  [ -n "${address}" ] || return 1
+  printf '%s\n' "${address}" | awk -F. '
+    NF != 4 { exit 1 }
+    {
+      for (i = 1; i <= 4; i++) {
+        if ($i !~ /^[0-9]+$/ || $i < 0 || $i > 255) exit 1
+      }
+    }' || return 1
+  printf '%s\n' "${address}"
+}
+
 cluster_restore_meta_path() {
   if [ -z "${VALKEY_DATA_DIR:-}" ]; then
     classify restore-env no "VALKEY_DATA_DIR is required; no data-path fallback"
@@ -390,9 +410,9 @@ load_cluster_restore_meta() {
 restore_cluster_from_meta() {
   local meta="$1" roster shard_line shard fqdns first self_first
   local coord primary_count=0 coord_host="" current_nodes current_ids
-  local host other_known other_nodes other_ids other_id met=0
+  local host other_known other_nodes other_ids other_id meet_address met=0
   local self_id missing range out total i
-  local primary_hosts=() primary_ids=()
+  local primary_hosts=() primary_ids=() meet_hosts=() meet_addresses=()
 
   load_cluster_restore_meta "${meta}" || return 1
   roster=$(each_shard_fqdn_list) || return 1
@@ -452,8 +472,9 @@ restore_cluster_from_meta() {
     return 1
   }
 
-  # Only the deterministic coordinator writes MEET. A fresh node (known=1)
-  # may be introduced; an independently configured disjoint node is refused.
+  # Only the deterministic coordinator writes MEET. Materialize and validate
+  # every pending peer address before the first mutation, so a DNS gap cannot
+  # leave a partially introduced roster. Disjoint configured nodes are refused.
   if self_is_coordinator_pod "${coord}"; then
     for ((i=0; i<${#primary_hosts[@]}; i++)); do
       host="${primary_hosts[$i]}"; other_id="${primary_ids[$i]}"
@@ -477,13 +498,23 @@ restore_cluster_from_meta() {
         classify restore-meet yes "membership gossip with ${host} is incomplete; deferring before mutation"
         return 1
       fi
+      meet_address=$(resolve_cluster_meet_address "${host}") || {
+        classify restore-dns yes "cannot resolve restored primary ${host} to an IPv4 address for CLUSTER MEET"
+        return 1
+      }
+      meet_hosts+=("${host}")
+      meet_addresses+=("${meet_address}")
+    done
+    for ((i=0; i<${#meet_hosts[@]}; i++)); do
+      host="${meet_hosts[$i]}"
+      meet_address="${meet_addresses[$i]}"
       build_cli "${coord_host}"
-      out=$("${_cli[@]}" CLUSTER MEET "${host}" "${SERVICE_PORT}" 2>&1) || {
-        classify restore-meet yes "CLUSTER MEET ${host} failed: ${out}"
+      out=$("${_cli[@]}" CLUSTER MEET "${meet_address}" "${SERVICE_PORT}" 2>&1) || {
+        classify restore-meet yes "CLUSTER MEET ${host} (${meet_address}) failed: ${out}"
         return 1
       }
       case "${out}" in '(error)'*|'ERR '*)
-        classify restore-meet yes "CLUSTER MEET ${host} returned protocol error: ${out}"
+        classify restore-meet yes "CLUSTER MEET ${host} (${meet_address}) returned protocol error: ${out}"
         return 1 ;;
       esac
       met=$((met + 1))

--- a/addons/valkey/scripts/valkey-cluster-manage.sh
+++ b/addons/valkey/scripts/valkey-cluster-manage.sh
@@ -970,7 +970,7 @@ open_slots_present() {
 repair_open_slots() {
   local via="${1}" fix_out
   build_cluster_cli
-  fix_out=$(echo yes | "${_ccli[@]}" --cluster fix "${via}:${SERVICE_PORT}" 2>&1) || {
+  fix_out=$("${_ccli[@]}" --cluster fix "${via}:${SERVICE_PORT}" <<< yes 2>&1) || {
     classify join-fix yes "cluster fix for open slots failed (re-entry re-drives): $(echo "${fix_out}" | tail -2 | tr '\n' ';')"
     return 1
   }

--- a/addons/valkey/scripts/valkey-cluster-server-start.sh
+++ b/addons/valkey/scripts/valkey-cluster-server-start.sh
@@ -17,6 +17,7 @@
 #   CURRENT_POD_IP                current pod IP (KB var)
 #   CURRENT_SHARD_POD_FQDN_LIST   comma list of this shard's pod FQDNs (KB var)
 #   SERVICE_PORT                  data port (KB var)
+#   VALKEY_DATA_DIR               persistent data directory (KB var)
 # Optional env:
 #   CLUSTER_BUS_PORT              cluster bus port (default SERVICE_PORT+10000)
 #   VALKEY_DEFAULT_PASSWORD       default-user password (requirepass + ACL)
@@ -40,15 +41,31 @@ load_common_library() {
 # Fail-fast validation: cluster mode without its contract inputs must never
 # limp along on defaults (design contract class 1/2 — no silent fallback).
 validate_required_env() {
-  local missing=""
+  local missing="" canonical_data_dir
   [ -z "${CURRENT_POD_NAME:-}" ] && missing="${missing} CURRENT_POD_NAME"
   [ -z "${CURRENT_POD_IP:-}" ] && missing="${missing} CURRENT_POD_IP"
   [ -z "${CURRENT_SHARD_POD_FQDN_LIST:-}" ] && missing="${missing} CURRENT_SHARD_POD_FQDN_LIST"
   [ -z "${SERVICE_PORT:-}" ] && missing="${missing} SERVICE_PORT"
+  [ -z "${VALKEY_DATA_DIR:-}" ] && missing="${missing} VALKEY_DATA_DIR"
   if [ -n "${missing}" ]; then
     echo "ERROR: valkey-cluster-server-start.sh missing required env:${missing} — refusing to start in cluster mode." >&2
     return 1
   fi
+  case "${VALKEY_DATA_DIR}" in
+    /*) [ "${VALKEY_DATA_DIR}" != "/" ] || {
+      echo "ERROR: VALKEY_DATA_DIR must not be the filesystem root." >&2
+      return 1
+    } ;;
+    *) echo "ERROR: VALKEY_DATA_DIR must be an absolute path." >&2; return 1 ;;
+  esac
+  canonical_data_dir=$(cd -P "${VALKEY_DATA_DIR}" 2>/dev/null && pwd -P) || {
+    echo "ERROR: VALKEY_DATA_DIR must name an existing directory." >&2
+    return 1
+  }
+  [ "${canonical_data_dir}" = "${VALKEY_DATA_DIR}" ] || {
+    echo "ERROR: VALKEY_DATA_DIR must be a canonical path without symlinks or dot segments." >&2
+    return 1
+  }
   validate_port_range SERVICE_PORT "${SERVICE_PORT}" || return 1
   if [ -n "${CLUSTER_BUS_PORT:-}" ]; then
     validate_port_range CLUSTER_BUS_PORT "${CLUSTER_BUS_PORT}" || return 1
@@ -85,6 +102,186 @@ resolve_self_fqdn() {
   done
   echo "ERROR: pod '${CURRENT_POD_NAME}' not found in CURRENT_SHARD_POD_FQDN_LIST='${CURRENT_SHARD_POD_FQDN_LIST}'." >&2
   return 1
+}
+
+offline_restore_marker_content() {
+  printf 'rdb_sha256=%s\nmeta_sha256=%s\npod=%s' "${1}" "${2}" "${CURRENT_POD_NAME}"
+}
+
+cluster_restore_state_content() {
+  printf 'phase=%s\nmeta_sha256=%s' "${1}" "${2}"
+}
+
+offline_restored_aof_is_pristine() {
+  local expected_rdb_sha256="${1}" append_dirname append_filename append_dir base incr manifest
+  local expected_manifest actual_manifest unexpected base_sha256
+  append_dirname="${VALKEY_APPEND_DIRNAME-appendonlydir}"
+  append_filename="${VALKEY_APPEND_FILENAME-appendonly.aof}"
+  case "${append_dirname}" in
+    ''|*/*|.|..)
+      echo "ERROR: unsafe restored replica AOF path contract." >&2
+      return 1 ;;
+  esac
+  case "${append_filename}" in
+    ''|*/*|.|..)
+      echo "ERROR: unsafe restored replica AOF path contract." >&2
+      return 1 ;;
+  esac
+  append_dir="${VALKEY_DATA_DIR}/${append_dirname}"
+  base="${append_dir}/${append_filename}.1.base.rdb"
+  incr="${append_dir}/${append_filename}.1.incr.aof"
+  manifest="${append_dir}/${append_filename}.manifest"
+  [ -d "${append_dir}" ] && [ ! -L "${append_dir}" ] || return 1
+  [ -f "${base}" ] && [ ! -L "${base}" ] && \
+    [ -f "${incr}" ] && [ ! -L "${incr}" ] && \
+    [ -f "${manifest}" ] && [ ! -L "${manifest}" ] || return 1
+  [ ! -s "${incr}" ] || return 1
+  base_sha256=$(sha256sum "${base}" 2>/dev/null | awk '{print $1}')
+  [ "${base_sha256}" = "${expected_rdb_sha256}" ] || return 1
+  expected_manifest=$(printf 'file %s seq 1 type b\nfile %s seq 1 type i' \
+    "$(basename "${base}")" "$(basename "${incr}")")
+  actual_manifest=$(cat "${manifest}" 2>/dev/null) || return 1
+  [ "${actual_manifest}" = "${expected_manifest}" ] || return 1
+  unexpected=$(find "${append_dir}" -mindepth 1 -maxdepth 1 \
+    ! -name "$(basename "${base}")" \
+    ! -name "$(basename "${incr}")" \
+    ! -name "$(basename "${manifest}")" -print) || return 1
+  [ -z "${unexpected}" ]
+}
+
+# Restore jobs populate the same per-shard archive onto every PVC. A non-first
+# pod must discard that redundant copy before valkey-server starts, while no
+# client can race the cleanup. The two-stage marker makes crashes before/after
+# deletion distinguishable and prevents a later restart from clearing data
+# that has already been replicated into this pod.
+prepare_restored_replica_offline() {
+  local meta="${VALKEY_DATA_DIR}/cluster-meta" first digest_count rdb_sha256 actual_rdb_sha256
+  local prepare_marker prepared_marker expected actual tmp append_dirname meta_sha256
+  local restore_state="${VALKEY_DATA_DIR}/.kb-cluster-restore-state"
+  local state_phase state_meta_sha256 state_lines
+  if [ -L "${meta}" ]; then
+    echo "ERROR: cluster-meta is not a safe regular file." >&2
+    return 1
+  fi
+  if [ ! -f "${meta}" ]; then
+    if [ -e "${restore_state}" ] || [ -L "${restore_state}" ]; then
+      [ -f "${restore_state}" ] && [ ! -L "${restore_state}" ] || {
+        echo "ERROR: cluster restore state is not a safe regular file." >&2
+        return 1
+      }
+      actual=$(cat "${restore_state}" 2>/dev/null) || return 1
+      state_lines=$(printf '%s\n' "${actual}" | awk 'NF {n++} END {print n+0}')
+      state_phase=$(printf '%s\n' "${actual}" | sed -n '1s/^phase=//p')
+      state_meta_sha256=$(printf '%s\n' "${actual}" | sed -n '2s/^meta_sha256=//p')
+      case "${state_meta_sha256}" in ''|*[!0-9a-fA-F]*) state_meta_sha256="" ;; esac
+      if [ "${state_lines}" -eq 2 ] && [ "${state_phase}" = "formed" ] && [ "${#state_meta_sha256}" -eq 64 ]; then
+        return 0
+      fi
+      echo "ERROR: prepared cluster restore state lacks cluster-meta; refusing ordinary startup." >&2
+      return 1
+    fi
+    if [ -e "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare" ] || \
+       [ -e "${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared" ]; then
+      echo "ERROR: offline restore marker lacks cluster-meta; refusing ordinary startup." >&2
+      return 1
+    fi
+    return 0
+  fi
+  meta_sha256=$(sha256sum "${meta}" 2>/dev/null | awk '{print $1}')
+  [ "${#meta_sha256}" -eq 64 ] || { echo "ERROR: cannot identify restored replica cluster-meta." >&2; return 1; }
+  [ -f "${restore_state}" ] && [ ! -L "${restore_state}" ] || {
+    echo "ERROR: cluster-meta lacks its exact restore-state contract." >&2
+    return 1
+  }
+  actual=$(cat "${restore_state}" 2>/dev/null) || return 1
+  if [ "${actual}" = "$(cluster_restore_state_content formed "${meta_sha256}")" ]; then
+    return 0
+  fi
+  [ "${actual}" = "$(cluster_restore_state_content prepared "${meta_sha256}")" ] || {
+    echo "ERROR: cluster restore state does not match cluster-meta." >&2
+    return 1
+  }
+
+  digest_count=$(grep -c '^rdb_sha256=' "${meta}" || true)
+  [ "${digest_count}" -eq 1 ] || { echo "ERROR: restored replica cluster-meta requires exactly one rdb_sha256." >&2; return 1; }
+  rdb_sha256=$(grep '^rdb_sha256=' "${meta}" | cut -d= -f2-)
+  case "${rdb_sha256}" in ''|*[!0-9a-fA-F]*) echo "ERROR: invalid restored replica rdb_sha256." >&2; return 1 ;; esac
+  [ "${#rdb_sha256}" -eq 64 ] || { echo "ERROR: invalid restored replica rdb_sha256 length." >&2; return 1; }
+  first=$(printf '%s\n' "${CURRENT_SHARD_POD_FQDN_LIST}" | tr ',' '\n' | grep -v '^$' | LC_ALL=C sort | head -1)
+  [ -n "${first}" ] || { echo "ERROR: restored shard roster has no first pod." >&2; return 1; }
+  [ "${first%%.*}" != "${CURRENT_POD_NAME}" ] || return 0
+
+  prepare_marker="${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepare"
+  prepared_marker="${VALKEY_DATA_DIR}/.kb-restored-replica-offline-prepared"
+  append_dirname="${VALKEY_APPEND_DIRNAME-appendonlydir}"
+  case "${append_dirname}" in
+    ''|*/*|.|..)
+      echo "ERROR: unsafe restored replica AOF directory name '${append_dirname}'." >&2
+      return 1 ;;
+  esac
+  expected=$(offline_restore_marker_content "${rdb_sha256}" "${meta_sha256}")
+  if [ -e "${prepared_marker}" ] || [ -L "${prepared_marker}" ]; then
+    [ -f "${prepared_marker}" ] && [ ! -L "${prepared_marker}" ] || {
+      echo "ERROR: offline prepared marker is not a safe regular file." >&2
+      return 1
+    }
+    actual=$(cat "${prepared_marker}" 2>/dev/null) || return 1
+    [ "${actual}" = "${expected}" ] || { echo "ERROR: offline prepared marker does not match this restore target." >&2; return 1; }
+    if [ -e "${prepare_marker}" ] || [ -L "${prepare_marker}" ]; then
+      [ -f "${prepare_marker}" ] && [ ! -L "${prepare_marker}" ] || {
+        echo "ERROR: offline prepare marker is not a safe regular file." >&2
+        return 1
+      }
+      actual=$(cat "${prepare_marker}" 2>/dev/null) || return 1
+      [ "${actual}" = "${expected}" ] || { echo "ERROR: offline prepare marker does not match this restore target." >&2; return 1; }
+    fi
+    return 0
+  fi
+
+  if [ -e "${prepare_marker}" ] || [ -L "${prepare_marker}" ]; then
+    [ -f "${prepare_marker}" ] && [ ! -L "${prepare_marker}" ] || {
+      echo "ERROR: offline prepare marker is not a safe regular file." >&2
+      return 1
+    }
+    actual=$(cat "${prepare_marker}" 2>/dev/null) || return 1
+    [ "${actual}" = "${expected}" ] || { echo "ERROR: offline prepare marker does not match this restore target." >&2; return 1; }
+  else
+    [ -f "${VALKEY_DATA_DIR}/dump.rdb" ] && [ ! -L "${VALKEY_DATA_DIR}/dump.rdb" ] || {
+      echo "ERROR: restored replica dump.rdb is not a safe regular file." >&2
+      return 1
+    }
+    actual_rdb_sha256=$(sha256sum "${VALKEY_DATA_DIR}/dump.rdb" 2>/dev/null | awk '{print $1}')
+    [ "${actual_rdb_sha256}" = "${rdb_sha256}" ] || { echo "ERROR: restored replica dump.rdb does not match cluster-meta." >&2; return 1; }
+    offline_restored_aof_is_pristine "${rdb_sha256}" || { echo "ERROR: restored replica multipart AOF is not the pristine restore seed." >&2; return 1; }
+    tmp=$(mktemp "${prepare_marker}.tmp.XXXXXX") || {
+      echo "ERROR: cannot allocate offline restore prepare marker." >&2
+      return 1
+    }
+    printf '%s\n' "${expected}" > "${tmp}" && mv -f "${tmp}" "${prepare_marker}" && sync || {
+      rm -f "${tmp}"
+      echo "ERROR: cannot persist offline restore prepare marker." >&2
+      return 1
+    }
+  fi
+
+  rm -f "${VALKEY_DATA_DIR}/dump.rdb"
+  rm -rf "${VALKEY_DATA_DIR:?}/${append_dirname}"
+  sync
+  [ ! -e "${VALKEY_DATA_DIR}/dump.rdb" ] && [ ! -e "${VALKEY_DATA_DIR}/${append_dirname}" ] || {
+    echo "ERROR: restored replica payload remains after offline preparation." >&2
+    return 1
+  }
+  tmp=$(mktemp "${prepared_marker}.tmp.XXXXXX") || {
+    echo "ERROR: cannot allocate offline restore prepared marker." >&2
+    return 1
+  }
+  printf '%s\n' "${expected}" > "${tmp}" && mv -f "${tmp}" "${prepared_marker}" && sync || {
+    rm -f "${tmp}"
+    echo "ERROR: cannot persist offline restore prepared marker." >&2
+    return 1
+  }
+  rm -f "${prepare_marker}"
+  echo "Prepared restored replica ${CURRENT_POD_NAME} offline before valkey-server start."
 }
 
 build_cluster_conf() {
@@ -151,5 +348,6 @@ ${__SOURCED__:+false} : || return 0
 load_common_library
 validate_required_env || exit 1
 self_fqdn=$(resolve_self_fqdn) || exit 1
+prepare_restored_replica_offline || exit 1
 conf_file=$(build_cluster_conf "${self_fqdn}")
 start_cluster_server "${conf_file}"

--- a/addons/valkey/templates/backuppolicytemplate.yaml
+++ b/addons/valkey/templates/backuppolicytemplate.yaml
@@ -78,16 +78,13 @@ spec:
 # archived — it is cluster identity and must be regenerated on restore.
 #
 # v1 restore compatibility matrix:
-#   ANY cluster datafile restore         -> NOT SUPPORTED (refused at
-#                                           prepareData before pods start):
-#                                           same shard count is not a
-#                                           sufficient condition — source
-#                                           slot layouts (post-rebalance)
-#                                           cannot be guaranteed to match a
-#                                           re-formed cluster's even split.
-#                                           Archives record source_shards +
-#                                           shard_slot_ranges so the planned
-#                                           slot-aware restore can be built.
+#   same shard count cluster -> cluster  -> supported. prepareData validates
+#                                           each source target's cluster-meta;
+#                                           postProvision rebuilds membership
+#                                           and assigns that archive's exact
+#                                           shard_slot_ranges before replicas
+#                                           attach. Overlap/gap fails closed.
+#   different shard count               -> unsupported (source_shards guard)
 #   cluster <-> replication/standalone   -> unsupported
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: BackupPolicyTemplate

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -108,6 +108,10 @@ spec:
       value: "6379"
     - name: CLUSTER_BUS_PORT
       value: "16379"
+    # prepareData leaves validated cluster-meta on the restored ordinal-0
+    # volume. postProvision consumes it to rebuild source slot ownership.
+    - name: VALKEY_DATA_DIR
+      value: {{ $.Values.dataMountPath | quote }}
     - name: VALKEY_DEFAULT_USER
       valueFrom:
         credentialVarRef:

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -237,6 +237,9 @@ spec:
     postProvision:
       exec:
         container: valkey-cluster
+        # Restore completion is PVC-local. Any-pod success can mark the
+        # Component complete while a sibling PVC still holds prepared state.
+        targetPodSelector: All
         command:
           - /bin/bash
           - -c

--- a/addons/valkey/templates/cmpd-valkey-cluster.yaml
+++ b/addons/valkey/templates/cmpd-valkey-cluster.yaml
@@ -108,8 +108,9 @@ spec:
       value: "6379"
     - name: CLUSTER_BUS_PORT
       value: "16379"
-    # prepareData leaves validated cluster-meta on the restored ordinal-0
-    # volume. postProvision consumes it to rebuild source slot ownership.
+    # prepareData leaves validated cluster-meta plus an exact restore-state
+    # marker on every restored volume. Non-first pods discard their redundant
+    # payload offline before server start; postProvision commits formed state.
     - name: VALKEY_DATA_DIR
       value: {{ $.Values.dataMountPath | quote }}
     - name: VALKEY_DEFAULT_USER


### PR DESCRIPTION
## Summary

- persist per-shard slot ownership and snapshot RDB SHA-256 in cluster backup metadata
- restore same-shard-count archives by rebuilding primary membership and reclaiming archived slots
- resolve restored peer FQDNs to validated IPv4 addresses before `CLUSTER MEET`
- require every observed cluster member to map uniquely to the configured KubeBlocks shard/pod roster
- require every designated restored primary to have a unique `CLUSTER MYID` before any meet or slot write
- prepare every restored non-first replica offline before Valkey accepts clients
- let each restored replica validate its PVC-local authorization and attach itself
- preserve a validated per-pod formed tombstone so repeated `All` iterations are zero-write successes

## Current exact head

- head: `fffda798a6bef4aa92cc1fc30d8167649e7f032e`
- tree: `db1bd981cae917c12a0889087006c1c03da33bdd`
- parent/base dependency: `c04f666c66ec2e98340b354600ce9f41e295924c` on `athena/valkey-cluster-topology`
- state: Draft and stacked; the parent is not in `main`

## First-red evidence

The parent head completed Backup but rejected cluster archives during Restore. Frozen packet outer SHA-256: `b03b7cba...98ab`.

Head `666ba2269b19351d237c80d7cc4258825e61ad9c` restored all six pods but passed peer FQDNs directly to `CLUSTER MEET`; Valkey rejected them and left three isolated primaries. Frozen packet outer SHA-256: `8757149e77e06e6adb587159c3844bc361b226dbdcaf014fee145bedac68a8e1`.

Head `4a890f6d90059652b44842e306505724960bbcf0` converged the three primaries, then exposed that restored ordinal-1 pods were still data-bearing singleton masters. Frozen packet outer SHA-256: `beffd04d6d033e8d9e4efe2a39b1c65f1ecbdc8bdb380f496fb23f7a05c79f84`.

Read-only follow-up found matching per-shard ordinal-0/1 base RDB and manifest SHA-256 values, with all six incremental AOF files at 0 bytes. Corrected packet outer SHA-256: `2683fb79794f44bb4ba3eca35d216fad4bbe111b5617bbcdb535692e3105cca5`.

Head `1c058ac5df103f2dd7d85f0b758efb5b462f132e` completed the engine path in one fresh CT11 run: 6/6 Ready, six-node membership, 16384 slots, replicas bound to intended parents, matching per-shard DBSIZE, and 60/60 data readback. The strict terminal gate still failed because only 3/6 PVCs reached `phase=formed`.

Head `007ad7e459dba8971de96aca38dec5e31f468d6a` selected all pods, then focused review proved a fixed-order deadlock: primaries waited for replica actions that could not run after the first retryable error.

Head `fc9971c3b78185e8a1086a1374a19471bf2d1d3b` removed the ordering dependency. Primaries close only primary duties; replicas validate, self-attach, and close only their own binding.

Head `8e146dd528de694d7b91974e1765cec677c9acb8` added configured-roster validation after a focused RED showed that identical primary views containing the same foreign slotless node could otherwise reach `ADDSLOTSRANGE`.

The second-pass RED on `8e146dd5` modeled three isolated primaries sharing one `CLUSTER MYID`. The old code skipped every `MEET`, reached `ADDSLOTSRANGE`, and produced one recorded slot write. Head `062f281a` requires the designated primary IDs to be unique before reading the coordinator view or performing any cluster mutation. The corrected example returns `restore-membership`, `retry_safe=no`, and records zero writes.

A solo subagent review then found that the generic already-formed fast path could commit and delete local restore metadata without revalidating archived ownership. The pre-fix probe returned `RC=0 META_EXISTS=no RESTORE_VALIDATION=0`. Current head `fffda798` routes every existing `cluster-meta` through the local primary-ownership or restored-replica preparation path before the generic formed fast path.

## Safety contract

The restore job validates a canonical non-root data directory and safe append names before writing. It removes attempt-owned partial payload after extraction or validation failure. Cluster archives atomically persist `.kb-cluster-restore-state` as `phase=prepared`, bound to the exact `cluster-meta` SHA-256.

Before server start, a restored non-first pod must prove:

- exact regular non-symlink metadata, RDB, restore state, offline markers, and multipart AOF files
- `dump.rdb` matches the backup-recorded SHA-256
- multipart AOF is exactly the seeded base RDB, empty incremental AOF, and exact manifest with no extra files
- coexisting offline markers across a crash boundary are exact and bound to this pod and metadata

It then persists an offline prepare marker, deletes only the verified redundant RDB/AOF payload, persists the prepared marker, and starts Valkey. No restore path issues online `FLUSHALL`, `CLUSTER RESET`, or destructive online cleanup.

Before `MEET` or slot assignment, the current head requires:

- the source and target shard counts to match
- every designated primary to answer and return a non-empty, unique engine node ID
- every observed node address to map to exactly one configured shard/pod FQDN
- every primary view to contain every designated primary ID
- archived slot ranges to be valid, non-overlapping, and owned only by the intended restored primary

Configured replicas already attached during convergence are allowed. Foreign members, duplicate configured-address mappings, duplicate designated primary IDs, malformed views, slot overlap, and slot ownership outside the archived ranges fail closed before writes.

## Scope and boundary

This supports sharded restore only when source and target shard counts match. Different shard counts remain a hard failure. Peer resolution is intentionally IPv4-only. Cluster archives created before the `rdb_sha256` metadata field fail closed and must be recreated.

Runtime acceptance is not claimed for head `fffda798a6bef4aa92cc1fc30d8167649e7f032e`. Runtime evidence is N=0 on this exact head. Older CT11 runs are diagnostic evidence only and do not migrate to this head.

Solo subagent-assisted focused review is complete with PASS / 0 remaining blocker. Exact-head CI is 7/7 SUCCESS. This PR is not merge-ready because exact-head runtime remains N=0, and it remains stacked on a parent branch that has not landed in `main`.

## Verification

- pre-fix duplicate-primary-ID contract: 40 examples, 1 failure; recorded `ADDSLOTSRANGE` write
- pre-fix formed-fast-path probe: `RC=0 META_EXISTS=no RESTORE_VALIDATION=0`
- exact-head restore-slot contract on Bash 3.2: 40 examples, 0 failures
- exact-head restore-slot contract on Bash 5.3: 40 examples, 0 failures
- affected restore/manage/start specs on Bash 3.2: 176 examples, 0 failures
- affected restore/manage/start specs on Bash 5.3: 176 examples, 0 failures
- full Valkey suite on Bash 3.2: 274 examples, 0 failures
- full Valkey suite on Bash 5.3: 527 examples, 0 failures
- Bash syntax checks, scoped ShellCheck, and `git diff --check`: PASS
- exact-head GitHub CI: 7/7 SUCCESS
- solo subagent-assisted focused review: PASS / 0 blocker
