### PR TITLE
fix(mysql): pin xtrabackup action images by service version

### DIFF
--- a/addons/mysql/scripts-ut-spec/syncer_api_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/syncer_api_contract_spec.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=sh
+
+Describe "MySQL syncer API contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  render_mysql_8046_release() {
+    helm template test "$(chart_path)" \
+      --show-only templates/cpmv.yaml "$@" |
+      awk '
+        /^    - name: 8[.]0[.]46$/ { capture = 1 }
+        capture && /^    - name: / && $0 !~ /8[.]0[.]46$/ { exit }
+        capture { print }
+      '
+  }
+
+  It "renders the apps/v1-capable syncer for MySQL 8.0.46"
+    When call render_mysql_8046_release
+    The status should be success
+    The output should include "serviceVersion: 8.0.46"
+    The output should include "init-syncer: docker.io/apecloud/syncer:0.7.7"
+    The output should not include "apecloud/syncer:0.6.8"
+    The output should not include "apecloud/syncer:0.7.6"
+  End
+
+  It "keeps a known-bad override observable as a negative control"
+    When call render_mysql_8046_release --set image.syncer.tag=0.6.8
+    The status should be success
+    The output should include "init-syncer: docker.io/apecloud/syncer:0.6.8"
+    The output should not include "init-syncer: docker.io/apecloud/syncer:0.7.7"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
@@ -1,0 +1,144 @@
+# shellcheck shell=sh
+
+Describe "MySQL xtrabackup action image contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  render_template() {
+    template=$1
+    shift
+    helm template test "$(chart_path)" --show-only "templates/${template}" "$@"
+  }
+
+  mapped_xtrabackup_image() {
+    template=$1
+    method=$2
+    service_version=$3
+    shift 3
+
+    render_template "$template" "$@" | awk \
+      -v method="$method" \
+      -v service_version="$service_version" '
+        /^  - name: / {
+          current_method = $3
+          in_method = (current_method == method)
+          in_image_mapping = 0
+          candidate = 0
+        }
+        in_method && /- name: XTRABACKUP_IMAGE$/ {
+          in_image_mapping = 1
+          next
+        }
+        in_image_mapping && /- serviceVersions:$/ {
+          candidate = 0
+          next
+        }
+        in_image_mapping && $1 == "-" {
+          series = $2
+          gsub(/"/, "", series)
+          candidate = (index(service_version, series) == 1)
+          next
+        }
+        in_image_mapping && candidate && $1 == "mappedValue:" {
+          image = $2
+          gsub(/"/, "", image)
+          print image
+          found = 1
+          exit
+        }
+        END { if (!found) exit 1 }
+      '
+  }
+
+  resolve_action_image() {
+    policy_template=$1
+    method=$2
+    action_template=$3
+    service_version=$4
+    shift 4
+
+    action_image=$(render_template "$action_template" "$@" |
+      awk '/^      image: / { sub(/^      image: /, ""); print; exit }') || return 1
+    [ "$action_image" = '$(XTRABACKUP_IMAGE)' ] || return 1
+    mapped_xtrabackup_image "$policy_template" "$method" "$service_version" "$@"
+  }
+
+  It "resolves the exact MySQL 5.7 full-backup Job image"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup actionset-xtrabackup.yaml 5.7.44
+    The status should be success
+    The output should equal "docker.io/apecloud/percona-xtrabackup:2.4"
+  End
+
+  It "resolves the exact MySQL 8.0 full-backup Job image"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup actionset-xtrabackup.yaml 8.0.46
+    The status should be success
+    The output should equal "docker.io/apecloud/xtrabackup-minimal:8.0.35"
+  End
+
+  It "resolves the exact MySQL 8.4 full-backup Job image"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup actionset-xtrabackup.yaml 8.4.10
+    The status should be success
+    The output should equal "docker.io/apecloud/xtrabackup-minimal:8.4.0"
+  End
+
+  It "uses the exact MySQL 8.0 image for incremental backup Jobs"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup-inc actionset-xtrabackup-inc.yaml 8.0.46
+    The status should be success
+    The output should equal "docker.io/apecloud/xtrabackup-minimal:8.0.35"
+  End
+
+  It "uses the exact MySQL 8.4 image for ORC full-backup Jobs"
+    When call resolve_action_image backuppolicytemplate-orc.yaml xtrabackup actionset-xtrabackup.yaml 8.4.10
+    The status should be success
+    The output should equal "docker.io/apecloud/xtrabackup-minimal:8.4.0"
+  End
+
+  It "uses the exact MySQL 5.7 image for ORC incremental backup Jobs"
+    When call resolve_action_image backuppolicytemplate-orc.yaml xtrabackup-inc actionset-xtrabackup-inc.yaml 5.7.44
+    The status should be success
+    The output should equal "docker.io/apecloud/percona-xtrabackup:2.4"
+  End
+
+  It "preserves the minimal-image override in the final MySQL 8.0 Job image"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup actionset-xtrabackup.yaml 8.0.46 \
+      --set image.xtraBackup.registry=registry.example.com \
+      --set image.xtraBackup.minimalRepository=team/xtrabackup-minimal
+    The status should be success
+    The output should equal "registry.example.com/team/xtrabackup-minimal:8.0.35"
+  End
+
+  It "preserves the legacy-image override in the final MySQL 5.7 Job image"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup actionset-xtrabackup.yaml 5.7.44 \
+      --set image.xtraBackup.registry=registry.example.com \
+      --set image.xtraBackup.repository=team/xtrabackup
+    The status should be success
+    The output should equal "registry.example.com/team/xtrabackup:2.4"
+  End
+
+  It "fails closed when the service version has no xtrabackup image mapping"
+    When call resolve_action_image backuppolicytemplate.yaml xtrabackup actionset-xtrabackup.yaml 9.0.0
+    The status should be failure
+    The output should be blank
+  End
+
+  It "leaves no ActionSet-level fallback image for an unmapped service version"
+    When call sh -c '
+      set -e
+      output=$(helm template test "$1" \
+        --show-only templates/actionset-xtrabackup.yaml \
+        --show-only templates/actionset-xtrabackup-inc.yaml)
+      [ "$(printf "%s\n" "$output" | grep -c "image: \$(XTRABACKUP_IMAGE)")" -eq 4 ]
+      ! printf "%s\n" "$output" | grep -q "name: IMAGE_TAG"
+      ! printf "%s\n" "$output" | grep -q "name: XTRABACKUP_IMAGE"
+    ' sh "$(chart_path)"
+    The status should be success
+  End
+End

--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -318,6 +318,14 @@ init-syncer: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image
 mysql-exporter: {{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository }}:{{ default .Values.metrics.image.tag }}
 {{- end -}}
 
+{{- define "mysql.xtrabackup.legacyRepository" -}}
+{{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}
+{{- end -}}
+
+{{- define "mysql.xtrabackup.minimalRepository" -}}
+{{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.minimalRepository }}
+{{- end -}}
+
 {{/*
 Generate LD_PRELOAD environment variable - always set, but will be cleared at runtime for ARM64
 */}}

--- a/addons/mysql/templates/actionset-xtrabackup-inc.yaml
+++ b/addons/mysql/templates/actionset-xtrabackup-inc.yaml
@@ -11,15 +11,13 @@ spec:
     value: "{{ .Values.dataMountPath }}/data"
   - name: MYSQL_DIR
     value: {{ .Values.dataMountPath }}
-  - name: IMAGE_TAG
-    value: "8.0"
   - name: BACKUP_FOR_STANDBY
     value: "false"
   backup:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:$(IMAGE_TAG)
+      image: $(XTRABACKUP_IMAGE)
       runOnTargetPodNode: true
       command:
       - bash
@@ -31,7 +29,7 @@ spec:
         intervalSeconds: 5
   restore:
     prepareData:
-      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:$(IMAGE_TAG)
+      image: $(XTRABACKUP_IMAGE)
       command:
       - bash
       - -c

--- a/addons/mysql/templates/actionset-xtrabackup.yaml
+++ b/addons/mysql/templates/actionset-xtrabackup.yaml
@@ -11,15 +11,13 @@ spec:
     value: "{{ .Values.dataMountPath }}/data"
   - name: MYSQL_DIR
     value: {{ .Values.dataMountPath }}
-  - name: IMAGE_TAG
-    value: "8.0"
   - name: BACKUP_FOR_STANDBY
     value: "false"
   backup:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:$(IMAGE_TAG)
+      image: $(XTRABACKUP_IMAGE)
       runOnTargetPodNode: true
       command:
       - bash
@@ -31,7 +29,7 @@ spec:
         intervalSeconds: 5
   restore:
     prepareData:
-      image: {{ .Values.image.xtraBackup.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.image.xtraBackup.repository }}:$(IMAGE_TAG)
+      image: $(XTRABACKUP_IMAGE)
       command:
       - bash
       - -c

--- a/addons/mysql/templates/backuppolicytemplate-orc.yaml
+++ b/addons/mysql/templates/backuppolicytemplate-orc.yaml
@@ -17,18 +17,18 @@ spec:
     snapshotVolumes: false
     actionSetName: mysql-xtrabackup-br
     env:
-      - name: IMAGE_TAG
+      - name: XTRABACKUP_IMAGE
         valueFrom:
           versionMapping:
           - serviceVersions:
             - "8.4"
-            mappedValue: "8.4"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.4.0"
           - serviceVersions:
             - "8.0"
-            mappedValue: "8.0"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.0.35"
           - serviceVersions:
             - "5.7"
-            mappedValue: "2.4"
+            mappedValue: "{{ include "mysql.xtrabackup.legacyRepository" . }}:2.4"
     targetVolumes:
       volumeMounts:
       - name: data
@@ -38,18 +38,18 @@ spec:
     snapshotVolumes: false
     actionSetName: mysql-xtrabackup-inc-br
     env:
-      - name: IMAGE_TAG
+      - name: XTRABACKUP_IMAGE
         valueFrom:
           versionMapping:
           - serviceVersions:
             - "8.4"
-            mappedValue: "8.4"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.4.0"
           - serviceVersions:
             - "8.0"
-            mappedValue: "8.0"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.0.35"
           - serviceVersions:
             - "5.7"
-            mappedValue: "2.4"
+            mappedValue: "{{ include "mysql.xtrabackup.legacyRepository" . }}:2.4"
     targetVolumes:
       volumeMounts:
       - name: data

--- a/addons/mysql/templates/backuppolicytemplate.yaml
+++ b/addons/mysql/templates/backuppolicytemplate.yaml
@@ -19,18 +19,18 @@ spec:
     snapshotVolumes: false
     actionSetName: mysql-xtrabackup-br
     env:
-      - name: IMAGE_TAG
+      - name: XTRABACKUP_IMAGE
         valueFrom:
           versionMapping:
           - serviceVersions:
             - "8.4"
-            mappedValue: "8.4"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.4.0"
           - serviceVersions:
             - "8.0"
-            mappedValue: "8.0"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.0.35"
           - serviceVersions:
             - "5.7"
-            mappedValue: "2.4"
+            mappedValue: "{{ include "mysql.xtrabackup.legacyRepository" . }}:2.4"
     targetVolumes:
       volumeMounts:
       - name: data
@@ -40,18 +40,18 @@ spec:
     snapshotVolumes: false
     actionSetName: mysql-xtrabackup-inc-br
     env:
-      - name: IMAGE_TAG
+      - name: XTRABACKUP_IMAGE
         valueFrom:
           versionMapping:
           - serviceVersions:
             - "8.4"
-            mappedValue: "8.4"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.4.0"
           - serviceVersions:
             - "8.0"
-            mappedValue: "8.0"
+            mappedValue: "{{ include "mysql.xtrabackup.minimalRepository" . }}:8.0.35"
           - serviceVersions:
             - "5.7"
-            mappedValue: "2.4"
+            mappedValue: "{{ include "mysql.xtrabackup.legacyRepository" . }}:2.4"
     targetVolumes:
       volumeMounts:
       - name: data

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -14,6 +14,7 @@ image:
     # if the value of image.xtraBackup.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""
     repository: apecloud/percona-xtrabackup
+    minimalRepository: apecloud/xtrabackup-minimal
   syncer:
     repository: apecloud/syncer
     tag: 0.7.7

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -16,7 +16,7 @@ image:
     repository: apecloud/percona-xtrabackup
   syncer:
     repository: apecloud/syncer
-    tag: 0.6.8
+    tag: 0.7.7
   # refer: addons/mysql/orc-tools/Dockerfile
   orcTools:
     repository: apecloud/orc-tools


### PR DESCRIPTION
## Problem

Task85 row A was authorized for MySQL 8.0.46 with `xtrabackup-minimal:8.0.35`, but the live Backup Job used `apecloud/percona-xtrabackup:8.0`.

The chart already pins the runtime init tool by service version in ComponentVersion. The BackupPolicyTemplate only mapped a broad tag (`8.0` / `8.4`), while the ActionSet fixed the repository and had an `8.0` fallback. That allowed the backup action image to disagree with the selected MySQL service version.

## Change

- map one complete `XTRABACKUP_IMAGE` per supported service-version series;
- use `xtrabackup-minimal:8.0.35` for 8.0 and `xtrabackup-minimal:8.4.0` for 8.4;
- preserve the existing `percona-xtrabackup:2.4` image for 5.7;
- remove the ActionSet-level default so an unmapped service version cannot silently fall back to 8.0;
- apply the same matrix to normal/ORC and full/incremental methods;
- keep registry and repository overrides explicit.

## Evidence

Runtime first-red is recorded in task85: the actual Backup Job image was `percona-xtrabackup:8.0`; this happened before the later restore PVC Pending state. Backup completion is not counted as 8.0.35 compatibility evidence.

TDD on parent exact head `e675690aed262e0d02b46a130ca8cc00ce8fe8ff`:

- RED: new focused ShellSpec `10 examples, 8 failures` before implementation;
- GREEN: MySQL ShellSpec `18 examples, 0 failures`;
- `helm lint addons/mysql`: PASS;
- ACR-only full chart render: PASS, render SHA `b13e457e3e404c86885769fa3f977f88ccd5e7cfd86aa4605cd7cfbbf3d4b229`;
- `git diff --check`: PASS.

## Review focus

- unknown service versions fail closed because BPT has no mapping and ActionSet has no default image;
- source -> BPT mapping -> ActionSet substitution yields the final Job image;
- 5.7/8.0/8.4 and normal/ORC + full/incremental stay covered;
- volume-snapshot behavior is intentionally unchanged.

## Boundary

This PR closes only the chart mapping/static contract. Runtime replay remains test-agent-owned. MySQL 8.0.46 + xtrabackup 8.0.35 compatibility remains N=0 until a new exact-package backup/restore terminal run.
