### PR TITLE
fix(milvus): declare MinIO password generation

### DIFF
--- a/addons/milvus/templates/cmpd-minio.yaml
+++ b/addons/milvus/templates/cmpd-minio.yaml
@@ -14,6 +14,7 @@ spec:
   systemAccounts:
     - name: admin
       initAccount: true
+      passwordConfig: {}
   vars:
     - name: MINIO_ACCESS_KEY
       valueFrom:


### PR DESCRIPTION
## Problem

Fixes #3179. Addon half of apecloud/kubeblocks#10431.

Milvus MinIO declares its `admin` password credential as required, but the ComponentDefinition omits a password-generation configuration. Under the presence-aware account contract, omission means passwordless, which is invalid for MinIO.

## Change

Declare `passwordConfig: {}` for the MinIO `admin` system account. The KubeBlocks CRD then applies the standard `PasswordConfig` defaults and generation is explicit.

## Dependency

Blocked by apecloud/kubeblocks#10537, which introduces `SystemAccount.passwordConfig`.

Keep this PR draft and do not release it for a KubeBlocks version whose ComponentDefinition CRD lacks `spec.systemAccounts[].passwordConfig`. A fresh Milvus runtime rerun is required after the exact controller/API dependency is available.

## Validation

- `helm dependency build addons/milvus`
- `helm lint addons/milvus`
- `helm template milvus addons/milvus` renders MinIO with `passwordConfig: {}`
- `git diff --check`

Runtime validation: N=0 on this exact addon/controller pair; no runtime PASS is claimed.
