### PR TITLE
fix(rustfs): reject scale-up that creates pools too small for inherited parity

### DIFF
--- a/addons/rustfs/scripts-ut-spec/startup_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/startup_spec.sh
@@ -1,0 +1,108 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "startup_spec.sh skip cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "RustFS startup bash script tests"
+  Include ../scripts/startup.sh
+
+  Describe "default_parity_count()"
+    It "returns 0 for 1 drive"
+      When call default_parity_count 1
+      The output should equal "0"
+    End
+
+    It "returns 1 for 2 drives"
+      When call default_parity_count 2
+      The output should equal "1"
+    End
+
+    It "returns 1 for 3 drives"
+      When call default_parity_count 3
+      The output should equal "1"
+    End
+
+    It "returns 2 for 4 drives"
+      When call default_parity_count 4
+      The output should equal "2"
+    End
+
+    It "returns 2 for 5 drives"
+      When call default_parity_count 5
+      The output should equal "2"
+    End
+
+    It "returns 3 for 6 drives"
+      When call default_parity_count 6
+      The output should equal "3"
+    End
+
+    It "returns 4 for 8 drives"
+      When call default_parity_count 8
+      The output should equal "4"
+    End
+
+    It "returns 4 for 16 drives"
+      When call default_parity_count 16
+      The output should equal "4"
+    End
+  End
+
+  Describe "validate_pool_sizes()"
+    It "passes for single pool with 4 drives"
+      When call validate_pool_sizes "4"
+      The status should be success
+    End
+
+    It "passes for single pool with 2 drives"
+      When call validate_pool_sizes "2"
+      The status should be success
+    End
+
+    It "passes for equal-size pools 4,8 (two 4-drive pools)"
+      When call validate_pool_sizes "4,8"
+      The status should be success
+    End
+
+    It "passes for 4,7 (pool1=4 drives, pool2=3 drives, parity=2, data=1)"
+      When call validate_pool_sizes "4,7"
+      The status should be success
+    End
+
+    It "fails for 4,6 (pool2=2 drives, inherited parity=2, data=0)"
+      When call validate_pool_sizes "4,6"
+      The status should be failure
+      The error should include "TooFewDataShards"
+    End
+
+    It "fails for 4,5 (pool2=1 drive, inherited parity=2, data=-1)"
+      When call validate_pool_sizes "4,5"
+      The status should be failure
+      The error should include "TooFewDataShards"
+    End
+
+    It "passes for 2,4 (pool1=2 drives parity=1, pool2=2 drives, data=1)"
+      When call validate_pool_sizes "2,4"
+      The status should be success
+    End
+
+    It "passes for 3,6,9 (pool1=3 parity=1, all pools >=2)"
+      When call validate_pool_sizes "3,6,9"
+      The status should be success
+    End
+
+    It "fails for 6,8 (pool1=6 parity=3, pool2=2 drives, data=-1)"
+      When call validate_pool_sizes "6,8"
+      The status should be failure
+      The error should include "TooFewDataShards"
+    End
+
+    It "passes for 1 (single node, parity=0)"
+      When call validate_pool_sizes "1"
+      The status should be success
+    End
+  End
+End

--- a/addons/rustfs/scripts-ut-spec/startup_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/startup_spec.sh
@@ -175,6 +175,11 @@ Describe "RustFS startup bash script tests"
       The status should be success
     End
 
+    It "treats an explicit zero erasure set drive count as automatic layout"
+      When call validate_with_erasure_set_drive_count "0" "4,8"
+      The status should be success
+    End
+
     It "accepts the leading plus syntax accepted by Rust usize parsing"
       When call validate_with_erasure_set_drive_count "+3" "12,15"
       The status should be success
@@ -194,6 +199,16 @@ Describe "RustFS startup bash script tests"
 
     It "accepts a numeric erasure set override in single-node mode where RustFS ignores the layout override"
       When call validate_with_erasure_set_drive_count "4" "1"
+      The status should be success
+    End
+
+    It "accepts erasure set drive count one after parsing in single-node mode"
+      When call validate_with_erasure_set_drive_count "1" "1"
+      The status should be success
+    End
+
+    It "accepts the largest 64-bit erasure set drive count after parsing in single-node mode"
+      When call validate_with_erasure_set_drive_count "18446744073709551615" "1"
       The status should be success
     End
 
@@ -223,6 +238,16 @@ Describe "RustFS startup bash script tests"
 
     It "uses configured STANDARD parity instead of the default parity"
       When call validate_with_standard_storage_class "EC:1" "4,6"
+      The status should be success
+    End
+
+    It "accepts zero STANDARD parity"
+      When call validate_with_standard_storage_class "EC:0" "4,5"
+      The status should be success
+    End
+
+    It "accepts STANDARD parity equal to half of the first set"
+      When call validate_with_standard_storage_class "EC:2" "4,8"
       The status should be success
     End
 

--- a/addons/rustfs/scripts-ut-spec/startup_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/startup_spec.sh
@@ -9,6 +9,22 @@ fi
 Describe "RustFS startup bash script tests"
   Include ../scripts/startup.sh
 
+  validate_with_erasure_set_drive_count() {
+    export RUSTFS_ERASURE_SET_DRIVE_COUNT="$1"
+    validate_pool_sizes "$2"
+    status=$?
+    unset RUSTFS_ERASURE_SET_DRIVE_COUNT
+    return "$status"
+  }
+
+  validate_with_standard_storage_class() {
+    export RUSTFS_STORAGE_CLASS_STANDARD="$1"
+    validate_pool_sizes "$2"
+    status=$?
+    unset RUSTFS_STORAGE_CLASS_STANDARD
+    return "$status"
+  }
+
   Describe "default_parity_count()"
     It "returns 0 for 1 drive"
       When call default_parity_count 1
@@ -152,6 +168,96 @@ Describe "RustFS startup bash script tests"
     It "passes for 16,32 (pool0 dps=16 parity=4, pool1=16 dps=16, data=12)"
       When call validate_pool_sizes "16,32"
       The status should be success
+    End
+
+    It "uses the configured erasure set drive count for every pool"
+      When call validate_with_erasure_set_drive_count "3" "12,15"
+      The status should be success
+    End
+
+    It "accepts the leading plus syntax accepted by Rust usize parsing"
+      When call validate_with_erasure_set_drive_count "+3" "12,15"
+      The status should be success
+    End
+
+    It "fails the same history without the configured erasure set drive count"
+      When call validate_pool_sizes "12,15"
+      The status should be failure
+      The error should include "TooFewDataShards"
+    End
+
+    It "rejects an erasure set drive count that cannot divide a later pool"
+      When call validate_with_erasure_set_drive_count "4" "8,10"
+      The status should be failure
+      The error should include "RUSTFS_ERASURE_SET_DRIVE_COUNT=4"
+    End
+
+    It "accepts a numeric erasure set override in single-node mode where RustFS ignores the layout override"
+      When call validate_with_erasure_set_drive_count "4" "1"
+      The status should be success
+    End
+
+    It "rejects a set drive count outside the 64-bit Rust usize range before the single-node bypass"
+      When call validate_with_erasure_set_drive_count "18446744073709551616" "1"
+      The status should be failure
+      The error should include "outside the supported 64-bit unsigned integer range"
+    End
+
+    It "rejects an empty erasure set drive count before single-node startup"
+      When call validate_with_erasure_set_drive_count "" "1"
+      The status should be failure
+      The error should include "must be a non-negative decimal integer"
+    End
+
+    It "rejects an unsupported erasure set drive count"
+      When call validate_with_erasure_set_drive_count "1" "4"
+      The status should be failure
+      The error should include "supported divisor in [2,16]"
+    End
+
+    It "rejects an oversized erasure set drive count before shell arithmetic"
+      When call validate_with_erasure_set_drive_count "18446744073709551615" "4"
+      The status should be failure
+      The error should include "supported divisor in [2,16]"
+    End
+
+    It "uses configured STANDARD parity instead of the default parity"
+      When call validate_with_standard_storage_class "EC:1" "4,6"
+      The status should be success
+    End
+
+    It "accepts STANDARD parity with the Rust usize leading plus syntax"
+      When call validate_with_standard_storage_class "EC:+1" "4,6"
+      The status should be success
+    End
+
+    It "accepts STANDARD parity with leading zeroes"
+      When call validate_with_standard_storage_class "EC:01" "4,6"
+      The status should be success
+    End
+
+    It "treats an empty STANDARD value as default parity"
+      When call validate_with_standard_storage_class "" "4,6"
+      The status should be failure
+      The error should include "TooFewDataShards"
+    End
+
+    It "rejects malformed STANDARD storage class values"
+      When call validate_with_standard_storage_class "RS:1" "4,6"
+      The status should be failure
+      The error should include "RUSTFS_STORAGE_CLASS_STANDARD"
+    End
+
+    It "rejects STANDARD parity larger than half of the first set"
+      When call validate_with_standard_storage_class "EC:3" "4,8"
+      The status should be failure
+      The error should include "less than or equal to 2"
+    End
+
+    It "rejects STANDARD parity outside the 64-bit Rust usize range before shell arithmetic"
+      When call validate_with_standard_storage_class "EC:18446744073709551616" "4,8"
+      The status should be failure
+      The error should include "outside the supported 64-bit unsigned integer range"
     End
   End
 End

--- a/addons/rustfs/scripts-ut-spec/startup_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/startup_spec.sh
@@ -51,6 +51,45 @@ Describe "RustFS startup bash script tests"
     End
   End
 
+  Describe "drives_per_set()"
+    It "returns pool_size for small pools (4)"
+      When call drives_per_set 4
+      The output should equal "4"
+      The status should be success
+    End
+
+    It "returns pool_size for pools up to 16"
+      When call drives_per_set 16
+      The output should equal "16"
+      The status should be success
+    End
+
+    It "returns largest factor in [2,16] for 24 drives"
+      When call drives_per_set 24
+      The output should equal "12"
+      The status should be success
+    End
+
+    It "returns 5 for 25 drives (25=5x5)"
+      When call drives_per_set 25
+      The output should equal "5"
+      The status should be success
+    End
+
+    It "returns 16 for 32 drives"
+      When call drives_per_set 32
+      The output should equal "16"
+      The status should be success
+    End
+
+    It "fails for 17 drives (prime, no factor in [2,16])"
+      When call drives_per_set 17
+      The output should equal "0"
+      The status should be failure
+      The error should include "not divisible"
+    End
+  End
+
   Describe "validate_pool_sizes()"
     It "passes for single pool with 4 drives"
       When call validate_pool_sizes "4"
@@ -102,6 +141,16 @@ Describe "RustFS startup bash script tests"
 
     It "passes for 1 (single node, parity=0)"
       When call validate_pool_sizes "1"
+      The status should be success
+    End
+
+    It "passes for 25,28 (pool0 dps=5 parity=2, pool1=3 dps=3, data=1)"
+      When call validate_pool_sizes "25,28"
+      The status should be success
+    End
+
+    It "passes for 16,32 (pool0 dps=16 parity=4, pool1=16 dps=16, data=12)"
+      When call validate_pool_sizes "16,32"
       The status should be success
     End
   End

--- a/addons/rustfs/scripts/startup.sh
+++ b/addons/rustfs/scripts/startup.sh
@@ -72,6 +72,28 @@ default_parity_count() {
   esac
 }
 
+# RustFS splits each pool into erasure sets whose size is the largest
+# factor of pool_size in [2,16].  Parity is derived from that set size,
+# not from the raw pool drive count.
+drives_per_set() {
+  local pool_size=$1
+  if [ "$pool_size" -le 16 ]; then
+    echo "$pool_size"
+    return 0
+  fi
+  local d=16
+  while [ $d -ge 2 ]; do
+    if [ $((pool_size % d)) -eq 0 ]; then
+      echo "$d"
+      return 0
+    fi
+    d=$((d - 1))
+  done
+  echo "FATAL: pool has $pool_size drives which is not divisible by any erasure set size in [2,16]." >&2
+  echo 0
+  return 1
+}
+
 validate_pool_sizes() {
   local replicas=$1
   local prev=0
@@ -81,13 +103,18 @@ validate_pool_sizes() {
   IFS=','
   for cur in $replicas; do
     local pool_size=$((cur - prev))
+    local set_size
+    set_size=$(drives_per_set "$pool_size") || {
+      IFS="$old_ifs"
+      return 1
+    }
     if [ $pool_index -eq 0 ]; then
-      first_pool_parity=$(default_parity_count "$pool_size")
+      first_pool_parity=$(default_parity_count "$set_size")
     fi
-    if [ "$pool_size" -le "$first_pool_parity" ]; then
-      echo "FATAL: erasure pool $pool_index has $pool_size drive(s) but inherited parity is $first_pool_parity (from pool 0)." >&2
-      echo "data_blocks would be $((pool_size - first_pool_parity)) which causes TooFewDataShards panic." >&2
-      echo "Scale to a replica count where every pool has at least $((first_pool_parity + 1)) drives." >&2
+    if [ "$set_size" -le "$first_pool_parity" ]; then
+      echo "FATAL: erasure pool $pool_index has drives_per_set=$set_size but inherited parity is $first_pool_parity (from pool 0)." >&2
+      echo "data_blocks would be $((set_size - first_pool_parity)) which causes TooFewDataShards panic." >&2
+      echo "Scale to a replica count where every pool's erasure set has at least $((first_pool_parity + 1)) drives." >&2
       IFS="$old_ifs"
       return 1
     fi

--- a/addons/rustfs/scripts/startup.sh
+++ b/addons/rustfs/scripts/startup.sh
@@ -61,6 +61,43 @@ read_replicas_history() {
   echo "$content"
 }
 
+default_parity_count() {
+  local drives=$1
+  case $drives in
+    1) echo 0 ;;
+    2|3) echo 1 ;;
+    4|5) echo 2 ;;
+    6|7) echo 3 ;;
+    *) echo 4 ;;
+  esac
+}
+
+validate_pool_sizes() {
+  local replicas=$1
+  local prev=0
+  local first_pool_parity=""
+  local pool_index=0
+  local old_ifs="$IFS"
+  IFS=','
+  for cur in $replicas; do
+    local pool_size=$((cur - prev))
+    if [ $pool_index -eq 0 ]; then
+      first_pool_parity=$(default_parity_count "$pool_size")
+    fi
+    if [ "$pool_size" -le "$first_pool_parity" ]; then
+      echo "FATAL: erasure pool $pool_index has $pool_size drive(s) but inherited parity is $first_pool_parity (from pool 0)." >&2
+      echo "data_blocks would be $((pool_size - first_pool_parity)) which causes TooFewDataShards panic." >&2
+      echo "Scale to a replica count where every pool has at least $((first_pool_parity + 1)) drives." >&2
+      IFS="$old_ifs"
+      return 1
+    fi
+    prev=$cur
+    pool_index=$((pool_index + 1))
+  done
+  IFS="$old_ifs"
+  return 0
+}
+
 generate_volumes_env() {
   local replicas=$1
   local volumes=""
@@ -121,6 +158,10 @@ startup() {
 
   replicas=$(read_replicas_history "$replicas_history_file")
   echo "the rustfs replicas history is $replicas"
+
+  if ! validate_pool_sizes "$replicas"; then
+    exit 1
+  fi
 
   # Single node mode: use local data path
   if [ "$replicas" = "1" ]; then

--- a/addons/rustfs/scripts/startup.sh
+++ b/addons/rustfs/scripts/startup.sh
@@ -61,7 +61,8 @@ read_replicas_history() {
   echo "$content"
 }
 
-# Mirrors RustFS 1.0.0-beta.8 parity selection (init.rs).
+# Mirrors RustFS 1.0.0-beta.8 (64c0ede) parity selection
+# in crates/ecstore/src/config/storageclass.rs.
 # Re-verify on: engine version upgrade, #4801 merge, parity algorithm change.
 default_parity_count() {
   local drives=$1
@@ -74,10 +75,120 @@ default_parity_count() {
   esac
 }
 
-# Mirrors RustFS 1.0.0-beta.8 common_set_drive_count() (disks_layout.rs).
+parse_nonnegative_decimal() {
+  local value=$1
+  local name=$2
+  local original=$value
+  case "$value" in
+    +*) value=${value#+} ;;
+  esac
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "FATAL: $name must be a non-negative decimal integer, got '$original'." >&2
+      return 1
+      ;;
+  esac
+
+  while [ "${value#0}" != "$value" ]; do
+    value=${value#0}
+  done
+  value=${value:-0}
+
+  if [ "${#value}" -gt 20 ]; then
+    echo "FATAL: $name is outside the supported 64-bit unsigned integer range, got '$original'." >&2
+    return 1
+  fi
+  if [ "${#value}" -eq 20 ]; then
+    local first_digit
+    local remaining_digits
+    first_digit=${value%"${value#?}"}
+    remaining_digits=${value#?}
+    if [ "$first_digit" != "1" ] || [ "$remaining_digits" -gt 8446744073709551615 ]; then
+      echo "FATAL: $name is outside the supported 64-bit unsigned integer range, got '$original'." >&2
+      return 1
+    fi
+  fi
+  echo "$value"
+}
+
+configured_set_drive_count() {
+  if [ "${RUSTFS_ERASURE_SET_DRIVE_COUNT+x}" != "x" ]; then
+    # RustFS uses 0 as the explicit automatic-layout sentinel when unset.
+    echo 0
+    return 0
+  fi
+  parse_nonnegative_decimal "$RUSTFS_ERASURE_SET_DRIVE_COUNT" "RUSTFS_ERASURE_SET_DRIVE_COUNT"
+}
+
+# Mirrors lookup_config() and parse_storage_class() in the same beta.8
+# storageclass.rs: empty selects the default; non-empty must be EC:<parity>.
+standard_parity_count() {
+  local set_size=$1
+  local storage_class
+  storage_class=${RUSTFS_STORAGE_CLASS_STANDARD-}
+  if [ -z "$storage_class" ]; then
+    default_parity_count "$set_size"
+    return 0
+  fi
+
+  case "$storage_class" in
+    EC:*) ;;
+    *)
+      echo "FATAL: RUSTFS_STORAGE_CLASS_STANDARD has unsupported format '$storage_class'; expected EC:<parity>." >&2
+      return 1
+      ;;
+  esac
+
+  local parity
+  parity=$(parse_nonnegative_decimal "${storage_class#EC:}" "RUSTFS_STORAGE_CLASS_STANDARD parity") || return 1
+  local max_parity
+  max_parity=$((set_size / 2))
+  case "$parity" in
+    0|1|2|3|4|5|6|7|8)
+      if [ "$parity" -gt "$max_parity" ]; then
+        echo "FATAL: RUSTFS_STORAGE_CLASS_STANDARD parity $parity should be less than or equal to $max_parity for drives_per_set=$set_size." >&2
+        return 1
+      fi
+      ;;
+    *)
+      echo "FATAL: RUSTFS_STORAGE_CLASS_STANDARD parity $parity should be less than or equal to $max_parity for drives_per_set=$set_size." >&2
+      return 1
+      ;;
+  esac
+  echo "$parity"
+}
+
+# Mirrors RustFS 1.0.0-beta.8 (64c0ede) DisksLayout::new() and
+# common_set_drive_count() in crates/ecstore/src/disks_layout.rs.
 # Re-verify on: engine version upgrade, #4801 merge, SET_SIZES range change.
 drives_per_set() {
   local pool_size=$1
+  local configured
+  configured=$(configured_set_drive_count) || return 1
+
+  if [ "$pool_size" -eq 1 ]; then
+    echo 1
+    return 0
+  fi
+
+  case "$configured" in
+    0) ;;
+    2|3|4|5|6|7|8|9|10|11|12|13|14|15|16)
+      if [ $((pool_size % configured)) -ne 0 ]; then
+        echo "FATAL: pool has $pool_size drives but RUSTFS_ERASURE_SET_DRIVE_COUNT=$configured is not a supported divisor in [2,16]." >&2
+        echo 0
+        return 1
+      fi
+      echo "$configured"
+      return 0
+      ;;
+    *)
+      echo "FATAL: pool has $pool_size drives but RUSTFS_ERASURE_SET_DRIVE_COUNT=$configured is not a supported divisor in [2,16]." >&2
+      echo 0
+      return 1
+      ;;
+  esac
+
   if [ "$pool_size" -le 16 ]; then
     echo "$pool_size"
     return 0
@@ -110,7 +221,10 @@ validate_pool_sizes() {
       return 1
     }
     if [ $pool_index -eq 0 ]; then
-      first_pool_parity=$(default_parity_count "$set_size")
+      first_pool_parity=$(standard_parity_count "$set_size") || {
+        IFS="$old_ifs"
+        return 1
+      }
     fi
     if [ "$set_size" -le "$first_pool_parity" ]; then
       echo "FATAL: erasure pool $pool_index has drives_per_set=$set_size but inherited parity is $first_pool_parity (from pool 0)." >&2

--- a/addons/rustfs/scripts/startup.sh
+++ b/addons/rustfs/scripts/startup.sh
@@ -61,6 +61,8 @@ read_replicas_history() {
   echo "$content"
 }
 
+# Mirrors RustFS 1.0.0-beta.8 parity selection (init.rs).
+# Re-verify on: engine version upgrade, #4801 merge, parity algorithm change.
 default_parity_count() {
   local drives=$1
   case $drives in
@@ -72,9 +74,8 @@ default_parity_count() {
   esac
 }
 
-# RustFS splits each pool into erasure sets whose size is the largest
-# factor of pool_size in [2,16].  Parity is derived from that set size,
-# not from the raw pool drive count.
+# Mirrors RustFS 1.0.0-beta.8 common_set_drive_count() (disks_layout.rs).
+# Re-verify on: engine version upgrade, #4801 merge, SET_SIZES range change.
 drives_per_set() {
   local pool_size=$1
   if [ "$pool_size" -le 16 ]; then


### PR DESCRIPTION
## Summary

- Validate every RustFS erasure pool against the parity inherited from pool 0 before startup.
- Derive each pool's actual erasure-set size using the beta.8 `RUSTFS_ERASURE_SET_DRIVE_COUNT` semantics.
- Derive pool-0 parity using the beta.8 `RUSTFS_STORAGE_CLASS_STANDARD` semantics.
- Prevent deterministic `TooFewDataShards` startup panics without rejecting valid configured layouts.

## Root cause

RustFS beta.8 freezes `common_parity_drives` from the first pool's actual erasure set and applies it to later pools. If a later pool has `drives_per_set <= common_parity_drives`, its data-shard count becomes zero or negative and Reed-Solomon initialization panics.

The addon guard originally used raw pool sizes and default parity only. That diverged when RustFS split a pool into smaller erasure sets or when operators configured set size / STANDARD parity through environment variables.

## Configuration contract

- Unset or explicit-zero `RUSTFS_ERASURE_SET_DRIVE_COUNT` uses automatic layout.
- A set value follows 64-bit Rust `usize` parsing; single-node layout bypass occurs only after successful parsing.
- Non-single layouts require a configured set size in 2..16 that divides every pool.
- Empty `RUSTFS_STORAGE_CLASS_STANDARD` uses default parity; non-empty values must be `EC:<usize>` and no larger than half the first set.
- Later pools use the first pool parity, matching beta.8.

## Test plan

- [x] Red-first configuration regressions on the pre-fix implementation.
- [x] Focused RustFS startup ShellSpec: 47 examples, 0 failures.
- [x] Positive boundaries: explicit set `0`, single-node set `1` / `u64::MAX`, STANDARD `EC:0`, and parity exactly equal to half the first set.
- [x] Four targeted mutants are killed by only the new positive cases: 47/1, 47/2, 47/1, 47/1.
- [x] Covers configured/automatic layout, single-node ordering, leading `+` / zeroes, malformed/empty values, and 64-bit overflow before shell arithmetic.
- [x] Direct dash behavioral checks.
- [x] `sh -n`, `bash -n`, ShellCheck error, Helm lint/render, and `git diff --check` pass.

## Evidence boundary

These are code and static-test results only; they do not claim a Kubernetes runtime PASS or release readiness.
