### PR TITLE
fix(oceanbase-ce): mount configs for kbagent actions

### DIFF
--- a/addons/oceanbase-ce/templates/componentdefinition.yaml
+++ b/addons/oceanbase-ce/templates/componentdefinition.yaml
@@ -183,6 +183,10 @@ spec:
         volumeMounts:
           - name: scripts
             mountPath: /scripts
+          - name: oceanbase-config
+            mountPath: /kb-config
+          - name: oceanbase-sysvars
+            mountPath: /opt/oceanbase/sysvars
           - name: kb-tools
             mountPath: /kb_tools
           - name: metricslog


### PR DESCRIPTION
## Problem

In the latest KB-main OceanBase CE B-line run, O05 dynamic reconfigure was the first and only failing case. The run ended with 129 PASS / 1 FAIL / 0 SKIP. The kbagent action repeatedly tried to read `/kb-config/oceanbase.conf`, but its execution surface did not have the `oceanbase-config` volume mounted, so the OpsRequest remained `Reconfiguring`.

The ComponentDefinition declares `metrics` as `reconfigure.exec.container`. KubeBlocks shares that source container's volume mounts with the action execution surface, but the `metrics` container did not mount either configuration volume.

## Change

Mount the two configuration volumes on `metrics`:

- `oceanbase-config` at `/kb-config`
- `oceanbase-sysvars` at `/opt/oceanbase/sysvars`

The first mount closes the observed O05 failure mechanism. The second closes the analogous sysvars path used by the same reconfigure action contract; it is preventive contract completion, not a second observed runtime failure.

Contract references:

- `kubeblocks-addon-docs/docs/addon-api/05b-lifecycle-action-fields.md`: `Action.exec.container` shares the selected container's volume mounts with the action execution surface.
- `kubeblocks-addon-docs/docs/addon-api/05c-lifecycle-action-contracts.md`: explicitly selected action containers must independently expose required scripts and volume mounts.

## Local verification

- `helm dependency build addons/oceanbase-ce`
- `helm lint addons/oceanbase-ce`
- `helm template oceanbase-ce addons/oceanbase-ce --namespace oceanbase-ce-test`
- parsed the rendered ComponentDefinition and asserted both reconfigure configs select `metrics` and both config volumes are mounted at their required paths
- `git diff --check origin/main...HEAD`

All local checks passed after rebasing onto the latest `main`.

## Evidence boundary

- Runtime evidence is one pre-fix run: 129 PASS / 1 FAIL / 0 SKIP.
- The patched commit has not yet been runtime-retested.
- `backup`, `backup-minio`, and `chaos` were not run in that cycle.
- This PR is not evidence of a full-suite pass or release readiness.

Please focus review on whether `metrics` is the correct source container for both reconfigure actions and whether the two mount paths exactly match the configuration contracts.

Fixes #3197
