### PR TITLE
chore: upgrade syncer defaults to 0.7.7

### DIFF
--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -10,7 +10,7 @@ image:
   tag: 8.0.30-5.beta3.20240330.g94d1caf.15
   syncer:
     repository: apecloud/syncer
-    tag: 0.4.1
+    tag: 0.7.7
   walgImage:
     repository: apecloud/wal-g
     tag: mysql-8.0

--- a/addons/mariadb/values.yaml
+++ b/addons/mariadb/values.yaml
@@ -16,7 +16,7 @@ image:
     # Keep the chart default on a published syncer tag. Candidate or
     # engine-specific syncer builds must be supplied explicitly by values
     # override during validation, not baked into the release chart default.
-    tag: 0.6.7
+    tag: 0.7.7
 
 ## @param componentServiceVersion define default serviceVersion of each Component
 defaultServiceVersion:

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -17,7 +17,7 @@ image:
     tag: 1.29
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.7"
+    tag: "0.7.7"
   exporter:
     repository: apecloud/mongodb_exporter
     tag: "0.44.0"

--- a/addons/orioledb/values.yaml
+++ b/addons/orioledb/values.yaml
@@ -12,7 +12,7 @@ image:
   debug: false
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.5"
+    tag: "0.7.7"
 
 dataMountPath: /postgresql/mount_volume
 confMountPath: /postgresql/mount_conf

--- a/addons/vanilla-postgresql/values.yaml
+++ b/addons/vanilla-postgresql/values.yaml
@@ -38,7 +38,7 @@ image:
 
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.5"
+    tag: "0.7.7"
 
 dataMountPath: /postgresql/volume_data
 confMountPath: /postgresql/mount_conf


### PR DESCRIPTION
## Why

KubeBlocks PR apecloud/kubeblocks#10469 removed the pre-1.0 Cluster API and KubeBlocks 1.2 serves `apps.kubeblocks.io/v1` only. The syncer tags currently pinned by these charts request the removed `apps.kubeblocks.io/v1alpha1` API, so role discovery fails with an API 404 on KubeBlocks 1.2.

The source-side fix is merged in apecloud/syncer#288. The published `apecloud/syncer:0.7.7` image is built from source commit `fda7324024635be310573deb446b39b0e68a434e`, which contains that fix.

## What

Upgrade the default syncer image to 0.7.7 for the five affected public addons not already covered by another open PR:

- apecloud-mysql: 0.4.1 -> 0.7.7
- mariadb: 0.6.7 -> 0.7.7
- mongodb: 0.6.7 -> 0.7.7
- orioledb: 0.6.5 -> 0.7.7
- vanilla-postgresql: 0.6.5 -> 0.7.7

MySQL is intentionally not duplicated here: apecloud/kubeblocks-addons#3182 already changes its default from 0.6.8 to 0.7.7. Together, that PR and this PR cover all six current `kubeblocks-addons` charts with a syncer default.

No addon scripts or database behavior are changed.

## Image and old-pin verification

Docker Hub and Aliyun resolve syncer 0.7.7 to the same multi-architecture index:

- index: `sha256:2cf5d059a029f06372c615ddf79b2fc7ff1876934811932f049e8e7977d224dd`
- linux/amd64: `sha256:69b1d0acd11a82981367c58155e01d3f3d4c47d09d8f6189c50eeb0bfe3d6bd3`
- linux/arm64: `sha256:af19104a98308bfb4f12becfdb21cf2d68d6f044e2c9037e5799d1eefddc6d3c`

The inspected 0.7.7 arm64 binary embeds source `fda7324...34e`, contains the new apps/v1 `kbapi` client, and contains no old KubeBlocks apps/v1alpha1 package/API symbols.

The exact old images pinned by the six public charts were also inspected. Tags 0.4.1, 0.6.5, 0.6.7, and 0.6.8 all contain the old apps/v1alpha1 client symbols.

## Validation

- Pin contract RED before the change: expected 5 changed charts on 0.7.7, actual 0.
- Pin contract GREEN after the change: 5/5 changed charts on 0.7.7.
- `helm lint`: PASS for apecloud-mysql, mariadb, mongodb, orioledb, and vanilla-postgresql.
- Default Docker renders contain only `apecloud/syncer:0.7.7`:
  - apecloud-mysql: 1 reference
  - mariadb: 6 references
  - mongodb: 14 references
  - orioledb: 1 reference
  - vanilla-postgresql: 4 references
- Aliyun-registry renders contain the same 0.7.7 pins for all five charts, with no old pin in the rendered output.
- `git diff --check`: PASS.

## Upgrade boundary

This is a chart/default-image change. Existing database Pods keep the syncer binary they started with; they must be recreated or rolled to consume 0.7.7. HA clusters should roll one Pod at a time. A single-replica cluster may have a short interruption. Runtime acceptance must verify the new Pod UID and syncer image identity.

Static and image verification is complete. Per-addon KubeBlocks 1.2 runtime validation is still N=0 and is not claimed by this PR.
