### PR TITLE
chore(mongodb): upgrade syncer to 0.7.7

### DIFF
--- a/addons/mongodb/scripts-ut-spec/syncer_image_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/syncer_image_spec.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+
+Describe "MongoDB syncer image contract"
+
+  render_and_validate_syncer_image() {
+    local chart_dir
+
+    chart_dir=$(cd .. && pwd)
+    # shellcheck disable=SC2016 # Ruby owns interpolation inside this program.
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update | ruby -ryaml -e '
+      expected = "docker.io/apecloud/syncer:0.7.7"
+      documents = YAML.load_stream($stdin.read).compact
+
+      component_versions = documents.select { |doc| doc["kind"] == "ComponentVersion" }
+      versions = component_versions.select do |doc|
+        %w[mongodb mongodb-shard].include?(doc.dig("metadata", "name"))
+      end
+      abort "expected mongodb and mongodb-shard ComponentVersions" unless versions.length == 2
+
+      versions.each do |version|
+        releases = version.dig("spec", "releases")
+        abort "#{version.dig("metadata", "name")} releases are missing" unless releases.is_a?(Array) && !releases.empty?
+        releases.each do |release|
+          actual = release.dig("images", "init-syncer")
+          abort "#{version.dig("metadata", "name")} #{release["name"]} init-syncer=#{actual.inspect}, expected #{expected}" unless actual == expected
+        end
+      end
+
+      definitions = documents.select { |doc| doc["kind"] == "ComponentDefinition" }
+      direct_images = definitions.flat_map do |definition|
+        Array(definition.dig("spec", "runtime", "initContainers")).map do |container|
+          container["image"] if container["name"] == "init-syncer" && container.key?("image")
+        end.compact
+      end
+      abort "expected two direct init-syncer images, got #{direct_images.length}" unless direct_images.length == 2
+      abort "direct init-syncer image mismatch: #{direct_images.inspect}" unless direct_images.all? { |image| image == expected }
+
+      rendered = documents.to_s
+      abort "stale syncer 0.6.7 remains in rendered resources" if rendered.include?("apecloud/syncer:0.6.7")
+
+      puts "syncer image contract passed: #{expected}"
+    '
+  }
+
+  It "pins every MongoDB init-syncer mapping to 0.7.7"
+    When call render_and_validate_syncer_image
+    The status should be success
+    The output should include "syncer image contract passed: docker.io/apecloud/syncer:0.7.7"
+  End
+End

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -17,7 +17,7 @@ image:
     tag: 1.29
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.7"
+    tag: "0.7.7"
   exporter:
     repository: apecloud/mongodb_exporter
     tag: "0.44.0"


### PR DESCRIPTION
## Problem

The MongoDB addon still pins `apecloud/syncer:0.6.7`. The release candidate needs syncer `0.7.7` before runtime acceptance continues.

Live evidence from the superseded candidate confirmed the old Pod init container used `syncer:0.6.7`, image digest `sha256:832ab614...`, and copied that binary into `/tools` for the MongoDB container.

## Change

- Pin `image.syncer.tag` to `0.7.7`.
- Add a ShellSpec render contract covering all MongoDB and mongodb-shard ComponentVersion releases plus direct ComponentDefinition init-syncer images.
- Fail if rendered resources retain `apecloud/syncer:0.6.7`.

This branch is rebased directly on current `main`; the PR contains only `addons/mongodb/values.yaml` and `addons/mongodb/scripts-ut-spec/syncer_image_spec.sh`.

## Verification

Exact head: `9e8b2b201780d90d2b2e3ea4f9ff90333052b319`

- Focused ShellSpec: 1 example, 0 failures.
- All MongoDB ShellSpec: 10 examples, 0 failures.
- Helm lint: 1 chart, 0 failures.
- ShellCheck: pass.
- `git diff --check`: pass.
- Render contract checks every MongoDB and mongodb-shard release mapping, both direct init-syncer images, and absence of stale `0.6.7`.
- Docker Hub remote linux/amd64 manifest: `sha256:69b1d0acd11a82981367c58155e01d3f3d4c47d09d8f6189c50eeb0bfe3d6bd3`.
- OCI revision label: `fda7324024635be310573deb446b39b0e68a434e`, which includes syncer PR #288 (`apps/v1alpha1` client migrated to `apps/v1`).

The OCI `org.opencontainers.image.version` label is stale (`0.1.0-alpha.0`), so it is not accepted as program-version proof.

## Runtime boundary

This PR proves the chart/render pin only. It does not claim a live MongoDB Pod is running the new image. Runtime acceptance will separately verify Pod init-container image, imageID, exit/restart state, and `/tools/syncer --version` plus `/tools/syncerctl --version`; those binary commands must identify revision `fda7324...`. Then the full MongoDB suite restarts from a clean candidate pin.
