### PR TITLE
fix(rabbitmq): restore single-segment volume target paths

### DIFF
--- a/addons/rabbitmq/dataprotection/restore.sh
+++ b/addons/rabbitmq/dataprotection/restore.sh
@@ -3,9 +3,26 @@ set -Eeuo pipefail
 
 DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
 # Backup jobs inject DP_TARGET_POD_NAME. Volume-populator AsDataSource prepareData
-# may only inject DP_TARGET_RELATIVE_PATH (= pod identity / archive stem). Prefer
-# POD_NAME when present; otherwise accept RELATIVE_PATH so KB12 dataSource restore works.
-TARGET_POD_NAME="${DP_TARGET_POD_NAME:-${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}}"
+# may only inject DP_TARGET_RELATIVE_PATH, either as <pod-name> or
+# <target-name>/<pod-name>. DP_BACKUP_BASE_PATH is already scoped to that path,
+# so the archive key always uses only the final pod-name segment.
+if [ -n "${DP_TARGET_POD_NAME:-}" ]; then
+  TARGET_POD_NAME="${DP_TARGET_POD_NAME}"
+else
+  TARGET_RELATIVE_PATH="${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}"
+  case "${TARGET_RELATIVE_PATH}" in
+    /*|*/|*/*/*)
+      echo "ERROR: DP_TARGET_RELATIVE_PATH must be one pod segment or <target-name>/<target-pod-name>" >&2
+      exit 1
+      ;;
+    */*)
+      TARGET_POD_NAME="${TARGET_RELATIVE_PATH##*/}"
+      ;;
+    *)
+      TARGET_POD_NAME="${TARGET_RELATIVE_PATH}"
+      ;;
+  esac
+fi
 ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
 
 [ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"

--- a/addons/rabbitmq/dataprotection/restore.sh
+++ b/addons/rabbitmq/dataprotection/restore.sh
@@ -3,26 +3,9 @@ set -Eeuo pipefail
 
 DATA_DIR="${DATA_DIR:-/var/lib/rabbitmq}"
 # Backup jobs inject DP_TARGET_POD_NAME. Volume-populator AsDataSource prepareData
-# may only inject DP_TARGET_RELATIVE_PATH (= target name / target pod name).
-# DP_BACKUP_BASE_PATH is already scoped to that relative path, so only its final
-# pod-name segment belongs in the archive key.
-if [ -n "${DP_TARGET_POD_NAME:-}" ]; then
-  TARGET_POD_NAME="${DP_TARGET_POD_NAME}"
-else
-  TARGET_RELATIVE_PATH="${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}"
-  TARGET_NAME="${TARGET_RELATIVE_PATH%%/*}"
-  TARGET_POD_NAME="${TARGET_RELATIVE_PATH#*/}"
-  if [ "${TARGET_NAME}" = "${TARGET_RELATIVE_PATH}" ] || [ -z "${TARGET_NAME}" ] || [ -z "${TARGET_POD_NAME}" ]; then
-    echo "ERROR: DP_TARGET_RELATIVE_PATH must be <target-name>/<target-pod-name>" >&2
-    exit 1
-  fi
-  case "${TARGET_POD_NAME}" in
-    */*)
-      echo "ERROR: DP_TARGET_RELATIVE_PATH must be <target-name>/<target-pod-name>" >&2
-      exit 1
-      ;;
-  esac
-fi
+# may only inject DP_TARGET_RELATIVE_PATH (= pod identity / archive stem). Prefer
+# POD_NAME when present; otherwise accept RELATIVE_PATH so KB12 dataSource restore works.
+TARGET_POD_NAME="${DP_TARGET_POD_NAME:-${DP_TARGET_RELATIVE_PATH:?DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required}}"
 ARCHIVE_NAME="${TARGET_POD_NAME}.tar.zst"
 
 [ -n "${DP_DATASAFED_BIN_PATH:-}" ] && export PATH="${PATH}:${DP_DATASAFED_BIN_PATH}"

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -132,6 +132,7 @@ DATASAFED
       PATH="${bin_dir}:${PATH}" \
         DATA_DIR="${data_dir}" \
         DP_TARGET_POD_NAME="rabbitmq-cluster-rabbitmq-0" \
+        DP_TARGET_RELATIVE_PATH="ignored/extra/depth" \
         DP_BACKUP_BASE_PATH="/backup/base" \
         FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
         bash "${restore_script}"
@@ -189,6 +190,81 @@ DATASAFED
     ' _ "${restore_script}"
     The status should be success
     The stdout should include "restore prepareData completed"
+  End
+
+  It "uses the final pod segment from a two-segment volume-populator target path"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      tmp_dir="$(mktemp -d)"
+      trap "rm -rf \"${tmp_dir}\"" EXIT
+      data_dir="${tmp_dir}/data"
+      bin_dir="${tmp_dir}/bin"
+      payload_dir="${tmp_dir}/payload"
+      mkdir -p "${data_dir}" "${bin_dir}" "${payload_dir}"
+      printf "restored-via-relative\n" > "${payload_dir}/restored.txt"
+      tar -cf "${tmp_dir}/payload.tar" -C "${payload_dir}" .
+      cat > "${bin_dir}/datasafed" <<'"'"'DATASAFED'"'"'
+#!/bin/bash
+set -e
+case "$1" in
+  list)
+    test "${DATASAFED_BACKEND_BASE_PATH}" = "${EXPECTED_BACKUP_BASE_PATH}"
+    printf "%s\n" "${EXPECTED_TARGET_POD_NAME}.tar.zst"
+    ;;
+  pull)
+    cat "${FAKE_ARCHIVE_PATH}"
+    ;;
+  *)
+    echo "unexpected datasafed command: $*" >&2
+    exit 1
+    ;;
+esac
+DATASAFED
+      printf "#!/bin/bash\nexit 0\n" > "${bin_dir}/chown"
+      chmod +x "${bin_dir}/datasafed" "${bin_dir}/chown"
+      unset DP_TARGET_POD_NAME || true
+      PATH="${bin_dir}:${PATH}" \
+        DATA_DIR="${data_dir}" \
+        DP_TARGET_RELATIVE_PATH="rabbitmq/rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_TARGET_POD_NAME="rmq-br-5400-rabbitmq-2" \
+        FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
+        bash "${restore_script}"
+      test -f "${data_dir}/restored.txt"
+      test ! -f "${data_dir}/.kb-data-protection"
+    ' _ "${restore_script}"
+    The status should be success
+    The stdout should include "restore prepareData completed"
+  End
+
+  It "fails closed when the target relative path has an empty final segment"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      unset DP_TARGET_POD_NAME || true
+      DATA_DIR="$(mktemp -d)" \
+        DP_TARGET_RELATIVE_PATH="rabbitmq/" \
+        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq" \
+        bash "${restore_script}"
+    ' _ "${restore_script}"
+    The status should be failure
+    The stderr should include "must be one pod segment or <target-name>/<target-pod-name>"
+  End
+
+  It "fails closed when the target relative path has extra depth"
+    When call bash -c '
+      set -Eeuo pipefail
+      restore_script="$1"
+      unset DP_TARGET_POD_NAME || true
+      DATA_DIR="$(mktemp -d)" \
+        DP_TARGET_RELATIVE_PATH="repo/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base/repo/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        bash "${restore_script}"
+    ' _ "${restore_script}"
+    The status should be failure
+    The stderr should include "must be one pod segment or <target-name>/<target-pod-name>"
   End
 
   It "fails closed when neither DP_TARGET_POD_NAME nor DP_TARGET_RELATIVE_PATH is set"

--- a/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
+++ b/addons/rabbitmq/scripts-ut-spec/backup_restore_contract_spec.sh
@@ -143,7 +143,7 @@ DATASAFED
     The stdout should include "restore prepareData completed"
   End
 
-  It "uses only the pod-name stem from the volume-populator target relative path"
+  It "accepts the single-segment volume-populator target path as the archive stem"
     When call bash -c '
       set -Eeuo pipefail
       restore_script="$1"
@@ -178,9 +178,9 @@ DATASAFED
       unset DP_TARGET_POD_NAME || true
       PATH="${bin_dir}:${PATH}" \
         DATA_DIR="${data_dir}" \
-        DP_TARGET_RELATIVE_PATH="rabbitmq/rmq-br-5400-rabbitmq-2" \
-        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
-        EXPECTED_BACKUP_BASE_PATH="/backup/base/rabbitmq/rmq-br-5400-rabbitmq-2" \
+        DP_TARGET_RELATIVE_PATH="rmq-br-5400-rabbitmq-2" \
+        DP_BACKUP_BASE_PATH="/backup/base/rmq-br-5400-rabbitmq-2" \
+        EXPECTED_BACKUP_BASE_PATH="/backup/base/rmq-br-5400-rabbitmq-2" \
         EXPECTED_TARGET_POD_NAME="rmq-br-5400-rabbitmq-2" \
         FAKE_ARCHIVE_PATH="${tmp_dir}/payload.tar" \
         bash "${restore_script}"
@@ -200,20 +200,6 @@ DATASAFED
     ' _ "${restore_script}"
     The status should be failure
     The stderr should include "DP_TARGET_POD_NAME or DP_TARGET_RELATIVE_PATH is required"
-  End
-
-  It "fails closed when the target relative path has no pod-name segment"
-    When call bash -c '
-      set -Eeuo pipefail
-      restore_script="$1"
-      unset DP_TARGET_POD_NAME || true
-      DATA_DIR="$(mktemp -d)" \
-        DP_TARGET_RELATIVE_PATH="rabbitmq/" \
-        DP_BACKUP_BASE_PATH="/backup/base/rabbitmq" \
-        bash "${restore_script}"
-    ' _ "${restore_script}"
-    The status should be failure
-    The stderr should include "must be <target-name>/<target-pod-name>"
   End
 
   It "reconciles the restored system account idempotently after RabbitMQ is ready"


### PR DESCRIPTION
## Problem

The integrated candidate `f48116a5` includes #3183's assumption that KB 1.2 volume-populator injects `DP_TARGET_RELATIVE_PATH=<target-name>/<target-pod-name>`.

In task #81 full runtime, all three prepareData Jobs instead received a single pod-identity segment, for example:

```text
DP_TARGET_RELATIVE_PATH=rmq-br-1974-rabbitmq-2
DP_BACKUP_BASE_PATH=.../rmq-br-1974-rabbitmq-2
```

The restore action rejected that value before `datasafed pull`, all three Jobs reached `BackoffLimitExceeded`, and B/R T05 was the full run's sole failure (`PASS=396 FAIL=1 SKIP=12`).

## Fix

Restore the parent behavior from `0c027e5d`: prefer `DP_TARGET_POD_NAME`, otherwise use the injected single-segment `DP_TARGET_RELATIVE_PATH` directly as the archive stem. `DP_BACKUP_BASE_PATH` remains unchanged because DP already scopes it to the target pod.

This is a one-commit correction on top of the exact integrated candidate branch.

## Evidence

- TDD RED on `f48116a5`: focused contract spec 14 examples / 1 failure with the observed single-segment input; stderr was the exact runtime rejection.
- GREEN on head `80f98fe3`: focused 14/0; all RabbitMQ ShellSpecs 28/0.
- `bash -n`, ShellCheck, and `git diff --check` pass.
- Runtime evidence and sealed artifact are linked on #3183: <https://github.com/apecloud/kubeblocks-addons/pull/3183#issuecomment-4963853648>.

Evidence scope is one full run / one topology with three target PVCs. A focused B/R rerun on this exact head is required before broader acceptance.
