### PR TITLE
fix(rabbitmq): derive restore archive stem from target path

### DIFF
--- a/addons/rabbitmq/dataprotection/restore.sh
+++ b/addons/rabbitmq/dataprotection/restore.sh
@@ -3,9 +3,26 @@ set -Eeuo pipefail
 
 DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
 # Backup jobs inject DP_TARGET_POD_NAME. Volume-populator AsDataSource prepareData
-# may only inject DP_TARGET_RELATIVE_PATH (= pod identity / archive stem). Prefer
-# POD_NAME when present; otherwise accept RELATIVE_PATH so KB12 dataSource restore works.
-TARGET_POD_NAME="${DP_TARGET_POD_NAME:-${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}}"
+# may only inject DP_TARGET_RELATIVE_PATH (= target name / target pod name).
+# DP_BACKUP_BASE_PATH is already scoped to that relative path, so only its final
+# pod-name segment belongs in the archive key.
+if [ -n "${DP_TARGET_POD_NAME:-}" ]; then
+  TARGET_POD_NAME="${DP_TARGET_POD_NAME}"
+else
+  TARGET_RELATIVE_PATH="${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}"
+  TARGET_NAME="${TARGET_RELATIVE_PATH%%/*}"
+  TARGET_POD_NAME="${TARGET_RELATIVE_PATH#*/}"
+  if [ "${TARGET_NAME}" = "${TARGET_RELATIVE_PATH}" ] || [ -z "${TARGET_NAME}" ] || [ -z "${TARGET_POD_NAME}" ]; then
+    echo "ERROR: DP_TARGET_RELATIVE_PATH must be <target-name>/<target-pod-name>" >&2
+    exit 1
+  fi
+  case "${TARGET_POD_NAME}" in
+    */*)
+      echo "ERROR: DP_TARGET_RELATIVE_PATH must be <target-name>/<target-pod-name>" >&2
+      exit 1
+      ;;
+  esac
+fi
 ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
 
 [ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -143,7 +143,7 @@ DATASAFED
     The stdout should include "restore prepareData completed"
   End
 
-  It "falls back to DP_TARGET_RELATIVE_PATH when volume-populator omits DP_TARGET_POD_NAME"
+  It "uses only the pod-name stem from the volume-populator target relative path"
     When call bash -c '
       set -Eeuo pipefail
       restore_script="$1"
@@ -160,8 +160,8 @@ DATASAFED
 set -e
 case "$1" in
   list)
-    # Archive key matches the relative path / pod identity injected by volume populator.
-    printf "%s\n" "${DP_TARGET_RELATIVE_PATH}.tar.zst"
+    test "${DATASAFED_BACKEND_BASE_PATH}" = "${EXPECTED_BACKUP_BASE_PATH}"
+    printf "%s\n" "${EXPECTED_TARGET_POD_NAME}.tar.zst"
     ;;
   pull)
     cat "${FAKE_ARCHIVE_PATH}"
@@ -178,8 +178,10 @@ DATASAFED
       unset DP_TARGET_POD_NAME || true
       PATH="${bin_dir}:${PATH}" \
         DATA_DIR="${data_dir}" \
-        DP_TARGET_RELATIVE_PATH="rmq-br-5400-rabbitmq-2" \
-        DP_BACKUP_BASE_PATH="/backup/base" \
+        DP_TARGET_RELATIVE_PATH="rabbitmq/rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_TARGET_POD_NAME="rmq-br-5400-rabbitmq-2" \
         FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
         bash "${restore_script}"
       test -f "${data_dir}/restored.txt"
@@ -198,6 +200,20 @@ DATASAFED
     ' _ "${restore_script}"
     The status should be failure
     The stderr should include "DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required"
+  End
+
+  It "fails closed when the target relative path has no pod-name segment"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      unset DP_TARGET_POD_NAME || true
+      DATA_DIR="$(mktemp -d)" \
+        DP_TARGET_RELATIVE_PATH="rabbitmq/" \
+        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq" \
+        bash "${restore_script}"
+    ' _ "${restore_script}"
+    The status should be failure
+    The stderr should include "must be <target-name>/<target-pod-name>"
   End
 
   It "reconciles the restored system account idempotently after RabbitMQ is ready"


### PR DESCRIPTION
## Problem

Volume-populator restore supplies `DP_TARGET_RELATIVE_PATH` as `<target-name>/<target-pod-name>`. `DP_BACKUP_BASE_PATH` is already scoped to that relative path. Treating the full relative path as the archive stem makes restore look for `<target-name>/<target-pod-name>.tar.zst` inside the per-target base path, while backup writes `<target-pod-name>.tar.zst`.

This addresses the current human review blocker on #3113 without changing the backup artifact layout.

## Fix

- Prefer `DP_TARGET_POD_NAME` when the backup/restore job provides it.
- Otherwise require exactly `<target-name>/<target-pod-name>` and derive only the final pod-name segment.
- Fail closed when the relative path has no target or pod segment, or has extra path segments.
- Keep `DATASAFED_BACKEND_BASE_PATH` equal to the injected `DP_BACKUP_BASE_PATH`.
- Update the contract test to use the actual `<target>/<pod>` shape and assert both base path and archive key.

## Validation

- RED before implementation: focused ShellSpec looked for `rabbitmq/rmq-br-5400-rabbitmq-2.tar.zst`.
- Additional RED: `rabbitmq/` was incorrectly accepted as archive stem `rabbitmq` before the fail-closed guard.
- GREEN after implementation: focused RabbitMQ backup/restore ShellSpec, 15 examples / 0 failures.
- `shellcheck addons/rabbitmq/dataprotection/restore.sh`
- `bash -n addons/rabbitmq/dataprotection/restore.sh`
- `git diff --check`

Runtime B/R evidence is intentionally not claimed by this static fix; the exact repinned candidate still needs same-identity backup/restore validation.
