### PR TITLE
fix(clickhouse): mark keeper voters as quorum participants

### DIFF
--- a/addons/clickhouse/Chart.yaml
+++ b/addons/clickhouse/Chart.yaml
@@ -6,7 +6,7 @@ description: ClickHouse is an open-source column-oriented OLAP database manageme
 
 type: application
 
-version: 1.2.0-alpha.0
+version: 1.2.0-alpha.1
 
 appVersion: 25.9.7
 

--- a/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
+++ b/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
@@ -11,7 +11,7 @@ rendered_metadata_name() {
 
   printf '%s\n' "$rendered" | awk '
     $0 == "metadata:" { in_metadata = 1; next }
-    in_metadata && $1 == "name:" && name == "" { name = $2; in_metadata = 0 }
+    in_metadata && $1 == "name:" && !found { name = $2; found = 1; in_metadata = 0 }
     END { print name }
   '
 }
@@ -22,9 +22,9 @@ rendered_role_quorum_value() {
   rendered=$(render_clickhouse_template templates/cmpd-keeper.yaml) || return
 
   printf '%s\n' "$rendered" | awk -v role="$role" '
-    $0 ~ "^[[:space:]]*- name: " role "$" { in_role = 1; next }
-    in_role && $0 ~ "^[[:space:]]*- name:" { in_role = 0 }
-    in_role && $1 == "participatesInQuorum:" && value == "" { value = $2; in_role = 0 }
+    !seen_role && $0 ~ "^[[:space:]]*- name: " role "$" { in_role = 1; seen_role = 1; next }
+    in_role && $0 ~ "^[[:space:]]*- name:" { in_role = 0; done = 1 }
+    in_role && $1 == "participatesInQuorum:" && !done { value = $2; in_role = 0; done = 1 }
     END { print value }
   '
 }
@@ -34,7 +34,7 @@ rendered_component_def_reference() {
   rendered=$(render_clickhouse_template "$1") || return
 
   printf '%s\n' "$rendered" |
-    awk '$1 == "componentDef:" && value == "" { value = $2 } END { print value }'
+    awk '$1 == "componentDef:" && !found { value = $2; found = 1 } END { print value }'
 }
 
 rendered_keeper_selector_contract() {
@@ -43,9 +43,9 @@ rendered_keeper_selector_contract() {
   component_version=$(render_clickhouse_template templates/cmpv.yaml) || return
 
   cluster_selector=$(printf '%s\n' "$cluster_definition" |
-    awk '$1 == "compDef:" && $2 ~ /^\^clickhouse-keeper-/ && value == "" { value = $2 } END { print value }')
+    awk '$1 == "compDef:" && $2 ~ /^\^clickhouse-keeper-/ && !found { value = $2; found = 1 } END { print value }')
   version_selector=$(printf '%s\n' "$component_version" |
-    awk '$1 == "-" && $2 ~ /^\^clickhouse-keeper-/ && value == "" { value = $2 } END { print value }')
+    awk '$1 == "-" && $2 ~ /^\^clickhouse-keeper-/ && !found { value = $2; found = 1 } END { print value }')
   printf '%s|%s\n' "$cluster_selector" "$version_selector"
 }
 
@@ -126,5 +126,29 @@ Describe "ClickHouse Keeper quorum role contract"
     When call rendered_old_version_reference_count
     The status should be success
     The output should eq "0"
+  End
+
+  Context "when the first componentDef reference is empty"
+    Mock render_clickhouse_template
+      printf 'componentDef:\ncomponentDef: later\n'
+    End
+
+    It "does not replace it with a later reference"
+      When call rendered_component_def_reference ignored.yaml
+      The status should be success
+      The output should eq ""
+    End
+  End
+
+  Context "when the first matching role omits participatesInQuorum"
+    Mock render_clickhouse_template
+      printf '%s\n' '- name: leader' '- name: follower' '- name: leader' '  participatesInQuorum: true'
+    End
+
+    It "does not accept the value from a duplicate later role"
+      When call rendered_role_quorum_value leader
+      The status should be success
+      The output should eq ""
+    End
   End
 End

--- a/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
+++ b/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+role_quorum_value() {
+  local role="$1"
+  local template_file="$2"
+
+  awk -v role="$role" '
+    $0 ~ "^[[:space:]]*- name: " role "$" { in_role = 1; next }
+    in_role && $0 ~ "^[[:space:]]*- name:" { exit }
+    in_role && $1 == "participatesInQuorum:" { print $2; exit }
+  ' "$template_file"
+}
+
+Describe "ClickHouse Keeper quorum role contract"
+  template_file="../templates/cmpd-keeper.yaml"
+
+  It "marks the leader as a quorum participant"
+    When call role_quorum_value leader "$template_file"
+    The status should be success
+    The output should eq "true"
+  End
+
+  It "marks followers as quorum participants"
+    When call role_quorum_value follower "$template_file"
+    The status should be success
+    The output should eq "true"
+  End
+
+  It "keeps observers outside the voting quorum"
+    When call role_quorum_value observer "$template_file"
+    The status should be success
+    The output should eq "false"
+  End
+End

--- a/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
+++ b/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
@@ -11,7 +11,8 @@ rendered_metadata_name() {
 
   printf '%s\n' "$rendered" | awk '
     $0 == "metadata:" { in_metadata = 1; next }
-    in_metadata && $1 == "name:" { print $2; exit }
+    in_metadata && $1 == "name:" && name == "" { name = $2; in_metadata = 0 }
+    END { print name }
   '
 }
 
@@ -22,8 +23,9 @@ rendered_role_quorum_value() {
 
   printf '%s\n' "$rendered" | awk -v role="$role" '
     $0 ~ "^[[:space:]]*- name: " role "$" { in_role = 1; next }
-    in_role && $0 ~ "^[[:space:]]*- name:" { exit }
-    in_role && $1 == "participatesInQuorum:" { print $2; exit }
+    in_role && $0 ~ "^[[:space:]]*- name:" { in_role = 0 }
+    in_role && $1 == "participatesInQuorum:" && value == "" { value = $2; in_role = 0 }
+    END { print value }
   '
 }
 
@@ -31,7 +33,8 @@ rendered_component_def_reference() {
   local rendered
   rendered=$(render_clickhouse_template "$1") || return
 
-  printf '%s\n' "$rendered" | awk '$1 == "componentDef:" { print $2; exit }'
+  printf '%s\n' "$rendered" |
+    awk '$1 == "componentDef:" && value == "" { value = $2 } END { print value }'
 }
 
 rendered_keeper_selector_contract() {
@@ -40,9 +43,9 @@ rendered_keeper_selector_contract() {
   component_version=$(render_clickhouse_template templates/cmpv.yaml) || return
 
   cluster_selector=$(printf '%s\n' "$cluster_definition" |
-    awk '$1 == "compDef:" && $2 ~ /^\^clickhouse-keeper-/ { print $2; exit }')
+    awk '$1 == "compDef:" && $2 ~ /^\^clickhouse-keeper-/ && value == "" { value = $2 } END { print value }')
   version_selector=$(printf '%s\n' "$component_version" |
-    awk '$1 == "-" && $2 ~ /^\^clickhouse-keeper-/ { print $2; exit }')
+    awk '$1 == "-" && $2 ~ /^\^clickhouse-keeper-/ && value == "" { value = $2 } END { print value }')
   printf '%s|%s\n' "$cluster_selector" "$version_selector"
 }
 

--- a/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
+++ b/addons/clickhouse/scripts-ut-spec/keeper_quorum_contract_spec.sh
@@ -1,35 +1,127 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034
 
-role_quorum_value() {
-  local role="$1"
-  local template_file="$2"
+render_clickhouse_template() {
+  helm template clickhouse .. --show-only "$1"
+}
 
-  awk -v role="$role" '
+rendered_metadata_name() {
+  local rendered
+  rendered=$(render_clickhouse_template "$1") || return
+
+  printf '%s\n' "$rendered" | awk '
+    $0 == "metadata:" { in_metadata = 1; next }
+    in_metadata && $1 == "name:" { print $2; exit }
+  '
+}
+
+rendered_role_quorum_value() {
+  local role="$1"
+  local rendered
+  rendered=$(render_clickhouse_template templates/cmpd-keeper.yaml) || return
+
+  printf '%s\n' "$rendered" | awk -v role="$role" '
     $0 ~ "^[[:space:]]*- name: " role "$" { in_role = 1; next }
     in_role && $0 ~ "^[[:space:]]*- name:" { exit }
     in_role && $1 == "participatesInQuorum:" { print $2; exit }
-  ' "$template_file"
+  '
+}
+
+rendered_component_def_reference() {
+  local rendered
+  rendered=$(render_clickhouse_template "$1") || return
+
+  printf '%s\n' "$rendered" | awk '$1 == "componentDef:" { print $2; exit }'
+}
+
+rendered_keeper_selector_contract() {
+  local cluster_definition component_version cluster_selector version_selector
+  cluster_definition=$(render_clickhouse_template templates/clusterdefinition.yaml) || return
+  component_version=$(render_clickhouse_template templates/cmpv.yaml) || return
+
+  cluster_selector=$(printf '%s\n' "$cluster_definition" |
+    awk '$1 == "compDef:" && $2 ~ /^\^clickhouse-keeper-/ { print $2; exit }')
+  version_selector=$(printf '%s\n' "$component_version" |
+    awk '$1 == "-" && $2 ~ /^\^clickhouse-keeper-/ { print $2; exit }')
+  printf '%s|%s\n' "$cluster_selector" "$version_selector"
+}
+
+rendered_keeper_bypass_count() {
+  local rendered
+  rendered=$(render_clickhouse_template templates/cmpd-keeper.yaml) || return
+  printf '%s\n' "$rendered" | grep -cF 'apps.kubeblocks.io/skip-immutable-check:' || true
+}
+
+rendered_old_version_reference_count() {
+  local rendered
+  rendered=$(helm template clickhouse ..) || return
+  printf '%s\n' "$rendered" | grep -cF '1.2.0-alpha.0' || true
 }
 
 Describe "ClickHouse Keeper quorum role contract"
-  template_file="../templates/cmpd-keeper.yaml"
-
   It "marks the leader as a quorum participant"
-    When call role_quorum_value leader "$template_file"
+    When call rendered_role_quorum_value leader
     The status should be success
     The output should eq "true"
   End
 
   It "marks followers as quorum participants"
-    When call role_quorum_value follower "$template_file"
+    When call rendered_role_quorum_value follower
     The status should be success
     The output should eq "true"
   End
 
   It "keeps observers outside the voting quorum"
-    When call role_quorum_value observer "$template_file"
+    When call rendered_role_quorum_value observer
     The status should be success
     The output should eq "false"
+  End
+
+  It "publishes a new versioned Keeper ComponentDefinition"
+    When call rendered_metadata_name templates/cmpd-keeper.yaml
+    The status should be success
+    The output should eq "clickhouse-keeper-1.2.0-alpha.1"
+  End
+
+  It "moves the ClickHouse ComponentDefinition to the same chart version"
+    When call rendered_metadata_name templates/cmpd-ch.yaml
+    The status should be success
+    The output should eq "clickhouse-1.2.0-alpha.1"
+  End
+
+  It "moves the Keeper ParametersDefinition reference to the new name"
+    When call rendered_component_def_reference templates/paramsdef-keeper.yaml
+    The status should be success
+    The output should eq "clickhouse-keeper-1.2.0-alpha.1"
+  End
+
+  It "moves the ClickHouse config ParametersDefinition reference to the new name"
+    When call rendered_component_def_reference templates/paramsdef-config.yaml
+    The status should be success
+    The output should eq "clickhouse-1.2.0-alpha.1"
+  End
+
+  It "moves the ClickHouse user ParametersDefinition reference to the new name"
+    When call rendered_component_def_reference templates/paramsdef-user.yaml
+    The status should be success
+    The output should eq "clickhouse-1.2.0-alpha.1"
+  End
+
+  It "keeps topology and ComponentVersion selectors compatible with the new Keeper name"
+    When call rendered_keeper_selector_contract
+    The status should be success
+    The output should eq "^clickhouse-keeper-1.*|^clickhouse-keeper-1.*"
+  End
+
+  It "does not retain the immutable-check bypass on the new Keeper definition"
+    When call rendered_keeper_bypass_count
+    The status should be success
+    The output should eq "0"
+  End
+
+  It "does not render references to the old chart version"
+    When call rendered_old_version_reference_count
+    The status should be success
+    The output should eq "0"
   End
 End

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -206,11 +206,11 @@ spec:
   roles:
     - name: leader
       updatePriority: 3
-      participatesInQuorum: false
+      participatesInQuorum: true
       isExclusive: true
     - name: follower
       updatePriority: 2
-      participatesInQuorum: false
+      participatesInQuorum: true
     - name: observer
       updatePriority: 1
       participatesInQuorum: false

--- a/addons/clickhouse/templates/cmpd-keeper.yaml
+++ b/addons/clickhouse/templates/cmpd-keeper.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "clickhouse.labels" . | nindent 4 }}
   annotations:
     {{- include "clickhouse.annotations" . | nindent 4 }}
-    apps.kubeblocks.io/skip-immutable-check: "true"
 spec:
   provider: ApeCloud
   description: {{ .Chart.Description }}


### PR DESCRIPTION
## Problem

ClickHouse Keeper is a Raft quorum, but its ComponentDefinition marks every role as `participatesInQuorum: false`. That prevents KubeBlocks from recognizing the leader and followers as voting roles when it plans rolling updates, scale-in, Stop, and recovery operations.

`spec.roles` is also part of the KubeBlocks ComponentDefinition immutable hash. Publishing corrected roles under the unchanged `1.2.0-alpha.0` chart/name would depend on `skip-immutable-check` rather than the formal versioned upgrade contract.

Contract sources:
- `kubeblocks-addon-docs/docs/addon-api/05a-lifecycle-roles-and-probe.md`
- `kubeblocks-addon-docs/docs/design/addon-componentdefinition-upgrade-guide.md`

## Change

- mark Keeper `leader` and `follower` as quorum participants
- keep `observer` outside the voting quorum
- advance the chart from `1.2.0-alpha.0` to `1.2.0-alpha.1`, producing new versioned ClickHouse/Keeper ComponentDefinition names and references
- remove `skip-immutable-check` from the new Keeper definition
- extend the focused ShellSpec from source literals to Helm-rendered quorum, version/name, reference-chain, selector, bypass-absence, and old-version-exclusion checks

## TDD evidence

- original role-only pre-fix proof: 3 examples / 2 failures
- expanded render contract on former head `31633d3`: 11 examples / 7 failures
- corrected current head: 11 examples / 0 failures
- ShellCheck on the focused spec: PASS
- Helm dependency build and lint: PASS
- rendered ComponentDefinitions: `clickhouse-1.2.0-alpha.1`, `clickhouse-keeper-1.2.0-alpha.1`
- rendered ParametersDefinition references moved to the matching new names
- old `1.2.0-alpha.0` render references: 0
- `git diff --check`: PASS

## Scope boundary

This is an independently identified product-contract fix. It is not claimed as the root cause of the separate HSC03 runtime failure reported on idc3; that runtime classification remains owned by the test evidence.

Closes #3199
