### PR TITLE
fix(mongodb): quote parameter ownership matchers

### DIFF
--- a/addons/mongodb/scripts-ut-spec/parameters_definition_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/parameters_definition_spec.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+
+Describe "MongoDB ParametersDefinition ownership contract"
+
+  render_and_validate_parameters_definitions() {
+    local chart_dir render_dir status
+
+    chart_dir=${MONGODB_CHART_DIR:-$(cd .. && pwd)}
+    render_dir=$(mktemp -d)
+
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update > "$render_dir/default.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" --dependency-update \
+        --set resourceNamePrefix=static-resource > "$render_dir/resource-prefix.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" --dependency-update \
+        --set cmpdVersionPrefix=static-cmpd > "$render_dir/cmpd-prefix.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" --dependency-update \
+        --set resourceNamePrefix=static-resource \
+        --set cmpdVersionPrefix=static-cmpd > "$render_dir/both-prefixes.yaml" &&
+      ruby -ryaml -e '
+        paths = ARGV
+        all_names = []
+
+        paths.each do |path|
+          documents = YAML.load_stream(File.read(path)).compact
+          definitions = documents.select { |doc| doc["kind"] == "ComponentDefinition" }
+          parameter_definitions = documents.select { |doc| doc["kind"] == "ParametersDefinition" }
+
+          abort "#{path}: expected two ParametersDefinitions" unless parameter_definitions.length == 2
+
+          owners = definitions.select do |definition|
+            Array(definition.dig("spec", "configs")).any? do |config|
+              config["name"] == "mongodb-config" && config["externalManaged"] == true
+            end
+          end
+          abort "#{path}: expected four externally managed mongodb-config owners" unless owners.length == 4
+
+          matchers = parameter_definitions.map do |definition|
+            Regexp.new(definition.dig("spec", "componentDef"))
+          end
+
+          owners.each do |owner|
+            name = owner.dig("metadata", "name")
+            matching = matchers.count { |matcher| matcher.match?(name) }
+            abort "#{path}: #{name} is covered #{matching} times" unless matching == 1
+
+            near_collision = name.sub(".", "x")
+            next if near_collision == name
+            abort "#{path}: regex also matches near-collision #{near_collision}" if matchers.any? { |matcher| matcher.match?(near_collision) }
+          end
+
+          all_names.concat(parameter_definitions.map { |definition| definition.dig("metadata", "name") })
+        end
+
+        abort "ParametersDefinition names collide across prefix renders" unless all_names.uniq.length == all_names.length
+        puts "ParametersDefinition ownership contract passed for #{paths.length} renders"
+      ' "$render_dir/default.yaml" "$render_dir/resource-prefix.yaml" \
+        "$render_dir/cmpd-prefix.yaml" "$render_dir/both-prefixes.yaml"
+    status=$?
+
+    rm -rf "$render_dir"
+    return "$status"
+  }
+
+  It "quotes component names and isolates cluster-scoped names across prefix dimensions"
+    When call render_and_validate_parameters_definitions
+    The status should be success
+    The output should include "ParametersDefinition ownership contract passed for 4 renders"
+  End
+End

--- a/addons/mongodb/scripts-ut-spec/parameters_definition_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/parameters_definition_spec.sh
@@ -8,17 +8,18 @@ Describe "MongoDB ParametersDefinition ownership contract"
     chart_dir=${MONGODB_CHART_DIR:-$(cd .. && pwd)}
     render_dir=$(mktemp -d)
 
-    helm template kb-addon-mongodb "$chart_dir" --dependency-update > "$render_dir/default.yaml" &&
-      helm template kb-addon-mongodb "$chart_dir" --dependency-update \
+    helm dependency build "$chart_dir" >/dev/null || return
+    helm template kb-addon-mongodb "$chart_dir" > "$render_dir/default.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" \
         --set resourceNamePrefix=static-resource > "$render_dir/resource-prefix.yaml" &&
-      helm template kb-addon-mongodb "$chart_dir" --dependency-update \
+      helm template kb-addon-mongodb "$chart_dir" \
         --set cmpdVersionPrefix=static-cmpd > "$render_dir/cmpd-prefix.yaml" &&
-      helm template kb-addon-mongodb "$chart_dir" --dependency-update \
+      helm template kb-addon-mongodb "$chart_dir" \
         --set resourceNamePrefix=static-resource \
         --set cmpdVersionPrefix=static-cmpd > "$render_dir/both-prefixes.yaml" &&
       ruby -ryaml -e '
         paths = ARGV
-        all_names = []
+        stable_names = nil
 
         paths.each do |path|
           documents = YAML.load_stream(File.read(path)).compact
@@ -26,6 +27,9 @@ Describe "MongoDB ParametersDefinition ownership contract"
           parameter_definitions = documents.select { |doc| doc["kind"] == "ParametersDefinition" }
 
           abort "#{path}: expected two ParametersDefinitions" unless parameter_definitions.length == 2
+          names = parameter_definitions.map { |definition| definition.dig("metadata", "name") }.sort
+          stable_names ||= names
+          abort "#{path}: retained ParametersDefinition names changed" unless names == stable_names
 
           owners = definitions.select do |definition|
             Array(definition.dig("spec", "configs")).any? do |config|
@@ -47,11 +51,8 @@ Describe "MongoDB ParametersDefinition ownership contract"
             next if near_collision == name
             abort "#{path}: regex also matches near-collision #{near_collision}" if matchers.any? { |matcher| matcher.match?(near_collision) }
           end
-
-          all_names.concat(parameter_definitions.map { |definition| definition.dig("metadata", "name") })
         end
 
-        abort "ParametersDefinition names collide across prefix renders" unless all_names.uniq.length == all_names.length
         puts "ParametersDefinition ownership contract passed for #{paths.length} renders"
       ' "$render_dir/default.yaml" "$render_dir/resource-prefix.yaml" \
         "$render_dir/cmpd-prefix.yaml" "$render_dir/both-prefixes.yaml"
@@ -61,7 +62,7 @@ Describe "MongoDB ParametersDefinition ownership contract"
     return "$status"
   }
 
-  It "quotes component names and isolates cluster-scoped names across prefix dimensions"
+  It "quotes component names while preserving retained object identities"
     When call render_and_validate_parameters_definitions
     The status should be success
     The output should include "ParametersDefinition ownership contract passed for 4 renders"

--- a/addons/mongodb/templates/_helpers.tpl
+++ b/addons/mongodb/templates/_helpers.tpl
@@ -188,23 +188,3 @@ Define config server component definition name prefix
 {{- define "cfgServer.componentDefNamePrefix" -}}
 {{- printf "mongo-config-server-" -}}
 {{- end -}}
-
-{{/*
-Define the ParametersDefinition name prefix. ParametersDefinition is
-cluster-scoped, so its name must follow both chart isolation dimensions.
-*/}}
-{{- define "mongodb.parametersDefinitionNamePrefix" -}}
-{{- if ne (len .Values.resourceNamePrefix) 0 -}}
-{{ .Values.resourceNamePrefix }}-
-{{- end -}}
-{{- end -}}
-
-{{/*
-Define the ParametersDefinition version suffix shared with ComponentDefinitions.
-*/}}
-{{- define "mongodb.parametersDefinitionVersion" -}}
-{{- if ne (len .Values.cmpdVersionPrefix) 0 -}}
-{{ .Values.cmpdVersionPrefix }}-
-{{- end -}}
-{{ .Chart.Version }}
-{{- end -}}

--- a/addons/mongodb/templates/_helpers.tpl
+++ b/addons/mongodb/templates/_helpers.tpl
@@ -188,3 +188,23 @@ Define config server component definition name prefix
 {{- define "cfgServer.componentDefNamePrefix" -}}
 {{- printf "mongo-config-server-" -}}
 {{- end -}}
+
+{{/*
+Define the ParametersDefinition name prefix. ParametersDefinition is
+cluster-scoped, so its name must follow both chart isolation dimensions.
+*/}}
+{{- define "mongodb.parametersDefinitionNamePrefix" -}}
+{{- if ne (len .Values.resourceNamePrefix) 0 -}}
+{{ .Values.resourceNamePrefix }}-
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the ParametersDefinition version suffix shared with ComponentDefinitions.
+*/}}
+{{- define "mongodb.parametersDefinitionVersion" -}}
+{{- if ne (len .Values.cmpdVersionPrefix) 0 -}}
+{{ .Values.cmpdVersionPrefix }}-
+{{- end -}}
+{{ .Chart.Version }}
+{{- end -}}

--- a/addons/mongodb/templates/paramsdef.yaml
+++ b/addons/mongodb/templates/paramsdef.yaml
@@ -2,13 +2,13 @@
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:
-  name: {{ printf "mongodb-config-pd-%s" .Chart.Version }}
+  name: {{ printf "%smongodb-config-pd-%s" (include "mongodb.parametersDefinitionNamePrefix" .) (include "mongodb.parametersDefinitionVersion" .) }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
-  componentDef: {{ printf "^(%s|%s|%s)$" (include "mongodb.compDefName" .) (include "mongodbShard.compDefName" .) (include "cfgServer.compDefName" .) | quote }}
+  componentDef: {{ printf "^(%s|%s|%s)$" (include "mongodb.compDefName" . | regexQuoteMeta) (include "mongodbShard.compDefName" . | regexQuoteMeta) (include "cfgServer.compDefName" . | regexQuoteMeta) | quote }}
   templateName: mongodb-config
   fileName: mongodb.conf
   fileFormatConfig:
@@ -31,13 +31,13 @@ spec:
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:
-  name: {{ printf "mongos-config-pd-%s" .Chart.Version }}
+  name: {{ printf "%smongos-config-pd-%s" (include "mongodb.parametersDefinitionNamePrefix" .) (include "mongodb.parametersDefinitionVersion" .) }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   annotations:
     {{- include "mongodb.annotations" . | nindent 4 }}
 spec:
-  componentDef: {{ printf "^%s$" (include "mongos.compDefName" .) | quote }}
+  componentDef: {{ printf "^%s$" (include "mongos.compDefName" . | regexQuoteMeta) | quote }}
   templateName: mongodb-config
   fileName: mongos.conf
   fileFormatConfig:

--- a/addons/mongodb/templates/paramsdef.yaml
+++ b/addons/mongodb/templates/paramsdef.yaml
@@ -2,7 +2,7 @@
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:
-  name: {{ printf "%smongodb-config-pd-%s" (include "mongodb.parametersDefinitionNamePrefix" .) (include "mongodb.parametersDefinitionVersion" .) }}
+  name: {{ printf "mongodb-config-pd-%s" .Chart.Version }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   annotations:
@@ -31,7 +31,7 @@ spec:
 apiVersion: parameters.kubeblocks.io/v1alpha1
 kind: ParametersDefinition
 metadata:
-  name: {{ printf "%smongos-config-pd-%s" (include "mongodb.parametersDefinitionNamePrefix" .) (include "mongodb.parametersDefinitionVersion" .) }}
+  name: {{ printf "mongos-config-pd-%s" .Chart.Version }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
## Problem

MongoDB `ParametersDefinition.spec.componentDef` interpolates rendered ComponentDefinition names as unescaped regular expressions. Chart-version dots therefore match arbitrary characters, so a matcher for `mongo-config-server-1.2.0-alpha.0` also accepts near-collisions such as `mongo-config-server-1x2.0-alpha.0`.

The two ParametersDefinition objects also carry `helm.sh/resource-policy: keep`. Their historical metadata names must remain stable across upgrades; this PR intentionally does not derive them from user prefixes.

## Change

- quote every rendered ComponentDefinition name with Helm `regexQuoteMeta` before constructing the anchored ownership regex
- preserve the historical `mongodb-config-pd-<chartVersion>` and `mongos-config-pd-<chartVersion>` object identities
- add a focused ShellSpec covering default, `resourceNamePrefix`, `cmpdVersionPrefix`, and combined renders
- assert exact single ownership, reject dotted near-collisions, and assert retained identities remain stable across all renders
- materialize Helm dependencies separately so repository-status output cannot enter YAML parsing

## TDD / verification

Base: `41801859b685dea4f8d603b7aa4b90a7fb52e2d1`
Head: `8e2601669b29472230ed73b4696205cf2ade2cb1`

- focused ShellSpec against exact base: RED, 1 example / 1 failure; first error is regex matching `mongo-config-server-1x2.0-alpha.0`
- focused ShellSpec against exact head on Bash 3.2 and Bash 5.3: GREEN, 1/0 each
- all MongoDB ShellSpec against exact head: 10/0
- Helm lint: 1 chart / 0 failures
- ShellCheck and `git diff --check`: pass

## Scope and boundary

Net scope is two files: the two quoted matchers and their regression spec. The reviewed prefix-derived naming helpers and metadata-name changes are removed completely because retained-object renames cannot guarantee upgrade-safe single ownership.

All evidence is offline/static. MongoDB runtime remains `N=0/NOT_RUN`; this PR does not claim runtime PASS or release readiness.
