### PR TITLE
fix(apecloud-mysql): render API-valid runtime fields

### DIFF
--- a/addons/apecloud-mysql/scripts-ut-spec/cmpd_runtime_contract_spec.sh
+++ b/addons/apecloud-mysql/scripts-ut-spec/cmpd_runtime_contract_spec.sh
@@ -1,0 +1,108 @@
+# shellcheck shell=bash
+
+Describe "ApeCloud MySQL ComponentDefinition runtime render contract"
+
+  validate_runtime_contract() {
+    local mode="$1"
+    local chart_dir
+    local -a helm_args
+
+    chart_dir=$(cd .. && pwd)
+    helm_args=(template kb-addon-apecloud-mysql "$chart_dir" --dependency-update)
+    case "$mode" in
+      enabled)
+        helm_args+=(--set logCollector.enabled=true)
+        ;;
+      sensitive)
+        helm_args+=(
+          --set-string cluster.templateConfig=true
+          --set-string cluster.customConfig=123
+          --set-string cluster.dynamicConfig=alpha:beta
+        )
+        ;;
+    esac
+
+    helm "${helm_args[@]}" | ruby -ryaml -e '
+      mode = ARGV.fetch(0)
+      documents = YAML.load_stream($stdin.read).compact
+      matches = documents.select do |doc|
+        doc["kind"] == "ComponentDefinition" &&
+          doc.dig("metadata", "name")&.match?(/^apecloud-mysql-/)
+      end
+      abort "expected one ApeCloud MySQL ComponentDefinition, got #{matches.length}" unless matches.length == 1
+
+      runtime = matches.first.dig("spec", "runtime")
+      abort "runtime is missing" unless runtime.is_a?(Hash)
+      containers = runtime.fetch("containers")
+
+      find_container = lambda do |name|
+        found = containers.select { |container| container["name"] == name }
+        abort "expected one #{name} container, got #{found.length}" unless found.length == 1
+        found.first
+      end
+
+      env_value = lambda do |container, name|
+        found = container.fetch("env").select { |entry| entry["name"] == name }
+        abort "expected one #{name} env entry, got #{found.length}" unless found.length == 1
+        entry = found.first
+        abort "#{name} must contain a value key" unless entry.key?("value")
+        value = entry["value"]
+        abort "#{name} value must be a string, got #{value.class}" unless value.is_a?(String)
+        value
+      end
+
+      mysql = find_container.call("mysql")
+      expected = if mode == "sensitive"
+                   {
+                     "MYSQL_TEMPLATE_CONFIG" => "true",
+                     "MYSQL_CUSTOM_CONFIG" => "123",
+                     "MYSQL_DYNAMIC_CONFIG" => "alpha:beta"
+                   }
+                 else
+                   {
+                     "MYSQL_TEMPLATE_CONFIG" => "",
+                     "MYSQL_CUSTOM_CONFIG" => "",
+                     "MYSQL_DYNAMIC_CONFIG" => ""
+                   }
+                 end
+
+      expected.each do |name, value|
+        actual = env_value.call(mysql, name)
+        abort "#{name} expected #{value.inspect}, got #{actual.inspect}" unless actual == value
+      end
+
+      vtablet = find_container.call("vtablet")
+      grpc_port = env_value.call(vtablet, "VTTABLET_GRPC_PORT")
+      abort "VTTABLET_GRPC_PORT expected \"16100\", got #{grpc_port.inspect}" unless grpc_port == "16100"
+
+      if mode == "enabled"
+        volumes = runtime["volumes"]
+        abort "runtime.volumes must be an array" unless volumes.is_a?(Array)
+        names = volumes.map { |volume| volume.fetch("name") }
+        abort "runtime.volumes expected [\"log-data\"], got #{names.inspect}" unless names == ["log-data"]
+      else
+        abort "runtime must omit volumes when log collection is disabled" if runtime.key?("volumes")
+      end
+
+      puts "runtime render contract passed for #{mode}"
+    ' "$mode"
+  }
+
+  It "renders API-valid string env values and omits disabled volumes"
+    When call validate_runtime_contract default
+    The status should be success
+    The output should include "runtime render contract passed for default"
+  End
+
+  It "renders the log volume as an array when log collection is enabled"
+    When call validate_runtime_contract enabled
+    The status should be success
+    The output should include "runtime render contract passed for enabled"
+  End
+
+  It "preserves YAML-sensitive config values as strings"
+    When call validate_runtime_contract sensitive
+    The status should be success
+    The output should include "runtime render contract passed for sensitive"
+  End
+End

--- a/addons/apecloud-mysql/scripts-ut-spec/cmpd_runtime_contract_spec.sh
+++ b/addons/apecloud-mysql/scripts-ut-spec/cmpd_runtime_contract_spec.sh
@@ -8,7 +8,8 @@ Describe "ApeCloud MySQL ComponentDefinition runtime render contract"
     local -a helm_args
 
     chart_dir=$(cd .. && pwd)
-    helm_args=(template kb-addon-apecloud-mysql "$chart_dir" --dependency-update)
+    helm dependency build "$chart_dir" >/dev/null || return 1
+    helm_args=(template kb-addon-apecloud-mysql "$chart_dir")
     case "$mode" in
       enabled)
         helm_args+=(--set logCollector.enabled=true)

--- a/addons/apecloud-mysql/templates/_helpers.tpl
+++ b/addons/apecloud-mysql/templates/_helpers.tpl
@@ -345,11 +345,11 @@ env:
   - name: CLUSTER_START_INDEX
     value: {{ .Values.cluster.clusterStartIndex | default "1" | quote }}
   - name: MYSQL_TEMPLATE_CONFIG
-    value: {{ if .Values.cluster.templateConfig }}{{ .Values.cluster.templateConfig }}{{ end }}
+    value: {{ .Values.cluster.templateConfig | default "" | quote }}
   - name: MYSQL_CUSTOM_CONFIG
-    value: {{ if .Values.cluster.customConfig }}{{ .Values.cluster.customConfig }}{{ end }}
+    value: {{ .Values.cluster.customConfig | default "" | quote }}
   - name: MYSQL_DYNAMIC_CONFIG
-    value: {{ if .Values.cluster.dynamicConfig }}{{ .Values.cluster.dynamicConfig }}{{ end }}
+    value: {{ .Values.cluster.dynamicConfig | default "" | quote }}
   - name: KB_EMBEDDED_WESQL
     value: {{ .Values.cluster.kbWeSQLImage | default "1" | quote }}
   - name: KB_MYSQL_VOLUME_DIR
@@ -420,6 +420,7 @@ env:
   - name: VTTABLET_PORT
     value: "15100"
   - name: VTTABLET_GRPC_PORT
+    value: "16100"
   - name: VTCTLD_HOST
     value: "$(CLUSTER_NAME)-wescale-ctrl-headless"
   - name: VTCTLD_WEB_PORT

--- a/addons/apecloud-mysql/templates/cmpd-apecloudmysql.yaml
+++ b/addons/apecloud-mysql/templates/cmpd-apecloudmysql.yaml
@@ -62,5 +62,7 @@ spec:
         {{- include "apecloud-mysql.spec.runtime.vtablet" . |  nindent 8 }}
       - name: mysql-exporter
         {{- include "apecloud-mysql.spec.runtime.exporter" . | nindent 8 }}
+    {{- if .Values.logCollector.enabled }}
     volumes:
-      {{- include "apecloud-mysql.spec.runtime.volumes" . | nindent 4 }}
+      {{- include "apecloud-mysql.spec.runtime.volumes" . | nindent 6 }}
+    {{- end }}

--- a/addons/apecloud-mysql/values.yaml
+++ b/addons/apecloud-mysql/values.yaml
@@ -10,7 +10,7 @@ image:
   tag: 8.0.30-5.beta3.20240330.g94d1caf.15
   syncer:
     repository: apecloud/syncer
-    tag: 0.4.1
+    tag: 0.7.7
   walgImage:
     repository: apecloud/wal-g
     tag: mysql-8.0

--- a/addons/mongodb/values.yaml
+++ b/addons/mongodb/values.yaml
@@ -17,7 +17,7 @@ image:
     tag: 1.29
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.7"
+    tag: "0.7.7"
   exporter:
     repository: apecloud/mongodb_exporter
     tag: "0.44.0"

--- a/addons/mysql/values.yaml
+++ b/addons/mysql/values.yaml
@@ -16,7 +16,7 @@ image:
     repository: apecloud/percona-xtrabackup
   syncer:
     repository: apecloud/syncer
-    tag: 0.6.8
+    tag: 0.7.7
   # refer: addons/mysql/orc-tools/Dockerfile
   orcTools:
     repository: apecloud/orc-tools

--- a/addons/orioledb/values.yaml
+++ b/addons/orioledb/values.yaml
@@ -12,7 +12,7 @@ image:
   debug: false
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.5"
+    tag: "0.7.7"
 
 dataMountPath: /postgresql/mount_volume
 confMountPath: /postgresql/mount_conf

--- a/addons/vanilla-postgresql/values.yaml
+++ b/addons/vanilla-postgresql/values.yaml
@@ -38,7 +38,7 @@ image:
 
   syncer:
     repository: apecloud/syncer
-    tag: "0.6.5"
+    tag: "0.7.7"
 
 dataMountPath: /postgresql/volume_data
 confMountPath: /postgresql/mount_conf


### PR DESCRIPTION
## Problem

An exact PR #3195 chart install failed before any `Cluster` was created because the rendered ApeCloud MySQL `ComponentDefinition` violated the KubeBlocks API schema:

- `MYSQL_TEMPLATE_CONFIG`, `MYSQL_CUSTOM_CONFIG`, and `MYSQL_DYNAMIC_CONFIG` rendered as YAML `null`, but env values must be strings.
- `VTTABLET_GRPC_PORT` had no `value`.
- `spec.runtime.volumes` rendered as `null` when log collection was disabled, but the field must be an array when present.

The affected helper was unchanged between PR #3195 base and head, so this predates the syncer bump but blocks runtime verification of that exact head.

## Fix

- Normalize the three schema-nullable config values to quoted strings, using `""` for null.
- Set `VTTABLET_GRPC_PORT` to the declared container port `16100`.
- Omit the complete `runtime.volumes` property when log collection is disabled; render `log-data` as an array when enabled.
- Add a rendered-manifest ShellSpec contract covering default, enabled, and YAML-sensitive string values.

## Verification

- TDD before fix: 3 examples, 3 failures (`NilClass` / `TrueClass` env values).
- After fix: ApeCloud MySQL focused contract 3/3; all ApeCloud MySQL ShellSpec 28/28.
- `helm lint addons/apecloud-mysql`: PASS.
- Default and `logCollector.enabled=true` full chart renders: PASS.
- `bash -n`, ShellCheck error level, and `git diff --check`: PASS.
- Independent code review of exact commit `e1425859`: NO BLOCKER.

Full-repository ShellSpec is not green in this checkout: 1000 examples produced 9 failures in unrelated FalkorDB dependency and MariaDB render tests. This PR does not change those paths.

### Runtime follow-up for syncer 0.7.7 rows

All accepted packets bind exact head `e1425859d0e8249cca954b96c2dab9a6c499f9c5` to immutable chart/package and live image identities.

| Addon | Focused scope | Result | Cleanup | Evidence |
|---|---|---|---|---|
| `apecloud-mysql` | 8.0.30, 3 replicas, one sample | N=1, PASS25/0/0; provision and actual Service SQL through scale/switchover | clean, no force/finalizer | [packet](https://github.com/apecloud/kubeblocks-addons/pull/3203#issuecomment-4976568894) |
| `mysql` | 5.7.44, 8.0.46, 8.4.10, one sample per version | aggregate N=3; each PASS35/0/0; provision and actual Service SQL | clean per sample, no force/finalizer | [packet](https://github.com/apecloud/kubeblocks-addons/pull/3203#issuecomment-4976568894) |
| `mongodb` | one independent fresh sample | N=1 CLEAN, PASS28/0/0; 3-replica provision, primary Service write/read, readonly secondary Service read | clean, workload residue0 | [packet](https://github.com/apecloud/kubeblocks-addons/pull/3203#issuecomment-4976860842) |
| `orioledb` | one independent fresh sample | N=1 CLEAN; provision and actual Service DNS SQL | whole-vcluster clean, residue0 | [packet](https://github.com/apecloud/kubeblocks-addons/pull/3203#issuecomment-4976786803) |
| `vanilla-postgresql` | one independent fresh sample | N=1 CLEAN; provision and actual Service DNS SQL | whole-vcluster clean, residue0 | [packet](https://github.com/apecloud/kubeblocks-addons/pull/3203#issuecomment-4976820412) |

The first MongoDB sample remains separately recorded as provisional/environment-accommodated because it changed live StatefulSet CPU after launch and preserved cleanup. It contributes 0 to the clean MongoDB row and has not been rewritten.

## Boundary

The static/render fix is closed. The human-review runtime provision and actual Service-connectivity gap is closed for the five exact-head addon packages above.

Runtime evidence remains focused and exact-head only: one sample per listed row/version, except the aggregate MySQL count across three versions. It does not isolate the e142 one-commit effect on the otherwise unchanged `mysql` chart, and it is not row C, repeat `N>=2` per version, full matrix/fullsuite, broad regression, scale/day-2/DataProtection coverage for every addon, soak, T1r2, generalized quality, or release-ready evidence.

Merge order remains stacked onto PR #3195's head branch.
