### PR TITLE
fix(falkordb): map backup image by service version

### DIFF
--- a/addons/falkordb/scripts-ut-spec/backup_image_version_mapping_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/backup_image_version_mapping_spec.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# shellcheck disable=SC2016
+
+Describe "FalkorDB backup image version mapping"
+  chart_path() {
+    printf '%s/addons/falkordb\n' "$(cd "${SHELLSPEC_PROJECT_ROOT:-.}" && pwd)"
+  }
+
+  render_template() {
+    helm template test "$(chart_path)" \
+      --set image.registry=registry.example.com \
+      --set image.repository=team/falkordb \
+      --show-only "templates/$1"
+  }
+
+  It "defers all FalkorDB ActionSet jobs to the backup policy version mapping"
+    When call render_template backupactionset.yaml
+    The status should be success
+    The output should include 'image: $(FALKORDB_IMAGE)'
+    The output should not include 'registry.example.com/team/falkordb:'
+    The output should satisfy awk '
+      /image: \$\(FALKORDB_IMAGE\)/ { mapped++ }
+      END { exit mapped == 9 ? 0 : 1 }
+    '
+  End
+
+  It "maps standalone datafile and PITR jobs to every service version image"
+    When call render_template backuppolicytemplate.yaml
+    The status should be success
+    The output should satisfy awk '
+      /name: FALKORDB_IMAGE/ { names++ }
+      /mappedValue: registry.example.com\/team\/falkordb:v4.12.5/ { v412++ }
+      /mappedValue: registry.example.com\/team\/falkordb:v4.14.12/ { v414++ }
+      END { exit names == 2 && v412 == 2 && v414 == 2 ? 0 : 1 }
+    '
+  End
+
+  It "maps cluster datafile jobs to every service version image"
+    When call render_template backuppolicytemplateforcluster.yaml
+    The status should be success
+    The output should satisfy awk '
+      /name: FALKORDB_IMAGE/ { names++ }
+      /mappedValue: registry.example.com\/team\/falkordb:v4.12.5/ { v412++ }
+      /mappedValue: registry.example.com\/team\/falkordb:v4.14.12/ { v414++ }
+      END { exit names == 1 && v412 == 1 && v414 == 1 ? 0 : 1 }
+    '
+  End
+End

--- a/addons/falkordb/scripts-ut-spec/backup_image_version_mapping_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/backup_image_version_mapping_spec.sh
@@ -13,10 +13,27 @@ Describe "FalkorDB backup image version mapping"
       --show-only "templates/$1"
   }
 
-  It "defers all FalkorDB ActionSet jobs to the backup policy version mapping"
+  It "keeps the legacy ActionSet image contract for existing backups"
     When call render_template backupactionset.yaml
     The status should be success
-    The output should include 'image: $(FALKORDB_IMAGE)'
+    The output should not include 'image: $(FALKORDB_IMAGE)'
+    The output should satisfy awk '
+      /^  name: falkordb-physical-br$/ { physical++ }
+      /^  name: falkordb-cluster-br$/ { cluster++ }
+      /^  name: falkordb-for-pitr$/ { pitr++ }
+      /image: registry.example.com\/team\/falkordb:v4.12.5/ { legacy++ }
+      END {
+        exit physical == 1 && cluster == 1 && pitr == 1 && legacy == 9 ? 0 : 1
+      }
+    '
+  End
+
+  It "defers all version-aware ActionSet jobs to the backup policy mapping"
+    When call render_template backupactionset-v2.yaml
+    The status should be success
+    The output should include 'name: falkordb-physical-br-v2'
+    The output should include 'name: falkordb-cluster-br-v2'
+    The output should include 'name: falkordb-for-pitr-v2'
     The output should not include 'registry.example.com/team/falkordb:'
     The output should satisfy awk '
       /image: \$\(FALKORDB_IMAGE\)/ { mapped++ }
@@ -28,6 +45,13 @@ Describe "FalkorDB backup image version mapping"
     When call render_template backuppolicytemplate.yaml
     The status should be success
     The output should satisfy awk '
+      /actionSetName: falkordb-physical-br-v2$/ { physical++ }
+      /actionSetName: falkordb-for-pitr-v2$/ { pitr++ }
+      /actionSetName: falkordb-physical-br$/ { legacy++ }
+      /actionSetName: falkordb-for-pitr$/ { legacy++ }
+      END { exit physical == 1 && pitr == 1 && legacy == 0 ? 0 : 1 }
+    '
+    The output should satisfy awk '
       /name: FALKORDB_IMAGE/ { names++ }
       /mappedValue: registry.example.com\/team\/falkordb:v4.12.5/ { v412++ }
       /mappedValue: registry.example.com\/team\/falkordb:v4.14.12/ { v414++ }
@@ -38,6 +62,11 @@ Describe "FalkorDB backup image version mapping"
   It "maps cluster datafile jobs to every service version image"
     When call render_template backuppolicytemplateforcluster.yaml
     The status should be success
+    The output should satisfy awk '
+      /actionSetName: falkordb-cluster-br-v2$/ { cluster++ }
+      /actionSetName: falkordb-cluster-br$/ { legacy++ }
+      END { exit cluster == 1 && legacy == 0 ? 0 : 1 }
+    '
     The output should satisfy awk '
       /name: FALKORDB_IMAGE/ { names++ }
       /mappedValue: registry.example.com\/team\/falkordb:v4.12.5/ { v412++ }

--- a/addons/falkordb/templates/backupactionset-v2.yaml
+++ b/addons/falkordb/templates/backupactionset-v2.yaml
@@ -1,7 +1,7 @@
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: ActionSet
 metadata:
-  name: falkordb-physical-br
+  name: falkordb-physical-br-v2
   labels:
     clusterdefinition.kubeblocks.io/name: falkordb
     {{- include "falkordb.labels" . | nindent 4 }}
@@ -16,7 +16,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       runOnTargetPodNode: true
       syncProgress:
         enabled: true
@@ -28,7 +28,7 @@ spec:
         {{- .Files.Get "dataprotection/backup.sh" | nindent 8 }}
   restore:
     prepareData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       command:
       - bash
       - -c
@@ -42,14 +42,14 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/restore-keys.sh" | nindent 10 }}
-        image: {{ include "falkordb4.image" . }}
+        image: $(FALKORDB_IMAGE)
         onError: Fail
         runOnTargetPodNode: true
 ---
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: ActionSet
 metadata:
-  name: falkordb-cluster-br
+  name: falkordb-cluster-br-v2
   labels:
     clusterdefinition.kubeblocks.io/name: falkordb-cluster
     {{- include "falkordb.labels" . | nindent 4 }}
@@ -66,7 +66,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       runOnTargetPodNode: true
       syncProgress:
         enabled: true
@@ -78,7 +78,7 @@ spec:
         {{- .Files.Get "dataprotection/backup.sh" | nindent 8 }}
   restore:
     prepareData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       command:
       - bash
       - -c
@@ -91,7 +91,7 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/wait-for-cluster-ready.sh" | nindent 10 }}
-        image: {{ include "falkordb4.image" . }}
+        image: $(FALKORDB_IMAGE)
         onError: Fail
         runOnTargetPodNode: true
     - job:
@@ -107,7 +107,7 @@ spec:
 apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: ActionSet
 metadata:
-  name: falkordb-for-pitr
+  name: falkordb-for-pitr-v2
   labels:
     clusterdefinition.kubeblocks.io/name: falkordb
     {{- include "falkordb.labels" . | nindent 4 }}
@@ -124,7 +124,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       runOnTargetPodNode: true
       syncProgress:
         enabled: true
@@ -138,7 +138,7 @@ spec:
         {{- .Files.Get "dataprotection/pitr-backup.sh" | nindent 8 }}
   restore:
     prepareData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       command:
       - bash
       - -c
@@ -154,42 +154,7 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/restore-keys.sh" | nindent 10 }}
-        image: {{ include "falkordb4.image" . }}
+        image: $(FALKORDB_IMAGE)
         onError: Fail
         runOnTargetPodNode: true
     baseBackupRequired: false
----
-apiVersion: dataprotection.kubeblocks.io/v1alpha1
-kind: ActionSet
-metadata:
-  name: falkordb-for-rebuild-instance
-  labels:
-    clusterdefinition.kubeblocks.io/name: falkordb
-    {{- include "falkordb.labels" . | nindent 4 }}
-spec:
-  backupType: Full
-  env:
-    - name: DATA_DIR
-      value: {{ .Values.dataMountPath }}
-    - name: REBUILD_CLUSTER_INSTANCE
-      value: "false"
-  backup:
-    backupData:
-      image: {{ include "busybox.image" . }}
-      runOnTargetPodNode: true
-      syncProgress:
-        enabled: true
-        intervalSeconds: 5
-      command:
-      - sh
-      - -c
-      - |
-        {{- .Files.Get "dataprotection/backup_for_rebuild.sh" | nindent 8 }}
-  restore:
-    prepareData:
-      image: {{ include "busybox.image" . }}
-      command:
-      - sh
-      - -c
-      - |
-        {{- .Files.Get "dataprotection/restore-cluster-users.sh" | nindent 8 }}

--- a/addons/falkordb/templates/backupactionset.yaml
+++ b/addons/falkordb/templates/backupactionset.yaml
@@ -16,7 +16,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       runOnTargetPodNode: true
       syncProgress:
         enabled: true
@@ -28,7 +28,7 @@ spec:
         {{- .Files.Get "dataprotection/backup.sh" | nindent 8 }}
   restore:
     prepareData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       command:
       - bash
       - -c
@@ -42,7 +42,7 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/restore-keys.sh" | nindent 10 }}
-        image: {{ include "falkordb4.image" . }}
+        image: $(FALKORDB_IMAGE)
         onError: Fail
         runOnTargetPodNode: true
 ---
@@ -66,7 +66,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       runOnTargetPodNode: true
       syncProgress:
         enabled: true
@@ -78,7 +78,7 @@ spec:
         {{- .Files.Get "dataprotection/backup.sh" | nindent 8 }}
   restore:
     prepareData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       command:
       - bash
       - -c
@@ -91,7 +91,7 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/wait-for-cluster-ready.sh" | nindent 10 }}
-        image: {{ include "falkordb4.image" . }}
+        image: $(FALKORDB_IMAGE)
         onError: Fail
         runOnTargetPodNode: true
     - job:
@@ -124,7 +124,7 @@ spec:
     preBackup: []
     postBackup: []
     backupData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       runOnTargetPodNode: true
       syncProgress:
         enabled: true
@@ -138,7 +138,7 @@ spec:
         {{- .Files.Get "dataprotection/pitr-backup.sh" | nindent 8 }}
   restore:
     prepareData:
-      image: {{ include "falkordb4.image" . }}
+      image: $(FALKORDB_IMAGE)
       command:
       - bash
       - -c
@@ -154,7 +154,7 @@ spec:
         - -c
         - |
           {{- .Files.Get "dataprotection/restore-keys.sh" | nindent 10 }}
-        image: {{ include "falkordb4.image" . }}
+        image: $(FALKORDB_IMAGE)
         onError: Fail
         runOnTargetPodNode: true
     baseBackupRequired: false

--- a/addons/falkordb/templates/backuppolicytemplate.yaml
+++ b/addons/falkordb/templates/backuppolicytemplate.yaml
@@ -20,6 +20,18 @@ spec:
         volumeMounts:
           - name: data
             mountPath: {{ .Values.dataMountPath }}
+      env:
+        - name: FALKORDB_IMAGE
+          valueFrom:
+            versionMapping:
+              {{- $repository := printf "%s/%s" (.Values.image.registry | default "docker.io") .Values.image.repository }}
+              {{- range .Values.falkordbVersions }}
+              {{- range .mirrorVersions }}
+              - serviceVersions:
+                  - {{ .version }}
+                mappedValue: {{ $repository }}:{{ .imageTag }}
+              {{- end }}
+              {{- end }}
     - name: aof
       snapshotVolumes: false
       actionSetName: falkordb-for-pitr
@@ -27,6 +39,18 @@ spec:
         volumeMounts:
           - name: data
             mountPath: {{ .Values.dataMountPath }}
+      env:
+        - name: FALKORDB_IMAGE
+          valueFrom:
+            versionMapping:
+              {{- $repository := printf "%s/%s" (.Values.image.registry | default "docker.io") .Values.image.repository }}
+              {{- range .Values.falkordbVersions }}
+              {{- range .mirrorVersions }}
+              - serviceVersions:
+                  - {{ .version }}
+                mappedValue: {{ $repository }}:{{ .imageTag }}
+              {{- end }}
+              {{- end }}
     - name: volume-snapshot
       snapshotVolumes: true
       targetVolumes:

--- a/addons/falkordb/templates/backuppolicytemplate.yaml
+++ b/addons/falkordb/templates/backuppolicytemplate.yaml
@@ -15,7 +15,7 @@ spec:
   backupMethods:
     - name: datafile
       snapshotVolumes: false
-      actionSetName: falkordb-physical-br
+      actionSetName: falkordb-physical-br-v2
       targetVolumes:
         volumeMounts:
           - name: data
@@ -34,7 +34,7 @@ spec:
               {{- end }}
     - name: aof
       snapshotVolumes: false
-      actionSetName: falkordb-for-pitr
+      actionSetName: falkordb-for-pitr-v2
       targetVolumes:
         volumeMounts:
           - name: data

--- a/addons/falkordb/templates/backuppolicytemplateforcluster.yaml
+++ b/addons/falkordb/templates/backuppolicytemplateforcluster.yaml
@@ -15,7 +15,7 @@ spec:
   backupMethods:
   - name: datafile
     snapshotVolumes: false
-    actionSetName: falkordb-cluster-br
+    actionSetName: falkordb-cluster-br-v2
     targetVolumes:
       volumeMounts:
         - name: data

--- a/addons/falkordb/templates/backuppolicytemplateforcluster.yaml
+++ b/addons/falkordb/templates/backuppolicytemplateforcluster.yaml
@@ -20,6 +20,18 @@ spec:
       volumeMounts:
         - name: data
           mountPath: {{ .Values.dataMountPath }}
+    env:
+      - name: FALKORDB_IMAGE
+        valueFrom:
+          versionMapping:
+            {{- $repository := printf "%s/%s" (.Values.image.registry | default "docker.io") .Values.image.repository }}
+            {{- range .Values.falkordbVersions }}
+            {{- range .mirrorVersions }}
+            - serviceVersions:
+                - {{ .version }}
+              mappedValue: {{ $repository }}:{{ .imageTag }}
+            {{- end }}
+            {{- end }}
   - name: backup-for-rebuild-instance
     actionSetName: falkordb-for-rebuild-instance
     env:


### PR DESCRIPTION
Closes #3192

## Problem

FalkorDB ActionSets rendered the chart-default engine image into every backup and restore job, so new backups did not follow the target Cluster service version. A direct replacement of the existing ActionSet image fields would introduce a second failure: old Backup objects persist the legacy ActionSet names, but do not persist `FALKORDB_IMAGE`, so their restores must continue to resolve the original fixed-image ActionSets.

This PR preserves both contracts:

- old Backup objects keep resolving the unchanged legacy ActionSet names and their original v4.12.5 image;
- new BackupPolicyTemplates select version-aware ActionSets whose engine image is mapped from the target service version.

## Change

- preserve `falkordb-physical-br`, `falkordb-cluster-br`, and `falkordb-for-pitr` as legacy fixed-image ActionSets for existing Backup restore compatibility;
- add `falkordb-physical-br-v2`, `falkordb-cluster-br-v2`, and `falkordb-for-pitr-v2` for new backups;
- point the standalone and cluster BackupPolicyTemplates at the new `-v2` ActionSets;
- add `FALKORDB_IMAGE` `versionMapping` entries for standalone `datafile`, standalone `aof`, and cluster `datafile` methods;
- derive mapped refs from the same registry, repository, and mirror-version values as ComponentVersion rendering;
- leave the independent busybox rebuild and ape-dts cluster restore jobs unchanged;
- add render-contract tests for the legacy names/images, the version-aware names/images, and exact 4.12.5/4.14.12 mappings.

## Evidence

TDD causal check: applying the current spec to base `b55707f0` produced 3 failing examples: the `-v2` template was absent and both BackupPolicyTemplates still selected legacy ActionSets.

Current-head checks at `e0e51ace56f20b43e6a8083a06fea44619670b32`:

- focused backup mapping ShellSpec: 4 examples, 0 failures;
- full FalkorDB ShellSpec on bash 5.3: 210 examples, 0 failures;
- full FalkorDB ShellSpec on system bash 3.2: 42 examples, 0 failures, 4 existing bash-version skips;
- `helm lint addons/falkordb`: pass;
- focused Helm render: 3 legacy ActionSets with 9 fixed v4.12.5 engine images, 3 version-aware ActionSets with 9 mapped engine images, and 3 policy references to `-v2` with no legacy policy reference;
- ShellCheck for the mapping spec: pass;
- `git diff --check`: pass.

No Kubernetes environment was mutated by this code change. Runtime validation remains required for a fresh 4.14.12 provision, backup/restore, and service connectivity.