### PR TITLE
fix(redis): bound cluster lifecycle actions

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
@@ -1,0 +1,148 @@
+# shellcheck shell=bash
+
+Describe "Redis Cluster lifecycle action contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/redis" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  ruby_not_available() { ! command -v ruby >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+  Skip if "ruby not available" ruby_not_available
+
+  render_lifecycle_templates() {
+    tmp_render=$(mktemp -t redis-lifecycle-render-XXXXXX)
+    helm template test "$(chart_path)" \
+      --dependency-update \
+      --show-only templates/cmpd-redis-cluster.yaml \
+      --show-only templates/shardingdefinition.yaml >"$tmp_render"
+  }
+
+  validate_timeout_contract() {
+    render_lifecycle_templates || return $?
+    ruby -ryaml -e '
+      documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
+      post_provision = documents.map do |document|
+        next unless document["kind"] == "ComponentDefinition"
+        next unless document.dig("metadata", "name").start_with?("redis-cluster-")
+        document.dig("spec", "lifecycleActions", "postProvision")
+      end.compact
+      abort "expected four Redis Cluster postProvision actions, got #{post_provision.length}" unless post_provision.length == 4
+      post_timeouts = post_provision.map { |action| action.fetch("timeoutSeconds") }
+      abort "postProvision timeoutSeconds must all be 50, got #{post_timeouts.inspect}" unless post_timeouts == [50, 50, 50, 50]
+
+      sharding = documents.select { |document| document["kind"] == "ShardingDefinition" }
+      abort "expected one ShardingDefinition, got #{sharding.length}" unless sharding.length == 1
+      shard_timeout = sharding.first.dig("spec", "lifecycleActions", "shardRemove", "timeoutSeconds")
+      abort "shardRemove timeoutSeconds must be 50, got #{shard_timeout.inspect}" unless shard_timeout == 50
+
+      puts "lifecycle timeout contract passed"
+    ' "$tmp_render"
+  }
+
+  extract_lifecycle_command() {
+    action=$1
+    major=${2:-7}
+    ruby -ryaml -e '
+      documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
+      action = ARGV.fetch(1)
+      major = ARGV.fetch(2)
+      command = if action == "postProvision"
+        definition = documents.find do |document|
+          document["kind"] == "ComponentDefinition" &&
+            document.dig("metadata", "name").start_with?("redis-cluster-#{major}-")
+        end
+        abort "missing Redis Cluster #{major} ComponentDefinition" unless definition
+        definition.dig("spec", "lifecycleActions", "postProvision", "exec", "command", 2)
+      else
+        definition = documents.find { |document| document["kind"] == "ShardingDefinition" }
+        abort "missing Redis ShardingDefinition" unless definition
+        definition.dig("spec", "lifecycleActions", "shardRemove", "exec", "command", 2)
+      end
+      abort "missing #{action} shell command" unless command
+      print command
+    ' "$tmp_render" "$action" "$major"
+  }
+
+  write_fake_manage_script() {
+    script=$1
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'printf "manage stdout\\n"' \
+      'printf "manage stderr\\n" >&2' \
+      'exit "${FAKE_MANAGE_RC:-0}"' >"$script"
+    chmod +x "$script"
+  }
+
+  run_lifecycle_command() {
+    action=$1
+    major=${2:-7}
+    legacy=${3:-false}
+    rc=${4:-0}
+
+    render_lifecycle_templates || return $?
+    tmp_scripts=$(mktemp -d -t redis-lifecycle-scripts-XXXXXX)
+    write_fake_manage_script "$tmp_scripts/redis-cluster-manage.sh"
+    write_fake_manage_script "$tmp_scripts/redis-cluster6-manage.sh"
+
+    command=$(extract_lifecycle_command "$action" "$major") || return $?
+    command=${command//\/scripts\//$tmp_scripts/}
+    LEGACY_REDIS=$legacy FAKE_MANAGE_RC=$rc /bin/bash -c "$command"
+  }
+
+  cleanup_lifecycle_contract() {
+    [ -n "${tmp_render:-}" ] && rm -f "$tmp_render" 2>/dev/null || true
+    [ -n "${tmp_scripts:-}" ] && rm -rf "$tmp_scripts" 2>/dev/null || true
+    rm -f /tmp/post-provision.log /tmp/pre-terminate.log 2>/dev/null || true
+  }
+  AfterEach 'cleanup_lifecycle_contract'
+
+  It "keeps postProvision and shardRemove inside the kbagent 60-second clamp"
+    When call validate_timeout_contract
+    The status should be success
+    The output should include "lifecycle timeout contract passed"
+  End
+
+  It "replays postProvision failure diagnostics and preserves the manage rc"
+    When call run_lifecycle_command postProvision 7 false 23
+    The status should eq 23
+    The stderr should include "manage stdout"
+    The stderr should include "manage stderr"
+  End
+
+  It "keeps successful postProvision output out of stderr"
+    When call run_lifecycle_command postProvision 7 false 0
+    The status should be success
+    The stderr should be blank
+  End
+
+  It "replays modern shardRemove failure diagnostics and preserves the manage rc"
+    When call run_lifecycle_command shardRemove 7 false 24
+    The status should eq 24
+    The stderr should include "manage stdout"
+    The stderr should include "manage stderr"
+  End
+
+  It "replays legacy shardRemove failure diagnostics and preserves the manage rc"
+    When call run_lifecycle_command shardRemove 6 true 25
+    The status should eq 25
+    The stderr should include "manage stdout"
+    The stderr should include "manage stderr"
+  End
+
+  It "keeps successful modern shardRemove output out of stderr"
+    When call run_lifecycle_command shardRemove 7 false 0
+    The status should be success
+    The stderr should be blank
+  End
+
+  It "keeps successful legacy shardRemove output out of stderr"
+    When call run_lifecycle_command shardRemove 6 true 0
+    The status should be success
+    The stderr should be blank
+  End
+End

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -468,13 +468,20 @@ spec:
           - redis
           - getrole
     postProvision:
-      timeoutSeconds: 600
+      timeoutSeconds: 50
       exec:
         container: redis-cluster
         command:
           - /bin/bash
           - -c
-          - /scripts/{{ $redisClusterManageScripts }} --post-provision  > /tmp/post-provision.log 2>&1
+          - |
+            log=/tmp/post-provision.log
+            /scripts/{{ $redisClusterManageScripts }} --post-provision >"$log" 2>&1
+            rc=$?
+            if [ "$rc" -ne 0 ]; then
+              cat "$log" >&2
+            fi
+            exit "$rc"
         ## all lifecycle actions share the same env
         env:
           - name: CURRENT_POD_NAME

--- a/addons/redis/templates/shardingdefinition.yaml
+++ b/addons/redis/templates/shardingdefinition.yaml
@@ -19,17 +19,23 @@ spec:
       shared: true
   lifecycleActions:
     shardRemove:
-      timeoutSeconds: 600
+      timeoutSeconds: 50
       exec:
         container: redis-cluster
         command:
           - /bin/bash
           - -c
           - |
+            log=/tmp/pre-terminate.log
             if [ "$LEGACY_REDIS" == "true" ]; then
-               /scripts/redis-cluster6-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
+              /scripts/redis-cluster6-manage.sh --pre-terminate >"$log" 2>&1
             else
-               /scripts/redis-cluster-manage.sh --pre-terminate > /tmp/pre-terminate.log 2>&1
+              /scripts/redis-cluster-manage.sh --pre-terminate >"$log" 2>&1
             fi
+            rc=$?
+            if [ "$rc" -ne 0 ]; then
+              cat "$log" >&2
+            fi
+            exit "$rc"
       retryPolicy:
         maxRetries: 10


### PR DESCRIPTION
## Problem

The canonical `all` static run stopped in S07 before creating any Redis workload. Redis Cluster `postProvision` and `shardRemove` each declared a 600-second action timeout, while KubeBlocks kbagent clamps every lifecycle action call to 60 seconds. Both actions also redirected command output to a file without replaying it when the manage script failed, so the caller received a non-zero status without the failure diagnostics.

Observed evidence:
- Canonical run: 55 passed / 3 failed / 0 skipped, exit 1, fail-stop in the static suite.
- Redis addon source and live readback both showed the two 600-second action surfaces.
- KubeBlocks source at the pinned candidate showed the 60-second action-call clamp.
- The pre-fix source-contract test reproduced four failures: all four rendered Redis Cluster `postProvision` definitions were 600 seconds, and postProvision plus modern/legacy shardRemove hid stdout/stderr on failure.

## Fix

- Set Redis Cluster `postProvision` and `shardRemove` to 50 seconds, leaving a 10-second margin inside the kbagent clamp.
- Capture the manage script status immediately after execution.
- Replay the action log to stderr only when the status is non-zero, then exit with the original status.
- Keep the modern and legacy shardRemove branches on one shared log/status closeout.
- Add a rendered source-contract ShellSpec covering timeouts, failure diagnostics, original status preservation, and quiet successful paths.

The Redis manage-script algorithms are unchanged.

## Validation

- Focused ShellSpec: Bash 3 `7/0`, Bash 5 `7/0`.
- Full Redis ShellSpec on Bash 5: `451/0`.
- ShellCheck error-level and Bash 3/Bash 5 syntax checks: pass for the new spec and all three unique rendered lifecycle commands.
- Helm lint: 1 chart, 0 failures.
- Structured full render: 4 postProvision + 1 shardRemove actions satisfy the 50-second and closeout contract.
- Base-to-patched full render diff contains only those five lifecycle-action surfaces.
- `git diff --check`: pass.

Artifact identities:
- chart `redis-1.2.0-alpha.0.tgz`: `fdf3b962cfd7277a0503d98954dd8a5b47bd7c4daf7554df8fe09346472d6975`
- full patched render: `1ee8096fceadb7827b85275d168ee8246e11678dfa8bc9a2abce342dd6badf49`
- base-to-patched render diff: `ab4d4292d2edc1a5444003bad8dcda1eb3e9dfd9de51fbb319b42a8604781417`

## Review focus

- Confirm 50 seconds is the intended addon-side budget under the 60-second kbagent clamp.
- Confirm the action log is emitted only on failure and the original manage-script status cannot be overwritten by `cat` or branch closeout.
- Confirm legacy and modern shardRemove paths share the same closeout.

## Boundary

This is the product/addon fix for the canonical `all` S07 static first-red. It is not runtime PASS or full-suite PASS. The PR is intentionally based on frozen composite `20bf1ba747003f829587ac52e87b697fe039ad90`; after focused review, the Redis team will rebuild and freeze a new composite before Max performs a fresh runtime/full-suite rerun.
