### PR TITLE
fix(milvus): migrate embedded MinIO credentials

### DIFF
--- a/addons-cluster/milvus/Chart.yaml
+++ b/addons-cluster/milvus/Chart.yaml
@@ -4,7 +4,7 @@ description: A Milvus cluster Helm chart for KubeBlocks.
 
 type: application
 
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 
 appVersion: 2.3.2
 

--- a/addons-cluster/milvus/Chart.yaml
+++ b/addons-cluster/milvus/Chart.yaml
@@ -4,7 +4,7 @@ description: A Milvus cluster Helm chart for KubeBlocks.
 
 type: application
 
-version: 1.2.0-alpha.1
+version: 1.2.0-alpha.0
 
 appVersion: 2.3.2
 

--- a/addons-cluster/milvus/templates/standalone.yaml
+++ b/addons-cluster/milvus/templates/standalone.yaml
@@ -11,7 +11,7 @@ spec:
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
   componentSpecs:
     - name: etcd
-      componentDef: etcd-
+      componentDef: etcd
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
     - name: minio
-      componentDef: milvus-minio-
+      componentDef: milvus-minio-{{ .Chart.Version }}
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
     - name: milvus
-      componentDef: milvus-standalone-
+      componentDef: milvus-standalone-{{ .Chart.Version }}
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}

--- a/addons-cluster/milvus/templates/standalone.yaml
+++ b/addons-cluster/milvus/templates/standalone.yaml
@@ -11,7 +11,6 @@ spec:
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
   componentSpecs:
     - name: etcd
-      componentDef: etcd
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}
@@ -20,7 +19,6 @@ spec:
       {{- end }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
     - name: minio
-      componentDef: milvus-minio-{{ .Chart.Version }}
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}
@@ -29,7 +27,6 @@ spec:
       {{- end }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
     - name: milvus
-      componentDef: milvus-standalone-{{ .Chart.Version }}
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}

--- a/addons-cluster/milvus/templates/standalone.yaml
+++ b/addons-cluster/milvus/templates/standalone.yaml
@@ -11,6 +11,7 @@ spec:
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
   componentSpecs:
     - name: etcd
+      componentDef: etcd-
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}

--- a/addons-cluster/milvus/templates/standalone.yaml
+++ b/addons-cluster/milvus/templates/standalone.yaml
@@ -19,6 +19,7 @@ spec:
       {{- end }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
     - name: minio
+      componentDef: milvus-minio-
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}
@@ -27,6 +28,7 @@ spec:
       {{- end }}
       {{- include "kblib.componentMonitor" . | indent 6 }}
     - name: milvus
+      componentDef: milvus-standalone-
       replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if .Values.persistence.enabled }}

--- a/addons/milvus/Chart.yaml
+++ b/addons/milvus/Chart.yaml
@@ -5,7 +5,7 @@ description: A cloud-native vector database, storage for next generation AI appl
 type: application
 
 # This is the chart version
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 
 home: https://milvus.io/
 icon: https://github.com/milvus-io/artwork/blob/master/horizontal/color/milvus-horizontal-color.png

--- a/addons/milvus/README.md
+++ b/addons/milvus/README.md
@@ -66,6 +66,11 @@ Helm update of the existing Cluster's `spec.componentSpecs`: KubeBlocks owns
 that atomic field after topology resolution, so another field manager can be
 rejected or can overwrite controller-owned state.
 
+The addon upgrade also narrows the retained alpha.0 and current alpha.1
+Milvus parameter definitions to their exact ComponentDefinition versions.
+This prevents both definitions from claiming the same `user.yaml` file while
+the Cluster transitions between immutable component versions.
+
 Then edit the namespace, Cluster name, and OpsRequest name in
 `examples/upgrade-embedded-minio-credential.yaml` and create it. The KubeBlocks
 `Upgrade` OpsRequest changes the two ComponentDefinitions through the owning

--- a/addons/milvus/README.md
+++ b/addons/milvus/README.md
@@ -54,6 +54,33 @@ Milvus is an open source (Apache-2.0 licensed) vector database built to power em
 
 ## Examples
 
+### Upgrade an affected standalone cluster to 1.2.0-alpha.1
+
+Milvus addon `1.2.0-alpha.1` replaces the embedded MinIO `admin` account with a
+generated `root` account. Existing standalone Clusters must switch both the
+embedded MinIO component and the Milvus component to the new immutable
+ComponentDefinitions.
+
+First upgrade the Milvus addon definitions to `1.2.0-alpha.1`. Do not force a
+Helm update of the existing Cluster's `spec.componentSpecs`: KubeBlocks owns
+that atomic field after topology resolution, so another field manager can be
+rejected or can overwrite controller-owned state.
+
+Then edit the namespace and Cluster name in
+`examples/upgrade-embedded-minio-credential.yaml` and apply it. The KubeBlocks
+`Upgrade` OpsRequest changes the two ComponentDefinitions through the owning
+control plane:
+
+```bash
+kubectl apply -f examples/upgrade-embedded-minio-credential.yaml
+```
+
+Wait for the OpsRequest to reach `Succeed` before checking the Cluster. The
+expected definitions are `milvus-minio-1.2.0-alpha.1` and
+`milvus-standalone-1.2.0-alpha.1`; both components then reference the new
+non-empty `root` credential. Do not use server-side apply
+`--force-conflicts` on the Cluster as a migration shortcut.
+
 ### Create
 
 #### Standalone Mode

--- a/addons/milvus/README.md
+++ b/addons/milvus/README.md
@@ -69,7 +69,11 @@ rejected or can overwrite controller-owned state.
 Then edit the namespace, Cluster name, and OpsRequest name in
 `examples/upgrade-embedded-minio-credential.yaml` and create it. The KubeBlocks
 `Upgrade` OpsRequest changes the two ComponentDefinitions through the owning
-control plane:
+control plane. The example sets `preConditionDeadlineSeconds: 600` because an
+affected alpha.0 Cluster can still be `Creating` while MinIO is failing; the
+OpsRequest waits boundedly for KubeBlocks to classify the Cluster `Abnormal`,
+which is an allowed Upgrade source phase. Do not replace this wait with
+`force: true`:
 
 ```bash
 kubectl create -f examples/upgrade-embedded-minio-credential.yaml
@@ -87,7 +91,10 @@ bash scripts/recover-embedded-minio-credential.sh \
 
 The helper first waits until the MinIO Component and InstanceSet both show
 `milvus-minio-1.2.0-alpha.1` and the new `root` Secret has non-empty credential
-data. Only then, if the sole MinIO Pod still uses the alpha.0 definition, it
+data. It validates the bounded precondition wait and rejects `force`; if the
+OpsRequest reaches a terminal failure while desired state is pending, it exits
+immediately with that state. Only after desired state is ready, if the sole
+MinIO Pod still uses the alpha.0 definition, it
 verifies that the Pod is controlled by the expected InstanceSet and deletes
 that Pod without deleting its PVC or either Secret. KubeBlocks recreates the
 Pod from the alpha.1 template. The helper exits successfully only after the
@@ -98,8 +105,8 @@ uses alpha.1.
 
 Finally, verify Milvus service connectivity. Both MinIO and Milvus must consume
 the new non-empty `root` credential. Do not use server-side apply
-`--force-conflicts` on the Cluster as a migration shortcut, and do not delete
-the affected PVC.
+`--force-conflicts` on the Cluster or `force: true` on the OpsRequest as a
+migration shortcut, and do not delete the affected PVC.
 
 ### Create
 

--- a/addons/milvus/README.md
+++ b/addons/milvus/README.md
@@ -66,20 +66,40 @@ Helm update of the existing Cluster's `spec.componentSpecs`: KubeBlocks owns
 that atomic field after topology resolution, so another field manager can be
 rejected or can overwrite controller-owned state.
 
-Then edit the namespace and Cluster name in
-`examples/upgrade-embedded-minio-credential.yaml` and apply it. The KubeBlocks
+Then edit the namespace, Cluster name, and OpsRequest name in
+`examples/upgrade-embedded-minio-credential.yaml` and create it. The KubeBlocks
 `Upgrade` OpsRequest changes the two ComponentDefinitions through the owning
 control plane:
 
 ```bash
-kubectl apply -f examples/upgrade-embedded-minio-credential.yaml
+kubectl create -f examples/upgrade-embedded-minio-credential.yaml
 ```
 
-Wait for the OpsRequest to reach `Succeed` before checking the Cluster. The
-expected definitions are `milvus-minio-1.2.0-alpha.1` and
-`milvus-standalone-1.2.0-alpha.1`; both components then reference the new
-non-empty `root` credential. Do not use server-side apply
-`--force-conflicts` on the Cluster as a migration shortcut.
+An affected alpha.0 MinIO Pod is already NotReady because its generated
+`admin` password is empty. KubeBlocks intentionally does not roll an unavailable
+Pod during a normal component upgrade. After creating the OpsRequest, run the
+bounded recovery helper with the same namespace, Cluster, and OpsRequest names:
+
+```bash
+bash scripts/recover-embedded-minio-credential.sh \
+  demo milvus-standalone milvus-standalone-minio-root-migrate
+```
+
+The helper first waits until the MinIO Component and InstanceSet both show
+`milvus-minio-1.2.0-alpha.1` and the new `root` Secret has non-empty credential
+data. Only then, if the sole MinIO Pod still uses the alpha.0 definition, it
+verifies that the Pod is controlled by the expected InstanceSet and deletes
+that Pod without deleting its PVC or either Secret. KubeBlocks recreates the
+Pod from the alpha.1 template. The helper exits successfully only after the
+replacement Pod is Ready, the OpsRequest is `Succeed`, and the Cluster is
+`Running`; each wait has a finite timeout and reports its first and last
+observations on failure. It is safe to rerun after the replacement Pod already
+uses alpha.1.
+
+Finally, verify Milvus service connectivity. Both MinIO and Milvus must consume
+the new non-empty `root` credential. Do not use server-side apply
+`--force-conflicts` on the Cluster as a migration shortcut, and do not delete
+the affected PVC.
 
 ### Create
 

--- a/addons/milvus/examples/upgrade-embedded-minio-credential.yaml
+++ b/addons/milvus/examples/upgrade-embedded-minio-credential.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: demo
 spec:
   clusterName: milvus-standalone
+  # An affected alpha.0 Cluster can still be Creating while its MinIO Pod is
+  # failing. Wait boundedly for KubeBlocks to classify it Abnormal instead of
+  # failing this Upgrade immediately or bypassing the phase gate with force.
+  preConditionDeadlineSeconds: 600
   type: Upgrade
   upgrade:
     components:

--- a/addons/milvus/examples/upgrade-embedded-minio-credential.yaml
+++ b/addons/milvus/examples/upgrade-embedded-minio-credential.yaml
@@ -1,0 +1,14 @@
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  generateName: milvus-standalone-minio-credential-
+  namespace: demo
+spec:
+  clusterName: milvus-standalone
+  type: Upgrade
+  upgrade:
+    components:
+      - componentName: minio
+        componentDefinitionName: milvus-minio-1.2.0-alpha.1
+      - componentName: milvus
+        componentDefinitionName: milvus-standalone-1.2.0-alpha.1

--- a/addons/milvus/examples/upgrade-embedded-minio-credential.yaml
+++ b/addons/milvus/examples/upgrade-embedded-minio-credential.yaml
@@ -1,7 +1,7 @@
 apiVersion: operations.kubeblocks.io/v1alpha1
 kind: OpsRequest
 metadata:
-  generateName: milvus-standalone-minio-credential-
+  name: milvus-standalone-minio-root-migrate
   namespace: demo
 spec:
   clusterName: milvus-standalone

--- a/addons/milvus/releases_notes.yaml
+++ b/addons/milvus/releases_notes.yaml
@@ -2,7 +2,7 @@ releases:
   - version: "1.2.0-alpha.1"
     released_at: ""
     status: "alpha"
-    notes: "Migrate embedded MinIO credentials to a generated root account. Existing affected standalone Clusters use the shipped Upgrade OpsRequest plus the bounded recovery helper, which replaces only the stale alpha.0 MinIO Pod after the alpha.1 desired contract is visible."
+    notes: "Migrate embedded MinIO credentials to a generated root account. Existing affected standalone Clusters use the shipped Upgrade OpsRequest with a bounded Cluster-phase precondition plus the recovery helper, which replaces only the stale alpha.0 MinIO Pod after the alpha.1 desired contract is visible."
     git_branch: "main"
     git_tag: ""
     commit_sha: ""

--- a/addons/milvus/releases_notes.yaml
+++ b/addons/milvus/releases_notes.yaml
@@ -2,7 +2,7 @@ releases:
   - version: "1.2.0-alpha.1"
     released_at: ""
     status: "alpha"
-    notes: "Migrate embedded MinIO credentials to a generated root account. Existing standalone Clusters must upgrade the minio and milvus ComponentDefinitions through an Upgrade OpsRequest."
+    notes: "Migrate embedded MinIO credentials to a generated root account. Existing affected standalone Clusters use the shipped Upgrade OpsRequest plus the bounded recovery helper, which replaces only the stale alpha.0 MinIO Pod after the alpha.1 desired contract is visible."
     git_branch: "main"
     git_tag: ""
     commit_sha: ""

--- a/addons/milvus/releases_notes.yaml
+++ b/addons/milvus/releases_notes.yaml
@@ -2,7 +2,7 @@ releases:
   - version: "1.2.0-alpha.1"
     released_at: ""
     status: "alpha"
-    notes: "Migrate embedded MinIO credentials to a generated root account. Existing affected standalone Clusters use the shipped Upgrade OpsRequest with a bounded Cluster-phase precondition plus the recovery helper, which replaces only the stale alpha.0 MinIO Pod after the alpha.1 desired contract is visible."
+    notes: "Migrate embedded MinIO credentials to a generated root account. Existing affected standalone Clusters use the shipped Upgrade OpsRequest with a bounded Cluster-phase precondition plus the recovery helper, which replaces only the stale alpha.0 MinIO Pod after the alpha.1 desired contract is visible. Retained alpha.0 and current alpha.1 Milvus parameter definitions are bound to their exact ComponentDefinition versions so they cannot both claim user.yaml during migration."
     git_branch: "main"
     git_tag: ""
     commit_sha: ""

--- a/addons/milvus/releases_notes.yaml
+++ b/addons/milvus/releases_notes.yaml
@@ -1,4 +1,12 @@
 releases:
+  - version: "1.2.0-alpha.1"
+    released_at: ""
+    status: "alpha"
+    notes: "Migrate embedded MinIO credentials to a generated root account. Existing standalone Clusters must upgrade the minio and milvus ComponentDefinitions through an Upgrade OpsRequest."
+    git_branch: "main"
+    git_tag: ""
+    commit_sha: ""
+    breaking_changes: "The embedded MinIO system account changes from admin to root."
   - version: "1.0.1"
     released_at: "2025-09-11"
     status: "stable"

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -91,6 +91,8 @@ client_contract=true"
       puts "etcd=#{components.dig("etcd", "componentDef")}"
       puts "minio=#{components.dig("minio", "componentDef")}"
       puts "milvus=#{components.dig("milvus", "componentDef")}"
+      pattern = /\A[a-z]([a-z0-9.\-]*[a-z0-9])?\z/
+      puts "schema_valid=#{components.values.all? { |item| item["componentDef"].match?(pattern) }}"
     '
   }
 
@@ -98,9 +100,10 @@ client_contract=true"
     When call render_upgrade_contract
     The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.1
 definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
-etcd=etcd-
-minio=milvus-minio-
-milvus=milvus-standalone-"
+etcd=etcd
+minio=milvus-minio-1.2.0-alpha.1
+milvus=milvus-standalone-1.2.0-alpha.1
+schema_valid=true"
     The status should be success
   End
 End

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -94,7 +94,8 @@ client_contract=true"
     ruby -ryaml -e '
       migration = YAML.load_file("../examples/upgrade-embedded-minio-credential.yaml")
       components = migration.dig("spec", "upgrade", "components").to_h { |item| [item["componentName"], item] }
-      puts "migration=#{migration.dig("metadata", "name")},#{migration.dig("spec", "type")},#{components.dig("minio", "componentDefinitionName")},#{components.dig("milvus", "componentDefinitionName")}"
+      forced = migration.dig("spec", "force") == true ? "true" : "false"
+      puts "migration=#{migration.dig("metadata", "name")},#{migration.dig("spec", "type")},precondition=#{migration.dig("spec", "preConditionDeadlineSeconds")},force=#{forced},#{components.dig("minio", "componentDefinitionName")},#{components.dig("milvus", "componentDefinitionName")}"
     '
   }
 
@@ -103,7 +104,7 @@ client_contract=true"
     The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.0
 definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
 cluster_definition_api=topology
-migration=milvus-standalone-minio-root-migrate,Upgrade,milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1"
+migration=milvus-standalone-minio-root-migrate,Upgrade,precondition=600,force=false,milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1"
     The status should be success
   End
 End

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -88,6 +88,7 @@ client_contract=true"
       abort "standalone Cluster not rendered" unless cluster
 
       components = cluster.dig("spec", "componentSpecs").to_h { |item| [item["name"], item] }
+      puts "etcd=#{components.dig("etcd", "componentDef")}"
       puts "minio=#{components.dig("minio", "componentDef")}"
       puts "milvus=#{components.dig("milvus", "componentDef")}"
     '
@@ -97,6 +98,7 @@ client_contract=true"
     When call render_upgrade_contract
     The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.1
 definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
+etcd=etcd-
 minio=milvus-minio-
 milvus=milvus-standalone-"
     The status should be success

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -82,6 +82,7 @@ client_contract=true"
       puts "definitions=#{names.grep(/milvus-(minio|standalone)-/).sort.join(",")}"
     '
 
+    helm dependency build ../../../addons-cluster/milvus >/dev/null
     helm template milvus-cluster ../../../addons-cluster/milvus --set mode=standalone | ruby -ryaml -e '
       cluster = YAML.load_stream(ARGF.read).compact.find { |document| document["kind"] == "Cluster" }
       abort "standalone Cluster not rendered" unless cluster

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -77,9 +77,34 @@ client_contract=true"
     printf 'versions=%s,%s\n' "$addon_version" "$cluster_version"
 
     helm template milvus .. | ruby -ryaml -e '
-      definitions = YAML.load_stream(ARGF.read).compact.select { |document| document["kind"] == "ComponentDefinition" }
+      documents = YAML.load_stream(ARGF.read).compact
+      definitions = documents.select { |document| document["kind"] == "ComponentDefinition" }
       names = definitions.map { |definition| definition.dig("metadata", "name") }
-      puts "definitions=#{names.grep(/milvus-(minio|standalone)-/).sort.join(",")}"
+      definition_names = names.grep(/milvus-(minio|standalone)-/).sort.join(",")
+      puts "definitions=#{definition_names}"
+
+      parameter_definitions = documents.select do |document|
+        document["kind"] == "ParametersDefinition" &&
+          document.dig("metadata", "name").start_with?("milvus-standalone-pd-")
+      end.sort_by { |document| document.dig("metadata", "name") }
+      abort "expected two Milvus standalone ParametersDefinitions" unless parameter_definitions.length == 2
+
+      bindings = parameter_definitions.map do |definition|
+        [definition.dig("metadata", "name"), definition.dig("spec", "componentDef")]
+      end
+      binding_names = bindings.map { |name, pattern| "#{name}:#{pattern}" }.join(",")
+      puts "parameter_definitions=#{binding_names}"
+
+      component_definitions = %w[
+        milvus-standalone-1.2.0-alpha.0
+        milvus-standalone-1.2.0-alpha.1
+      ]
+      matrix = bindings.map do |name, pattern|
+        matches = component_definitions.select { |component_definition| Regexp.new(pattern).match?(component_definition) }
+        abort "#{name} must match exactly one ComponentDefinition" unless matches.length == 1
+        "#{name}:#{matches.first}"
+      end
+      puts "parameter_binding_matrix=#{matrix.join(",")}"
     '
 
     helm dependency build ../../../addons-cluster/milvus >/dev/null
@@ -103,6 +128,8 @@ client_contract=true"
     When call render_upgrade_contract
     The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.0
 definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
+parameter_definitions=milvus-standalone-pd-1.2.0-alpha.0:^milvus-standalone-1[.]2[.]0-alpha[.]0$,milvus-standalone-pd-1.2.0-alpha.1:^milvus-standalone-1[.]2[.]0-alpha[.]1$
+parameter_binding_matrix=milvus-standalone-pd-1.2.0-alpha.0:milvus-standalone-1.2.0-alpha.0,milvus-standalone-pd-1.2.0-alpha.1:milvus-standalone-1.2.0-alpha.1
 cluster_definition_api=topology
 migration=milvus-standalone-minio-root-migrate,Upgrade,precondition=600,force=false,milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1"
     The status should be success

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -1,0 +1,71 @@
+# shellcheck shell=bash
+
+Describe "Milvus embedded MinIO credential contract"
+  render_contract() {
+    helm template milvus .. | ruby -ryaml -e '
+      documents = YAML.load_stream(ARGF.read).compact
+      component = documents.find do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("spec", "serviceKind") == "milvus-minio"
+      end
+      abort "milvus-minio ComponentDefinition not rendered" unless component
+
+      account = component.dig("spec", "systemAccounts").find do |item|
+        item["name"] == "admin"
+      end
+      abort "admin system account not rendered" unless account
+
+      policy = account["passwordGenerationPolicy"] || {}
+      puts "policy=#{policy.values_at("length", "numDigits", "numSymbols", "letterCase").join(",")}"
+
+      vars = component.dig("spec", "vars").to_h { |item| [item["name"], item] }
+      user_ref = vars.dig("MINIO_ROOT_USER", "valueFrom", "credentialVarRef") || {}
+      password_ref = vars.dig("MINIO_ROOT_PASSWORD", "valueFrom", "credentialVarRef") || {}
+      puts "user=#{user_ref.values_at("name", "optional", "username").join(",")}"
+      puts "password=#{password_ref.values_at("name", "optional", "password").join(",")}"
+      puts "server_legacy=#{vars.key?("MINIO_ACCESS_KEY") || vars.key?("MINIO_SECRET_KEY")}"
+
+      standalone = documents.find do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("spec", "serviceKind") == "milvus" &&
+          document["metadata"]["name"].include?("standalone")
+      end
+      abort "milvus standalone ComponentDefinition not rendered" unless standalone
+
+      client_vars = standalone.dig("spec", "vars").to_h { |item| [item["name"], item] }
+      access_ref = client_vars.dig("MINIO_ACCESS_KEY", "valueFrom", "credentialVarRef") || {}
+      secret_ref = client_vars.dig("MINIO_SECRET_KEY", "valueFrom", "credentialVarRef") || {}
+      puts "client_access=#{access_ref.values_at("name", "optional", "username").join(",")}"
+      puts "client_secret=#{secret_ref.values_at("name", "optional", "password").join(",")}"
+      puts "client_root=#{client_vars.key?("MINIO_ROOT_USER") || client_vars.key?("MINIO_ROOT_PASSWORD")}"
+
+      clients = documents.select do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("spec", "serviceKind") == "milvus"
+      end
+      client_contract = clients.all? do |document|
+        names = document.dig("spec", "vars").map { |item| item["name"] }
+        names.include?("MINIO_ACCESS_KEY") &&
+          names.include?("MINIO_SECRET_KEY") &&
+          !names.include?("MINIO_ROOT_USER") &&
+          !names.include?("MINIO_ROOT_PASSWORD")
+      end
+      puts "client_components=#{clients.map { |document| document["metadata"]["name"].sub(/-1[.].*$/, "") }.sort.join(",")}"
+      puts "client_contract=#{client_contract}"
+    '
+  }
+
+  It "renders an explicit non-empty password policy and separates server and client variables"
+    When call render_contract
+    The output should eq "policy=16,4,0,MixedCases
+user=admin,false,Required
+password=admin,false,Required
+server_legacy=false
+client_access=admin,false,Required
+client_secret=admin,false,Required
+client_root=false
+client_components=milvus-datanode,milvus-indexnode,milvus-mixcoord,milvus-proxy,milvus-querynode,milvus-standalone
+client_contract=true"
+    The status should be success
+  End
+End

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -11,9 +11,10 @@ Describe "Milvus embedded MinIO credential contract"
       abort "milvus-minio ComponentDefinition not rendered" unless component
 
       account = component.dig("spec", "systemAccounts").find do |item|
-        item["name"] == "admin"
+        item["name"] == "root"
       end
-      abort "admin system account not rendered" unless account
+      abort "root system account not rendered" unless account
+      puts "accounts=#{component.dig("spec", "systemAccounts").map { |item| item["name"] }.join(",")}"
 
       policy = account["passwordGenerationPolicy"] || {}
       puts "policy=#{policy.values_at("length", "numDigits", "numSymbols", "letterCase").join(",")}"
@@ -57,15 +58,46 @@ Describe "Milvus embedded MinIO credential contract"
 
   It "renders an explicit non-empty password policy and separates server and client variables"
     When call render_contract
-    The output should eq "policy=16,4,0,MixedCases
-user=admin,false,Required
-password=admin,false,Required
+    The output should eq "accounts=root
+policy=16,4,0,MixedCases
+user=root,false,Required
+password=root,false,Required
 server_legacy=false
-client_access=admin,false,Required
-client_secret=admin,false,Required
+client_access=root,false,Required
+client_secret=root,false,Required
 client_root=false
 client_components=milvus-datanode,milvus-indexnode,milvus-mixcoord,milvus-proxy,milvus-querynode,milvus-standalone
 client_contract=true"
+    The status should be success
+  End
+
+  render_upgrade_contract() {
+    addon_version=$(awk '$1 == "version:" { print $2; exit }' ../Chart.yaml)
+    cluster_version=$(awk '$1 == "version:" { print $2; exit }' ../../../addons-cluster/milvus/Chart.yaml)
+    printf 'versions=%s,%s\n' "$addon_version" "$cluster_version"
+
+    helm template milvus .. | ruby -ryaml -e '
+      definitions = YAML.load_stream(ARGF.read).compact.select { |document| document["kind"] == "ComponentDefinition" }
+      names = definitions.map { |definition| definition.dig("metadata", "name") }
+      puts "definitions=#{names.grep(/milvus-(minio|standalone)-/).sort.join(",")}"
+    '
+
+    helm template milvus-cluster ../../../addons-cluster/milvus --set mode=standalone | ruby -ryaml -e '
+      cluster = YAML.load_stream(ARGF.read).compact.find { |document| document["kind"] == "Cluster" }
+      abort "standalone Cluster not rendered" unless cluster
+
+      components = cluster.dig("spec", "componentSpecs").to_h { |item| [item["name"], item] }
+      puts "minio=#{components.dig("minio", "componentDef")}"
+      puts "milvus=#{components.dig("milvus", "componentDef")}"
+    '
+  }
+
+  It "publishes a new immutable definition version and upgrades both credential consumers"
+    When call render_upgrade_contract
+    The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.1
+definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
+minio=milvus-minio-
+milvus=milvus-standalone-"
     The status should be success
   End
 End

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -94,7 +94,7 @@ client_contract=true"
     ruby -ryaml -e '
       migration = YAML.load_file("../examples/upgrade-embedded-minio-credential.yaml")
       components = migration.dig("spec", "upgrade", "components").to_h { |item| [item["componentName"], item] }
-      puts "migration=#{migration.dig("spec", "type")},#{components.dig("minio", "componentDefinitionName")},#{components.dig("milvus", "componentDefinitionName")}"
+      puts "migration=#{migration.dig("metadata", "name")},#{migration.dig("spec", "type")},#{components.dig("minio", "componentDefinitionName")},#{components.dig("milvus", "componentDefinitionName")}"
     '
   }
 
@@ -103,7 +103,7 @@ client_contract=true"
     The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.0
 definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
 cluster_definition_api=topology
-migration=Upgrade,milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1"
+migration=milvus-standalone-minio-root-migrate,Upgrade,milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1"
     The status should be success
   End
 End

--- a/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
+++ b/addons/milvus/scripts-ut-spec/minio_credential_contract_spec.sh
@@ -87,23 +87,23 @@ client_contract=true"
       cluster = YAML.load_stream(ARGF.read).compact.find { |document| document["kind"] == "Cluster" }
       abort "standalone Cluster not rendered" unless cluster
 
-      components = cluster.dig("spec", "componentSpecs").to_h { |item| [item["name"], item] }
-      puts "etcd=#{components.dig("etcd", "componentDef")}"
-      puts "minio=#{components.dig("minio", "componentDef")}"
-      puts "milvus=#{components.dig("milvus", "componentDef")}"
-      pattern = /\A[a-z]([a-z0-9.\-]*[a-z0-9])?\z/
-      puts "schema_valid=#{components.values.all? { |item| item["componentDef"].match?(pattern) }}"
+      components = cluster.dig("spec", "componentSpecs")
+      puts "cluster_definition_api=#{components.none? { |item| item.key?("componentDef") } ? "topology" : "direct"}"
+    '
+
+    ruby -ryaml -e '
+      migration = YAML.load_file("../examples/upgrade-embedded-minio-credential.yaml")
+      components = migration.dig("spec", "upgrade", "components").to_h { |item| [item["componentName"], item] }
+      puts "migration=#{migration.dig("spec", "type")},#{components.dig("minio", "componentDefinitionName")},#{components.dig("milvus", "componentDefinitionName")}"
     '
   }
 
-  It "publishes a new immutable definition version and upgrades both credential consumers"
+  It "publishes immutable definitions and migrates existing components through Upgrade OpsRequest"
     When call render_upgrade_contract
-    The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.1
+    The output should eq "versions=1.2.0-alpha.1,1.2.0-alpha.0
 definitions=milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1
-etcd=etcd
-minio=milvus-minio-1.2.0-alpha.1
-milvus=milvus-standalone-1.2.0-alpha.1
-schema_valid=true"
+cluster_definition_api=topology
+migration=Upgrade,milvus-minio-1.2.0-alpha.1,milvus-standalone-1.2.0-alpha.1"
     The status should be success
   End
 End

--- a/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
+++ b/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
@@ -70,7 +70,7 @@ case "${1:-} ${2:-}" in
       *spec.force*) printf '%s' "${FAKE_FORCE:-false}" ;;
       *componentName==\"minio\"*) printf '%s' "${target_def}" ;;
       *componentName==\"milvus\"*) printf '%s' "${target_milvus_def}" ;;
-      *status.phase*) if [[ -n "${FAKE_OPS_PHASE:-}" ]]; then printf '%s' "${FAKE_OPS_PHASE}"; elif ${deleted}; then printf '%s' 'Succeed'; else printf '%s' 'Running'; fi ;;
+      *status.phase*) if ${deleted} && [[ -n "${FAKE_FINAL_OPS_PHASE:-}" ]]; then printf '%s' "${FAKE_FINAL_OPS_PHASE}"; elif [[ -n "${FAKE_OPS_PHASE:-}" ]]; then printf '%s' "${FAKE_OPS_PHASE}"; elif ${deleted}; then printf '%s' 'Succeed'; else printf '%s' 'Running'; fi ;;
       *) printf 'unexpected OpsRequest query: %s\n' "${output}" >&2; exit 64 ;;
     esac
     ;;
@@ -128,6 +128,14 @@ EOF
 
   run_failed_before_desired() {
     DESIRED_READY=false FAKE_OPS_PHASE=Failed run_recovery
+  }
+
+  run_cancelled_after_replacement() {
+    FAKE_FINAL_OPS_PHASE=Cancelled run_recovery
+  }
+
+  run_aborted_after_replacement() {
+    FAKE_FINAL_OPS_PHASE=Aborted run_recovery
   }
 
   It "replaces only the stale failed MinIO Pod after the desired alpha.1 contract is visible"
@@ -195,5 +203,23 @@ EOF
     The stderr should include "OpsRequest reached Failed while waiting for desired contract"
     The contents of file "${calls_file}" should not include "get pods"
     The contents of file "${calls_file}" should not include "delete pod"
+  End
+
+  It "reports a Cancelled OpsRequest immediately after replacing the stale Pod"
+    When call run_cancelled_after_replacement
+    The status should be failure
+    The output should include "replacement-pod=demo-minio-0,uid-new,Ready"
+    The stderr should include "OpsRequest reached Cancelled"
+    The stderr should not include "recovery did not converge"
+    The contents of file "${calls_file}" should include "delete pod demo-minio-0 --wait=false"
+  End
+
+  It "reports an Aborted OpsRequest immediately after replacing the stale Pod"
+    When call run_aborted_after_replacement
+    The status should be failure
+    The output should include "replacement-pod=demo-minio-0,uid-new,Ready"
+    The stderr should include "OpsRequest reached Aborted"
+    The stderr should not include "recovery did not converge"
+    The contents of file "${calls_file}" should include "delete pod demo-minio-0 --wait=false"
   End
 End

--- a/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
+++ b/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
@@ -25,13 +25,13 @@ deleted=false
 
 case "${1:-} ${2:-}" in
   "get component")
-    printf '%s' "${target_def}"
+    if [[ "${DESIRED_READY:-true}" == "true" ]]; then printf '%s' "${target_def}"; else printf '%s' 'milvus-minio-1.2.0-alpha.0'; fi
     ;;
   "get instanceset")
-    printf '%s' "${target_def}"
+    if [[ "${DESIRED_READY:-true}" == "true" ]]; then printf '%s' "${target_def}"; else printf '%s' 'milvus-minio-1.2.0-alpha.0'; fi
     ;;
   "get secret")
-    printf '%s' 'cm9vdA==|cGFzc3dvcmQ='
+    if [[ "${DESIRED_READY:-true}" == "true" ]]; then printf '%s' 'cm9vdA==|cGFzc3dvcmQ='; fi
     ;;
   "get pods")
     printf '%s\n' 'demo-minio-0'
@@ -66,9 +66,11 @@ case "${1:-} ${2:-}" in
     case "${output}" in
       *spec.clusterName*) printf '%s' "${FAKE_OPS_CLUSTER:-demo}" ;;
       *spec.type*) printf '%s' 'Upgrade' ;;
+      *spec.preConditionDeadlineSeconds*) printf '%s' "${FAKE_PRECONDITION_DEADLINE:-600}" ;;
+      *spec.force*) printf '%s' "${FAKE_FORCE:-false}" ;;
       *componentName==\"minio\"*) printf '%s' "${target_def}" ;;
       *componentName==\"milvus\"*) printf '%s' "${target_milvus_def}" ;;
-      *status.phase*) if ${deleted}; then printf '%s' 'Succeed'; else printf '%s' 'Running'; fi ;;
+      *status.phase*) if [[ -n "${FAKE_OPS_PHASE:-}" ]]; then printf '%s' "${FAKE_OPS_PHASE}"; elif ${deleted}; then printf '%s' 'Succeed'; else printf '%s' 'Running'; fi ;;
       *) printf 'unexpected OpsRequest query: %s\n' "${output}" >&2; exit 64 ;;
     esac
     ;;
@@ -116,6 +118,18 @@ EOF
     FAKE_OPS_CLUSTER=other-cluster run_recovery
   }
 
+  run_without_bounded_precondition() {
+    FAKE_PRECONDITION_DEADLINE=0 run_recovery
+  }
+
+  run_forced_opsrequest() {
+    FAKE_FORCE=true run_recovery
+  }
+
+  run_failed_before_desired() {
+    DESIRED_READY=false FAKE_OPS_PHASE=Failed run_recovery
+  }
+
   It "replaces only the stale failed MinIO Pod after the desired alpha.1 contract is visible"
     When call run_recovery
     The status should be success
@@ -156,6 +170,29 @@ EOF
     When call run_wrong_opsrequest
     The status should be failure
     The stderr should include "OpsRequest cluster mismatch"
+    The contents of file "${calls_file}" should not include "get pods"
+    The contents of file "${calls_file}" should not include "delete pod"
+  End
+
+  It "requires the published bounded precondition wait before inspecting Pods"
+    When call run_without_bounded_precondition
+    The status should be failure
+    The stderr should include "precondition deadline mismatch"
+    The contents of file "${calls_file}" should not include "get pods"
+  End
+
+  It "rejects force instead of bypassing the Cluster phase safety gate"
+    When call run_forced_opsrequest
+    The status should be failure
+    The stderr should include "must not use force"
+    The contents of file "${calls_file}" should not include "get pods"
+  End
+
+  It "reports a terminal OpsRequest immediately while waiting for desired state"
+    When call run_failed_before_desired
+    The status should be failure
+    The output should include "opsrequest-contract=valid"
+    The stderr should include "OpsRequest reached Failed while waiting for desired contract"
     The contents of file "${calls_file}" should not include "get pods"
     The contents of file "${calls_file}" should not include "delete pod"
   End

--- a/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
+++ b/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
@@ -1,0 +1,162 @@
+# shellcheck shell=bash
+
+Describe "Milvus embedded MinIO credential recovery"
+  setup() {
+    tmpdir=$(mktemp -d -t milvus-minio-recovery-XXXXXX)
+    state_dir="${tmpdir}/state"
+    mkdir -p "${state_dir}"
+    calls_file="${state_dir}/calls"
+    fake_kubectl="${tmpdir}/kubectl"
+
+    cat >"${fake_kubectl}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${FAKE_STATE_DIR}/calls"
+if [[ "${1:-}" == "-n" ]]; then
+  shift 2
+fi
+
+target_def="milvus-minio-1.2.0-alpha.1"
+target_milvus_def="milvus-standalone-1.2.0-alpha.1"
+deleted=false
+[[ -f "${FAKE_STATE_DIR}/deleted" ]] && deleted=true
+[[ "${START_TARGET:-false}" == "true" ]] && deleted=true
+
+case "${1:-} ${2:-}" in
+  "get component")
+    printf '%s' "${target_def}"
+    ;;
+  "get instanceset")
+    printf '%s' "${target_def}"
+    ;;
+  "get secret")
+    printf '%s' 'cm9vdA==|cGFzc3dvcmQ='
+    ;;
+  "get pods")
+    printf '%s\n' 'demo-minio-0'
+    ;;
+  "get pod")
+    output="${*: -1}"
+    case "${output}" in
+      *metadata.uid*)
+        if ${deleted}; then printf '%s' 'uid-new'; else printf '%s' 'uid-old'; fi
+        ;;
+      *app\\.kubernetes\\.io/component*)
+        if ${deleted}; then printf '%s' "${target_def}"; else printf '%s' "${OLD_DEF:-milvus-minio-1.2.0-alpha.0}"; fi
+        ;;
+      *ownerReferences*)
+        printf '%s' "${FAKE_OWNER_KIND:-InstanceSet}|demo-minio"
+        ;;
+      *status.conditions*)
+        if ${deleted}; then printf '%s' 'True'; else printf '%s' 'False'; fi
+        ;;
+      *)
+        printf 'unexpected pod query: %s\n' "${output}" >&2
+        exit 64
+        ;;
+    esac
+    ;;
+  "delete pod")
+    touch "${FAKE_STATE_DIR}/deleted"
+    printf '%s\n' 'pod "demo-minio-0" deleted'
+    ;;
+  "get opsrequest")
+    output="${*: -1}"
+    case "${output}" in
+      *spec.clusterName*) printf '%s' "${FAKE_OPS_CLUSTER:-demo}" ;;
+      *spec.type*) printf '%s' 'Upgrade' ;;
+      *componentName==\"minio\"*) printf '%s' "${target_def}" ;;
+      *componentName==\"milvus\"*) printf '%s' "${target_milvus_def}" ;;
+      *status.phase*) if ${deleted}; then printf '%s' 'Succeed'; else printf '%s' 'Running'; fi ;;
+      *) printf 'unexpected OpsRequest query: %s\n' "${output}" >&2; exit 64 ;;
+    esac
+    ;;
+  "get cluster")
+    printf '%s' 'Running'
+    ;;
+  *)
+    printf 'unexpected kubectl call: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+EOF
+    chmod +x "${fake_kubectl}"
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  run_recovery() {
+    FAKE_STATE_DIR="${state_dir}" \
+      KUBECTL="${fake_kubectl}" \
+      POLL_INTERVAL_SECONDS=0 \
+      DESIRED_TIMEOUT_SECONDS=2 \
+      READY_TIMEOUT_SECONDS=2 \
+      bash ../scripts/recover-embedded-minio-credential.sh demo demo demo-minio-root-migrate
+  }
+
+  run_already_target() {
+    START_TARGET=true run_recovery
+  }
+
+  run_wrong_owner() {
+    FAKE_OWNER_KIND=StatefulSet run_recovery
+  }
+
+  run_unknown_definition() {
+    OLD_DEF=milvus-minio-9.9.9 run_recovery
+  }
+
+  run_wrong_opsrequest() {
+    FAKE_OPS_CLUSTER=other-cluster run_recovery
+  }
+
+  It "replaces only the stale failed MinIO Pod after the desired alpha.1 contract is visible"
+    When call run_recovery
+    The status should be success
+    The output should include "desired-contract=ready"
+    The output should include "stale-pod=demo-minio-0,uid-old"
+    The output should include "replacement-pod=demo-minio-0,uid-new,Ready"
+    The output should include "recovery=Succeed,cluster=Running"
+    The contents of file "${calls_file}" should include "delete pod demo-minio-0 --wait=false"
+    The contents of file "${calls_file}" should not include "delete pvc"
+    The contents of file "${calls_file}" should not include "delete secret"
+  End
+
+  It "is idempotent when the Pod already uses the target definition"
+    When call run_already_target
+    The status should be success
+    The output should include "replacement=not-needed"
+    The output should include "recovery=Succeed,cluster=Running"
+    The contents of file "${calls_file}" should not include "delete pod"
+  End
+
+  It "fails closed instead of deleting a Pod not owned by the expected InstanceSet"
+    When call run_wrong_owner
+    The status should be failure
+    The output should include "desired-contract=ready"
+    The stderr should include "unexpected controller owner"
+    The contents of file "${calls_file}" should not include "delete pod"
+  End
+
+  It "refuses to replace a Pod from an unrecognized definition"
+    When call run_unknown_definition
+    The status should be failure
+    The output should include "opsrequest-contract=valid"
+    The stderr should include "unsupported definition"
+    The contents of file "${calls_file}" should not include "delete pod"
+  End
+
+  It "rejects an OpsRequest for another Cluster before inspecting or deleting Pods"
+    When call run_wrong_opsrequest
+    The status should be failure
+    The stderr should include "OpsRequest cluster mismatch"
+    The contents of file "${calls_file}" should not include "get pods"
+    The contents of file "${calls_file}" should not include "delete pod"
+  End
+End

--- a/addons/milvus/scripts/recover-embedded-minio-credential.sh
+++ b/addons/milvus/scripts/recover-embedded-minio-credential.sh
@@ -5,9 +5,10 @@ set -euo pipefail
 TARGET_MINIO_DEF="milvus-minio-1.2.0-alpha.1"
 TARGET_MILVUS_DEF="milvus-standalone-1.2.0-alpha.1"
 AFFECTED_MINIO_DEF="milvus-minio-1.2.0-alpha.0"
+EXPECTED_PRECONDITION_DEADLINE_SECONDS="600"
 KUBECTL="${KUBECTL:-kubectl}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-3}"
-DESIRED_TIMEOUT_SECONDS="${DESIRED_TIMEOUT_SECONDS:-300}"
+DESIRED_TIMEOUT_SECONDS="${DESIRED_TIMEOUT_SECONDS:-900}"
 READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-600}"
 
 usage() {
@@ -59,11 +60,15 @@ require_uint READY_TIMEOUT_SECONDS "${READY_TIMEOUT_SECONDS}"
 command -v "${KUBECTL}" >/dev/null 2>&1 || fail "kubectl command is not executable: ${KUBECTL}"
 
 validate_migration_contract() {
-  local ops_cluster ops_type minio_def milvus_def
+  local ops_cluster ops_type precondition_deadline force minio_def milvus_def
   ops_cluster=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
     -o jsonpath='{.spec.clusterName}' 2>/dev/null || true)
   ops_type=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
     -o jsonpath='{.spec.type}' 2>/dev/null || true)
+  precondition_deadline=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+    -o jsonpath='{.spec.preConditionDeadlineSeconds}' 2>/dev/null || true)
+  force=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+    -o jsonpath='{.spec.force}' 2>/dev/null || true)
   minio_def=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
     -o jsonpath='{.spec.upgrade.components[?(@.componentName=="minio")].componentDefinitionName}' 2>/dev/null || true)
   milvus_def=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
@@ -73,25 +78,39 @@ validate_migration_contract() {
     fail "OpsRequest cluster mismatch: expected ${cluster}, got ${ops_cluster:-missing}"
   [[ "${ops_type}" == "Upgrade" ]] ||
     fail "OpsRequest type mismatch: expected Upgrade, got ${ops_type:-missing}"
+  [[ "${precondition_deadline}" == "${EXPECTED_PRECONDITION_DEADLINE_SECONDS}" ]] ||
+    fail "OpsRequest precondition deadline mismatch: expected ${EXPECTED_PRECONDITION_DEADLINE_SECONDS}, got ${precondition_deadline:-missing}"
+  [[ -z "${force}" || "${force}" == "false" ]] ||
+    fail "OpsRequest must not use force to bypass the Cluster phase safety gate"
   [[ "${minio_def}" == "${TARGET_MINIO_DEF}" ]] ||
     fail "OpsRequest MinIO definition mismatch: expected ${TARGET_MINIO_DEF}, got ${minio_def:-missing}"
   [[ "${milvus_def}" == "${TARGET_MILVUS_DEF}" ]] ||
     fail "OpsRequest Milvus definition mismatch: expected ${TARGET_MILVUS_DEF}, got ${milvus_def:-missing}"
-  printf 'opsrequest-contract=valid,name=%s\n' "${opsrequest}"
+  printf 'opsrequest-contract=valid,name=%s,precondition=%s,force=false\n' \
+    "${opsrequest}" "${precondition_deadline}"
 }
 
 wait_for_desired_contract() {
-  local deadline first="" last="" comp_def template_def credential_shape current
+  local deadline first="" last="" ops_phase cluster_phase comp_def template_def credential_shape current
   deadline=$(($(date +%s) + DESIRED_TIMEOUT_SECONDS))
 
   while (($(date +%s) <= deadline)); do
+    ops_phase=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    cluster_phase=$("${KUBECTL}" -n "${namespace}" get cluster "${cluster}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    case "${ops_phase}" in
+      Failed|Cancelled|Aborted)
+        fail "OpsRequest reached ${ops_phase} while waiting for desired contract; cluster=${cluster_phase:-missing}"
+        ;;
+    esac
     comp_def=$("${KUBECTL}" -n "${namespace}" get component "${component}" \
       -o jsonpath='{.spec.compDef}' 2>/dev/null || true)
     template_def=$("${KUBECTL}" -n "${namespace}" get instanceset "${instanceset}" \
       -o jsonpath='{.spec.template.metadata.labels.app\.kubernetes\.io/component}' 2>/dev/null || true)
     credential_shape=$("${KUBECTL}" -n "${namespace}" get secret "${root_secret}" \
       -o jsonpath='{.data.username}{"|"}{.data.password}' 2>/dev/null || true)
-    current="component=${comp_def},template=${template_def},credential=$([[ "${credential_shape}" == ?*'|'?* ]] && printf non-empty || printf missing)"
+    current="ops=${ops_phase:-missing},cluster=${cluster_phase:-missing},component=${comp_def},template=${template_def},credential=$([[ "${credential_shape}" == ?*'|'?* ]] && printf non-empty || printf missing)"
     [[ -n "${first}" ]] || first="${current}"
     last="${current}"
 

--- a/addons/milvus/scripts/recover-embedded-minio-credential.sh
+++ b/addons/milvus/scripts/recover-embedded-minio-credential.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TARGET_MINIO_DEF="milvus-minio-1.2.0-alpha.1"
+TARGET_MILVUS_DEF="milvus-standalone-1.2.0-alpha.1"
+AFFECTED_MINIO_DEF="milvus-minio-1.2.0-alpha.0"
+KUBECTL="${KUBECTL:-kubectl}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-3}"
+DESIRED_TIMEOUT_SECONDS="${DESIRED_TIMEOUT_SECONDS:-300}"
+READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-600}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: recover-embedded-minio-credential.sh NAMESPACE CLUSTER [OPSREQUEST]
+
+Run this after creating the Upgrade OpsRequest shipped with Milvus addon
+1.2.0-alpha.1. The script waits for the alpha.1 desired MinIO contract, then
+replaces only the stale MinIO Pod if it is still on the affected alpha.0
+definition. It never deletes Secrets or PVCs.
+EOF
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+is_dns_label() {
+  [[ "$1" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] && ((${#1} <= 63))
+}
+
+require_uint() {
+  [[ "$2" =~ ^[0-9]+$ ]] || fail "$1 must be a non-negative integer"
+}
+
+[[ $# -eq 2 || $# -eq 3 ]] || {
+  usage
+  exit 64
+}
+
+namespace="$1"
+cluster="$2"
+opsrequest="${3:-${cluster}-minio-root-migrate}"
+component="${cluster}-minio"
+instanceset="${cluster}-minio"
+root_secret="${cluster}-minio-account-root"
+selector="app.kubernetes.io/instance=${cluster},apps.kubeblocks.io/component-name=minio"
+
+is_dns_label "${namespace}" || fail "namespace is not a DNS label: ${namespace}"
+is_dns_label "${cluster}" || fail "cluster is not a DNS label: ${cluster}"
+is_dns_label "${opsrequest}" || fail "OpsRequest is not a DNS label: ${opsrequest}"
+require_uint POLL_INTERVAL_SECONDS "${POLL_INTERVAL_SECONDS}"
+require_uint DESIRED_TIMEOUT_SECONDS "${DESIRED_TIMEOUT_SECONDS}"
+require_uint READY_TIMEOUT_SECONDS "${READY_TIMEOUT_SECONDS}"
+((DESIRED_TIMEOUT_SECONDS > 0)) || fail "DESIRED_TIMEOUT_SECONDS must be greater than zero"
+((READY_TIMEOUT_SECONDS > 0)) || fail "READY_TIMEOUT_SECONDS must be greater than zero"
+
+command -v "${KUBECTL}" >/dev/null 2>&1 || fail "kubectl command is not executable: ${KUBECTL}"
+
+validate_migration_contract() {
+  local ops_cluster ops_type minio_def milvus_def
+  ops_cluster=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+    -o jsonpath='{.spec.clusterName}' 2>/dev/null || true)
+  ops_type=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+    -o jsonpath='{.spec.type}' 2>/dev/null || true)
+  minio_def=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+    -o jsonpath='{.spec.upgrade.components[?(@.componentName=="minio")].componentDefinitionName}' 2>/dev/null || true)
+  milvus_def=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+    -o jsonpath='{.spec.upgrade.components[?(@.componentName=="milvus")].componentDefinitionName}' 2>/dev/null || true)
+
+  [[ "${ops_cluster}" == "${cluster}" ]] ||
+    fail "OpsRequest cluster mismatch: expected ${cluster}, got ${ops_cluster:-missing}"
+  [[ "${ops_type}" == "Upgrade" ]] ||
+    fail "OpsRequest type mismatch: expected Upgrade, got ${ops_type:-missing}"
+  [[ "${minio_def}" == "${TARGET_MINIO_DEF}" ]] ||
+    fail "OpsRequest MinIO definition mismatch: expected ${TARGET_MINIO_DEF}, got ${minio_def:-missing}"
+  [[ "${milvus_def}" == "${TARGET_MILVUS_DEF}" ]] ||
+    fail "OpsRequest Milvus definition mismatch: expected ${TARGET_MILVUS_DEF}, got ${milvus_def:-missing}"
+  printf 'opsrequest-contract=valid,name=%s\n' "${opsrequest}"
+}
+
+wait_for_desired_contract() {
+  local deadline first="" last="" comp_def template_def credential_shape current
+  deadline=$(($(date +%s) + DESIRED_TIMEOUT_SECONDS))
+
+  while (($(date +%s) <= deadline)); do
+    comp_def=$("${KUBECTL}" -n "${namespace}" get component "${component}" \
+      -o jsonpath='{.spec.compDef}' 2>/dev/null || true)
+    template_def=$("${KUBECTL}" -n "${namespace}" get instanceset "${instanceset}" \
+      -o jsonpath='{.spec.template.metadata.labels.app\.kubernetes\.io/component}' 2>/dev/null || true)
+    credential_shape=$("${KUBECTL}" -n "${namespace}" get secret "${root_secret}" \
+      -o jsonpath='{.data.username}{"|"}{.data.password}' 2>/dev/null || true)
+    current="component=${comp_def},template=${template_def},credential=$([[ "${credential_shape}" == ?*'|'?* ]] && printf non-empty || printf missing)"
+    [[ -n "${first}" ]] || first="${current}"
+    last="${current}"
+
+    if [[ "${comp_def}" == "${TARGET_MINIO_DEF}" &&
+          "${template_def}" == "${TARGET_MINIO_DEF}" &&
+          "${credential_shape}" == ?*'|'?* ]]; then
+      printf 'desired-contract=ready,first=%s,last=%s\n' "${first}" "${last}"
+      return 0
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+  done
+
+  fail "desired contract did not converge within ${DESIRED_TIMEOUT_SECONDS}s; first=${first}; last=${last}"
+}
+
+one_minio_pod() {
+  local names count
+  names=$("${KUBECTL}" -n "${namespace}" get pods -l "${selector}" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  count=$(printf '%s\n' "${names}" | awk 'NF { count++ } END { print count + 0 }')
+  [[ "${count}" == "1" ]] || fail "expected exactly one MinIO Pod, found ${count}"
+  printf '%s\n' "${names}" | awk 'NF { print; exit }'
+}
+
+pod_uid() {
+  "${KUBECTL}" -n "${namespace}" get pod "$1" -o jsonpath='{.metadata.uid}'
+}
+
+pod_definition() {
+  "${KUBECTL}" -n "${namespace}" get pod "$1" \
+    -o jsonpath='{.metadata.labels.app\.kubernetes\.io/component}'
+}
+
+pod_ready() {
+  "${KUBECTL}" -n "${namespace}" get pod "$1" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+}
+
+pod_controller_owner() {
+  "${KUBECTL}" -n "${namespace}" get pod "$1" \
+    -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].kind}{"|"}{.metadata.ownerReferences[?(@.controller==true)].name}'
+}
+
+wait_for_replacement() {
+  local old_uid="$1" require_new_uid="$2" deadline first="" last="" pod uid definition ready current
+  deadline=$(($(date +%s) + READY_TIMEOUT_SECONDS))
+
+  while (($(date +%s) <= deadline)); do
+    pod=$(one_minio_pod 2>/dev/null || true)
+    if [[ -n "${pod}" ]]; then
+      uid=$(pod_uid "${pod}" 2>/dev/null || true)
+      definition=$(pod_definition "${pod}" 2>/dev/null || true)
+      ready=$(pod_ready "${pod}" 2>/dev/null || true)
+      current="pod=${pod},uid=${uid},definition=${definition},ready=${ready}"
+      [[ -n "${first}" ]] || first="${current}"
+      last="${current}"
+      if [[ "${definition}" == "${TARGET_MINIO_DEF}" && "${ready}" == "True" ]] &&
+         { [[ "${require_new_uid}" == "false" ]] || [[ "${uid}" != "${old_uid}" ]]; }; then
+        printf 'replacement-pod=%s,%s,Ready,first=%s,last=%s\n' "${pod}" "${uid}" "${first}" "${last}"
+        return 0
+      fi
+    else
+      current="pod=missing"
+      [[ -n "${first}" ]] || first="${current}"
+      last="${current}"
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+  done
+
+  fail "replacement Pod did not become Ready within ${READY_TIMEOUT_SECONDS}s; first=${first}; last=${last}"
+}
+
+wait_for_operation_and_cluster() {
+  local deadline first="" last="" ops_phase cluster_phase current
+  deadline=$(($(date +%s) + READY_TIMEOUT_SECONDS))
+
+  while (($(date +%s) <= deadline)); do
+    ops_phase=$("${KUBECTL}" -n "${namespace}" get opsrequest "${opsrequest}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    cluster_phase=$("${KUBECTL}" -n "${namespace}" get cluster "${cluster}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    current="ops=${ops_phase},cluster=${cluster_phase}"
+    [[ -n "${first}" ]] || first="${current}"
+    last="${current}"
+
+    [[ "${ops_phase}" != "Failed" ]] || fail "OpsRequest reached Failed; first=${first}; last=${last}"
+    if [[ "${ops_phase}" == "Succeed" && "${cluster_phase}" == "Running" ]]; then
+      printf 'recovery=Succeed,cluster=Running,first=%s,last=%s\n' "${first}" "${last}"
+      return 0
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+  done
+
+  fail "recovery did not converge within ${READY_TIMEOUT_SECONDS}s; first=${first}; last=${last}"
+}
+
+validate_migration_contract
+wait_for_desired_contract
+
+pod=$(one_minio_pod)
+old_uid=$(pod_uid "${pod}")
+definition=$(pod_definition "${pod}")
+
+if [[ "${definition}" == "${TARGET_MINIO_DEF}" ]]; then
+  printf 'replacement=not-needed,pod=%s,uid=%s\n' "${pod}" "${old_uid}"
+  require_new_uid=false
+else
+  [[ "${definition}" == "${AFFECTED_MINIO_DEF}" ]] ||
+    fail "refusing to replace Pod with unsupported definition: ${definition:-missing}"
+  owner=$(pod_controller_owner "${pod}")
+  [[ "${owner}" == "InstanceSet|${instanceset}" ]] ||
+    fail "unexpected controller owner for ${pod}: ${owner}"
+  printf 'stale-pod=%s,%s,definition=%s\n' "${pod}" "${old_uid}" "${definition}"
+  "${KUBECTL}" -n "${namespace}" delete pod "${pod}" --wait=false
+  require_new_uid=true
+fi
+
+wait_for_replacement "${old_uid}" "${require_new_uid}"
+wait_for_operation_and_cluster

--- a/addons/milvus/scripts/recover-embedded-minio-credential.sh
+++ b/addons/milvus/scripts/recover-embedded-minio-credential.sh
@@ -196,7 +196,11 @@ wait_for_operation_and_cluster() {
     [[ -n "${first}" ]] || first="${current}"
     last="${current}"
 
-    [[ "${ops_phase}" != "Failed" ]] || fail "OpsRequest reached Failed; first=${first}; last=${last}"
+    case "${ops_phase}" in
+      Failed|Cancelled|Aborted)
+        fail "OpsRequest reached ${ops_phase}; first=${first}; last=${last}"
+        ;;
+    esac
     if [[ "${ops_phase}" == "Succeed" && "${cluster_phase}" == "Running" ]]; then
       printf 'recovery=Succeed,cluster=Running,first=%s,last=%s\n' "${first}" "${last}"
       return 0

--- a/addons/milvus/templates/_helpers.tpl
+++ b/addons/milvus/templates/_helpers.tpl
@@ -77,6 +77,42 @@ Define milvus standalone component definition regex pattern
 {{- end -}}
 
 {{/*
+Shared Milvus standalone ParametersDefinition contract.
+*/}}
+{{- define "milvus-standalone.parametersDefinitionSpec" -}}
+templateName: config
+fileName: user.yaml
+fileFormatConfig:
+  format: yaml
+parametersSchema:
+  topLevelKey: MilvusStandaloneParameter
+  cue: |-
+    #MilvusStandaloneParameter: {
+      ...
+      log?: {
+        ...
+        level?: string & ("debug" | "info" | "warn" | "error" | "panic" | "fatal") | *"info"
+      }
+      proxy?: {
+        ...
+        maxNameLength?: int & >=1 & <=32768 | *255
+        maxFieldNum?: int & >=1 & <=2048 | *64
+        maxDimension?: int & >=1 & <=32768 | *32768
+      }
+      common?: {
+        ...
+        gracefulTime?: int & >=0 & <=600000 | *5000
+      }
+    }
+staticParameters:
+  - log.level
+  - proxy.maxNameLength
+  - proxy.maxFieldNum
+  - proxy.maxDimension
+  - common.gracefulTime
+{{- end -}}
+
+{{/*
 Define milvus minio component definition name
 */}}
 {{- define "milvus-minio.cmpdName" -}}

--- a/addons/milvus/templates/cmpd-minio.yaml
+++ b/addons/milvus/templates/cmpd-minio.yaml
@@ -12,7 +12,7 @@ spec:
   serviceKind: milvus-minio
   serviceVersion: 8.0.17
   systemAccounts:
-    - name: admin
+    - name: root
       initAccount: true
       passwordGenerationPolicy:
         length: 16
@@ -23,13 +23,13 @@ spec:
     - name: MINIO_ROOT_USER
       valueFrom:
         credentialVarRef:
-          name: admin
+          name: root
           optional: false
           username: Required
     - name: MINIO_ROOT_PASSWORD
       valueFrom:
         credentialVarRef:
-          name: admin
+          name: root
           optional: false
           password: Required
   volumes:

--- a/addons/milvus/templates/cmpd-minio.yaml
+++ b/addons/milvus/templates/cmpd-minio.yaml
@@ -14,14 +14,19 @@ spec:
   systemAccounts:
     - name: admin
       initAccount: true
+      passwordGenerationPolicy:
+        length: 16
+        numDigits: 4
+        numSymbols: 0
+        letterCase: MixedCases
   vars:
-    - name: MINIO_ACCESS_KEY
+    - name: MINIO_ROOT_USER
       valueFrom:
         credentialVarRef:
           name: admin
           optional: false
           username: Required
-    - name: MINIO_SECRET_KEY
+    - name: MINIO_ROOT_PASSWORD
       valueFrom:
         credentialVarRef:
           name: admin

--- a/addons/milvus/templates/cmpd-standalone.yaml
+++ b/addons/milvus/templates/cmpd-standalone.yaml
@@ -38,14 +38,14 @@ spec:
       valueFrom:
         credentialVarRef:
           compDef: {{ include "milvus-minio.cmpdRegexpPattern" . }}
-          name: admin
+          name: root
           optional: false
           username: Required
     - name: MINIO_SECRET_KEY
       valueFrom:
         credentialVarRef:
           compDef: {{ include "milvus-minio.cmpdRegexpPattern" . }}
-          name: admin
+          name: root
           optional: false
           password: Required
   volumes:

--- a/addons/milvus/templates/paramdef-standalone.yaml
+++ b/addons/milvus/templates/paramdef-standalone.yaml
@@ -1,40 +1,24 @@
+{{- $root := . -}}
+{{- $currentComponentDef := include "milvus-standalone.cmpdName" . -}}
+{{- $bindings := list
+  (dict
+    "name" "milvus-standalone-pd-1.2.0-alpha.0"
+    "componentDef" "^milvus-standalone-1[.]2[.]0-alpha[.]0$")
+  (dict
+    "name" (printf "milvus-standalone-pd-%s" .Chart.Version)
+    "componentDef" (printf "^%s$" ($currentComponentDef | replace "." "[.]")))
+-}}
+{{- range $binding := $bindings }}
+---
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:
-  name: milvus-standalone-pd-{{ .Chart.Version }}
+  name: {{ $binding.name }}
   labels:
-    {{- include "milvus.labels" . | nindent 4 }}
+    {{- include "milvus.labels" $root | nindent 4 }}
   annotations:
-    {{- include "milvus.annotations" . | nindent 4 }}
+    {{- include "milvus.annotations" $root | nindent 4 }}
 spec:
-  componentDef: {{ include "milvus-standalone.cmpdRegexpPattern" . }}
-  templateName: config
-  fileName: user.yaml
-  fileFormatConfig:
-    format: yaml
-  parametersSchema:
-    topLevelKey: MilvusStandaloneParameter
-    cue: |-
-      #MilvusStandaloneParameter: {
-        ...
-        log?: {
-          ...
-          level?: string & ("debug" | "info" | "warn" | "error" | "panic" | "fatal") | *"info"
-        }
-        proxy?: {
-          ...
-          maxNameLength?: int & >=1 & <=32768 | *255
-          maxFieldNum?: int & >=1 & <=2048 | *64
-          maxDimension?: int & >=1 & <=32768 | *32768
-        }
-        common?: {
-          ...
-          gracefulTime?: int & >=0 & <=600000 | *5000
-        }
-      }
-  staticParameters:
-    - log.level
-    - proxy.maxNameLength
-    - proxy.maxFieldNum
-    - proxy.maxDimension
-    - common.gracefulTime
+  componentDef: {{ $binding.componentDef | quote }}
+  {{- include "milvus-standalone.parametersDefinitionSpec" $root | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
## Problem

The Milvus embedded MinIO `admin` system account did not declare a password generation policy. KubeBlocks can therefore materialize a zero-length generated password. The account update path preserves generated Secret data, so merely adding a policy or changing server environment variable names does not repair an already affected Component.

The embedded MinIO server also used deprecated `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` variable names, while this image's server contract is `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`.

During an alpha.0-to-alpha.1 component migration, both retained versioned Milvus `ParametersDefinition` objects also matched the same broad `^milvus-standalone-` expression and claimed `user.yaml`. KubeBlocks rejects that duplicate file ownership before it creates the Milvus `ComponentParameter`, config `ConfigMap`, or workload.

## Fix

- publish immutable Milvus addon version `1.2.0-alpha.1`
- replace the embedded MinIO account identity `admin` with `root`, forcing KubeBlocks to create a new credential instead of preserving the old zero-length generated password
- declare an explicit 16-character mixed-case password policy for `root`
- expose `root` to the MinIO server through `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`
- keep the Milvus client environment contract on `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`, but make standalone reference the new `root` account
- keep the standard cluster chart on `1.2.0-alpha.0` and topology-based definition resolution; it must not directly rewrite the controller-owned atomic `Cluster.spec.componentSpecs` list
- update the retained alpha.0 Milvus parameter definition to match only `milvus-standalone-1.2.0-alpha.0`, and bind the current definition only to `milvus-standalone-1.2.0-alpha.1`; both expressions are end-anchored so future versions cannot overlap
- add a supported existing-Cluster migration manifest using KubeBlocks `Upgrade` OpsRequest with exact `componentDefinitionName` values for both `minio` and `milvus`, plus a bounded 600-second precondition wait for an affected Cluster to leave `Creating`
- add a bounded, fail-closed recovery helper for the already-NotReady alpha.0 MinIO Pod
- document the migration and explicitly prohibit `--force-conflicts`, OpsRequest `force: true`, and PVC deletion as shortcuts
- add rendered and behavioral contract coverage for the account, variable separation, immutable definition names, non-overlapping parameter bindings, unchanged topology API, two-component Upgrade OpsRequest, and recovery helper

For an affected standalone Cluster, upgrade the addon definitions, create `addons/milvus/examples/upgrade-embedded-minio-credential.yaml`, then run `bash addons/milvus/scripts/recover-embedded-minio-credential.sh NAMESPACE CLUSTER OPSREQUEST`.

The helper first verifies that the supplied OpsRequest targets the same Cluster, has the published 600-second precondition deadline, does not use force, and selects both exact alpha.1 definitions. It uses bounded polling until the MinIO Component and InstanceSet desired template both select alpha.1 and the new `root` Secret contains non-empty username/password data; a terminal OpsRequest fails immediately. If the sole MinIO Pod is still on the known affected alpha.0 definition, the helper verifies its exact InstanceSet controller owner and deletes only that Pod with `--wait=false`; it never deletes a Secret or PVC. It then requires a new Pod UID on alpha.1 to become Ready, followed by OpsRequest `Succeed` and Cluster `Running`. Reruns are idempotent after the Pod already uses alpha.1. Unknown definitions, wrong owners, wrong OpsRequests, missing/duplicate Pods, and bounded-window exhaustion all fail closed.

## Verification

Current head `28ac0419ba458a644c7e91aeb682ab6fb21ab0c1` (rebased onto target `main` head `41801859b685dea4f8d603b7aa4b90a7fb52e2d1`):

- focused Milvus ShellSpec: 10 examples, 0 failures on Bash 3.2
- the rendered parameter binding matrix is exactly alpha.0→alpha.0 and alpha.1→alpha.1, with no cross-match
- ShellCheck: PASS
- `helm lint addons/milvus`: PASS
- `helm lint addons-cluster/milvus`: PASS
- both charts render successfully
- Helm package contains the migration manifest and recovery helper
- `git diff --check`: PASS
- repository-wide local ShellSpec is non-green only in unrelated FalkorDB/MariaDB suites; there is no FalkorDB/MariaDB diff, while the GitHub repository ShellSpec check passes on this exact head
- pinned KubeBlocks source `5a57a85922ef7fb8f704cc1d51f656a62f771485` confirms:
  - Upgrade OpsRequest owns the exact ComponentDefinition switch
  - duplicate matching ParametersDefinitions for one config file are rejected
  - `preConditionDeadlineSeconds` waits boundedly for an allowed Cluster phase; `force` would bypass the safety gate and is intentionally rejected
  - InstanceSet update checks require the old Pod to be Ready/Available before normal rollout, matching the frozen affected evidence

All GitHub checks pass on this exact rebased head, including repository ShellSpec, ShellCheck, generated-files, and addon/cluster chart checks. Magnus completed the required design/code re-review with `finished / NO BLOCKER @ 28ac0419`. The PR remains formally review-required.

## Evidence boundary

This is not release-ready. The current rebased head `28ac0419ba458a644c7e91aeb682ab6fb21ab0c1` has one exact-head targeted-path sample set and one exact-head full-suite sample:

- targeted Test identity: tests base `5e5d0b86e0b498eff4a1b4f4da52f0f15b906de1` + patch `1fc81f1ee55c835755e2f5bba9cff59374b2adae58bfa0746324dd3de4878b91`, republished harness `564c4333c4ceaea9dedeb8c3022da2cc25308c6b424e6aff2a102c966c50de65`
- fresh standalone N=1 PASS: alpha.1 MinIO/Milvus definitions, root username/password lengths 4/16, exact non-overlapping ParametersDefinitions, Milvus ComponentParameter/config handoff, SDK write/verify, and guest/host cleanup residue 0
- affected alpha.0-to-alpha.1 N=1 PASS: zero-length old admin baseline; deadline-600/no-force Upgrade + recovery helper; stale alpha.0 MinIO Pod replaced by a new alpha.1 UID; OpsRequest `Succeed` 2/2 and Cluster `Running`; etcd/MinIO PVC UIDs unchanged; root lengths 4/16; exact non-overlapping ParametersDefinitions; ComponentParameter/config handoff; SDK write/verify; guest/host cleanup residue 0; no force cleanup
- targeted lean evidence attachment `5f7e92ed-1893-4589-b19b-886ba8752920`, independently verified SHA256 `d29bf02c1888e12e31d202d0426e41a190082c7971a38ab2bd030859ae3124b8`
- full-suite Test identity: tests base `5e5d0b86e0b498eff4a1b4f4da52f0f15b906de1` + patch `1fc81f1ee55c835755e2f5bba9cff59374b2adae58bfa0746324dd3de4878b91`, harness `0cb5e598bec24b72c09552041fcec4c684dbb6021489f91cedc4a0192e679e12`
- full suite N=1: `PASS=141 FAIL=0 SKIP=1`, runner/final rc 0, first blocker none; smoke 5/0/0, ops 19/0/0, cluster 20/0/0, chaos 21/0/0, reconfigure 25/0/0, backup-restore 1/0/1, hscale 21/0/0, TLS 16/0/0, expose 13/0/0
- the only skip is BR00 because the selected environment has no VolumeSnapshotClass/CSI snapshot capability; backup/restore runtime therefore remains unexecuted, not passed
- full-suite guest and host namespace/Helm/PV cleanup residue 0 through normal uninstall/delete, with no force cleanup
- full-suite lean evidence attachment `272084c9-3e0b-416a-a0b7-28e5c68dacfc`, independently verified SHA256 `53e42419a2381bb52a60f42c9fce3ebbadef57186aae756d210e74d654c0d212`
- dedicated BR00-BR04 attempt used Test-owned idc4 `nfs-shared` / `nfs-snapshot` through vcluster, harness `708efb381aacfce1e0080e1a98331d974516bbdc58994867264540e8e4253aea`
- BR00a-d passed (guest VSC visible, MinIO BackupRepo Ready, source Running, BackupPolicy generated), then BR00e stopped before Backup creation because vcluster mapped every host CSI PV to guest `flexVolume.driver=fake`; no guest PV CSI driver could match `nfs.csi.k8s.io`
- this is an L1 environment/virtualization boundary, not a product failure; BR runtime remains N=0
- blocked-attempt attachment `31af6a71-fa45-485d-bbff-fd833b0c87fe`, independently verified SHA256 `db9ea31cb08c8121d6507a4b66674b650d8d65005803314e414850af856b2ceb`
- blocked-attempt cleanup residue 0: guest scene removed with the vcluster; host namespace, Helm release, and PVs absent after normal deletion with no force

This closes the requested exact-head fresh and affected paths plus one exact-head full-suite N=1 sample. It is not repeated release-readiness evidence. The BR00-BR04 runtime lane now requires an entrance that preserves the workload PV's real CSI driver alongside a matching VolumeSnapshotClass; the tested vcluster fake-PV projection cannot provide that contract.

The prior exact head `5d805dfb10ba51bbb73b5dec055a7e167d1e67fc` had N=1 path evidence only:

- fresh standalone N=1 PASS, including exact current definitions, root username/password lengths 4/16 bytes, MinIO `MINIO_ROOT_*`, non-overlapping parameter bindings, Milvus ComponentParameter/config handoff, SDK write/verify, and cleanup residue 0
- affected alpha.0-to-alpha.1 N=1 PASS after a Test-owned harness resume: recovery helper `Succeed`, Upgrade OpsRequest `Succeed` 2/2, Cluster and all three Components Running, exact non-overlapping parameter bindings, finished Milvus ComponentParameter/config handoff, root credential lengths 4/16, MinIO root environment, SDK write/verify PASS, and cleanup residue 0
- initial attachment `4cf4e991-1222-4701-9d55-467bcd802edf`, SHA256 `d827853c4fff213311efc306fb03cb79bc232bd4504c29df768f7e1efde1bf66`
- same-pin resume attachment `7b87bf72-0a2d-4ae9-b635-9e6163d487e9`, SHA256 `cf766e2c055c359d56a72c92a8ddc0b00c0832cf3bdff1d30ba27d3cf3bf2028`
- earlier `df117df6...` root-cause attachment `0c936764-25da-4e36-9491-8fc6fe21ba32`, SHA256 `4c8cec75ea3896ed1471b4c9018d3d84760c5e0935145f0149d7ed528e15d3b8`

Those samples remain evidence for `5d805dfb...`; they do not transfer to `28ac0419...` after the target-head rebase.

### Current target-branch audit

- target branch: `main` @ `41801859b685dea4f8d603b7aa4b90a7fb52e2d1`
- included Milvus PR: #3194 @ `28ac0419ba458a644c7e91aeb682ab6fb21ab0c1`
- excluded Milvus draft PR #3180 @ `59f4ef01b68636a4f93bbdf1eef8b2663a72fe48`: superseded by #3194 and depends on the separate `SystemAccount.passwordConfig` controller/API proposal; it has runtime N=0 and must not be mixed into this candidate
- other open PRs by the shared `weicao` account target other addon engines and are excluded by Milvus scope





