### PR TITLE
fix(kafka): use action replica env in custom ops

### DIFF
--- a/addons/kafka/scripts-ut-spec/common_spec.sh
+++ b/addons/kafka/scripts-ut-spec/common_spec.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "common_spec.sh skips cases because bash 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Kafka common script tests"
+  Include ../scripts/common.sh
+
+  setup() {
+    kafka_config_path="$(mktemp -d)"
+    KAFKA_ADMIN_USER="admin"
+    KAFKA_ADMIN_PASSWORD="admin-password"
+    KAFKA_CLIENT_USER="client"
+    KAFKA_CLIENT_PASSWORD="client-password"
+    KB_KAFKA_SASL_ENABLE="true"
+    KB_KAFKA_ENABLE_SASL_SCRAM="false"
+    KB_KAFKA_SASL_USE_KB_BUILTIN="true"
+  }
+
+  cleanup() {
+    rm -rf "$kafka_config_path"
+  }
+
+  BeforeEach "setup"
+  AfterEach "cleanup"
+
+  It "writes PLAIN server user entries for the managed admin and client"
+    When call build_server_jaas_config \
+      "org.apache.kafka.common.security.plain.PlainLoginModule required"
+    The status should be success
+    The path "$kafka_config_path/kafka_jaas.conf" should include \
+      'user_admin="admin-password"'
+    The path "$kafka_config_path/kafka_jaas.conf" should include \
+      'user_client="client-password"'
+  End
+End

--- a/addons/kafka/scripts-ut-spec/common_spec.sh
+++ b/addons/kafka/scripts-ut-spec/common_spec.sh
@@ -10,14 +10,14 @@ Describe "Kafka common script tests"
   Include ../scripts/common.sh
 
   setup() {
-    kafka_config_path="$(mktemp -d)"
-    KAFKA_ADMIN_USER="admin"
-    KAFKA_ADMIN_PASSWORD="admin-password"
-    KAFKA_CLIENT_USER="client"
-    KAFKA_CLIENT_PASSWORD="client-password"
-    KB_KAFKA_SASL_ENABLE="true"
-    KB_KAFKA_ENABLE_SASL_SCRAM="false"
-    KB_KAFKA_SASL_USE_KB_BUILTIN="true"
+    export kafka_config_path="$(mktemp -d)"
+    export KAFKA_ADMIN_USER="admin"
+    export KAFKA_ADMIN_PASSWORD="admin-password"
+    export KAFKA_CLIENT_USER="client"
+    export KAFKA_CLIENT_PASSWORD="client-password"
+    export KB_KAFKA_SASL_ENABLE="true"
+    export KB_KAFKA_ENABLE_SASL_SCRAM="false"
+    export KB_KAFKA_SASL_USE_KB_BUILTIN="true"
   }
 
   cleanup() {
@@ -31,9 +31,10 @@ Describe "Kafka common script tests"
     When call build_server_jaas_config \
       "org.apache.kafka.common.security.plain.PlainLoginModule required"
     The status should be success
-    The path "$kafka_config_path/kafka_jaas.conf" should include \
+    The output should include "[sasl] write jaas config"
+    The contents of file "$kafka_config_path/kafka_jaas.conf" should include \
       'user_admin="admin-password"'
-    The path "$kafka_config_path/kafka_jaas.conf" should include \
+    The contents of file "$kafka_config_path/kafka_jaas.conf" should include \
       'user_client="client-password"'
   End
 End

--- a/addons/kafka/scripts-ut-spec/common_spec.sh
+++ b/addons/kafka/scripts-ut-spec/common_spec.sh
@@ -10,7 +10,8 @@ Describe "Kafka common script tests"
   Include ../scripts/common.sh
 
   setup() {
-    export kafka_config_path="$(mktemp -d)"
+    kafka_config_path="$(mktemp -d)"
+    export kafka_config_path
     export KAFKA_ADMIN_USER="admin"
     export KAFKA_ADMIN_PASSWORD="admin-password"
     export KAFKA_CLIENT_USER="client"

--- a/addons/kafka/scripts-ut-spec/opsdefinition_service_spec.sh
+++ b/addons/kafka/scripts-ut-spec/opsdefinition_service_spec.sh
@@ -23,9 +23,38 @@ validate_opsdefinition_service_names() {
   return "$status"
 }
 
+validate_opsdefinition_replica_vars() {
+  status=0
+
+  for file in \
+    ../templates/opsdefinitions/topic.yaml \
+    ../templates/opsdefinitions/quota.yaml \
+    ../templates/opsdefinitions/useracl.yaml
+  do
+    if ! grep -q 'KB_COMP_REPLICAS' "$file"; then
+      echo "$file: does not use the action pod replica variable KB_COMP_REPLICAS"
+      status=1
+    fi
+
+    if grep -q '\${COMPONENT_REPLICAS}' "$file"; then
+      echo "$file: uses the runtime pod replica variable COMPONENT_REPLICAS"
+      status=1
+    fi
+  done
+
+  return "$status"
+}
+
 Describe "Kafka OpsDefinition service bindings"
   It "uses the declared advertised-listener service for broker and combined components"
     When call validate_opsdefinition_service_names
+    The status should be success
+    The output should be blank
+  End
+
+
+  It "uses the replica count injected into the action pod"
+    When call validate_opsdefinition_replica_vars
     The status should be success
     The output should be blank
   End

--- a/addons/kafka/scripts-ut-spec/opsdefinition_service_spec.sh
+++ b/addons/kafka/scripts-ut-spec/opsdefinition_service_spec.sh
@@ -36,10 +36,55 @@ validate_opsdefinition_replica_vars() {
       status=1
     fi
 
+    if ! grep -Fq '[[ "${KB_COMP_REPLICAS:-}" =~ ^[1-9][0-9]*$ ]]' "$file"; then
+      echo "$file: does not reject a missing or invalid KB_COMP_REPLICAS value"
+      status=1
+    fi
+
     if grep -q '\${COMPONENT_REPLICAS}' "$file"; then
       echo "$file: uses the runtime pod replica variable COMPONENT_REPLICAS"
       status=1
     fi
+  done
+
+  return "$status"
+}
+
+validate_opsdefinition_replica_guard_behavior() {
+  status=0
+
+  for file in \
+    ../templates/opsdefinitions/topic.yaml \
+    ../templates/opsdefinitions/quota.yaml \
+    ../templates/opsdefinitions/useracl.yaml
+  do
+    guard=$(sed -n '/\[\[ "${KB_COMP_REPLICAS:-}" =~/,/^[[:space:]]*SERVERS=()/p' "$file" | sed '$d; s/^[[:space:]]*//')
+
+    for value in __UNSET__ "" 0 -1 abc 01 "1 "
+    do
+      if [ "$value" = "__UNSET__" ]; then
+        output=$(env -u KB_COMP_REPLICAS bash -c "$guard" 2>&1)
+      else
+        output=$(env KB_COMP_REPLICAS="$value" bash -c "$guard" 2>&1)
+      fi
+      guard_status=$?
+
+      if [ "$guard_status" -eq 0 ] || [ "$output" != "KB_COMP_REPLICAS must be a positive integer" ]; then
+        echo "$file: invalid replica value '$value' did not fail with the expected error"
+        status=1
+      fi
+    done
+
+    for value in 1 10
+    do
+      output=$(env KB_COMP_REPLICAS="$value" bash -c "$guard" 2>&1)
+      guard_status=$?
+
+      if [ "$guard_status" -ne 0 ] || [ -n "$output" ]; then
+        echo "$file: valid replica value '$value' was rejected"
+        status=1
+      fi
+    done
   done
 
   return "$status"
@@ -55,6 +100,12 @@ Describe "Kafka OpsDefinition service bindings"
 
   It "uses the replica count injected into the action pod"
     When call validate_opsdefinition_replica_vars
+    The status should be success
+    The output should be blank
+  End
+
+  It "fails fast unless the action pod replica count is a positive integer"
+    When call validate_opsdefinition_replica_guard_behavior
     The status should be success
     The output should be blank
   End

--- a/addons/kafka/scripts/common.sh
+++ b/addons/kafka/scripts/common.sh
@@ -82,7 +82,9 @@ build_server_jaas_config() {
 KafkaServer {
   ${login_module}
   username="$KAFKA_ADMIN_USER"
-  password="$admin_password";
+  password="$admin_password"
+  user_$KAFKA_ADMIN_USER="$admin_password"
+  user_$KAFKA_CLIENT_USER="$client_password";
 };
 KafkaClient {
   ${login_module}

--- a/addons/kafka/templates/opsdefinitions/quota.yaml
+++ b/addons/kafka/templates/opsdefinitions/quota.yaml
@@ -61,6 +61,10 @@ spec:
                 - -c
                 - |
                   set -e
+                  [[ "${KB_COMP_REPLICAS:-}" =~ ^[1-9][0-9]*$ ]] || {
+                    echo "KB_COMP_REPLICAS must be a positive integer" >&2
+                    exit 1
+                  }
                   SERVERS=()
                   for i in $(seq 0 $((${KB_COMP_REPLICAS}-1))); do
                     SERVERS+=("${KB_COMP_SVC_NAME}-${i}:${KB_COMP_SVC_PORT_BROKER}")

--- a/addons/kafka/templates/opsdefinitions/quota.yaml
+++ b/addons/kafka/templates/opsdefinitions/quota.yaml
@@ -62,7 +62,7 @@ spec:
                 - |
                   set -e
                   SERVERS=()
-                  for i in $(seq 0 $((${COMPONENT_REPLICAS}-1))); do
+                  for i in $(seq 0 $((${KB_COMP_REPLICAS}-1))); do
                     SERVERS+=("${KB_COMP_SVC_NAME}-${i}:${KB_COMP_SVC_PORT_BROKER}")
                   done
                   KB_CONNECT_ENDPOINT=$(printf "%s," "${SERVERS[@]}")

--- a/addons/kafka/templates/opsdefinitions/topic.yaml
+++ b/addons/kafka/templates/opsdefinitions/topic.yaml
@@ -67,7 +67,7 @@ spec:
                 - |
                   set -e
                   SERVERS=()
-                  for i in $(seq 0 $((${COMPONENT_REPLICAS}-1))); do
+                  for i in $(seq 0 $((${KB_COMP_REPLICAS}-1))); do
                     SERVERS+=("${KB_COMP_SVC_NAME}-${i}:${KB_COMP_SVC_PORT_BROKER}")
                   done
                   KB_CONNECT_ENDPOINT=$(printf "%s," "${SERVERS[@]}")

--- a/addons/kafka/templates/opsdefinitions/topic.yaml
+++ b/addons/kafka/templates/opsdefinitions/topic.yaml
@@ -66,6 +66,10 @@ spec:
                 - -c
                 - |
                   set -e
+                  [[ "${KB_COMP_REPLICAS:-}" =~ ^[1-9][0-9]*$ ]] || {
+                    echo "KB_COMP_REPLICAS must be a positive integer" >&2
+                    exit 1
+                  }
                   SERVERS=()
                   for i in $(seq 0 $((${KB_COMP_REPLICAS}-1))); do
                     SERVERS+=("${KB_COMP_SVC_NAME}-${i}:${KB_COMP_SVC_PORT_BROKER}")

--- a/addons/kafka/templates/opsdefinitions/useracl.yaml
+++ b/addons/kafka/templates/opsdefinitions/useracl.yaml
@@ -108,7 +108,7 @@ spec:
             - |
               set -e
               SERVERS=()
-              for i in $(seq 0 $((${COMPONENT_REPLICAS}-1))); do
+              for i in $(seq 0 $((${KB_COMP_REPLICAS}-1))); do
                 SERVERS+=("${KB_COMP_SVC_NAME}-${i}:${KB_COMP_SVC_PORT_BROKER}")
               done
               KB_CONNECT_ENDPOINT=$(printf "%s," "${SERVERS[@]}")

--- a/addons/kafka/templates/opsdefinitions/useracl.yaml
+++ b/addons/kafka/templates/opsdefinitions/useracl.yaml
@@ -107,6 +107,10 @@ spec:
             - -c
             - |
               set -e
+              [[ "${KB_COMP_REPLICAS:-}" =~ ^[1-9][0-9]*$ ]] || {
+                echo "KB_COMP_REPLICAS must be a positive integer" >&2
+                exit 1
+              }
               SERVERS=()
               for i in $(seq 0 $((${KB_COMP_REPLICAS}-1))); do
                 SERVERS+=("${KB_COMP_SVC_NAME}-${i}:${KB_COMP_SVC_PORT_BROKER}")


### PR DESCRIPTION
## Problem

The release-1.1 custom Ops action pod injects the current component replica
count as `KB_COMP_REPLICAS`. The Kafka topic, quota, and ACL action scripts read
`COMPONENT_REPLICAS`, which belongs to the runtime component path and is empty
in the action pod.

In the PR #3168 runtime run, the topic action therefore built an empty
`--bootstrap-server` endpoint even after the service name was corrected.

Later runtime rounds also proved the SASL PLAIN JAAS user-entry fix from merged
PR #2827, but the tester package was built from an uncommitted product diff.
Its runtime evidence is useful, but the package was not reproducible from its
recorded git head.

## Change

- use `KB_COMP_REPLICAS` in all three Kafka custom OpsDefinitions;
- fail fast with a clear error unless `KB_COMP_REPLICAS` is a positive decimal
  integer;
- extend the OpsDefinition regression spec to reject the runtime-pod variable
  and execute the exact embedded guard for unset, empty, invalid, and valid
  values in all three templates;
- integrate the already-merged PR #2827 JAAS PLAIN user-entry fix into this
  release-1.1 child branch;
- execute `build_server_jaas_config` in ShellSpec and assert the managed admin
  and client `user_*` entries in the generated file.

## Local evidence

Original variable-contract red before the code change: 2 examples / 1 failure,
reporting all three templates.

Guard-hardening TDD at current head `8dda9d555ce71922c776222b5b13cb86b5d71c9c`:

- new guard requirement before implementation: focused ShellSpec 2 examples /
  1 failure, reporting all three templates;
- focused ShellSpec after implementation: 3 examples / 0 failures;
- Kafka ShellSpec on Bash 5.3 before the JAAS integration: 24 examples / 0
  failures;
- invalid guard cases cover unset, empty, zero, negative, nonnumeric,
  leading-zero, and trailing-space values; valid cases cover `1` and `10`;
- Helm lint: 1 chart / 0 failures;
- Helm render succeeded; the explicit guard occurs in topic, quota, and user ACL
  commands, with no legacy `${COMPONENT_REPLICAS}` use;
- `git diff --check`: pass;
- independent subagent review after behavioral-test correction: NO BLOCKER,
  XP classes 1-8 clean.
- GitHub checks at `8dda9d55...`: 7 / 7 successful.

JAAS reproducibility TDD at current head
`367d32f5098a99582b22d4c72d5c28efa5e8d8df`:

- corrected execution spec against exact parent `8dda9d55...`: 1 example / 1
  failure because both managed `user_*` entries were absent;
- current focused spec: 1 example / 0 failures;
- current Kafka ShellSpec on Bash 5.3: 25 examples / 0 failures;
- new spec ShellCheck: clean; Bash syntax check: pass;
- Helm lint: 1 chart / 0 failures; `git diff --check`: pass;
- committed `common.sh` SHA256
  `e23c356278ddfc7ca91227a97940175b4637495129fadb9200cb81e254bf94c1`,
  exactly matching the script bytes extracted from the historical composite
  Helm release;
- independent Codex subagent: NO BLOCKER, XP classes 1-8 clean. Review artifact
  SHA256 `70bf01761c1e1ad890fd995689e3d015900863c785fffbe06098314f116949e3`.

GitHub checks at exact `367d32f5...`: 7 / 7 successful.

Magnus returned NO BLOCKER for #3168 at
`0f3c627a72ef2d36d2e6fb2a0c88ea5f2f43e7d4` and, after the hardening change,
fresh NO BLOCKER for #3202 at
`8dda9d555ce71922c776222b5b13cb86b5d71c9c`. Magnus also independently
reproduced the JAAS parent red 1/1, current green 1/0, full Kafka 25/0, and
returned fresh NO BLOCKER for exact `367d32f5...`. Focused runtime remains
required.

## Current candidate identity

The tester built exact clean head
`367d32f5098a99582b22d4c72d5c28efa5e8d8df` as chart
`kafka-1.0.3-pr3202-v3`, package SHA256
`d0aebcf2d0b74f1821e4cd75bd64e010a6d67bc0503b4a54c23ee17d0811c0cd`,
and deployed Helm revision 12 on 2026-07-15 10:19:59 +0800.

Committed, packaged, and deployed `common.sh` bytes all have SHA256
`e23c356278ddfc7ca91227a97940175b4637495129fadb9200cb81e254bf94c1`.
The live `kafka-server-scripts-tpl` ConfigMap is labeled with chart
`kafka-1.0.3-pr3202-v3`, and both KafkaServer blocks contain the managed admin
and client `user_*` entries. Candidate identity is closed.

Current exact-package runner-drift observations, not acceptance counts:

- Run 15 `ops-reconfigure-sasl-tls`: PASS 12 / FAIL 0 / SKIP 0, rc=0;
  evidence `20260715-102116-20521`.
- Run 16 `custom-ops-matrix`: PASS 33 / FAIL 0 / SKIP 2; evidence
  `20260715-102451-27473`. The skips are explicit specification boundaries:
  topic deletion disabled and no ACL authorizer configured.
- cleanup closed: namespace `kafka-pr3168-focused` NotFound and the
  all-namespace Cluster/OpsRequest query returned no resources.

Exact-v3 full-suite Run 18 is frozen at its first red: PASS 121 / FAIL 1 /
SKIP 0, rc=1, evidence `20260715-104837-89016`. The failing
`ops-scale-out` consumer matched the expected message in the final attempts but
the timeout wrapper returned rc=124. Scale-out reached `Succeed`, the Cluster
was Running with three pods, produce passed, and a subsequent unchanged-scene
manual consumer returned the expected message with rc=0.

The first blocker is Layer 2 runner provenance drift: the declared tests pin is
PR #764 `157de9cd0c61e1c14c2849e62443398cb8fa96e7`, but Run 18 actually used
`4299d9660f8f32241cb61ff69a8b66114358a1bc`. Those commits differ in nine Kafka
files and are not interchangeable. Run 18 is non-countable. A secondary probe
defect is also visible: the primary path rejects rc=124 plus matched output,
while a fallback path accepts the same outcome only when `--max-messages` is
unsupported. Product failure is unproven. Readback of `cluster_lib_sha` proved
Runs 15-19 all used `4299d966...`, not the declared tests pin, so all are
non-countable and current runtime acceptance is N=0.

Runner-drift cleanup is closed: the five runs used four owned namespaces
(`kafka-pr3168-focused`, `kafka-pr3168-n2`, `kafka-pr3168-n3`, and
`kafka-pr3168-full`); all four returned NotFound, the all-namespace
Cluster/OpsRequest query returned no resources, and no force or finalizer
operation was used.

The replacement tests pin is stacked PR #809 exact
`18a2b0b102bad04c25bc8e9f1484bc0195ee1df1`, whose ancestry includes PR #764
exact `157de9cd0c61e1c14c2849e62443398cb8fa96e7`. Relative to that parent it
changes only four Kafka test files (`+84/-2`): a shared
`consume_attempt_accepted` helper used by both consume paths, a real-code
four-case unit, its `static` suite registration, and its catalog entry.
Independent local verification reproduced parent RED rc=1, candidate unit
PASS4/0, bounded-wait PASS8/0, the full local static row PASS, bash-n green,
and a clean tree. Gina's fresh independent subagent review returned ACCEPT.
This exact tests pin starts the next runtime ledger at N=0; no earlier runtime
observation carries forward. PR #809 is now merged as
`54e3acf1e703695d67528797d122916eba41922c`; #764 was also marked merged, and
superseded Kafka test PRs #684, #681, and #653 were closed with replacement
comments. Those actions close tests PR process gates only.

### Latest exact-pin runtime update

On exact tests `18a2b0b...`, the current package produced isolated scale-out
N=1 PASS12/0/0 (`20260715-115635-34185`) and focused SASL/TLS plus custom Ops
N=1 and N=2, each PASS46/0/2 (`20260715-120141-63243`,
`20260715-121816-69752`). Those three completed scenes have closed cleanup.

The exact-pin full suite stopped at its first red with PASS143/FAIL1/SKIP0,
evidence `20260715-121211-41705`. The earlier chat label
`20260715-121236-44834` has no immutable archive mapping and is not used as an
evidence ID. The first blocker is Layer3 probe semantics:
after scale-in 3-to-1 reports OpsRequest `Succeed` and Cluster `Running`, the
runner performs one topic-create with no bounded Kafka convergence retry. That
call timed out with node 0 disconnected. Read-only broker API and topic-list
probes succeeded minutes later in the unchanged scene. This N=1 result does
not establish a controller or Kafka product defect. Focused N=3 was paused
mid-suite and is non-countable.

Observed-clean cleanup is closed by receipt
`cleanup-closeout-20260715T104956Z.md` SHA256
`0ff2880b81e395d5bbe7a50ce68e3d8be3a1954874437dbc9c466cdea8a89990`:
both namespaces are NotFound, global Cluster/OpsRequest is empty, and scoped
Pod/PVC readback has no match. It does not claim a deletion actor or any
force/finalizer action. The first-fail archive manifest SHA256 is
`1e2dc82426ca738fc40c82afcb9a28fb30cec1c61b628088168c071ab1f78be7`.

The bounded topic-create patch is now merged as kubeblocks-tests PR #831.
Reviewed head `81939c24aad292aa4fb0b442a64d54329736f9f4` became merge commit
`a110f26ee7b47fef87ed480b5e2be09852646c40`, the next tests pin. Offline
production-path coverage is PASS73/FAIL0: successful-empty broker discovery
falls back to the combined component, nonzero preserves rc/stderr and stops
before fallback/exec, successful-nonempty selects the broker, and a
TERM-ignoring child is strongly bounded with rc137 plus KILL evidence.
Independent tester and developer reviews returned no blocker.

A fresh combined-topology scale-in run on the reviewed PR #831 head passed the
pre-scale-in topic create and roundtrip, then froze at PASS10/FAIL1/SKIP0 after
all six post-scale-in topic-create attempts returned rc124 across the exact
211-second declared window. Evidence is `20260715-201310-32788`; freeze is
`first-fail-20260715-202055`. This proves the corrected bounded runner executed
and failed closed. It does not yet establish a controller or Kafka product
defect; five-layer classification of the unchanged scene is still open.
Runtime acceptance for the merge pin is N=0.

The two invalid-head diagnostic scenes were closed by ordinary namespace
cleanup with no force/finalizer mutation. Their scoped receipt SHAs are
`45e02817044d4e4cc5f7288abfc7fcdbcb65ce02270f8e45fefa58af6d8e0d5d` and
`3f9e22094aa829d879bba2a9894a384d508b5032a24c57a9ceb10f08f28499ec`.

## Previous runtime evidence

The prior head `da9bca63b531d1c8a803a91892498f86dbe9fae7`, package SHA256
`ab6127c9fa830d34ee373a4ff727f1e1dd23173231dee72dc80e767887c2fe86`, had one
focused release-1.1 runtime observation:

- existing dedicated vcluster `kafka-kb11-pr3168-v1`, not rebuilt;
- KubeBlocks `release-1.1@00a42539bc879c0748371fd51fecfb62dca77461`;
- tests `157de9cd0c61e1c14c2849e62443398cb8fa96e7`;
- `custom-ops-matrix`: rc=0, PASS 33 / FAIL 0 / SKIP 2;
- topic, quota, and user ACL OpsDefinitions reached `Succeed`; bootstrap
  endpoints were non-empty.

Evidence path on the test executor:
`/Users/apecloud/work/kubeblocks-tests/kafka/evidence/20260714-165625-85060`.

## Historical composite runtime evidence

The tester built `8dda9d555ce71922c776222b5b13cb86b5d71c9c` plus an uncommitted
diff equivalent to merged PR #2827 as
chart `1.0.3-pr3202-v2`, Helm revision 9, package SHA256
`a28e4a1c6ad1dcf40ae8680b5e5079bf9a4496c5b5a967b92c5cabd7a7b4c090`.

Focused `custom-ops-matrix` Run 11 terminal: PASS 33 / FAIL 0 / SKIP 2.
Topic-create, quota-set, and ACL-add reached `Succeed`; the expected topic-delete
and ACL paths were skipped for disabled engine features. Evidence run:
`20260715-062418-10452`.

Full-suite Run 12 terminal: PASS 213 / FAIL 0 / SKIP 3 across 14 completed
suites. Evidence run: `20260715-063539-39465`. The skips remain explicit
caveats: Chaos Mesh CRD absent, kbagent sidecar absent, and one OpsRequest
completing before the kill window.

High-risk Runs 13 and 14 added two independent rounds. Across Runs 11-14, six
high-risk suites reached cumulative N=3, 18 independent suite executions passed,
and no failure was reported. Evidence runs: `20260715-080521-58705` and
`20260715-085828-91257`.

Cleanup residue is closed for that scene: the test namespace returned NotFound,
and the all-namespace Cluster/OpsRequest query returned no resources.

## Boundary

The historical composite package has high-risk N=3 on one dedicated vcluster,
with the three skip caveats above. Its runner recorded only git head
`8dda9d55...` and omitted the dirty product diff, so it is not a reproducible
release candidate and is not described as PR #3202 exact-head acceptance.

Current committed head `367d32f5098a99582b22d4c72d5c28efa5e8d8df` makes those product bytes
reproducible and the v3 package/live byte identity gate is closed. Current
focused observations are green runner-drift history, not acceptance. Runs
15-19 are non-countable due to Layer2 runner provenance drift and have no
product-failure verdict. Corrected stacked tests pin `18a2b0b...` has closed
its local/review gate and starts acceptance from N=0. This PR remains Draft and
is not release-ready.

Parent: #3168 exact head
`0f3c627a72ef2d36d2e6fb2a0c88ea5f2f43e7d4`.
