### PR TITLE
fix(postgresql): rebuild replica after rewind failure

### DIFF
--- a/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
@@ -21,8 +21,7 @@ restore_data:
   command: bash /home/postgres/pgdata/kb_restore/kb_restore.sh --replica
 EOF
     cat > "${conf_dir}/patroni.yaml" <<'EOF'
-postgresql:
-  use_pg_rewind: true
+ttl: 30
 EOF
     cat > "${conf_dir}/kb_pitr.conf" <<'EOF'
 method: kb_restore_from_time
@@ -38,7 +37,8 @@ EOF
     export SPILO_CONFIGURATION='bootstrap:
   initdb:
   - auth-host: md5
-postgresql: {}'
+postgresql:
+  use_pg_rewind: true'
   }
 
   cleanup() {
@@ -54,6 +54,20 @@ import yaml
 with open(sys.argv[1], 'r') as stream:
     config = yaml.safe_load(stream)
 sys.exit(0 if 'recovery_conf' not in config['bootstrap']['kb_restore'] else 1)
+PY
+    printf "%s" "$?"
+  }
+
+  rewind_failure_reinitializes_replica() {
+    python3 - "${out}" <<'PY'
+import sys
+import yaml
+
+with open(sys.argv[1], 'r') as stream:
+    postgresql = yaml.safe_load(stream)['postgresql']
+
+assert postgresql['use_pg_rewind'] is True
+assert postgresql['remove_data_directory_on_rewind_failure'] is True
 PY
     printf "%s" "$?"
   }
@@ -81,6 +95,12 @@ PY
     The status should eq 0
     The contents of file "${out}" should not include "method: kb_restore"
     The contents of file "${out}" should not include "create_replica_methods:"
+  End
+
+  It "reinitializes a replica when pg_rewind fails"
+    When run python3 ../scripts/generate_patroni_yaml.py "${out}"
+    The status should eq 0
+    The result of function rewind_failure_reinitializes_replica should eq 0
   End
 
   It "keeps the recovery configuration for point-in-time restore"

--- a/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/generate_patroni_yaml_spec.sh
@@ -38,7 +38,10 @@ EOF
   initdb:
   - auth-host: md5
 postgresql:
-  use_pg_rewind: true'
+  use_pg_rewind: true
+  remove_data_directory_on_rewind_failure: false
+  parameters:
+    max_connections: 123'
   }
 
   cleanup() {
@@ -64,10 +67,16 @@ import sys
 import yaml
 
 with open(sys.argv[1], 'r') as stream:
-    postgresql = yaml.safe_load(stream)['postgresql']
+    config = yaml.safe_load(stream)
+
+postgresql = config['postgresql']
 
 assert postgresql['use_pg_rewind'] is True
 assert postgresql['remove_data_directory_on_rewind_failure'] is True
+assert postgresql['parameters']['max_connections'] == 123
+assert config['bootstrap']['initdb'][0]['auth-host'] == 'md5'
+assert config['bootstrap']['dcs']['ttl'] == 30
+assert 'remove_data_directory_on_rewind_failure' not in config['bootstrap']['dcs']
 PY
     printf "%s" "$?"
   }

--- a/addons/postgresql/scripts/generate_patroni_yaml.py
+++ b/addons/postgresql/scripts/generate_patroni_yaml.py
@@ -51,6 +51,7 @@ def main(filename):
     postgresql = local_config['postgresql']
     postgresql['config_dir'] = '/home/postgres/pgdata/conf'
     postgresql['custom_conf'] = '/home/postgres/conf/postgresql.conf'
+    postgresql['remove_data_directory_on_rewind_failure'] = True
 
     # add pg_hba.conf
     with open(os.path.join(conf_dir, 'pg_hba.conf'), 'r') as f:


### PR DESCRIPTION
## Problem

Closes #3171.

The PostgreSQL addon enables Patroni `use_pg_rewind`, but its generated local Patroni configuration leaves `remove_data_directory_on_rewind_failure` at the default `false`.

During the PR #3112 runtime acceptance, replication T08 Restart reproduced this failure:

1. the former primary ran `pg_rewind` against the new primary;
2. rewind failed because a required local WAL segment was missing;
3. Patroni reused the divergent PGDATA and kept trying to follow;
4. the replica stayed in startup and the Restart OpsRequest timed out.

## Fix

Set `postgresql.remove_data_directory_on_rewind_failure=true` in the final local Patroni configuration generated by `generate_patroni_yaml.py`.

This is intentionally limited to the observed rewind-exit failure path. It does not enable the separate diverged-timeline fallback and does not change restart ordering, KubeBlocks controller behavior, vcluster, or templates under `bootstrap.dcs`.

## TDD

- RED on base `5003f0515`: focused ShellSpec 4 examples / 1 failure with the exact missing fallback key.
- GREEN on this head: focused 4/0 under bash 3.2 and bash 5.3.
- Related PostgreSQL specs excluding the pre-existing macOS PITR portability case pass under bash 3.2 and bash 5.3.
- The excluded PITR failure is identical on clean base and candidate (`ls -lI` / BSD basename), so it is not introduced here.
- `python3 -m py_compile`, Helm dependency build, lint, render, rendered scripts ConfigMap check, and `git diff --check` pass.

## Review

Agent peer review of exact `09a37377e2f25db886e7b884dba2072fd60320c9`: APPROVE, 0 blocking findings. The reviewer independently verified that the key lands in the final top-level local `postgresql` mapping and is absent from `bootstrap.dcs`.

## Runtime boundary

The PR remains draft. Runtime validation is still required on the exact candidate:

1. focused fresh T08 Restart reproducer;
2. verify rewind failure triggers replica reinitialization through the existing replica method;
3. verify roles, readiness, replication, data consistency, and OpsRequest convergence;
4. then run a fresh replication suite from T01 before resuming full acceptance.
