### PR TITLE
fix(qdrant): serialize snapshot restore uploads

### DIFF
--- a/addons/qdrant/templates/actionset-datafile.yaml
+++ b/addons/qdrant/templates/actionset-datafile.yaml
@@ -27,6 +27,7 @@ spec:
         enabled: true
         intervalSeconds: 5
   restore:
+    postReadyExecutionPolicy: Serial
     postReady:
     - job:
         image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tools.repository }}:{{ .Values.image.tools.tag | default "latest" }}


### PR DESCRIPTION
## What
Opt Qdrant's snapshot restore ActionSet into serial postReady execution.

## Why
Qdrant backups target all nodes and produce one snapshot per node. Concurrent upload of all node snapshots caused overlapping shard recovery and left one consensus peer stopped in the captured 3-node restore. This opt-in uses the DataProtection serial postReady contract introduced by the companion KubeBlocks PR.

## Dependency
Requires the KubeBlocks `postReadyExecutionPolicy` API/controller change.

## Tests
- `helm dependency build addons/qdrant --skip-refresh`: PASS
- `helm lint addons/qdrant`: PASS
- rendered ActionSet contains exactly one `postReadyExecutionPolicy: Serial`: PASS
