### PR TITLE
fix(postgresql): accept legacy wal_compression bool strings

### DIFF
--- a/addons/postgresql/config/pg15-config-constraint.cue
+++ b/addons/postgresql/config/pg15-config-constraint.cue
@@ -1058,7 +1058,7 @@
 	wal_buffers?: int & >=-1 & <=262143 @storeResource(8KB)
 
 	// Compresses full-page writes written in WAL file.
-	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off")
+	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off" | "True" | "False" | "true" | "false")
 
 	// Sets the WAL resource managers for which WAL consistency checks are done.
 	wal_consistency_checking?: string

--- a/addons/postgresql/config/pg16-config-constraint.cue
+++ b/addons/postgresql/config/pg16-config-constraint.cue
@@ -1052,7 +1052,7 @@
 	wal_buffers?: int & >=-1 & <=262143 @storeResource(8KB)
 
 	// Compresses full-page writes written in WAL file.
-	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off")
+	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off" | "True" | "False" | "true" | "false")
 
 	// Sets the WAL resource managers for which WAL consistency checks are done.
 	wal_consistency_checking?: string

--- a/addons/postgresql/config/pg17-config-constraint.cue
+++ b/addons/postgresql/config/pg17-config-constraint.cue
@@ -1049,7 +1049,7 @@
 	wal_buffers?: int & >=-1 & <=262143 @storeResource(8KB)
 
 	// Compresses full-page writes written in WAL file.
-	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off")
+	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off" | "True" | "False" | "true" | "false")
 
 	// Sets the WAL resource managers for which WAL consistency checks are done.
 	wal_consistency_checking?: string

--- a/addons/postgresql/config/pg18-config-constraint.cue
+++ b/addons/postgresql/config/pg18-config-constraint.cue
@@ -1049,7 +1049,7 @@
 	wal_buffers?: int & >=-1 & <=262143 @storeResource(8KB)
 
 	// Compresses full-page writes written in WAL file.
-	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off")
+	wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off" | "True" | "False" | "true" | "false")
 
 	// Sets the WAL resource managers for which WAL consistency checks are done.
 	wal_consistency_checking?: string

--- a/addons/postgresql/scripts-ut-spec/wal_compression_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/wal_compression_spec.sh
@@ -4,7 +4,7 @@ Describe "PostgreSQL wal_compression configuration"
   assert_pg15_plus_wal_compression_contract() {
     local major="$1"
 
-    grep -Fq 'wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off")' "../config/pg${major}-config-constraint.cue"
+    grep -Fq 'wal_compression: string & (*"pglz" | "lz4" | "zstd" | "on" | "off" | "True" | "False" | "true" | "false")' "../config/pg${major}-config-constraint.cue"
     grep -Fq "wal_compression = 'pglz'" "../config/pg${major}-config.tpl"
   }
 


### PR DESCRIPTION
## Background

Existing PostgreSQL PG15+ / PG17 / PG18 clusters may already have legacy template values such as `wal_compression = 'True'` or `wal_compression = 'False'` materialized into custom templates or generated ConfigMaps.

The current addon PG15+ constraint only accepts the canonical enum values `on/off/pglz/lz4/zstd`. When a user modifies an unrelated parameter, KubeBlocks merges the existing template first. The old `True/False` value can therefore block the reconfigure path with a CUE validation error even though the user did not modify `wal_compression`.

Runtime evidence from the #19498 investigation:
- The affected `postgresql18-pd-1.0.4` template had `wal_compression = 'True'`.
- Controller logs showed `configuration.wal_compression` conflict against `"True"` while applying an unrelated parameter change.
- PostgreSQL 18 runtime accepted `True/on` with `SHOW wal_compression` returning `pglz`, and accepted `False/off` with `SHOW wal_compression` returning `off`.

## Changes

- Keep the PG15 / PG16 / PG17 / PG18 canonical values and default unchanged: `pglz/lz4/zstd/on/off`, with template default `pglz`.
- Add upgrade compatibility for legacy materialized bool strings: `True/False/true/false`.
- Update the focused shellspec so new templates still use `pglz` by default and the compatibility values are only accepted by the constraint.

## Validation

- `shellspec --load-path ./shellspec addons/postgresql/scripts-ut-spec/wal_compression_spec.sh`
- `for major in 15 16 17 18; do for value in True False true false; do printf 'configuration: { wal_compression: "%s" }\n' "$value" | cue vet -c=false "addons/postgresql/config/pg${major}-config-constraint.cue" - || exit 1; done; done`
- `helm dependency build addons/postgresql`
- `helm lint addons/postgresql`
- `helm template postgresql addons/postgresql >/tmp/postgresql-wal-compat-render.yaml`
- `git diff --check origin/main...HEAD && git diff --check`

## Boundary

This PR is an upgrade compatibility fix. It does not change the recommended contract for new PG15+ configurations. New configurations should continue to use `pglz/lz4/zstd/on/off`, and the template default remains `pglz`.
