### PR TITLE
feat: update syncer to 0.7.7

### DIFF
--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -10,7 +10,7 @@ image:
   tag: 8.0.30-5.beta3.20240330.g94d1caf.15
   syncer:
     repository: apecloud/syncer
-    tag: 0.4.1
+    tag: 0.7.7
   walgImage:
     repository: apecloud/wal-g
     tag: mysql-8.0

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -17,7 +17,7 @@ image:
     tag: 1.29
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.7"
+    tag: "0.7.7"
   exporter:
     repository: apecloud/mongodb_exporter
     tag: "0.44.0"

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -16,7 +16,7 @@ image:
     repository: apecloud/percona-xtrabackup
   syncer:
     repository: apecloud/syncer
-    tag: 0.6.8
+    tag: 0.7.7
   # refer: addons/mysql/orc-tools/Dockerfile
   orcTools:
     repository: apecloud/orc-tools

--- a/addons/orioledb/values.yaml
+++ b/addons/orioledb/values.yaml
@@ -12,7 +12,7 @@ image:
   debug: false
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.5"
+    tag: "0.7.7"
 
 dataMountPath: /postgresql/mount_volume
 confMountPath: /postgresql/mount_conf

--- a/addons/vanilla-postgresql/values.yaml
+++ b/addons/vanilla-postgresql/values.yaml
@@ -38,7 +38,7 @@ image:
 
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.5"
+    tag: "0.7.7"
 
 dataMountPath: /postgresql/volume_data
 confMountPath: /postgresql/mount_conf


### PR DESCRIPTION
## What changed

- Update the default syncer image tag to `0.7.7` for ApeCloud MySQL, MongoDB, MySQL, OrioleDB, and Vanilla PostgreSQL.

## Why

Keep all syncer-based addons aligned on the current published syncer release.

## Impact

Newly rendered addon workloads use `apecloud/syncer:0.7.7` by default.

## Validation

- Verified every `apecloud/syncer` tag in the affected charts is `0.7.7`.
- Ran `git diff --check origin/main...HEAD`.
