### PR TITLE
fix(mariadb): linearize primary write acceptance with HA authority

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
@@ -37,6 +37,7 @@ Describe "replication full-primary acceptance user fence"
       extract_function primary_write_gates_ready
       extract_function read_only_is_strongest_fail_closed
       extract_function rollback_fenced_primary_accept
+      extract_function rollback_locked_primary_accept
       extract_function set_primary_read_write
       cat <<'HARNESS'
 if [ "${MODE}" = "entry-not-fenced" ]; then
@@ -116,6 +117,30 @@ query_local_syncer_role() {
     printf '%s\n' primary
   fi
 }
+try_acquire_primary_write_commit_lock() {
+  trace_event commit-lock-acquired
+  return 0
+}
+release_primary_write_commit_lock() {
+  trace_event commit-lock-released
+  return 0
+}
+authoritative_primary_write_commit() {
+  trace_event syncer-authority-commit-begin
+  if [ "${MODE}" = "authority-lost" ] || [ "${MODE}" = "role-drift" ] || \
+     [ "${MODE}" = "role-drift-rollback-failure" ] || [ "${MODE}" = "role-drift-strongest-failure" ]; then
+    trace_event syncer-authority-commit-rejected
+    return 1
+  fi
+  if [ "${MODE}" = "open-failure" ]; then
+    trace_event global-read-only-open-failed
+    return 1
+  fi
+  GLOBAL_READ_ONLY=0
+  READ_ONLY_MODE=OFF
+  trace_event global-read-only-off
+  trace_event syncer-authority-commit-pass
+}
 local_sql() {
   case "$*" in
     *"SHOW GRANTS FOR"*)
@@ -190,6 +215,10 @@ mark_replication_pending() {
   rm -f "${DATA_DIR}/.primary-read-write-ready"
   trace_event replication-pending
 }
+mark_replication_ready() {
+  command touch "${DATA_DIR}/.replication-ready"
+  trace_event replication-ready-published
+}
 touch() {
   if [ "${MODE}" = "ready-publish-failure" ] && [ "$1" = "${DATA_DIR}/.primary-read-write-ready" ]; then
     trace_event ready-publish-failed
@@ -227,12 +256,22 @@ case "${MODE}" in
     [ "${global_line}" -lt "${ready_line}" ]
     [ "${local_line}" -lt "${ready_line}" ]
     [ "${remote_line}" -lt "${ready_line}" ]
+    replication_ready_line="$(grep -n '^replication-ready-published$' "${TRACE_FILE}" | cut -d: -f1)"
+    commit_lock_line="$(grep -n '^commit-lock-acquired$' "${TRACE_FILE}" | cut -d: -f1)"
+    syncer_commit_line="$(grep -n '^syncer-authority-commit-pass$' "${TRACE_FILE}" | cut -d: -f1)"
+    commit_unlock_line="$(grep -n '^commit-lock-released$' "${TRACE_FILE}" | cut -d: -f1)"
+    [ "${commit_lock_line}" -lt "${syncer_commit_line}" ]
+    [ "${syncer_commit_line}" -lt "${local_line}" ]
+    [ "${remote_line}" -lt "${commit_unlock_line}" ]
+    [ "${ready_line}" -lt "${commit_unlock_line}" ]
+    [ "${remote_line}" -lt "${replication_ready_line}" ]
+    [ "${replication_ready_line}" -lt "${commit_unlock_line}" ]
     ! grep -q 'open-before-required-gates' "${TRACE_FILE}"
     grep -q '^ordinary-business-writable$' "${TRACE_FILE}"
     grep -q '^local-root-writable$' "${TRACE_FILE}"
     grep -q '^remote-root-writable$' "${TRACE_FILE}"
     ;;
-  prestop|gate-prestop|entry-not-fenced|bypass-failure|bypass-super|bypass-all|gate-mode-failure|gate-failure|open-failure|local-unlock-failure|remote-unlock-failure|ready-publish-failure|role-drift)
+  prestop|gate-prestop|entry-not-fenced|bypass-failure|bypass-super|bypass-all|gate-mode-failure|gate-failure|authority-lost|open-failure|local-unlock-failure|remote-unlock-failure|ready-publish-failure|role-drift)
     [ "${accept_rc}" -eq 2 ]
     grep -q '^ordinary-business-rejected$' "${TRACE_FILE}"
     grep -q '^local-root-rejected$' "${TRACE_FILE}"
@@ -370,6 +409,14 @@ HARNESS
     When call run_accept_case open-failure
     The status should be success
     The output should include "global-read-only-open-failed"
+    The output should include "global-read-only-strongest"
+    The output should not include "ready-published"
+  End
+
+  It "uses the syncer lease-CAS commit and rolls back when authority is lost"
+    When call run_accept_case authority-lost
+    The status should be success
+    The output should include "syncer-authority-commit-rejected"
     The output should include "global-read-only-strongest"
     The output should not include "ready-published"
   End

--- a/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
@@ -50,6 +50,8 @@ fi
 LOCAL_ROOT_LOCKED=1
 REMOTE_ROOT_LOCKED=1
 REQUIRED_GATES_PASSED=0
+POST_COMMIT_RETURNED=0
+DEMOTED_AFTER_COMMIT=0
 
 trace_event() {
   printf '%s\n' "$1" >> "${TRACE_FILE}"
@@ -122,8 +124,18 @@ try_acquire_primary_write_commit_lock() {
   return 0
 }
 release_primary_write_commit_lock() {
+  inject_demote_after_commit_return
   trace_event commit-lock-released
   return 0
+}
+inject_demote_after_commit_return() {
+  if [ "${MODE}" = "post-commit-demote" ] && [ "${POST_COMMIT_RETURNED}" -eq 1 ] && [ "${DEMOTED_AFTER_COMMIT}" -eq 0 ]; then
+    GLOBAL_READ_ONLY=1
+    READ_ONLY_MODE=ON
+    command rm -f "${DATA_DIR}/.primary-read-write-ready" "${DATA_DIR}/.replication-ready"
+    DEMOTED_AFTER_COMMIT=1
+    trace_event run-cycle-demote-after-authority-commit
+  fi
 }
 authoritative_primary_write_commit() {
   trace_event syncer-authority-commit-begin
@@ -136,10 +148,22 @@ authoritative_primary_write_commit() {
     trace_event global-read-only-open-failed
     return 1
   fi
+  if [ "${LOCAL_ROOT_LOCKED}" -ne 0 ] || [ "${REMOTE_ROOT_LOCKED}" -ne 0 ]; then
+    trace_event syncer-commit-before-root-unlocks
+    return 1
+  fi
   GLOBAL_READ_ONLY=0
   READ_ONLY_MODE=OFF
   trace_event global-read-only-off
+  if [ "${MODE}" = "ready-publish-failure" ]; then
+    trace_event ready-publish-failed-after-global-open
+    return 1
+  fi
+  command touch "${DATA_DIR}/.primary-read-write-ready" "${DATA_DIR}/.replication-ready"
+  trace_event ready-published
+  trace_event replication-ready-published
   trace_event syncer-authority-commit-pass
+  POST_COMMIT_RETURNED=1
 }
 local_sql() {
   case "$*" in
@@ -172,6 +196,8 @@ local_sql() {
   esac
 }
 unlock_local_root_writes() {
+  inject_demote_after_commit_return
+  [ "${DEMOTED_AFTER_COMMIT}" -eq 0 ] || trace_event visible-transition-after-demote
   [ "${REQUIRED_GATES_PASSED}" -eq 1 ] || trace_event local-root-open-before-required-gates
   if [ "${MODE}" = "local-unlock-failure" ]; then
     trace_event local-root-unlock-failed
@@ -181,6 +207,8 @@ unlock_local_root_writes() {
   trace_event local-root-unlocked
 }
 unlock_remote_root_writes() {
+  inject_demote_after_commit_return
+  [ "${DEMOTED_AFTER_COMMIT}" -eq 0 ] || trace_event visible-transition-after-demote
   [ "${REQUIRED_GATES_PASSED}" -eq 1 ] || trace_event remote-root-open-before-required-gates
   if [ "${MODE}" = "remote-unlock-failure" ] || [ "${MODE}" = "rollback-failure" ]; then
     trace_event remote-root-unlock-failed
@@ -215,17 +243,7 @@ mark_replication_pending() {
   rm -f "${DATA_DIR}/.primary-read-write-ready"
   trace_event replication-pending
 }
-mark_replication_ready() {
-  command touch "${DATA_DIR}/.replication-ready"
-  trace_event replication-ready-published
-}
-touch() {
-  if [ "${MODE}" = "ready-publish-failure" ] && [ "$1" = "${DATA_DIR}/.primary-read-write-ready" ]; then
-    trace_event ready-publish-failed
-    return 1
-  fi
-  command touch "$@"
-}
+mark_replication_ready() { trace_event unexpected-addon-ready-publication; return 1; }
 prestop_watchdog_log() {
   trace_event "log:$*"
 }
@@ -236,7 +254,7 @@ MARIADB_ROOT_HOST=%
 [ "${MODE}" = "prestop" ] && command touch "${DATA_DIR}/.prestop-fence-started"
 set_primary_read_write "test-${MODE}" "require-dcs-primary"
 accept_rc=$?
-[ -f "${DATA_DIR}/.primary-read-write-ready" ] && trace_event ready-published
+[ -f "${DATA_DIR}/.primary-read-write-ready" ] && trace_event ready-observed-after-return
 if ordinary_business_can_write; then trace_event ordinary-business-writable; else trace_event ordinary-business-rejected; fi
 if local_root_can_write; then trace_event local-root-writable; else trace_event local-root-rejected; fi
 if remote_root_can_write; then trace_event remote-root-writable; else trace_event remote-root-rejected; fi
@@ -250,9 +268,10 @@ case "${MODE}" in
     local_line="$(grep -n '^local-root-unlocked$' "${TRACE_FILE}" | cut -d: -f1)"
     remote_line="$(grep -n '^remote-root-unlocked$' "${TRACE_FILE}" | cut -d: -f1)"
     ready_line="$(grep -n '^ready-published$' "${TRACE_FILE}" | cut -d: -f1)"
-    [ "${gate_line}" -lt "${global_line}" ]
     [ "${gate_line}" -lt "${local_line}" ]
     [ "${gate_line}" -lt "${remote_line}" ]
+    [ "${local_line}" -lt "${global_line}" ]
+    [ "${remote_line}" -lt "${global_line}" ]
     [ "${global_line}" -lt "${ready_line}" ]
     [ "${local_line}" -lt "${ready_line}" ]
     [ "${remote_line}" -lt "${ready_line}" ]
@@ -260,12 +279,14 @@ case "${MODE}" in
     commit_lock_line="$(grep -n '^commit-lock-acquired$' "${TRACE_FILE}" | cut -d: -f1)"
     syncer_commit_line="$(grep -n '^syncer-authority-commit-pass$' "${TRACE_FILE}" | cut -d: -f1)"
     commit_unlock_line="$(grep -n '^commit-lock-released$' "${TRACE_FILE}" | cut -d: -f1)"
-    [ "${commit_lock_line}" -lt "${syncer_commit_line}" ]
-    [ "${syncer_commit_line}" -lt "${local_line}" ]
+    [ "${commit_lock_line}" -lt "${local_line}" ]
+    [ "${remote_line}" -lt "${syncer_commit_line}" ]
     [ "${remote_line}" -lt "${commit_unlock_line}" ]
     [ "${ready_line}" -lt "${commit_unlock_line}" ]
     [ "${remote_line}" -lt "${replication_ready_line}" ]
     [ "${replication_ready_line}" -lt "${commit_unlock_line}" ]
+    grep -q '^ready-observed-after-return$' "${TRACE_FILE}"
+    ! grep -q '^unexpected-addon-ready-publication$' "${TRACE_FILE}"
     ! grep -q 'open-before-required-gates' "${TRACE_FILE}"
     grep -q '^ordinary-business-writable$' "${TRACE_FILE}"
     grep -q '^local-root-writable$' "${TRACE_FILE}"
@@ -286,6 +307,18 @@ case "${MODE}" in
     grep -q 'fail_closed=false' "${TRACE_FILE}"
     ! grep -q '^ready-published$' "${TRACE_FILE}"
     ;;
+  post-commit-demote)
+    [ "${accept_rc}" -eq 0 ]
+    [ "${READ_ONLY_MODE}" = "ON" ]
+    grep -q '^run-cycle-demote-after-authority-commit$' "${TRACE_FILE}"
+    grep -q '^ordinary-business-rejected$' "${TRACE_FILE}"
+    grep -q '^local-root-rejected$' "${TRACE_FILE}"
+    grep -q '^remote-root-rejected$' "${TRACE_FILE}"
+    [ ! -f "${DATA_DIR}/.primary-read-write-ready" ]
+    [ ! -f "${DATA_DIR}/.replication-ready" ]
+    ! grep -q '^visible-transition-after-demote$' "${TRACE_FILE}"
+    ! grep -q '^unexpected-addon-ready-publication$' "${TRACE_FILE}"
+    ;;
 esac
 HARNESS
     } > "${harness}"
@@ -302,6 +335,13 @@ HARNESS
     The output should include "required-gate-pass"
     The output should include "ready-published"
     The output should not include "open-before-required-gates"
+  End
+
+  It "has no addon-visible transition after the authority commit returns"
+    When call run_accept_case post-commit-demote
+    The status should be success
+    The output should include "run-cycle-demote-after-authority-commit"
+    The output should not include "visible-transition-after-demote"
   End
 
   It "keeps every user writer fenced when an internal required gate fails"
@@ -396,7 +436,7 @@ HARNESS
     The output should not include "ready-published"
   End
 
-  It "rolls all user writers back to fenced when remote-root unlock fails after global open"
+  It "rolls all user writers back when remote-root unlock fails before the authority commit"
     When call run_accept_case remote-unlock-failure
     The status should be success
     The output should include "global-read-only-strongest"
@@ -421,7 +461,7 @@ HARNESS
     The output should not include "ready-published"
   End
 
-  It "rolls all user writers back when local-root unlock fails after global open"
+  It "rolls all user writers back when local-root unlock fails before the authority commit"
     When call run_accept_case local-unlock-failure
     The status should be success
     The output should include "local-root-unlock-failed"
@@ -432,7 +472,7 @@ HARNESS
   It "rolls all user writers back when ready publication fails"
     When call run_accept_case ready-publish-failure
     The status should be success
-    The output should include "ready-publish-failed"
+    The output should include "ready-publish-failed-after-global-open"
     The output should include "global-read-only-strongest"
     The output should not include "ready-published"
   End

--- a/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
@@ -1,0 +1,361 @@
+# shellcheck shell=bash
+
+Describe "replication full-primary acceptance user fence"
+  entrypoint_file() {
+    printf "%s/addons/mariadb/scripts/replication-entrypoint.sh" "${SHELLSPEC_CWD:?}"
+  }
+
+  extract_function() {
+    function_name="$1"
+    awk -v function_name="${function_name}" '
+      $0 ~ "^[[:space:]]*" function_name "\\(\\)[[:space:]]*\\{" { inside = 1 }
+      inside {
+        print
+        line = $0
+        opens = gsub(/\{/, "", line)
+        closes = gsub(/\}/, "", line)
+        depth += opens - closes
+        if (depth == 0) exit
+      }
+      END { if (!inside) exit 1 }
+    ' "$(entrypoint_file)"
+  }
+
+  run_accept_case() {
+    mode="$1"
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/harness.sh"
+    trace="${work_dir}/trace"
+    data_dir="${work_dir}/data"
+    mkdir -p "${data_dir}"
+
+    {
+      printf '%s\n' '#!/usr/bin/env bash' 'set -u'
+      extract_function user_facing_root_read_only_bypass_is_absent
+      extract_function read_only_internal_admin_gate_is_active
+      extract_function set_internal_admin_gate_read_only
+      extract_function primary_write_gates_ready
+      extract_function rollback_fenced_primary_accept
+      extract_function set_primary_read_write
+      cat <<'HARNESS'
+if [ "${MODE}" = "entry-not-fenced" ]; then
+  GLOBAL_READ_ONLY=0
+else
+  GLOBAL_READ_ONLY=1
+fi
+LOCAL_ROOT_LOCKED=1
+REMOTE_ROOT_LOCKED=1
+REQUIRED_GATES_PASSED=0
+
+trace_event() {
+  printf '%s\n' "$1" >> "${TRACE_FILE}"
+}
+ordinary_business_can_write() {
+  [ "${GLOBAL_READ_ONLY}" -eq 0 ]
+}
+local_root_can_write() {
+  [ "${GLOBAL_READ_ONLY}" -eq 0 ] && [ "${LOCAL_ROOT_LOCKED}" -eq 0 ]
+}
+remote_root_can_write() {
+  [ "${GLOBAL_READ_ONLY}" -eq 0 ] && [ "${REMOTE_ROOT_LOCKED}" -eq 0 ]
+}
+assert_all_user_writers_rejected() {
+  ! ordinary_business_can_write && ! local_root_can_write && ! remote_root_can_write
+}
+sample_pre_gate_user_inserts() {
+  if ordinary_business_can_write; then
+    trace_event ordinary-business-insert-committed-before-required-gates
+  else
+    trace_event ordinary-business-insert-rejected-before-required-gates
+  fi
+  if local_root_can_write; then
+    trace_event local-root-insert-committed-before-required-gates
+  else
+    trace_event local-root-insert-rejected-before-required-gates
+  fi
+  if remote_root_can_write; then
+    trace_event remote-root-insert-committed-before-required-gates
+  else
+    trace_event remote-root-insert-rejected-before-required-gates
+  fi
+}
+read_only_is_fail_closed() {
+  [ "${GLOBAL_READ_ONLY}" -eq 1 ]
+}
+read_only_value() {
+  if [ "${GLOBAL_READ_ONLY}" -eq 1 ]; then
+    printf '%s\n' ON
+  else
+    printf '%s\n' OFF
+  fi
+}
+sql_quote() {
+  printf '%s\n' "$1"
+}
+primary_internal_root_write_ready() {
+  trace_event required-gate-begin
+  sample_pre_gate_user_inserts
+  if ! assert_all_user_writers_rejected; then
+    trace_event user-write-open-before-required-gates
+    return 1
+  fi
+  if [ "${MODE}" = "gate-failure" ]; then
+    trace_event required-gate-failed
+    return 1
+  fi
+  REQUIRED_GATES_PASSED=1
+  trace_event required-gate-pass
+}
+query_local_syncer_role() {
+  if [ "${MODE}" = "role-drift" ]; then
+    printf '%s\n' secondary
+  else
+    printf '%s\n' primary
+  fi
+}
+local_sql() {
+  case "$*" in
+    *"SHOW GRANTS FOR"*)
+      case "${MODE}" in
+        bypass-failure) printf '%s\n' 'GRANT READ_ONLY ADMIN ON *.* TO root' ;;
+        bypass-super) printf '%s\n' 'GRANT SUPER ON *.* TO root' ;;
+        bypass-all) printf '%s\n' 'GRANT ALL PRIVILEGES ON *.* TO root' ;;
+        *) printf '%s\n' 'GRANT SELECT ON *.* TO root' ;;
+      esac
+      ;;
+    *"SET GLOBAL read_only = ON;"*|*"SET GLOBAL read_only = 1;"*)
+      if [ "${MODE}" = "gate-mode-failure" ]; then
+        trace_event internal-admin-gate-read-only-failed
+        return 1
+      fi
+      GLOBAL_READ_ONLY=1
+      trace_event internal-admin-gate-read-only-on
+      ;;
+    *"SET GLOBAL read_only = 0;"*|*"SET GLOBAL read_only = 'OFF';"*)
+      if [ "${MODE}" = "open-failure" ]; then
+        trace_event global-read-only-open-failed
+        return 1
+      fi
+      [ "${REQUIRED_GATES_PASSED}" -eq 1 ] || trace_event global-open-before-required-gates
+      GLOBAL_READ_ONLY=0
+      trace_event global-read-only-off
+      ;;
+  esac
+}
+unlock_local_root_writes() {
+  [ "${REQUIRED_GATES_PASSED}" -eq 1 ] || trace_event local-root-open-before-required-gates
+  if [ "${MODE}" = "local-unlock-failure" ]; then
+    trace_event local-root-unlock-failed
+    return 1
+  fi
+  LOCAL_ROOT_LOCKED=0
+  trace_event local-root-unlocked
+}
+unlock_remote_root_writes() {
+  [ "${REQUIRED_GATES_PASSED}" -eq 1 ] || trace_event remote-root-open-before-required-gates
+  if [ "${MODE}" = "remote-unlock-failure" ] || [ "${MODE}" = "rollback-failure" ]; then
+    trace_event remote-root-unlock-failed
+    return 1
+  fi
+  REMOTE_ROOT_LOCKED=0
+  trace_event remote-root-unlocked
+}
+lock_local_root_writes() {
+  LOCAL_ROOT_LOCKED=1
+  trace_event local-root-locked
+}
+lock_remote_root_writes() {
+  if [ "${MODE}" = "rollback-failure" ]; then
+    trace_event remote-root-relock-failed
+    return 1
+  fi
+  REMOTE_ROOT_LOCKED=1
+  trace_event remote-root-locked
+}
+set_fail_closed_read_only() {
+  GLOBAL_READ_ONLY=1
+  trace_event global-read-only-on
+}
+mark_replication_pending() {
+  rm -f "${DATA_DIR}/.primary-read-write-ready"
+  trace_event replication-pending
+}
+touch() {
+  if [ "${MODE}" = "ready-publish-failure" ] && [ "$1" = "${DATA_DIR}/.primary-read-write-ready" ]; then
+    trace_event ready-publish-failed
+    return 1
+  fi
+  command touch "$@"
+}
+prestop_watchdog_log() {
+  trace_event "log:$*"
+}
+
+INTERNAL_LOCAL=(local_sql)
+MARIADB_ROOT_USER=root
+MARIADB_ROOT_HOST=%
+[ "${MODE}" = "prestop" ] && command touch "${DATA_DIR}/.prestop-fence-started"
+set_primary_read_write "test-${MODE}" "require-dcs-primary"
+accept_rc=$?
+[ -f "${DATA_DIR}/.primary-read-write-ready" ] && trace_event ready-published
+if ordinary_business_can_write; then trace_event ordinary-business-writable; else trace_event ordinary-business-rejected; fi
+if local_root_can_write; then trace_event local-root-writable; else trace_event local-root-rejected; fi
+if remote_root_can_write; then trace_event remote-root-writable; else trace_event remote-root-rejected; fi
+cat "${TRACE_FILE}"
+
+case "${MODE}" in
+  success)
+    [ "${accept_rc}" -eq 0 ]
+    gate_line="$(grep -n '^required-gate-pass$' "${TRACE_FILE}" | cut -d: -f1)"
+    global_line="$(grep -n '^global-read-only-off$' "${TRACE_FILE}" | cut -d: -f1)"
+    local_line="$(grep -n '^local-root-unlocked$' "${TRACE_FILE}" | cut -d: -f1)"
+    remote_line="$(grep -n '^remote-root-unlocked$' "${TRACE_FILE}" | cut -d: -f1)"
+    ready_line="$(grep -n '^ready-published$' "${TRACE_FILE}" | cut -d: -f1)"
+    [ "${gate_line}" -lt "${global_line}" ]
+    [ "${gate_line}" -lt "${local_line}" ]
+    [ "${gate_line}" -lt "${remote_line}" ]
+    [ "${global_line}" -lt "${ready_line}" ]
+    [ "${local_line}" -lt "${ready_line}" ]
+    [ "${remote_line}" -lt "${ready_line}" ]
+    ! grep -q 'open-before-required-gates' "${TRACE_FILE}"
+    grep -q '^ordinary-business-writable$' "${TRACE_FILE}"
+    grep -q '^local-root-writable$' "${TRACE_FILE}"
+    grep -q '^remote-root-writable$' "${TRACE_FILE}"
+    ;;
+  prestop|entry-not-fenced|bypass-failure|bypass-super|bypass-all|gate-mode-failure|gate-failure|open-failure|local-unlock-failure|remote-unlock-failure|ready-publish-failure)
+    [ "${accept_rc}" -eq 2 ]
+    grep -q '^ordinary-business-rejected$' "${TRACE_FILE}"
+    grep -q '^local-root-rejected$' "${TRACE_FILE}"
+    grep -q '^remote-root-rejected$' "${TRACE_FILE}"
+    ! grep -q '^ready-published$' "${TRACE_FILE}"
+    ;;
+  role-drift)
+    [ "${accept_rc}" -eq 1 ]
+    ! grep -q '^global-read-only-off$' "${TRACE_FILE}"
+    grep -q '^ordinary-business-rejected$' "${TRACE_FILE}"
+    ! grep -q '^ready-published$' "${TRACE_FILE}"
+    ;;
+  rollback-failure)
+    [ "${accept_rc}" -eq 3 ]
+    grep -q 'fail_closed=false' "${TRACE_FILE}"
+    ! grep -q '^ready-published$' "${TRACE_FILE}"
+    ;;
+esac
+HARNESS
+    } > "${harness}"
+
+    TRACE_FILE="${trace}" DATA_DIR="${data_dir}" MODE="${mode}" bash "${harness}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  It "keeps ordinary, local-root, and remote-root writers fenced until all required gates pass"
+    When call run_accept_case success
+    The status should be success
+    The output should include "required-gate-pass"
+    The output should include "ready-published"
+    The output should not include "open-before-required-gates"
+  End
+
+  It "keeps every user writer fenced when an internal required gate fails"
+    When call run_accept_case gate-failure
+    The status should be success
+    The output should include "required-gate-failed"
+    The output should not include "global-read-only-off"
+  End
+
+  It "refuses the internal-admin gate when a user-facing root has read-only bypass"
+    When call run_accept_case bypass-failure
+    The status should be success
+    The output should include "reason=admin-bypass-present"
+    The output should not include "global-read-only-off"
+    The output should not include "ready-published"
+  End
+
+  It "refuses the internal-admin gate when a user-facing root retains SUPER"
+    When call run_accept_case bypass-super
+    The status should be success
+    The output should include "reason=admin-bypass-present"
+    The output should not include "global-read-only-off"
+  End
+
+  It "refuses the internal-admin gate when a user-facing root retains ALL PRIVILEGES"
+    When call run_accept_case bypass-all
+    The status should be success
+    The output should include "reason=admin-bypass-present"
+    The output should not include "global-read-only-off"
+  End
+
+  It "fails closed when the server cannot enter internal-admin-only gate mode"
+    When call run_accept_case gate-mode-failure
+    The status should be success
+    The output should include "internal-admin-gate-read-only-failed"
+    The output should include "global-read-only-on"
+    The output should not include "ready-published"
+  End
+
+  It "repairs and rejects an entry state that is not fail-closed before running a gate"
+    When call run_accept_case entry-not-fenced
+    The status should be success
+    The output should include "global-read-only-on"
+    The output should not include "required-gate-begin"
+    The output should not include "ready-published"
+  End
+
+  It "keeps every user writer fenced when preStop interrupts acceptance"
+    When call run_accept_case prestop
+    The status should be success
+    The output should include "global-read-only-on"
+    The output should not include "required-gate-begin"
+    The output should not include "ready-published"
+  End
+
+  It "keeps the fence held when DCS leadership drifts after the internal gate"
+    When call run_accept_case role-drift
+    The status should be success
+    The output should include "ordinary-business-rejected"
+    The output should not include "global-read-only-off"
+  End
+
+  It "rolls all user writers back to fenced when remote-root unlock fails after global open"
+    When call run_accept_case remote-unlock-failure
+    The status should be success
+    The output should include "global-read-only-on"
+    The output should include "ordinary-business-rejected"
+    The output should include "local-root-rejected"
+    The output should include "remote-root-rejected"
+  End
+
+  It "rolls all user writers back when global read-only cannot be opened"
+    When call run_accept_case open-failure
+    The status should be success
+    The output should include "global-read-only-open-failed"
+    The output should include "global-read-only-on"
+    The output should not include "ready-published"
+  End
+
+  It "rolls all user writers back when local-root unlock fails after global open"
+    When call run_accept_case local-unlock-failure
+    The status should be success
+    The output should include "local-root-unlock-failed"
+    The output should include "global-read-only-on"
+    The output should not include "ready-published"
+  End
+
+  It "rolls all user writers back when ready publication fails"
+    When call run_accept_case ready-publish-failure
+    The status should be success
+    The output should include "ready-publish-failed"
+    The output should include "global-read-only-on"
+    The output should not include "ready-published"
+  End
+
+  It "surfaces rollback failure instead of publishing a false fail-closed state"
+    When call run_accept_case rollback-failure
+    The status should be success
+    The output should include "remote-root-relock-failed"
+    The output should include "fail_closed=false"
+    The output should not include "ready-published"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_full_accept_user_fence_spec.sh
@@ -35,13 +35,16 @@ Describe "replication full-primary acceptance user fence"
       extract_function read_only_internal_admin_gate_is_active
       extract_function set_internal_admin_gate_read_only
       extract_function primary_write_gates_ready
+      extract_function read_only_is_strongest_fail_closed
       extract_function rollback_fenced_primary_accept
       extract_function set_primary_read_write
       cat <<'HARNESS'
 if [ "${MODE}" = "entry-not-fenced" ]; then
   GLOBAL_READ_ONLY=0
+  READ_ONLY_MODE=OFF
 else
   GLOBAL_READ_ONLY=1
+  READ_ONLY_MODE=NO_LOCK_NO_ADMIN
 fi
 LOCAL_ROOT_LOCKED=1
 REMOTE_ROOT_LOCKED=1
@@ -83,11 +86,7 @@ read_only_is_fail_closed() {
   [ "${GLOBAL_READ_ONLY}" -eq 1 ]
 }
 read_only_value() {
-  if [ "${GLOBAL_READ_ONLY}" -eq 1 ]; then
-    printf '%s\n' ON
-  else
-    printf '%s\n' OFF
-  fi
+  printf '%s\n' "${READ_ONLY_MODE}"
 }
 sql_quote() {
   printf '%s\n' "$1"
@@ -103,11 +102,15 @@ primary_internal_root_write_ready() {
     trace_event required-gate-failed
     return 1
   fi
+  if [ "${MODE}" = "gate-prestop" ]; then
+    command touch "${DATA_DIR}/.prestop-fence-started"
+    trace_event prestop-started-inside-required-gate
+  fi
   REQUIRED_GATES_PASSED=1
   trace_event required-gate-pass
 }
 query_local_syncer_role() {
-  if [ "${MODE}" = "role-drift" ]; then
+  if [ "${MODE}" = "role-drift" ] || [ "${MODE}" = "role-drift-rollback-failure" ] || [ "${MODE}" = "role-drift-strongest-failure" ]; then
     printf '%s\n' secondary
   else
     printf '%s\n' primary
@@ -129,6 +132,7 @@ local_sql() {
         return 1
       fi
       GLOBAL_READ_ONLY=1
+      READ_ONLY_MODE=ON
       trace_event internal-admin-gate-read-only-on
       ;;
     *"SET GLOBAL read_only = 0;"*|*"SET GLOBAL read_only = 'OFF';"*)
@@ -165,7 +169,7 @@ lock_local_root_writes() {
   trace_event local-root-locked
 }
 lock_remote_root_writes() {
-  if [ "${MODE}" = "rollback-failure" ]; then
+  if [ "${MODE}" = "rollback-failure" ] || [ "${MODE}" = "role-drift-rollback-failure" ]; then
     trace_event remote-root-relock-failed
     return 1
   fi
@@ -174,7 +178,13 @@ lock_remote_root_writes() {
 }
 set_fail_closed_read_only() {
   GLOBAL_READ_ONLY=1
-  trace_event global-read-only-on
+  if [ "${MODE}" = "role-drift-strongest-failure" ]; then
+    READ_ONLY_MODE=ON
+    trace_event global-read-only-fallback-on
+  else
+    READ_ONLY_MODE=NO_LOCK_NO_ADMIN
+    trace_event global-read-only-strongest
+  fi
 }
 mark_replication_pending() {
   rm -f "${DATA_DIR}/.primary-read-write-ready"
@@ -222,20 +232,17 @@ case "${MODE}" in
     grep -q '^local-root-writable$' "${TRACE_FILE}"
     grep -q '^remote-root-writable$' "${TRACE_FILE}"
     ;;
-  prestop|entry-not-fenced|bypass-failure|bypass-super|bypass-all|gate-mode-failure|gate-failure|open-failure|local-unlock-failure|remote-unlock-failure|ready-publish-failure)
+  prestop|gate-prestop|entry-not-fenced|bypass-failure|bypass-super|bypass-all|gate-mode-failure|gate-failure|open-failure|local-unlock-failure|remote-unlock-failure|ready-publish-failure|role-drift)
     [ "${accept_rc}" -eq 2 ]
     grep -q '^ordinary-business-rejected$' "${TRACE_FILE}"
     grep -q '^local-root-rejected$' "${TRACE_FILE}"
     grep -q '^remote-root-rejected$' "${TRACE_FILE}"
+    [ "${READ_ONLY_MODE}" = "NO_LOCK_NO_ADMIN" ]
+    [ "${LOCAL_ROOT_LOCKED}" -eq 1 ]
+    [ "${REMOTE_ROOT_LOCKED}" -eq 1 ]
     ! grep -q '^ready-published$' "${TRACE_FILE}"
     ;;
-  role-drift)
-    [ "${accept_rc}" -eq 1 ]
-    ! grep -q '^global-read-only-off$' "${TRACE_FILE}"
-    grep -q '^ordinary-business-rejected$' "${TRACE_FILE}"
-    ! grep -q '^ready-published$' "${TRACE_FILE}"
-    ;;
-  rollback-failure)
+  rollback-failure|role-drift-rollback-failure|role-drift-strongest-failure)
     [ "${accept_rc}" -eq 3 ]
     grep -q 'fail_closed=false' "${TRACE_FILE}"
     ! grep -q '^ready-published$' "${TRACE_FILE}"
@@ -291,14 +298,14 @@ HARNESS
     When call run_accept_case gate-mode-failure
     The status should be success
     The output should include "internal-admin-gate-read-only-failed"
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should not include "ready-published"
   End
 
   It "repairs and rejects an entry state that is not fail-closed before running a gate"
     When call run_accept_case entry-not-fenced
     The status should be success
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should not include "required-gate-begin"
     The output should not include "ready-published"
   End
@@ -306,22 +313,54 @@ HARNESS
   It "keeps every user writer fenced when preStop interrupts acceptance"
     When call run_accept_case prestop
     The status should be success
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should not include "required-gate-begin"
     The output should not include "ready-published"
   End
 
-  It "keeps the fence held when DCS leadership drifts after the internal gate"
+  It "freshly rechecks preStop after the internal gate and rolls back the narrowed fence"
+    When call run_accept_case gate-prestop
+    The status should be success
+    The output should include "prestop-started-inside-required-gate"
+    The output should include "global-read-only-strongest"
+    The output should include "local-root-locked"
+    The output should include "remote-root-locked"
+    The output should not include "global-read-only-off"
+    The output should not include "ready-published"
+  End
+
+  It "rolls the narrowed fence back to strongest when DCS leadership drifts after the internal gate"
     When call run_accept_case role-drift
     The status should be success
+    The output should include "global-read-only-strongest"
+    The output should include "local-root-locked"
+    The output should include "remote-root-locked"
     The output should include "ordinary-business-rejected"
     The output should not include "global-read-only-off"
+  End
+
+  It "surfaces rollback failure after post-gate DCS drift as rc3"
+    When call run_accept_case role-drift-rollback-failure
+    The status should be success
+    The output should include "remote-root-relock-failed"
+    The output should include "fail_closed=false"
+    The output should not include "global-read-only-off"
+    The output should not include "ready-published"
+  End
+
+  It "surfaces failure to restore NO_LOCK_NO_ADMIN after DCS drift as rc3"
+    When call run_accept_case role-drift-strongest-failure
+    The status should be success
+    The output should include "global-read-only-fallback-on"
+    The output should include "fail_closed=false"
+    The output should not include "global-read-only-off"
+    The output should not include "ready-published"
   End
 
   It "rolls all user writers back to fenced when remote-root unlock fails after global open"
     When call run_accept_case remote-unlock-failure
     The status should be success
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should include "ordinary-business-rejected"
     The output should include "local-root-rejected"
     The output should include "remote-root-rejected"
@@ -331,7 +370,7 @@ HARNESS
     When call run_accept_case open-failure
     The status should be success
     The output should include "global-read-only-open-failed"
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should not include "ready-published"
   End
 
@@ -339,7 +378,7 @@ HARNESS
     When call run_accept_case local-unlock-failure
     The status should be success
     The output should include "local-root-unlock-failed"
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should not include "ready-published"
   End
 
@@ -347,7 +386,7 @@ HARNESS
     When call run_accept_case ready-publish-failure
     The status should be success
     The output should include "ready-publish-failed"
-    The output should include "global-read-only-on"
+    The output should include "global-read-only-strongest"
     The output should not include "ready-published"
   End
 

--- a/addons/mariadb/scripts-ut-spec/replication_prestop_sql_quote_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_prestop_sql_quote_spec.sh
@@ -1,0 +1,86 @@
+# shellcheck shell=bash
+
+Describe "replication preStop SQL literal quoting"
+  prestop_file() {
+    printf "%s/addons/mariadb/scripts/replication-prestop.sh" "${SHELLSPEC_CWD:?}"
+  }
+
+  extract_function_from() {
+    source_file="$1"
+    function_name="$2"
+    awk -v function_name="${function_name}" '
+      $0 ~ "^[[:space:]]*" function_name "\\(\\)[[:space:]]*\\{" { inside = 1 }
+      inside {
+        print
+        line = $0
+        opens = gsub(/\{/, "", line)
+        closes = gsub(/\}/, "", line)
+        depth += opens - closes
+        if (depth == 0) exit
+      }
+      END { if (!inside) exit 1 }
+    ' "${source_file}"
+  }
+
+  run_quote() {
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/quote.sh"
+    {
+      printf '%s\n' '#!/bin/sh'
+      extract_function_from "$(prestop_file)" prestop_sql_quote
+      printf '%s\n' 'prestop_sql_quote "$1"'
+    } > "${harness}"
+    sh "${harness}" "$1"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  run_lock_case() {
+    mode="$1"
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/lock.sh"
+    capture="${work_dir}/capture"
+    {
+      printf '%s\n' '#!/bin/sh'
+      extract_function_from "$(prestop_file)" prestop_sql_quote
+      extract_function_from "$(prestop_file)" lock_local_root_for_prestop
+      cat <<'HARNESS'
+prestop_log() { :; }
+run_sql() {
+  printf 'mode=%s\n%s\n' "$2" "$3" >> "${CAPTURE}"
+}
+MARIADB_ROOT_USER="us\\er'one"
+MARIADB_ROOT_PASSWORD="pa\\ss'end\\"
+export MARIADB_ROOT_USER MARIADB_ROOT_PASSWORD
+lock_local_root_for_prestop "quote-contract" "$1"
+cat "${CAPTURE}"
+HARNESS
+    } > "${harness}"
+    CAPTURE="${capture}" sh "${harness}" "${mode}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  It "escapes embedded and trailing backslashes before doubling quotes"
+    When call run_quote "a\\b'c\\"
+    The status should be success
+    The output should eq "a\\\\b''c\\\\"
+  End
+
+  It "uses the shared quoting contract in the socket fence path"
+    When call run_lock_case socket
+    The status should be success
+    The output should include "mode=socket"
+    The output should include "CREATE USER IF NOT EXISTS 'us\\\\er''one'@'localhost'"
+    The output should include "IDENTIFIED BY 'pa\\\\ss''end\\\\'"
+  End
+
+  It "uses the shared quoting contract in the TCP fence path"
+    When call run_lock_case tcp
+    The status should be success
+    The output should include "mode=tcp"
+    The output should include "ALTER USER 'us\\\\er''one'@'127.0.0.1' IDENTIFIED BY 'pa\\\\ss''end\\\\'"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_primary_write_commit_linearization_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_primary_write_commit_linearization_spec.sh
@@ -1,0 +1,170 @@
+# shellcheck shell=bash
+
+Describe "replication primary-write commit linearization"
+  entrypoint_file() {
+    printf "%s/addons/mariadb/scripts/replication-entrypoint.sh" "${SHELLSPEC_CWD:?}"
+  }
+
+  prestop_file() {
+    printf "%s/addons/mariadb/scripts/replication-prestop.sh" "${SHELLSPEC_CWD:?}"
+  }
+
+  extract_function_from() {
+    source_file="$1"
+    function_name="$2"
+    awk -v function_name="${function_name}" '
+      $0 ~ "^[[:space:]]*" function_name "\\(\\)[[:space:]]*\\{" { inside = 1 }
+      inside {
+        print
+        line = $0
+        opens = gsub(/\{/, "", line)
+        closes = gsub(/\}/, "", line)
+        depth += opens - closes
+        if (depth == 0) exit
+      }
+      END { if (!inside) exit 1 }
+    ' "${source_file}"
+  }
+
+  run_accept_then_prestop_interleaving() {
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/harness.sh"
+    trace="${work_dir}/trace"
+    data_dir="${work_dir}/data"
+    mkdir -p "${data_dir}"
+    printf '%s\n' NO_LOCK_NO_ADMIN > "${data_dir}/global"
+    touch "${data_dir}/local-locked" "${data_dir}/remote-locked"
+
+    {
+      printf '%s\n' '#!/usr/bin/env bash' 'set -u'
+      extract_function_from "$(entrypoint_file)" try_acquire_primary_write_commit_lock
+      extract_function_from "$(entrypoint_file)" release_primary_write_commit_lock
+      extract_function_from "$(entrypoint_file)" set_primary_read_write
+      extract_function_from "$(prestop_file)" acquire_primary_write_commit_lock_for_prestop
+      cat <<'HARNESS'
+PRIMARY_WRITE_COMMIT_LOCK_DIR="${DATA_DIR}/.primary-write-commit-lock"
+trace_event() { printf '%s\n' "$1" >> "${TRACE_FILE}"; }
+prestop_watchdog_log() { trace_event "accept:$*"; }
+prestop_log() { trace_event "prestop:$*"; }
+mark_replication_pending() {
+  rm -f "${DATA_DIR}/.primary-read-write-ready" "${DATA_DIR}/.replication-ready"
+  touch "${DATA_DIR}/.replication-pending"
+}
+mark_replication_ready() {
+  touch "${DATA_DIR}/.replication-ready"
+  rm -f "${DATA_DIR}/.replication-pending"
+  trace_event replication-ready-published
+}
+read_only_is_fail_closed() { return 0; }
+primary_write_gates_ready() { trace_event required-gates-pass; }
+rollback_locked_primary_accept() { trace_event unexpected-rollback; return 2; }
+rollback_fenced_primary_accept() { trace_event unexpected-rollback; return 0; }
+unlock_local_root_writes() { rm -f "${DATA_DIR}/local-locked"; trace_event local-unlocked; }
+unlock_remote_root_writes() { rm -f "${DATA_DIR}/remote-locked"; trace_event remote-unlocked; }
+authoritative_primary_write_commit() {
+  trace_event syncer-first-open-entered
+  i=0
+  while [ ! -f "${ALLOW_COMMIT}" ] && [ "${i}" -lt 50 ]; do
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ -f "${ALLOW_COMMIT}" ] || return 1
+  printf '%s\n' OFF > "${DATA_DIR}/global"
+  trace_event syncer-authority-commit-pass
+}
+
+run_accept() {
+  set_primary_read_write linearization require-dcs-primary
+  printf '%s\n' "$?" > "${ACCEPT_RC}"
+}
+run_prestop() {
+  acquire_primary_write_commit_lock_for_prestop || return 1
+  touch "${DATA_DIR}/.prestop-fence-started" "${DATA_DIR}/.replication-pending"
+  rm -f "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready"
+  printf '%s\n' NO_LOCK_NO_ADMIN > "${DATA_DIR}/global"
+  touch "${DATA_DIR}/local-locked" "${DATA_DIR}/remote-locked"
+  trace_event prestop-strongest-fence-complete
+}
+
+run_accept &
+accept_pid=$!
+i=0
+while ! grep -q '^syncer-first-open-entered$' "${TRACE_FILE}" 2>/dev/null && [ "${i}" -lt 50 ]; do
+  sleep 0.05
+  i=$((i + 1))
+done
+grep -q '^syncer-first-open-entered$' "${TRACE_FILE}"
+
+run_prestop &
+prestop_pid=$!
+sleep 0.2
+# preStop cannot publish its marker or fence while acceptance owns the commit.
+[ ! -f "${DATA_DIR}/.prestop-fence-started" ]
+! grep -q '^prestop-strongest-fence-complete$' "${TRACE_FILE}"
+
+touch "${ALLOW_COMMIT}"
+wait "${accept_pid}"
+wait "${prestop_pid}"
+
+[ "$(cat "${ACCEPT_RC}")" -eq 0 ]
+[ "$(cat "${DATA_DIR}/global")" = NO_LOCK_NO_ADMIN ]
+[ -f "${DATA_DIR}/local-locked" ]
+[ -f "${DATA_DIR}/remote-locked" ]
+[ ! -f "${DATA_DIR}/.primary-read-write-ready" ]
+[ -f "${DATA_DIR}/.prestop-fence-started" ]
+commit_line="$(grep -n '^syncer-authority-commit-pass$' "${TRACE_FILE}" | cut -d: -f1)"
+accept_line="$(grep -n 'primary-read-write label=linearization rc=0' "${TRACE_FILE}" | cut -d: -f1)"
+prestop_line="$(grep -n '^prestop-strongest-fence-complete$' "${TRACE_FILE}" | cut -d: -f1)"
+[ -n "${commit_line}" ]
+[ -n "${accept_line}" ]
+[ -n "${prestop_line}" ]
+[ "${commit_line}" -lt "${accept_line}" ]
+[ "${commit_line}" -lt "${prestop_line}" ]
+cat "${TRACE_FILE}"
+HARNESS
+    } > "${harness}"
+
+    TRACE_FILE="${trace}" DATA_DIR="${data_dir}" \
+      ALLOW_COMMIT="${work_dir}/allow" ACCEPT_RC="${work_dir}/accept-rc" \
+      bash "${harness}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  startup_clears_only_stale_commit_lock() {
+    awk '
+      /^if \[ ! -f "\$\{LIFECYCLE_MARKER\}" \]; then$/ { startup = 1 }
+      startup && /^elif \[ -f "\$\{DATA_DIR\}\/\.prestop-fence-started" \]; then$/ { startup = 0 }
+      startup && index($0, "rm -rf \"${PRIMARY_WRITE_COMMIT_LOCK_DIR}\"") { print; found++ }
+      END { exit(found == 1 ? 0 : 1) }
+    ' "$(entrypoint_file)"
+  }
+
+  prestop_acquires_commit_lock_before_marker() {
+    lock_line="$(grep -n '^acquire_primary_write_commit_lock_for_prestop || true$' "$(prestop_file)" | cut -d: -f1)"
+    marker_line="$(grep -n '^touch "${DATA_DIR}/.prestop-fence-started"' "$(prestop_file)" | cut -d: -f1)"
+    [ -n "${lock_line}" ]
+    [ -n "${marker_line}" ]
+    [ "${lock_line}" -lt "${marker_line}" ]
+  }
+
+  It "serializes first-open and preStop so the later preStop leaves the final state strongest-fenced"
+    When call run_accept_then_prestop_interleaving
+    The status should be success
+    The output should include "syncer-authority-commit-pass"
+    The output should include "prestop-strongest-fence-complete"
+    The output should not include "unexpected-rollback"
+  End
+
+  It "clears a stale commit owner only on a fresh container lifecycle"
+    When call startup_clears_only_stale_commit_lock
+    The status should be success
+    The output should include 'PRIMARY_WRITE_COMMIT_LOCK_DIR'
+  End
+
+  It "makes preStop own the commit lock before publishing its fence marker"
+    When call prestop_acquires_commit_lock_before_marker
+    The status should be success
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_primary_write_commit_linearization_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_primary_write_commit_linearization_spec.sh
@@ -113,7 +113,7 @@ wait "${prestop_pid}"
 [ ! -f "${DATA_DIR}/.primary-read-write-ready" ]
 [ -f "${DATA_DIR}/.prestop-fence-started" ]
 commit_line="$(grep -n '^syncer-authority-commit-pass$' "${TRACE_FILE}" | cut -d: -f1)"
-accept_line="$(grep -n 'primary-read-write label=linearization rc=0' "${TRACE_FILE}" | cut -d: -f1)"
+accept_line="$(grep -n 'primary-write-accept label=linearization rc=0' "${TRACE_FILE}" | cut -d: -f1)"
 prestop_line="$(grep -n '^prestop-strongest-fence-complete$' "${TRACE_FILE}" | cut -d: -f1)"
 [ -n "${commit_line}" ]
 [ -n "${accept_line}" ]
@@ -121,6 +121,103 @@ prestop_line="$(grep -n '^prestop-strongest-fence-complete$' "${TRACE_FILE}" | c
 [ "${commit_line}" -lt "${accept_line}" ]
 [ "${commit_line}" -lt "${prestop_line}" ]
 cat "${TRACE_FILE}"
+HARNESS
+    } > "${harness}"
+
+    TRACE_FILE="${trace}" DATA_DIR="${data_dir}" \
+      ALLOW_COMMIT="${work_dir}/allow" ACCEPT_RC="${work_dir}/accept-rc" \
+      bash "${harness}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  run_accept_held_past_prestop_lock_budget() {
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/harness.sh"
+    trace="${work_dir}/trace"
+    data_dir="${work_dir}/data"
+    mkdir -p "${data_dir}"
+    printf '%s\n' NO_LOCK_NO_ADMIN > "${data_dir}/global"
+    touch "${data_dir}/local-locked" "${data_dir}/remote-locked"
+
+    {
+      printf '%s\n' '#!/usr/bin/env bash' 'set -u'
+      extract_function_from "$(entrypoint_file)" try_acquire_primary_write_commit_lock
+      extract_function_from "$(entrypoint_file)" release_primary_write_commit_lock
+      extract_function_from "$(entrypoint_file)" set_primary_read_write
+      extract_function_from "$(prestop_file)" acquire_primary_write_commit_lock_for_prestop
+      cat <<'HARNESS'
+PRIMARY_WRITE_COMMIT_LOCK_DIR="${DATA_DIR}/.primary-write-commit-lock"
+trace_event() { printf '%s\n' "$1" >> "${TRACE_FILE}"; }
+prestop_watchdog_log() { trace_event "accept:$*"; }
+prestop_log() { trace_event "prestop:$*"; }
+# Scale only preStop's production 400 x 0.1s lock budget down for a fast unit
+# harness. The number of attempts and timeout branch remain production-exact.
+sleep() { command sleep 0.001; }
+mark_replication_pending() {
+  rm -f "${DATA_DIR}/.primary-read-write-ready" "${DATA_DIR}/.replication-ready"
+  touch "${DATA_DIR}/.replication-pending"
+}
+mark_replication_ready() {
+  touch "${DATA_DIR}/.replication-ready"
+  rm -f "${DATA_DIR}/.replication-pending"
+  trace_event replication-ready-published
+}
+read_only_is_fail_closed() { return 0; }
+primary_write_gates_ready() { trace_event required-gates-pass; }
+rollback_locked_primary_accept() { trace_event unexpected-rollback; return 2; }
+rollback_fenced_primary_accept() { trace_event unexpected-rollback; return 0; }
+unlock_local_root_writes() { rm -f "${DATA_DIR}/local-locked"; trace_event local-unlocked; }
+unlock_remote_root_writes() { rm -f "${DATA_DIR}/remote-locked"; trace_event remote-unlocked; }
+authoritative_primary_write_commit() {
+  trace_event syncer-first-open-entered
+  while [ ! -f "${ALLOW_COMMIT}" ]; do
+    command sleep 0.005
+  done
+  printf '%s\n' OFF > "${DATA_DIR}/global"
+  trace_event syncer-authority-commit-pass
+}
+
+run_accept() {
+  accept_rc=0
+  set_primary_read_write linearization-timeout require-dcs-primary || accept_rc=$?
+  printf '%s\n' "${accept_rc}" > "${ACCEPT_RC}"
+  return 0
+}
+run_prestop_timeout_branch() {
+  # The production hook must fail before any marker/SQL mutation when it
+  # cannot own the commit. Kubelet then terminates the whole container; model
+  # that external fail-close boundary by terminating the in-flight accept.
+  if ! acquire_primary_write_commit_lock_for_prestop; then
+    trace_event prestop-hook-failed-before-mutation
+    kill "${accept_pid}" 2>/dev/null || true
+    wait "${accept_pid}" 2>/dev/null || true
+    return 1
+  fi
+  touch "${DATA_DIR}/.prestop-fence-started" "${DATA_DIR}/.replication-pending"
+  rm -f "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready"
+  printf '%s\n' NO_LOCK_NO_ADMIN > "${DATA_DIR}/global"
+  touch "${DATA_DIR}/local-locked" "${DATA_DIR}/remote-locked"
+  trace_event prestop-timeout-fence-complete
+}
+
+run_accept &
+accept_pid=$!
+while ! grep -q '^syncer-first-open-entered$' "${TRACE_FILE}" 2>/dev/null; do
+  command sleep 0.005
+done
+
+run_prestop_timeout_branch || true
+grep -q 'reason=accept-owner-timeout' "${TRACE_FILE}"
+
+cat "${TRACE_FILE}"
+failure=0
+[ ! -f "${ACCEPT_RC}" ] || failure=1
+[ ! -f "${DATA_DIR}/.prestop-fence-started" ] || failure=1
+[ ! -f "${DATA_DIR}/.primary-read-write-ready" ] || failure=1
+[ ! -f "${DATA_DIR}/.replication-ready" ] || failure=1
+exit "${failure}"
 HARNESS
     } > "${harness}"
 
@@ -142,7 +239,7 @@ HARNESS
   }
 
   prestop_acquires_commit_lock_before_marker() {
-    lock_line="$(grep -n '^acquire_primary_write_commit_lock_for_prestop || true$' "$(prestop_file)" | cut -d: -f1)"
+    lock_line="$(grep -n '^if ! acquire_primary_write_commit_lock_for_prestop; then$' "$(prestop_file)" | cut -d: -f1)"
     marker_line="$(grep -n '^touch "${DATA_DIR}/.prestop-fence-started"' "$(prestop_file)" | cut -d: -f1)"
     [ -n "${lock_line}" ]
     [ -n "${marker_line}" ]
@@ -155,6 +252,13 @@ HARNESS
     The output should include "syncer-authority-commit-pass"
     The output should include "prestop-strongest-fence-complete"
     The output should not include "unexpected-rollback"
+  End
+
+  It "does not let an accept publish ready after preStop exhausts its commit-lock budget"
+    When call run_accept_held_past_prestop_lock_budget
+    The status should be success
+    The output should include "accept-owner-timeout"
+    The output should not include "replication-ready-published"
   End
 
   It "clears a stale commit owner only on a fresh container lifecycle"

--- a/addons/mariadb/scripts-ut-spec/replication_runtime_role_promotion_race_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_runtime_role_promotion_race_spec.sh
@@ -100,15 +100,72 @@ read_only_line="$(grep -n '^read-only-on$' "${TRACE_FILE}" | cut -d: -f1)"
 internal_open_line="$(grep -n '^primary-internal-writable$' "${TRACE_FILE}" | cut -d: -f1)"
 full_accept_line="$(grep -n '^full-primary-accept$' "${TRACE_FILE}" | cut -d: -f1)"
 [ -n "${read_only_line}" ]
-[ -n "${internal_open_line}" ]
 [ -n "${full_accept_line}" ]
-[ "${read_only_line}" -lt "${internal_open_line}" ]
-[ "${internal_open_line}" -lt "${full_accept_line}" ]
+[ -z "${internal_open_line}" ]
+[ "${read_only_line}" -lt "${full_accept_line}" ]
 HARNESS
     } > "${harness}"
 
     TRACE_FILE="${trace}" ROLE_COUNTER="${role_counter}" DATA_DIR="${data_dir}" \
       bash "${harness}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  run_business_writer_during_primary_accept() {
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/business-writer-harness.sh"
+    trace="${work_dir}/trace"
+
+    {
+      printf '%s\n' '#!/usr/bin/env bash' 'set -u'
+      extract_function accept_syncer_primary_promotion_from_replica_path
+      cat <<'HARNESS'
+GLOBAL_READ_ONLY=1
+trace_event() {
+  printf '%s\n' "$1" >> "${TRACE_FILE}"
+}
+query_local_syncer_role() {
+  printf '%s\n' primary
+}
+internal_sql() {
+  case "$*" in
+    *"SET GLOBAL read_only = 0;"*) GLOBAL_READ_ONLY=0 ;;
+    *"SET GLOBAL read_only = ON;"*) GLOBAL_READ_ONLY=1 ;;
+  esac
+}
+prestop_watchdog_log() {
+  trace_event "log:$*"
+}
+expose_sql_listener_for_primary_role() {
+  if [ "${GLOBAL_READ_ONLY}" -eq 0 ]; then
+    trace_event business-write-committed
+  else
+    trace_event business-write-rejected
+  fi
+}
+mark_replication_ready() {
+  trace_event primary-ready
+}
+set_fail_closed_read_only() {
+  if [ "${MODE:-}" = "rollback-failure" ]; then
+    trace_event read-only-fail-closed-failed
+    return 1
+  fi
+  GLOBAL_READ_ONLY=1
+  trace_event read-only-fail-closed
+}
+
+INTERNAL_LOCAL=(internal_sql)
+accept_syncer_primary_promotion_from_replica_path business-writer-window
+cat "${TRACE_FILE}"
+grep -q '^business-write-rejected$' "${TRACE_FILE}"
+! grep -q '^business-write-committed$' "${TRACE_FILE}"
+HARNESS
+    } > "${harness}"
+
+    TRACE_FILE="${trace}" bash "${harness}"
     rc=$?
     rm -rf "${work_dir}"
     return "${rc}"
@@ -146,17 +203,24 @@ internal_sql() {
   esac
 }
 prestop_watchdog_log() {
-  :
+  trace_event "log:$*"
 }
 expose_sql_listener_for_primary_role() {
   trace_event full-primary-accept
-  [ "${MODE}" != "accept-failure" ]
+  [ "${MODE}" != "accept-failure" ] && [ "${MODE}" != "rollback-failure" ]
 }
 mark_replication_ready() {
   trace_event primary-ready
 }
 
 INTERNAL_LOCAL=(internal_sql)
+set_fail_closed_read_only() {
+  if [ "${MODE}" = "rollback-failure" ]; then
+    trace_event read-only-rollback-failed
+    return 1
+  fi
+  trace_event read-only-rollback
+}
 accept_syncer_primary_promotion_from_replica_path safety-case
 accept_rc=$?
 cat "${TRACE_FILE}"
@@ -164,17 +228,22 @@ cat "${TRACE_FILE}"
 case "${MODE}" in
   role-change)
     [ "${accept_rc}" -eq 1 ]
-    grep -q '^primary-internal-writable$' "${TRACE_FILE}"
-    grep -q '^read-only-rollback$' "${TRACE_FILE}"
+    ! grep -q '^primary-internal-writable$' "${TRACE_FILE}"
+    grep -q 'reason=dcs-primary-changed global-read-only=held' "${TRACE_FILE}"
     ! grep -q '^full-primary-accept$' "${TRACE_FILE}"
     ;;
   accept-failure)
     [ "${accept_rc}" -eq 2 ]
-    open_line="$(grep -n '^primary-internal-writable$' "${TRACE_FILE}" | cut -d: -f1)"
     accept_line="$(grep -n '^full-primary-accept$' "${TRACE_FILE}" | cut -d: -f1)"
     rollback_line="$(grep -n '^read-only-rollback$' "${TRACE_FILE}" | cut -d: -f1)"
-    [ "${open_line}" -lt "${accept_line}" ]
+    ! grep -q '^primary-internal-writable$' "${TRACE_FILE}"
     [ "${accept_line}" -lt "${rollback_line}" ]
+    ;;
+  rollback-failure)
+    [ "${accept_rc}" -eq 3 ]
+    grep -q '^full-primary-accept$' "${TRACE_FILE}"
+    grep -q '^read-only-rollback-failed$' "${TRACE_FILE}"
+    grep -q 'fail_closed=false' "${TRACE_FILE}"
     ;;
 esac
 HARNESS
@@ -187,27 +256,41 @@ HARNESS
     return "${rc}"
   }
 
-  It "re-opens internal primary writes before the slow full-primary acceptance after promotion interrupts a secondary fence"
+  It "keeps the global read-only fence until full-primary acceptance after promotion interrupts a secondary fence"
     When call run_secondary_fence_promotion_race
     The status should be success
     The output should include "read-only-on"
-    The output should include "primary-internal-writable"
+    The output should not include "primary-internal-writable"
     The output should include "full-primary-accept"
   End
 
-  It "restores fail-closed read-only and skips full acceptance when DCS primary changes after the early internal open"
+  It "keeps an ordinary business writer fenced until full-primary acceptance"
+    When call run_business_writer_during_primary_accept
+    The status should be success
+    The output should include "business-write-rejected"
+    The output should not include "business-write-committed"
+  End
+
+  It "preserves fail-closed read-only and skips full acceptance when the DCS primary changes"
     When call run_primary_accept_safety_case role-change
     The status should be success
-    The output should include "primary-internal-writable"
-    The output should include "read-only-rollback"
+    The output should include "global-read-only=held"
+    The output should not include "primary-internal-writable"
     The output should not include "full-primary-accept"
   End
 
   It "restores fail-closed read-only when the full-primary acceptance fails"
     When call run_primary_accept_safety_case accept-failure
     The status should be success
-    The output should include "primary-internal-writable"
     The output should include "full-primary-accept"
     The output should include "read-only-rollback"
+    The output should not include "primary-internal-writable"
+  End
+
+  It "reports a rollback failure instead of claiming fail-closed success"
+    When call run_primary_accept_safety_case rollback-failure
+    The status should be success
+    The output should include "read-only-rollback-failed"
+    The output should include "fail_closed=false"
   End
 End

--- a/addons/mariadb/scripts-ut-spec/replication_runtime_role_promotion_race_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_runtime_role_promotion_race_spec.sh
@@ -1,0 +1,213 @@
+# shellcheck shell=bash
+
+Describe "replication runtime role promotion race"
+  entrypoint_file() {
+    printf "%s/addons/mariadb/scripts/replication-entrypoint.sh" "${SHELLSPEC_CWD:?}"
+  }
+
+  extract_function() {
+    function_name="$1"
+    awk -v function_name="${function_name}" '
+      $0 ~ "^[[:space:]]*" function_name "\\(\\)[[:space:]]*\\{" { inside = 1 }
+      inside {
+        print
+        line = $0
+        opens = gsub(/\{/, "", line)
+        closes = gsub(/\}/, "", line)
+        depth += opens - closes
+        if (depth == 0) exit
+      }
+      END { if (!inside) exit 1 }
+    ' "$(entrypoint_file)"
+  }
+
+  run_secondary_fence_promotion_race() {
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/race-harness.sh"
+    trace="${work_dir}/trace"
+    role_counter="${work_dir}/role-counter"
+    data_dir="${work_dir}/data"
+    mkdir -p "${data_dir}"
+    printf '0\n' > "${role_counter}"
+
+    {
+      printf '%s\n' '#!/usr/bin/env bash' 'set -u'
+      extract_function set_replica_read_only
+      extract_function replica_lock_abort_if_syncer_primary
+      extract_function accept_syncer_primary_promotion_from_replica_path
+      extract_function reconcile_sql_listener_for_syncer_secondary_once
+      cat <<'HARNESS'
+trace_event() {
+  printf '%s\n' "$1" >> "${TRACE_FILE}"
+}
+query_local_syncer_role() {
+  local call
+  call=$(( $(cat "${ROLE_COUNTER}") + 1 ))
+  printf '%s\n' "${call}" > "${ROLE_COUNTER}"
+  if [ "${call}" -le 3 ]; then
+    printf '%s\n' secondary
+  else
+    printf '%s\n' primary
+  fi
+}
+lock_remote_root_writes() {
+  trace_event remote-root-fenced
+}
+set_fail_closed_read_only() {
+  trace_event read-only-on
+}
+lock_local_root_writes() {
+  trace_event local-root-fenced
+}
+ensure_semisync_replica_role() {
+  trace_event semisync-secondary
+}
+internal_sql() {
+  case "$*" in
+    *"SET GLOBAL read_only = 0;"*) trace_event primary-internal-writable ;;
+  esac
+}
+prestop_watchdog_log() {
+  :
+}
+expose_sql_listener_for_primary_role() {
+  trace_event full-primary-accept
+}
+mark_replication_ready() {
+  trace_event primary-ready
+}
+mark_replication_pending() {
+  trace_event replication-pending
+}
+query_slave_status_verbose() {
+  return 1
+}
+slave_status_is_healthy() {
+  return 1
+}
+publish_replica_after_rejoin_ready() {
+  return 1
+}
+configure_replication_from_primary_service_once() {
+  return 1
+}
+
+INTERNAL_LOCAL=(internal_sql)
+reconcile_sql_listener_for_syncer_secondary_once
+
+cat "${TRACE_FILE}"
+read_only_line="$(grep -n '^read-only-on$' "${TRACE_FILE}" | cut -d: -f1)"
+internal_open_line="$(grep -n '^primary-internal-writable$' "${TRACE_FILE}" | cut -d: -f1)"
+full_accept_line="$(grep -n '^full-primary-accept$' "${TRACE_FILE}" | cut -d: -f1)"
+[ -n "${read_only_line}" ]
+[ -n "${internal_open_line}" ]
+[ -n "${full_accept_line}" ]
+[ "${read_only_line}" -lt "${internal_open_line}" ]
+[ "${internal_open_line}" -lt "${full_accept_line}" ]
+HARNESS
+    } > "${harness}"
+
+    TRACE_FILE="${trace}" ROLE_COUNTER="${role_counter}" DATA_DIR="${data_dir}" \
+      bash "${harness}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  run_primary_accept_safety_case() {
+    mode="$1"
+    work_dir="$(mktemp -d)"
+    harness="${work_dir}/accept-harness.sh"
+    trace="${work_dir}/trace"
+    role_counter="${work_dir}/role-counter"
+    printf '0\n' > "${role_counter}"
+
+    {
+      printf '%s\n' '#!/usr/bin/env bash' 'set -u'
+      extract_function accept_syncer_primary_promotion_from_replica_path
+      cat <<'HARNESS'
+trace_event() {
+  printf '%s\n' "$1" >> "${TRACE_FILE}"
+}
+query_local_syncer_role() {
+  local call
+  call=$(( $(cat "${ROLE_COUNTER}") + 1 ))
+  printf '%s\n' "${call}" > "${ROLE_COUNTER}"
+  if [ "${MODE}" = "role-change" ] && [ "${call}" -gt 1 ]; then
+    printf '%s\n' secondary
+  else
+    printf '%s\n' primary
+  fi
+}
+internal_sql() {
+  case "$*" in
+    *"SET GLOBAL read_only = 0;"*) trace_event primary-internal-writable ;;
+    *"SET GLOBAL read_only = ON;"*) trace_event read-only-rollback ;;
+  esac
+}
+prestop_watchdog_log() {
+  :
+}
+expose_sql_listener_for_primary_role() {
+  trace_event full-primary-accept
+  [ "${MODE}" != "accept-failure" ]
+}
+mark_replication_ready() {
+  trace_event primary-ready
+}
+
+INTERNAL_LOCAL=(internal_sql)
+accept_syncer_primary_promotion_from_replica_path safety-case
+accept_rc=$?
+cat "${TRACE_FILE}"
+
+case "${MODE}" in
+  role-change)
+    [ "${accept_rc}" -eq 1 ]
+    grep -q '^primary-internal-writable$' "${TRACE_FILE}"
+    grep -q '^read-only-rollback$' "${TRACE_FILE}"
+    ! grep -q '^full-primary-accept$' "${TRACE_FILE}"
+    ;;
+  accept-failure)
+    [ "${accept_rc}" -eq 2 ]
+    open_line="$(grep -n '^primary-internal-writable$' "${TRACE_FILE}" | cut -d: -f1)"
+    accept_line="$(grep -n '^full-primary-accept$' "${TRACE_FILE}" | cut -d: -f1)"
+    rollback_line="$(grep -n '^read-only-rollback$' "${TRACE_FILE}" | cut -d: -f1)"
+    [ "${open_line}" -lt "${accept_line}" ]
+    [ "${accept_line}" -lt "${rollback_line}" ]
+    ;;
+esac
+HARNESS
+    } > "${harness}"
+
+    TRACE_FILE="${trace}" ROLE_COUNTER="${role_counter}" MODE="${mode}" \
+      bash "${harness}"
+    rc=$?
+    rm -rf "${work_dir}"
+    return "${rc}"
+  }
+
+  It "re-opens internal primary writes before the slow full-primary acceptance after promotion interrupts a secondary fence"
+    When call run_secondary_fence_promotion_race
+    The status should be success
+    The output should include "read-only-on"
+    The output should include "primary-internal-writable"
+    The output should include "full-primary-accept"
+  End
+
+  It "restores fail-closed read-only and skips full acceptance when DCS primary changes after the early internal open"
+    When call run_primary_accept_safety_case role-change
+    The status should be success
+    The output should include "primary-internal-writable"
+    The output should include "read-only-rollback"
+    The output should not include "full-primary-accept"
+  End
+
+  It "restores fail-closed read-only when the full-primary acceptance fails"
+    When call run_primary_accept_safety_case accept-failure
+    The status should be success
+    The output should include "primary-internal-writable"
+    The output should include "full-primary-accept"
+    The output should include "read-only-rollback"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_runtime_role_promotion_race_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_runtime_role_promotion_race_spec.sh
@@ -256,7 +256,7 @@ HARNESS
     return "${rc}"
   }
 
-  It "keeps the global read-only fence until full-primary acceptance after promotion interrupts a secondary fence"
+  It "keeps the global read-only fence before full-primary acceptance after promotion interrupts a secondary fence"
     When call run_secondary_fence_promotion_race
     The status should be success
     The output should include "read-only-on"
@@ -264,7 +264,7 @@ HARNESS
     The output should include "full-primary-accept"
   End
 
-  It "keeps an ordinary business writer fenced until full-primary acceptance"
+  It "keeps an ordinary business writer fenced before full-primary acceptance"
     When call run_business_writer_during_primary_accept
     The status should be success
     The output should include "business-write-rejected"

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -3246,10 +3246,11 @@ EOF
         #   reconcile_secondary + configure_from_primary; the body of
         #   set_replica_read_only itself is the function definition not a
         #   self-call, so 4 caller patterns)
-        # + 1 (prestop_lock_failed_both literal in preStop script) + 14 (tier-annotated swallow lines;
-        #   reduced from 16 after CMPD consolidation PR #2933)
+        # + 1 (prestop_lock_failed_both literal in preStop script) + 12 (tier-annotated swallow lines;
+        #   reduced from 14 when required primary-accept rollback stopped swallowing
+        #   its two root re-lock failures)
         The status should be success
-        The output should equal "1 1 4 1 14 "
+        The output should equal "1 1 4 1 12 "
       End
     End
   End
@@ -3520,9 +3521,9 @@ EOF
         '
         The status should be success
         # Expected: 1 grant body explicit + 1 secondary fence + 4 explicit set_replica_read_only caller +
-        # 1 prestop_lock_failed_both (in prestop script) + 14 tier-annotated swallow (reduced from 16 after CMPD
-        # consolidation PR #2933) + 2 inline-quoted MONITOR loops
-        The output should equal "1 1 4 1 14 2 "
+        # 1 prestop_lock_failed_both (in prestop script) + 12 tier-annotated swallow (required
+        # primary-accept rollback now propagates its two root re-lock failures) + 2 inline-quoted MONITOR loops
+        The output should equal "1 1 4 1 12 2 "
       End
     End
   End

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -250,7 +250,17 @@ Describe "cmpd-replication.yaml rejoin fence template"
   End
 
   It "fails closed when read_only cannot be opened for a primary"
-    When call function_contains "set_primary_read_write" "rollback_fenced_primary_accept \"\${label}\" \"read-only-open\""
+    When call function_contains "set_primary_read_write" "rollback_locked_primary_accept \"\${label}\" \"read-only-open\""
+    The status should be success
+  End
+
+  It "uses the shared local commit lock before accepting primary writes"
+    When call function_contains "set_primary_read_write" "try_acquire_primary_write_commit_lock"
+    The status should be success
+  End
+
+  It "delegates fenced-promotion global open to syncer's lease-CAS commit"
+    When call function_contains "set_primary_read_write" "authoritative_primary_write_commit \"\${label}\""
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -239,38 +239,18 @@ Describe "cmpd-replication.yaml rejoin fence template"
     The status should be success
   End
 
-  It "probes local root table writes before publishing a primary as writable"
-    When call function_contains "primary_write_gates_ready" "primary_local_root_write_ready"
-    The status should be success
-  End
-
-  It "probes internal root table writes before publishing a primary as writable"
+  It "uses only the internal admin probe before publishing a primary as writable"
     When call function_contains "primary_write_gates_ready" "primary_internal_root_write_ready"
     The status should be success
   End
 
-  It "requires local root unlock before publishing a primary as writable"
-    When call function_contains "set_primary_read_write" "primary-read-write local-root-unlock rc=1"
-    The status should be success
-  End
-
-  It "requires remote root unlock before publishing a primary as writable"
-    When call function_contains "set_primary_read_write" "fail_primary_read_write_gate \"\${label}\" \"remote-root-unlock\""
-    The status should be success
-  End
-
-  It "records failed primary write gates before publishing a primary as writable"
-    When call function_contains "fail_primary_read_write_gate" "primary-read-write \${reason} rc=1"
-    The status should be success
-  End
-
-  It "re-fences remote root when a primary write gate fails"
-    When call function_contains "fail_primary_read_write_gate" "lock_remote_root_writes"
+  It "uses required rollback rather than best-effort failure handling"
+    When call function_contains "rollback_fenced_primary_accept" "fail_closed=false"
     The status should be success
   End
 
   It "fails closed when read_only cannot be opened for a primary"
-    When call function_contains "set_primary_read_write" "fail_primary_read_write_gate \"\${label}\" \"read-only-open\""
+    When call function_contains "set_primary_read_write" "rollback_fenced_primary_accept \"\${label}\" \"read-only-open\""
     The status should be success
   End
 

--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -25,6 +25,37 @@ Describe "cmpd-replication.yaml rejoin fence template"
     ' "$(template_file)"
   }
 
+  fenced_primary_commit_is_last_visible_step() {
+    awk '
+      index($0, "set_primary_read_write() {") { fn = 1 }
+      fn && index($0, "unlock_local_root_writes \"${label}\"") { local_unlock = NR }
+      fn && index($0, "unlock_remote_root_writes \"${label}\"") { remote_unlock = NR }
+      fn && index($0, "if [ \"${role_guard}\" = \"require-dcs-primary\" ]; then") { guarded = NR }
+      fn && index($0, "authoritative_primary_write_commit \"${label}\"") { commit = NR }
+      fn && commit && /^[[:space:]]*else$/ { bootstrap_else = NR; exit }
+      END {
+        exit(local_unlock && remote_unlock && guarded && commit && bootstrap_else &&
+             local_unlock < remote_unlock && remote_unlock < guarded &&
+             guarded < commit && commit < bootstrap_else ? 0 : 1)
+      }
+    ' "$(template_file)"
+  }
+
+  prestop_never_mutates_without_commit_lock() {
+    lock_line="$(grep -n '^if ! acquire_primary_write_commit_lock_for_prestop; then$' "$(prestop_file)" | cut -d: -f1)"
+    exit_line="$(awk -v lock="${lock_line}" 'NR > lock && /^  exit 1$/ { print NR; exit }' "$(prestop_file)")"
+    marker_line="$(grep -n '^touch "${DATA_DIR}/.prestop-fence-started"' "$(prestop_file)" | cut -d: -f1)"
+    [ -n "${lock_line}" ] && [ -n "${exit_line}" ] && [ -n "${marker_line}" ] || return 1
+    [ "${lock_line}" -lt "${exit_line}" ] && [ "${exit_line}" -lt "${marker_line}" ]
+  }
+
+  only_fresh_pod0_bootstrap_may_open_without_dcs_commit() {
+    callsites="$(grep -n 'expose_sql_listener_for_primary_role "' "$(template_file)")"
+    unguarded="$(printf '%s\n' "${callsites}" | grep -v '"fenced-promotion"' || true)"
+    [ "$(printf '%s\n' "${unguarded}" | awk 'NF { count++ } END { print count + 0 }')" -eq 1 ] || return 1
+    printf '%s\n' "${unguarded}" | grep -q 'expose_sql_listener_for_primary_role "default-pod0-primary"'
+  }
+
   wait_loop_queries_primary_before_reconcile() {
     primary_query_line="$(grep -n 'PRIMARY_SID=$(timeout 10 mariadb' "$(template_file)" | tail -1 | cut -d: -f1)"
     reconcile_line="$(grep -n 'reconcile_sql_listener_for_syncer_primary_once || true' "$(template_file)" | tail -1 | cut -d: -f1)"
@@ -261,6 +292,21 @@ Describe "cmpd-replication.yaml rejoin fence template"
 
   It "delegates fenced-promotion global open to syncer's lease-CAS commit"
     When call function_contains "set_primary_read_write" "authoritative_primary_write_commit \"\${label}\""
+    The status should be success
+  End
+
+  It "unlocks both root planes under the global fence before the authoritative commit"
+    When call fenced_primary_commit_is_last_visible_step
+    The status should be success
+  End
+
+  It "makes preStop exit before marker or SQL mutation when commit-lock acquisition times out"
+    When call prestop_never_mutates_without_commit_lock
+    The status should be success
+  End
+
+  It "requires the lease-CAS commit for every write-open except fresh pod-0 bootstrap"
+    When call only_fresh_pod0_bootstrap_may_open_without_dcs_commit
     The status should be success
   End
 

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -563,9 +563,37 @@ accept_syncer_primary_promotion_from_replica_path() {
   role="$(query_local_syncer_role || true)"
   [ "${role}" = "primary" ] || return 1
   prestop_watchdog_log "replica-path-accept-dcs-primary label=${label} action=accept-primary-promotion"
+
+  # r9 first-red: replica fencing can begin while syncer still reports
+  # secondary, then race with syncer promoting this same Pod. The slow
+  # full-primary path below must restore account grants and run write
+  # gates, which took long enough for syncer writecheck to observe the
+  # temporary read_only fence and release its freshly acquired lease.
+  #
+  # Open only the internal write plane immediately after confirming the
+  # authoritative DCS primary. User-facing local/remote accounts remain
+  # fenced until expose_sql_listener_for_primary_role completes all
+  # existing primary gates. Re-check DCS after opening to close the
+  # role-change window; any failure restores fail-closed read_only.
+  if ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
+    prestop_watchdog_log "replica-path-primary-internal-write-open label=${label} rc=1"
+    return 2
+  fi
+  role="$(query_local_syncer_role || true)"
+  if [ "${role}" != "primary" ]; then
+    "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = ON;" 2>/dev/null || true
+    prestop_watchdog_log "replica-path-primary-internal-write-open label=${label} rc=1 reason=dcs-primary-changed rollback=read-only-on"
+    return 1
+  fi
+  prestop_watchdog_log "replica-path-primary-internal-write-open label=${label} rc=0 user_accounts=fenced"
   if expose_sql_listener_for_primary_role "syncer-primary-during-${label}"; then
     mark_replication_ready
     return 0
+  fi
+  if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = ON;" 2>/dev/null; then
+    prestop_watchdog_log "replica-path-primary-internal-write-rollback label=${label} rc=0 reason=full-primary-accept-failed"
+  else
+    prestop_watchdog_log "replica-path-primary-internal-write-rollback label=${label} rc=1 reason=full-primary-accept-failed"
   fi
   return 2
 }

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -202,6 +202,7 @@ ROOT_LOCAL=(mariadb "-u${MARIADB_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${
 INTERNAL_LOCAL=(mariadb "-u${MARIADB_INTERNAL_ROOT_USER}" "-p${MARIADB_ROOT_PASSWORD}" -S "${SOCK}" -N -s)
 LOCAL=("${ROOT_LOCAL[@]}")
 LIFECYCLE_MARKER="/tmp/.mariadb-startup-lifecycle"
+PRIMARY_WRITE_COMMIT_LOCK_DIR="${DATA_DIR}/.primary-write-commit-lock"
 if [ ! -f "${LIFECYCLE_MARKER}" ]; then
   touch "${LIFECYCLE_MARKER}" 2>/dev/null || true
   if [ -f "${DATA_DIR}/.prestop-fence-started" ] || \
@@ -229,6 +230,10 @@ if [ ! -f "${LIFECYCLE_MARKER}" ]; then
     ${DATA_DIR}/.sql-listener-ready \
     ${DATA_DIR}/.primary-read-write-ready \
     ${DATA_DIR}/.replication-ready
+  # The lock directory belongs to the previous container process. A live
+  # container never removes another invocation's lock; only this new-lifecycle
+  # branch is allowed to clear a stale owner after process death.
+  rm -rf "${PRIMARY_WRITE_COMMIT_LOCK_DIR}"
 elif [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
   mkdir -p ${DATA_DIR}/log 2>/dev/null || true
   {
@@ -496,88 +501,121 @@ primary_write_gates_ready() {
   set_internal_admin_gate_read_only "${label}" || return 1
   primary_internal_root_write_ready "${label}" || return 1
 }
+try_acquire_primary_write_commit_lock() {
+  mkdir "${PRIMARY_WRITE_COMMIT_LOCK_DIR}" 2>/dev/null
+}
+release_primary_write_commit_lock() {
+  rmdir "${PRIMARY_WRITE_COMMIT_LOCK_DIR}" 2>/dev/null
+}
+force_release_primary_write_commit_lock() {
+  # Call only after strongest-fence rollback. Keeping removal separate from
+  # the normal rmdir prevents a new accept from entering before rollback if
+  # unexpected payload made the owner-private directory non-empty.
+  rm -rf "${PRIMARY_WRITE_COMMIT_LOCK_DIR}" 2>/dev/null
+}
+authoritative_primary_write_commit() {
+  local label="${1:-primary-write-commit}"
+  local rc
+  if [ ! -x /tools/syncerctl ]; then
+    prestop_watchdog_log "primary-write-commit label=${label} rc=1 reason=syncerctl-missing"
+    return 1
+  fi
+  timeout 5 /tools/syncerctl --host 127.0.0.1 --port 3601 primary-write-commit \
+    >> "${DATA_DIR}/log/prestop-watchdog.log" 2>&1
+  rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    prestop_watchdog_log "primary-write-commit label=${label} rc=0 authority=fresh-lease-cas"
+    return 0
+  fi
+  prestop_watchdog_log "primary-write-commit label=${label} rc=${rc} authority=rejected"
+  return "${rc}"
+}
+rollback_locked_primary_accept() {
+  local label="${1:-fenced-primary-accept}"
+  local reason="${2:-unknown}"
+  local rollback_rc=0
+  local release_rc=0
+  rollback_fenced_primary_accept "${label}" "${reason}" || rollback_rc=$?
+  if ! release_primary_write_commit_lock; then
+    release_rc=1
+    force_release_primary_write_commit_lock || release_rc=2
+  fi
+  if [ "${rollback_rc}" -eq 0 ] && [ "${release_rc}" -eq 0 ]; then
+    return 2
+  fi
+  prestop_watchdog_log "primary-write-commit-cleanup label=${label} reason=${reason} rollback_rc=${rollback_rc} release_rc=${release_rc} fail_closed=false"
+  return 3
+}
 set_primary_read_write() {
   local label="${1:-primary-read-write}"
   local role_guard="${2:-no-dcs-check}"
-  local role
+  local accept_rc
 
   # Do not let any user-facing writer open before all required gates pass.
   # LOCAL is the user-facing root and remains fenced here; INTERNAL_LOCAL is
   # the addon-owned admin used for both the pre-open probe and global toggle.
+  # Take the shared local commit lock before changing markers or fences so two
+  # accepts cannot roll one another backward, and preStop is totally ordered
+  # with the complete accept transaction.
+  if ! try_acquire_primary_write_commit_lock; then
+    if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
+      prestop_watchdog_log "primary-write-commit-lock label=${label} rc=2 owner=prestop"
+      return 2
+    fi
+    prestop_watchdog_log "primary-write-commit-lock label=${label} rc=1 owner=other-accept"
+    return 1
+  fi
+  prestop_watchdog_log "primary-write-commit-lock label=${label} rc=0 owner=accept"
+
   mark_replication_pending
   if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
-    if rollback_fenced_primary_accept "${label}" "prestop-fence-started"; then
-      return 2
-    fi
-    return 3
+    rollback_locked_primary_accept "${label}" "prestop-fence-started"
+    return $?
   fi
   if ! read_only_is_fail_closed; then
-    if rollback_fenced_primary_accept "${label}" "entry-not-fail-closed"; then
-      return 2
-    fi
-    return 3
+    rollback_locked_primary_accept "${label}" "entry-not-fail-closed"
+    return $?
   fi
   if ! primary_write_gates_ready "${label}"; then
-    if rollback_fenced_primary_accept "${label}" "internal-write-gate"; then
-      return 2
-    fi
-    return 3
+    rollback_locked_primary_accept "${label}" "internal-write-gate"
+    return $?
   fi
 
-  # The internal gate deliberately narrows NO_LOCK_NO_ADMIN to ON so the
-  # addon-owned admin can probe the local write plane.  ON is an intermediate
-  # state, not a safe early-exit state: preStop may have started while the
-  # gate was running, and DCS leadership may have changed after the caller's
-  # earlier role decision.  Re-read both immediately before the first
-  # user/global open and restore the full fence on either change.
+  # A forced preStop timeout may publish its marker without the lock before
+  # killing mariadbd. Recheck under our ownership after the required gate.
   if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
-    if rollback_fenced_primary_accept "${label}" "prestop-after-internal-gate"; then
-      return 2
-    fi
-    return 3
+    rollback_locked_primary_accept "${label}" "prestop-before-authority-commit"
+    return $?
   fi
+
   if [ "${role_guard}" = "require-dcs-primary" ]; then
-    role="$(query_local_syncer_role || true)"
-    if [ "${role}" != "primary" ]; then
-      if rollback_fenced_primary_accept "${label}" "dcs-primary-changed"; then
-        return 2
-      fi
-      return 3
+    if ! authoritative_primary_write_commit "${label}"; then
+      rollback_locked_primary_accept "${label}" "authority-commit-rejected"
+      return $?
     fi
-  fi
-  # Close the marker window while the DCS read above was in flight.  This is
-  # the final commit-point check before any user-facing write capability opens.
-  if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
-    if rollback_fenced_primary_accept "${label}" "prestop-before-user-open"; then
-      return 2
-    fi
-    return 3
-  fi
-
-  if ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null && \
-     ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
-    if rollback_fenced_primary_accept "${label}" "read-only-open"; then
-      return 2
-    fi
-    return 3
+  elif ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null && \
+       ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
+    rollback_locked_primary_accept "${label}" "read-only-open"
+    return $?
   fi
   if ! unlock_local_root_writes "${label}"; then
-    if rollback_fenced_primary_accept "${label}" "local-root-unlock"; then
-      return 2
-    fi
-    return 3
+    rollback_locked_primary_accept "${label}" "local-root-unlock"
+    return $?
   fi
   if ! unlock_remote_root_writes "${label}"; then
-    if rollback_fenced_primary_accept "${label}" "remote-root-unlock"; then
-      return 2
-    fi
-    return 3
+    rollback_locked_primary_accept "${label}" "remote-root-unlock"
+    return $?
   fi
   if ! rm -f "${DATA_DIR}/.remote-root-fence-role" || \
-     ! touch "${DATA_DIR}/.primary-read-write-ready"; then
-    if rollback_fenced_primary_accept "${label}" "ready-publish"; then
-      return 2
-    fi
+     ! touch "${DATA_DIR}/.primary-read-write-ready" || \
+     ! mark_replication_ready; then
+    rollback_locked_primary_accept "${label}" "ready-publish"
+    return $?
+  fi
+  if ! release_primary_write_commit_lock; then
+    rollback_fenced_primary_accept "${label}" "commit-lock-release" || accept_rc=$?
+    force_release_primary_write_commit_lock || true
+    prestop_watchdog_log "primary-write-commit-lock label=${label} rc=3 reason=release-failed rollback_rc=${accept_rc:-0} fail_closed=false"
     return 3
   fi
   prestop_watchdog_log "primary-read-write label=${label} rc=0 required-gates=passed user-writers=open ready=published"
@@ -667,7 +705,6 @@ accept_syncer_primary_promotion_from_replica_path() {
   expose_sql_listener_for_primary_role "syncer-primary-during-${label}" "fenced-promotion"
   accept_rc=$?
   if [ "${accept_rc}" -eq 0 ]; then
-    mark_replication_ready
     return 0
   fi
   if [ "${accept_rc}" -eq 3 ]; then
@@ -2076,7 +2113,6 @@ reconcile_sql_listener_for_syncer_primary_once() {
     # paths, so neither this repair loop nor a normal promotion emits the old
     # public syncerctl writecheck event before user writers are opened.
     expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener-no-writecheck" || return 1
-    mark_replication_ready
     prestop_watchdog_log "runtime-primary-listener-reconcile-repair-complete role=${role}"
     return 0
   fi
@@ -2095,7 +2131,6 @@ reconcile_sql_listener_for_syncer_primary_once() {
   fi
   prestop_watchdog_log "runtime-primary-listener-reconcile-begin role=${role}"
   expose_sql_listener_for_primary_role "syncer-promoted-primary" || return 1
-  mark_replication_ready
   prestop_watchdog_log "runtime-primary-listener-reconcile-complete role=${role}"
 }
 configure_replication_from_primary_service_once() {
@@ -2325,7 +2360,6 @@ if [ "${PRIMARY_SID}" = "${SERVICE_ID}" ]; then
     wait ${MARIADB_PID}
     exit 1
   fi
-  mark_replication_ready
   echo "Starting as primary (server_id=${SERVICE_ID})"
 elif [ -n "${SLAVE_STATUS}" ]; then
   # We have existing slave config from a previous run.
@@ -2438,7 +2472,6 @@ elif [ -n "${SLAVE_STATUS}" ]; then
           wait ${MARIADB_PID}
           exit 1
         fi
-        mark_replication_ready
         echo "Starting as primary (pod-0 with stale slave config, no primary found after ${no_primary_budget}s wait)"
       fi
       PRIMARY_SID=""  # signal: resolved locally; do not fall through to rejoin
@@ -2610,7 +2643,6 @@ else
   # elected primary, this pod can configure replication and publish
   # secondary only after replica health is real.
   if expose_sql_listener_for_primary_role "default-pod0-primary"; then
-    mark_replication_ready
     echo "Starting as primary by default (index=0)"
   else
     mark_replication_pending

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -588,16 +588,12 @@ set_primary_read_write() {
     return $?
   fi
 
-  if [ "${role_guard}" = "require-dcs-primary" ]; then
-    if ! authoritative_primary_write_commit "${label}"; then
-      rollback_locked_primary_accept "${label}" "authority-commit-rejected"
-      return $?
-    fi
-  elif ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null && \
-       ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
-    rollback_locked_primary_accept "${label}" "read-only-open"
-    return $?
-  fi
+  # Unlock both user-root account planes while global read_only=ON still
+  # rejects every user writer.  The authoritative syncer operation is the
+  # final visible commit: under the HA mutex it refreshes DCS, renews the lease
+  # by resourceVersion CAS, opens/readbacks global writes, and publishes both
+  # ready markers before its HTTP response.  Nothing below that response may
+  # unlock or publish, otherwise the next RunCycle could demote/release first.
   if ! unlock_local_root_writes "${label}"; then
     rollback_locked_primary_accept "${label}" "local-root-unlock"
     return $?
@@ -606,11 +602,26 @@ set_primary_read_write() {
     rollback_locked_primary_accept "${label}" "remote-root-unlock"
     return $?
   fi
-  if ! rm -f "${DATA_DIR}/.remote-root-fence-role" || \
-     ! touch "${DATA_DIR}/.primary-read-write-ready" || \
-     ! mark_replication_ready; then
-    rollback_locked_primary_accept "${label}" "ready-publish"
+  if ! rm -f "${DATA_DIR}/.remote-root-fence-role"; then
+    rollback_locked_primary_accept "${label}" "remote-root-marker-clear"
     return $?
+  fi
+  if [ "${role_guard}" = "require-dcs-primary" ]; then
+    if ! authoritative_primary_write_commit "${label}"; then
+      rollback_locked_primary_accept "${label}" "authority-commit-rejected"
+      return $?
+    fi
+  else
+    if ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null && \
+       ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
+      rollback_locked_primary_accept "${label}" "read-only-open"
+      return $?
+    fi
+    if ! touch "${DATA_DIR}/.primary-read-write-ready" || \
+       ! mark_replication_ready; then
+      rollback_locked_primary_accept "${label}" "ready-publish"
+      return $?
+    fi
   fi
   if ! release_primary_write_commit_lock; then
     rollback_fenced_primary_accept "${label}" "commit-lock-release" || accept_rc=$?
@@ -618,7 +629,7 @@ set_primary_read_write() {
     prestop_watchdog_log "primary-write-commit-lock label=${label} rc=3 reason=release-failed rollback_rc=${accept_rc:-0} fail_closed=false"
     return 3
   fi
-  prestop_watchdog_log "primary-read-write label=${label} rc=0 required-gates=passed user-writers=open ready=published"
+  prestop_watchdog_log "primary-write-accept label=${label} rc=0 required-gates=passed authority-commit-acknowledged=true"
   return 0
 }
 rollback_fenced_primary_accept() {
@@ -2112,7 +2123,7 @@ reconcile_sql_listener_for_syncer_primary_once() {
     # contract now uses the internal-admin, sql_log_bin=0 pre-open gate on all
     # paths, so neither this repair loop nor a normal promotion emits the old
     # public syncerctl writecheck event before user writers are opened.
-    expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener-no-writecheck" || return 1
+    expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener-no-writecheck" "fenced-promotion" || return 1
     prestop_watchdog_log "runtime-primary-listener-reconcile-repair-complete role=${role}"
     return 0
   fi
@@ -2130,7 +2141,7 @@ reconcile_sql_listener_for_syncer_primary_once() {
     prestop_watchdog_log "runtime-primary-listener-reconcile-override reason=dcs-primary-overrides-service-routing primary_sid=${primary_sid} service_id=${SERVICE_ID} syncer_role=${role}"
   fi
   prestop_watchdog_log "runtime-primary-listener-reconcile-begin role=${role}"
-  expose_sql_listener_for_primary_role "syncer-promoted-primary" || return 1
+  expose_sql_listener_for_primary_role "syncer-promoted-primary" "fenced-promotion" || return 1
   prestop_watchdog_log "runtime-primary-listener-reconcile-complete role=${role}"
 }
 configure_replication_from_primary_service_once() {
@@ -2356,7 +2367,7 @@ SLAVE_STATUS=$("${LOCAL[@]}" -e "SHOW SLAVE STATUS;" 2>/dev/null)
 if [ "${PRIMARY_SID}" = "${SERVICE_ID}" ]; then
   # Primary service routes to us — we are the current primary.
   # Clear any stale slave config and mark initialization as complete.
-  if ! expose_sql_listener_for_primary_role "primary-service-route"; then
+  if ! expose_sql_listener_for_primary_role "primary-service-route" "fenced-promotion"; then
     wait ${MARIADB_PID}
     exit 1
   fi
@@ -2468,7 +2479,7 @@ elif [ -n "${SLAVE_STATUS}" ]; then
         done
       fi
       if [ "${blocked_self_election_resolved}" != "true" ]; then
-        if ! expose_sql_listener_for_primary_role "stale-slave-no-primary"; then
+        if ! expose_sql_listener_for_primary_role "stale-slave-no-primary" "fenced-promotion"; then
           wait ${MARIADB_PID}
           exit 1
         fi
@@ -2642,6 +2653,10 @@ else
   # reconcile loop observe the syncer/DCS decision: if another pod is
   # elected primary, this pod can configure replication and publish
   # secondary only after replica health is real.
+  # This is the sole no-DCS write-open: a fresh pod-0 has neither a primary
+  # service target nor slave metadata, and syncer cannot hold a lease before
+  # the database first becomes reachable. Every recurring/repair path above
+  # must use fenced-promotion and the lease-CAS commit.
   if expose_sql_listener_for_primary_role "default-pod0-primary"; then
     echo "Starting as primary by default (index=0)"
   else

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -428,100 +428,154 @@ primary_internal_root_write_ready() {
   prestop_watchdog_log "primary-internal-root-write-ready label=${label} rc=1"
   return 1
 }
-primary_write_gates_ready() {
-  # alpha.110 P0a URGENT Direction E (Jack 15:26 + Helen TL 15:34 sealed +
-  # Edward 15:51 + Rocco 15:53 + Lily 15:54 4-cosign LGTM):
-  # Skip primary_local_root_write_ready syncerctl-writecheck step on
-  # reconcile-repair-begin path. Root cause: chart-side
-  # reconcile_sql_listener_for_syncer_primary_once fires
-  # `runtime-primary-listener-reconcile-repair-begin` every ~3s while
-  # syncer-role=primary but chart markers OUT-OF-SYNC; each iteration's
-  # writecheck INSERTs into kb_health_check generating 1 binlog event
-  # per fire → cumulative orphan events on local domain → post-
-  # reconfigure switchover GTID divergence → alpha.60 fail-closed →
-  # HA permanent refuse follow → cluster stuck Updating. Round 1c-G
-  # 2nd mdb-async-10271 saw 18 events accumulate in 2.5min loop fire
-  # window.
-  #
-  # alpha.110 P0a URGENT Direction E preserves alpha.99 Helen
-  # 2026-05-25 design intent (syncer's WriteCheck deliberately writes
-  # to binlog for replication health verification): happy-path
-  # writecheck still runs on normal primary promotion paths (line
-  # 1942/2134/2218/2383 callers use labels without "-no-writecheck"
-  # suffix). Only the reconcile-repair-begin path passes label with
-  # "-no-writecheck" suffix (per Rocco 15:53 stricter suffix-anchored
-  # pattern), triggering this case to skip the writecheck step while
-  # preserving primary_internal_root_write_ready (kb_addon_write_probe
-  # addon-owned + explicit SET sql_log_bin=0 per line 596-602 — NOT
-  # orphan event source) + marker emit + role probe + read_only +
-  # role transition logic in set_primary_read_write happy path.
-  local label="${1:-primary-write-gates-ready}"
-  case "${label}" in
-    *-no-writecheck)
-      prestop_watchdog_log "primary-write-gates-ready label=${label} reason=skip-writecheck-repair-path"
-      primary_internal_root_write_ready "${label}" || return 1
-      return 0
-      ;;
+user_facing_root_read_only_bypass_is_absent() {
+  local label="${1:-user-root-bypass-check}"
+  local user host grants seen=""
+  user="$(sql_quote "${MARIADB_ROOT_USER}")"
+  for host in localhost 127.0.0.1 "${MARIADB_ROOT_HOST:-%}"; do
+    case " ${seen} " in
+      *" ${host} "*) continue ;;
+    esac
+    seen="${seen} ${host}"
+    host="$(sql_quote "${host}")"
+    if ! grants="$("${INTERNAL_LOCAL[@]}" -e "SHOW GRANTS FOR '${user}'@'${host}';" 2>/dev/null)"; then
+      prestop_watchdog_log "user-root-bypass-check label=${label} host=${host} rc=1 reason=show-grants-failed"
+      return 1
+    fi
+    if printf '%s\n' "${grants}" | grep -Eiq 'READ_ONLY ADMIN|(^|[,[:space:]])SUPER([,[:space:]]|$)|ALL PRIVILEGES ON [`]?\*\.[`]?\*'; then
+      prestop_watchdog_log "user-root-bypass-check label=${label} host=${host} rc=1 reason=admin-bypass-present"
+      return 1
+    fi
+  done
+  prestop_watchdog_log "user-root-bypass-check label=${label} rc=0"
+  return 0
+}
+read_only_internal_admin_gate_is_active() {
+  local value
+  value="$(read_only_value || true)"
+  case "${value}" in
+    1|ON|NO_LOCK) return 0 ;;
   esac
-  primary_local_root_write_ready "${label}" || return 1
+  return 1
+}
+set_internal_admin_gate_read_only() {
+  local label="${1:-internal-admin-gate}"
+  # MariaDB NO_LOCK_NO_ADMIN also blocks READ_ONLY ADMIN, so the internal
+  # write probe cannot run in the strongest replica fence.  After proving all
+  # user-facing root accounts lack SUPER/READ_ONLY ADMIN/ALL, narrow the server
+  # to ON: ordinary and user-root writers remain fenced while only the
+  # addon-owned internal admin can execute the pre-open probe.
+  if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = ON;" 2>/dev/null && \
+     read_only_internal_admin_gate_is_active; then
+    prestop_watchdog_log "internal-admin-gate-read-only label=${label} value=ON rc=0 user-writers=fenced"
+    return 0
+  fi
+  if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 1;" 2>/dev/null && \
+     read_only_internal_admin_gate_is_active; then
+    prestop_watchdog_log "internal-admin-gate-read-only label=${label} value=1 rc=0 user-writers=fenced"
+    return 0
+  fi
+  prestop_watchdog_log "internal-admin-gate-read-only label=${label} rc=1"
+  return 1
+}
+primary_write_gates_ready() {
+  # r9 role-race contract: every required acceptance gate must run while
+  # global read_only and both user-facing root fences are still closed.
+  # syncerctl writecheck is intentionally strict under read_only and therefore
+  # cannot be a pre-open gate.  Use the addon-owned internal admin probe with
+  # sql_log_bin=0 instead; it validates the local write plane without exposing
+  # ordinary users or generating an orphan replication event.
+  local label="${1:-primary-write-gates-ready}"
+  prestop_watchdog_log "primary-write-gates-ready label=${label} mode=internal-admin-pre-open"
+  user_facing_root_read_only_bypass_is_absent "${label}" || return 1
+  set_internal_admin_gate_read_only "${label}" || return 1
   primary_internal_root_write_ready "${label}" || return 1
 }
-fail_primary_read_write_gate() {
-  local label="$1"
-  local reason="$2"
-  rm -f ${DATA_DIR}/.primary-read-write-ready
-  # tier=fail-path-defensive: this is the failure handler for an
-  # already-failed primary write gate; defensive locking is
-  # best-effort observability. The caller has already concluded
-  # the gate failed and is not about to publish ready/role.
-  lock_remote_root_writes "${label}-${reason}" || true # tier=fail-path-defensive
-  set_fail_closed_read_only "${label}-${reason}" || true # tier=fail-path-defensive
-  lock_local_root_writes "${label}-${reason}" || true # tier=fail-path-defensive
-  prestop_watchdog_log "primary-read-write ${reason} rc=1"
-}
 set_primary_read_write() {
-  # alpha.110 P0a URGENT Direction E (Jack 15:26 + 4-cosign sealed):
-  # accept label parameter so callers can pass "-no-writecheck" suffix
-  # through to primary_write_gates_ready for repair-path skip.
-  # Default label preserves alpha.109 and earlier behavior.
   local label="${1:-primary-read-write}"
+  local role_guard="${2:-no-dcs-check}"
+  local role
+
+  # Do not let any user-facing writer open before all required gates pass.
+  # LOCAL is the user-facing root and remains fenced here; INTERNAL_LOCAL is
+  # the addon-owned admin used for both the pre-open probe and global toggle.
+  mark_replication_pending
   if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
-    prestop_watchdog_log "skip-primary-read-write reason=prestop-fence-started"
-    mark_replication_pending
-    return 1
+    if rollback_fenced_primary_accept "${label}" "prestop-fence-started"; then
+      return 2
+    fi
+    return 3
+  fi
+  if ! read_only_is_fail_closed; then
+    if rollback_fenced_primary_accept "${label}" "entry-not-fail-closed"; then
+      return 2
+    fi
+    return 3
+  fi
+  if ! primary_write_gates_ready "${label}"; then
+    if rollback_fenced_primary_accept "${label}" "internal-write-gate"; then
+      return 2
+    fi
+    return 3
+  fi
+
+  if [ "${role_guard}" = "require-dcs-primary" ]; then
+    role="$(query_local_syncer_role || true)"
+    if [ "${role}" != "primary" ]; then
+      mark_replication_pending
+      prestop_watchdog_log "primary-read-write-defer label=${label} rc=1 reason=dcs-primary-changed global-read-only=held"
+      return 1
+    fi
+  fi
+
+  if ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null && \
+     ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
+    if rollback_fenced_primary_accept "${label}" "read-only-open"; then
+      return 2
+    fi
+    return 3
   fi
   if ! unlock_local_root_writes "${label}"; then
-    rm -f ${DATA_DIR}/.primary-read-write-ready
-    prestop_watchdog_log "primary-read-write local-root-unlock rc=1 label=${label}"
-    return 1
+    if rollback_fenced_primary_accept "${label}" "local-root-unlock"; then
+      return 2
+    fi
+    return 3
   fi
   if ! unlock_remote_root_writes "${label}"; then
-    fail_primary_read_write_gate "${label}" "remote-root-unlock"
+    if rollback_fenced_primary_accept "${label}" "remote-root-unlock"; then
+      return 2
+    fi
+    return 3
+  fi
+  if ! rm -f "${DATA_DIR}/.remote-root-fence-role" || \
+     ! touch "${DATA_DIR}/.primary-read-write-ready"; then
+    if rollback_fenced_primary_accept "${label}" "ready-publish"; then
+      return 2
+    fi
+    return 3
+  fi
+  prestop_watchdog_log "primary-read-write label=${label} rc=0 required-gates=passed user-writers=open ready=published"
+  return 0
+}
+rollback_fenced_primary_accept() {
+  local label="${1:-fenced-primary-accept}"
+  local reason="${2:-unknown}"
+  local rc=0
+
+  # This rollback is part of the required acceptance contract.  Do not hide
+  # failures: a stale ready marker or any user-writer fence that cannot be
+  # restored means the caller must report fail_closed=false.
+  mark_replication_pending
+  [ ! -f "${DATA_DIR}/.primary-read-write-ready" ] || rc=1
+  set_fail_closed_read_only "${label}-${reason}" || rc=1
+  lock_remote_root_writes "${label}-${reason}" || rc=1
+  lock_local_root_writes "${label}-${reason}" || rc=1
+  if [ "${rc}" -ne 0 ]; then
+    prestop_watchdog_log "fenced-primary-accept-rollback label=${label} reason=${reason} rc=1 fail_closed=false"
     return 1
   fi
-  if "${LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
-    if ! primary_write_gates_ready "${label}"; then
-      fail_primary_read_write_gate "${label}" "write-gate"
-      return 1
-    fi
-    rm -f ${DATA_DIR}/.remote-root-fence-role
-    touch ${DATA_DIR}/.primary-read-write-ready
-    prestop_watchdog_log "primary-read-write rc=0 label=${label}"
-    return 0
-  fi
-  if "${LOCAL[@]}" -e "SET GLOBAL read_only = 'OFF';" 2>/dev/null; then
-    if ! primary_write_gates_ready "${label}"; then
-      fail_primary_read_write_gate "${label}" "write-gate"
-      return 1
-    fi
-    rm -f ${DATA_DIR}/.remote-root-fence-role
-    touch ${DATA_DIR}/.primary-read-write-ready
-    prestop_watchdog_log "primary-read-write rc=0 label=${label}"
-    return 0
-  fi
-  fail_primary_read_write_gate "${label}" "read-only-open"
-  prestop_watchdog_log "primary-read-write rc=1 label=${label}"
-  return 1
+  prestop_watchdog_log "fenced-primary-accept-rollback label=${label} reason=${reason} rc=0 fail_closed=true"
+  return 0
 }
 mark_replication_pending() {
   rm -f ${DATA_DIR}/.replication-ready
@@ -559,7 +613,7 @@ replica_lock_abort_if_syncer_primary() {
   return 0
 }
 accept_syncer_primary_promotion_from_replica_path() {
-  local label="${1:-replica-path}" role
+  local label="${1:-replica-path}" role accept_rc
   role="$(query_local_syncer_role || true)"
   [ "${role}" = "primary" ] || return 1
   prestop_watchdog_log "replica-path-accept-dcs-primary label=${label} action=accept-primary-promotion"
@@ -579,9 +633,24 @@ accept_syncer_primary_promotion_from_replica_path() {
     return 1
   fi
   prestop_watchdog_log "replica-path-primary-accept-begin label=${label} global-read-only=held"
-  if expose_sql_listener_for_primary_role "syncer-primary-during-${label}"; then
+  expose_sql_listener_for_primary_role "syncer-primary-during-${label}" "fenced-promotion"
+  accept_rc=$?
+  if [ "${accept_rc}" -eq 0 ]; then
     mark_replication_ready
     return 0
+  fi
+  if [ "${accept_rc}" -eq 3 ]; then
+    prestop_watchdog_log "replica-path-primary-accept-rollback label=${label} rc=1 reason=full-primary-accept-failed fail_closed=false"
+    return 3
+  fi
+  if [ "${accept_rc}" -eq 2 ]; then
+    prestop_watchdog_log "replica-path-primary-accept-rollback label=${label} rc=0 reason=full-primary-accept-failed global-read-only=on"
+    return 2
+  fi
+  role="$(query_local_syncer_role || true)"
+  if [ "${role}" != "primary" ]; then
+    prestop_watchdog_log "replica-path-primary-accept-defer label=${label} rc=1 reason=dcs-primary-changed global-read-only=held"
+    return 1
   fi
   if ! set_fail_closed_read_only "${label}-full-primary-accept-failed"; then
     prestop_watchdog_log "replica-path-primary-accept-rollback label=${label} rc=1 reason=full-primary-accept-failed fail_closed=false"
@@ -1855,6 +1924,8 @@ reset_semisync_master_ack_receiver_if_enabled() {
 }
 expose_sql_listener_for_primary_role() {
   local label="$1"
+  local accept_mode="${2:-standard}"
+  local write_rc
   if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
     prestop_watchdog_log "skip-sql-listener-primary-expose label=${label} reason=prestop-fence-started"
     mark_replication_pending
@@ -1875,14 +1946,21 @@ expose_sql_listener_for_primary_role() {
       prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} reason=existing-listener-semisync-role-shape"
       return 1
     fi
-    if set_primary_read_write "${label}"; then
+    if [ "${accept_mode}" = "fenced-promotion" ]; then
+      set_primary_read_write "${label}" "require-dcs-primary"
+      write_rc=$?
+    else
+      set_primary_read_write "${label}"
+      write_rc=$?
+    fi
+    if [ "${write_rc}" -eq 0 ]; then
       touch ${DATA_DIR}/.sql-listener-ready
       prestop_watchdog_log "sql-listener-primary-existing-reconciled label=${label}"
       return 0
     fi
     mark_replication_pending
     prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} reason=existing-listener-local-write-not-ready"
-    return 1
+    return "${write_rc}"
   fi
   mark_replication_pending
   prestop_watchdog_log "sql-listener-primary-expose-begin label=${label}"
@@ -1899,10 +1977,17 @@ expose_sql_listener_for_primary_role() {
     prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} reason=fresh-listener-semisync-role-shape"
     return 1
   fi
-  if ! set_primary_read_write "${label}"; then
+  if [ "${accept_mode}" = "fenced-promotion" ]; then
+    set_primary_read_write "${label}" "require-dcs-primary"
+    write_rc=$?
+  else
+    set_primary_read_write "${label}"
+    write_rc=$?
+  fi
+  if [ "${write_rc}" -ne 0 ]; then
     mark_replication_pending
-    prestop_watchdog_log "sql-listener-primary-expose-failed label=${label}"
-    return 1
+    prestop_watchdog_log "sql-listener-primary-expose-failed label=${label} rc=${write_rc}"
+    return "${write_rc}"
   fi
   touch ${DATA_DIR}/.sql-listener-ready
   prestop_watchdog_log "sql-listener-primary-expose-complete label=${label}"
@@ -1955,17 +2040,10 @@ reconcile_sql_listener_for_syncer_primary_once() {
       return 0
     fi
     prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role}"
-    # alpha.110 P0a URGENT Direction E: pass "-no-writecheck" suffix
-    # to skip primary_local_root_write_ready syncerctl-writecheck in
-    # the repair path. Each loop iteration's writecheck INSERTs into
-    # kb_health_check generating 1 binlog event per fire; in Round
-    # 1c-G 2nd this fired 18 times in 2.5min on mdb-async-10271 pod-0
-    # accumulating 18 orphan events that caused post-reconfigure
-    # switchover GTID divergence + alpha.60 fail-closed. Skipping the
-    # writecheck here removes the orphan event source while preserving
-    # primary_internal_root_write_ready (kb_addon_write_probe addon-
-    # owned with explicit SET sql_log_bin=0) + marker emit + role
-    # probe + read_only management + lock/unlock logic.
+    # Keep the historical suffix for log continuity.  The r9 acceptance
+    # contract now uses the internal-admin, sql_log_bin=0 pre-open gate on all
+    # paths, so neither this repair loop nor a normal promotion emits the old
+    # public syncerctl writecheck event before user writers are opened.
     expose_sql_listener_for_primary_role "syncer-promoted-primary-existing-listener-no-writecheck" || return 1
     mark_replication_ready
     prestop_watchdog_log "runtime-primary-listener-reconcile-repair-complete role=${role}"

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -565,36 +565,29 @@ accept_syncer_primary_promotion_from_replica_path() {
   prestop_watchdog_log "replica-path-accept-dcs-primary label=${label} action=accept-primary-promotion"
 
   # r9 first-red: replica fencing can begin while syncer still reports
-  # secondary, then race with syncer promoting this same Pod. The slow
-  # full-primary path below must restore account grants and run write
-  # gates, which took long enough for syncer writecheck to observe the
-  # temporary read_only fence and release its freshly acquired lease.
-  #
-  # Open only the internal write plane immediately after confirming the
-  # authoritative DCS primary. User-facing local/remote accounts remain
-  # fenced until expose_sql_listener_for_primary_role completes all
-  # existing primary gates. Re-check DCS after opening to close the
-  # role-change window; any failure restores fail-closed read_only.
-  if ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null; then
-    prestop_watchdog_log "replica-path-primary-internal-write-open label=${label} rc=1"
-    return 2
-  fi
+  # secondary, then race with syncer promoting this same Pod. Keep the
+  # global read_only fence ON until the existing full-primary acceptance
+  # completes. MariaDB read_only is server-global, so turning it OFF here
+  # would also expose ordinary business users, not just kb_internal_root.
+  # Syncer's DCS-authoritative local leader heartbeat must instead use its
+  # dedicated READ_ONLY ADMIN connection while suppressing binlog output.
+  # Re-check DCS immediately before the full acceptance to close the role
+  # decision window without opening a write window first.
   role="$(query_local_syncer_role || true)"
   if [ "${role}" != "primary" ]; then
-    "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = ON;" 2>/dev/null || true
-    prestop_watchdog_log "replica-path-primary-internal-write-open label=${label} rc=1 reason=dcs-primary-changed rollback=read-only-on"
+    prestop_watchdog_log "replica-path-primary-accept-defer label=${label} rc=1 reason=dcs-primary-changed global-read-only=held"
     return 1
   fi
-  prestop_watchdog_log "replica-path-primary-internal-write-open label=${label} rc=0 user_accounts=fenced"
+  prestop_watchdog_log "replica-path-primary-accept-begin label=${label} global-read-only=held"
   if expose_sql_listener_for_primary_role "syncer-primary-during-${label}"; then
     mark_replication_ready
     return 0
   fi
-  if "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = ON;" 2>/dev/null; then
-    prestop_watchdog_log "replica-path-primary-internal-write-rollback label=${label} rc=0 reason=full-primary-accept-failed"
-  else
-    prestop_watchdog_log "replica-path-primary-internal-write-rollback label=${label} rc=1 reason=full-primary-accept-failed"
+  if ! set_fail_closed_read_only "${label}-full-primary-accept-failed"; then
+    prestop_watchdog_log "replica-path-primary-accept-rollback label=${label} rc=1 reason=full-primary-accept-failed fail_closed=false"
+    return 3
   fi
+  prestop_watchdog_log "replica-path-primary-accept-rollback label=${label} rc=0 reason=full-primary-accept-failed global-read-only=on"
   return 2
 }
 gtid_state_is_covered_by() {

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -567,7 +567,7 @@ accept_syncer_primary_promotion_from_replica_path() {
   # r9 first-red: replica fencing can begin while syncer still reports
   # secondary, then race with syncer promoting this same Pod. Keep the
   # global read_only fence ON until the existing full-primary acceptance
-  # completes. MariaDB read_only is server-global, so turning it OFF here
+  # takes control. MariaDB read_only is server-global, so turning it OFF here
   # would also expose ordinary business users, not just kb_internal_root.
   # Syncer's DCS-authoritative local leader heartbeat must instead use its
   # dedicated READ_ONLY ADMIN connection while suppressing binlog output.

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -265,6 +265,11 @@ read_only_is_fail_closed() {
   esac
   return 1
 }
+read_only_is_strongest_fail_closed() {
+  local value
+  value="$(read_only_value || true)"
+  [ "${value}" = "NO_LOCK_NO_ADMIN" ]
+}
 set_fail_closed_read_only() {
   local label="${1:-fail-closed}"
   if "${LOCAL[@]}" -e "SET GLOBAL read_only = NO_LOCK_NO_ADMIN;" 2>/dev/null && read_only_is_fail_closed; then
@@ -519,13 +524,34 @@ set_primary_read_write() {
     return 3
   fi
 
+  # The internal gate deliberately narrows NO_LOCK_NO_ADMIN to ON so the
+  # addon-owned admin can probe the local write plane.  ON is an intermediate
+  # state, not a safe early-exit state: preStop may have started while the
+  # gate was running, and DCS leadership may have changed after the caller's
+  # earlier role decision.  Re-read both immediately before the first
+  # user/global open and restore the full fence on either change.
+  if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
+    if rollback_fenced_primary_accept "${label}" "prestop-after-internal-gate"; then
+      return 2
+    fi
+    return 3
+  fi
   if [ "${role_guard}" = "require-dcs-primary" ]; then
     role="$(query_local_syncer_role || true)"
     if [ "${role}" != "primary" ]; then
-      mark_replication_pending
-      prestop_watchdog_log "primary-read-write-defer label=${label} rc=1 reason=dcs-primary-changed global-read-only=held"
-      return 1
+      if rollback_fenced_primary_accept "${label}" "dcs-primary-changed"; then
+        return 2
+      fi
+      return 3
     fi
+  fi
+  # Close the marker window while the DCS read above was in flight.  This is
+  # the final commit-point check before any user-facing write capability opens.
+  if [ -f "${DATA_DIR}/.prestop-fence-started" ]; then
+    if rollback_fenced_primary_accept "${label}" "prestop-before-user-open"; then
+      return 2
+    fi
+    return 3
   fi
 
   if ! "${INTERNAL_LOCAL[@]}" -e "SET GLOBAL read_only = 0;" 2>/dev/null && \
@@ -568,6 +594,11 @@ rollback_fenced_primary_accept() {
   mark_replication_pending
   [ ! -f "${DATA_DIR}/.primary-read-write-ready" ] || rc=1
   set_fail_closed_read_only "${label}-${reason}" || rc=1
+  # ON is sufficient for ordinary replica writers, but not for this rollback:
+  # the pre-open gate has already proved and used the addon-owned READ_ONLY
+  # ADMIN bypass.  A non-primary early exit must restore NO_LOCK_NO_ADMIN so
+  # that internal admin cannot keep writing either.
+  read_only_is_strongest_fail_closed || rc=1
   lock_remote_root_writes "${label}-${reason}" || rc=1
   lock_local_root_writes "${label}-${reason}" || rc=1
   if [ "${rc}" -ne 0 ]; then

--- a/addons/mariadb/scripts/replication-prestop.sh
+++ b/addons/mariadb/scripts/replication-prestop.sh
@@ -3,6 +3,7 @@ DATA_DIR="${MARIADB_DATADIR:-/var/lib/mysql}"
 LOG_DIR="${DATA_DIR}/log"
 LOG_FILE="${LOG_DIR}/prestop-fence.log"
 INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
+PRIMARY_WRITE_COMMIT_LOCK_DIR="${DATA_DIR}/.primary-write-commit-lock"
 mkdir -p "${LOG_DIR}" 2>/dev/null || true
 prestop_log() {
   line="$(date -u +"%Y-%m-%dT%H:%M:%SZ") prestop-fence $*"
@@ -93,9 +94,24 @@ wait_mariadbd_exit() {
   return 1
 }
 
+acquire_primary_write_commit_lock_for_prestop() {
+  attempt=0
+  while [ "${attempt}" -lt 50 ]; do
+    if mkdir "${PRIMARY_WRITE_COMMIT_LOCK_DIR}" 2>/dev/null; then
+      prestop_log "primary-write-commit-lock rc=0 owner=prestop attempts=${attempt}"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.1
+  done
+  prestop_log "primary-write-commit-lock rc=1 reason=accept-owner-timeout attempts=${attempt} fail_closed=process-termination"
+  return 1
+}
+
 prestop_log "begin pod=${POD_NAME:-unknown}"
+acquire_primary_write_commit_lock_for_prestop || true
 touch "${DATA_DIR}/.prestop-fence-started" "${DATA_DIR}/.replication-pending" 2>/dev/null || true
-rm -f "${DATA_DIR}/.replication-ready" 2>/dev/null || true
+rm -f "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready" 2>/dev/null || true
 # alpha.64 v2 (Jack 10:32 HOLD blocker 2): Tier B preStop
 # required LOCK MUST NOT be silently swallowed by trailing
 # `|| true`. socket→tcp fallback is best-effort attempt
@@ -142,11 +158,15 @@ if ! wait_mariadbd_exit 15; then
     kill -KILL ${pids} 2>/dev/null || true
   fi
   if ! wait_mariadbd_exit 5; then
+    rm -f "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready" 2>/dev/null || true
+    touch "${DATA_DIR}/.replication-pending" 2>/dev/null || true
     touch "${DATA_DIR}/.prestop-fence-failed" 2>/dev/null || true
     prestop_log "end status=failed"
     exit 0
   fi
 fi
 
+rm -f "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready" 2>/dev/null || true
+touch "${DATA_DIR}/.replication-pending" 2>/dev/null || true
 touch "${DATA_DIR}/.prestop-fence-complete" 2>/dev/null || true
 prestop_log "end status=complete"

--- a/addons/mariadb/scripts/replication-prestop.sh
+++ b/addons/mariadb/scripts/replication-prestop.sh
@@ -96,7 +96,13 @@ wait_mariadbd_exit() {
 
 acquire_primary_write_commit_lock_for_prestop() {
   attempt=0
-  while [ "${attempt}" -lt 50 ]; do
+  # The container hook has a 120s termination grace budget. Wait at most 40s
+  # for an in-flight accept to finish, leaving roughly 80s for the existing
+  # bounded SQL fencing (3s per call), TERM/KILL, and exit verification.  A
+  # timeout must NOT continue into marker/SQL mutations without the lock;
+  # returning non-zero makes kubelet proceed with process termination, which
+  # is the only truthful fail-close claim for this exceptional branch.
+  while [ "${attempt}" -lt 400 ]; do
     if mkdir "${PRIMARY_WRITE_COMMIT_LOCK_DIR}" 2>/dev/null; then
       prestop_log "primary-write-commit-lock rc=0 owner=prestop attempts=${attempt}"
       return 0
@@ -109,7 +115,10 @@ acquire_primary_write_commit_lock_for_prestop() {
 }
 
 prestop_log "begin pod=${POD_NAME:-unknown}"
-acquire_primary_write_commit_lock_for_prestop || true
+if ! acquire_primary_write_commit_lock_for_prestop; then
+  prestop_log "end status=commit-lock-timeout fail_closed=process-termination"
+  exit 1
+fi
 touch "${DATA_DIR}/.prestop-fence-started" "${DATA_DIR}/.replication-pending" 2>/dev/null || true
 rm -f "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready" 2>/dev/null || true
 # alpha.64 v2 (Jack 10:32 HOLD blocker 2): Tier B preStop

--- a/addons/mariadb/scripts/replication-prestop.sh
+++ b/addons/mariadb/scripts/replication-prestop.sh
@@ -34,7 +34,10 @@ fence_read_only() {
     || true
 }
 prestop_sql_quote() {
-  printf "%s" "$1" | sed "s/'/''/g"
+  # Keep the same MariaDB string-literal contract as replication-entrypoint,
+  # roleprobe, and switchover: under the default sql_mode a backslash is an
+  # escape character, so it must be doubled before single quotes are doubled.
+  printf "%s" "$1" | sed -e 's/\\/\\\\/g' -e "s/'/''/g"
 }
 lock_local_root_for_prestop() {
   # alpha.64 v1 (Jack 09:35 RED): drop SUPER (admin bypass).


### PR DESCRIPTION
## Problem and runtime evidence

Fresh focused r9 on addon source `378d7934e8d2f0b167035275b5c5ca7d77a9627b` and syncer `10ee54d8ec86f5d04db0fc6f7628fcde46b2432c` hit a first non-environment red during planned switchover.

The addon secondary reconcile fenced the candidate with global `read_only=ON` while syncer promoted that same Pod. Full addon primary acceptance took about five seconds; syncer then treated the fenced leader as unhealthy and released the new lease.

Frozen focused boundary (`N=1`, full suite not launched): Promote `1 -> 1`, marker present `25/25`, old primary unavailable `25/25`, candidate writable `23/25`, lease refresh `1 -> 1`, expiry `0 -> 14`. Evidence outer SHA256 is `d6281be829a6f749e27ed316cf80d41b8a3fba277f07ddc17d4796588e94c581`; root manifest SHA256 is `58d7a21ab4b32c70c70fe7bb6015a9c810106e2faa9cd8944682e46669a873b4` (`65/65`). Natural convergence after the failure window does not turn r9 into a PASS.

## Rejected designs

The following addon exacts and the previous cross-layer pair are withdrawn and must not be packaged or launched:

- `7e23d315...`: opened global read-only early and incorrectly described it as an internal-only write plane.
- `fde4576b...`: left the production order opening user writers before required gates.
- `137f9c47...`: checked preStop only before the internal gate and failed to restore the strongest fence on post-gate DCS drift.
- `efd452617...`: added more fresh reads, but an independent production-function interleaving proved that completed preStop fencing and DCS drift could still be overwritten at the first open. Audit SHA256 `eb65c682b9edd20db961aa6fb900a77bad7dd350c7e12fc3f1151ca334ff5fc2`; repro SHA256 `e5be68045e687d98a369d262b7489d0b2886ff1073eae8d4340ad2a100624c78`.
- addon `786f9188...` + syncer `9742c492...`: serialized the first open but still left root unlock and readiness publication after the authoritative HTTP commit. It also let recurring/repair callers use a stale `getrole==primary` observation as direct-open authority. The old preStop path additionally continued marker/SQL mutation after its five-second lock budget expired.

More snapshots or a shorter post-response tail cannot make a read-followed-by-write sequence atomic. This revision removes those windows.

## Corrected linearizable contract

Addon exact `aa6ed6508c17febc312e4c2fef704433abc82ab5` works with syncer PR #304 exact `8cfcc248fccf9b0d7011ce78db8831342a0714b8`:

1. `set_primary_read_write` owns an atomic local commit lock through its complete acceptance attempt.
2. user-root bypass checks run first; global read-only is narrowed to `ON`, which still fences ordinary user writers.
3. local and remote root accounts are unlocked while that global user fence remains active. The remote-root fence marker is removed under the same lock.
4. fenced promotion calls `syncerctl primary-write-commit` as the last visible commit operation. After HTTP success the addon only releases its local lock and emits a neutral acknowledgement log; it does not open writes, unlock accounts, or publish readiness.
5. syncer serializes the authoritative operation with HA cycles. Under one mutex it refreshes DCS, requires the local lease, performs Kubernetes `resourceVersion` CAS, opens and reads back MariaDB global writes, clears pending/divergence, and publishes `.primary-read-write-ready` plus `.replication-ready` (the latter last) before returning success.
6. any syncer filesystem-publication failure removes both ready markers, restores pending, and returns an error so addon rollback runs.
7. `Demote` publishes pending and removes both ready markers before it tightens MariaDB read-only. If that transition fails, demotion fails and the switchover handler does not release the lease.
8. a still-running leader that exceeds the health-failure threshold must also complete `Demote` before lease release and recovery. Demote failure must renew DCS authority; if renewal fails, it fail-stops and positively verifies the local DB is no longer running. These branches never release or recover a writable/ready old primary, and incomplete fail-stop is reported `fail_closed=false`.
9. every recurring, repair, service-route, stale-data, and syncer-promoted acceptance call uses fenced promotion. Only a true first `default-pod0-primary` bootstrap with no DCS lease may use the addon-owned standard path.
10. recurring syncer `Promote` prepares replication only. It never opens writes or publishes readiness.
11. preStop shares the local commit lock. Within the container's 120-second termination budget it waits at most 40 seconds; if the lock remains unavailable, it exits `1` before any marker or SQL mutation. Kubelet process termination is the truthful exceptional fail-close boundary, so this branch does not claim durable strongest-fence or root-lock state.

Rollback still distinguishes a complete strongest fence plus both root locks (`rc=2`) from incomplete rollback (`rc=3`, `fail_closed=false`). MariaDB `NO_LOCK_NO_ADMIN` remains the required complete rollback state because `ON` permits the addon-owned `READ_ONLY ADMIN` account to write.

## Predecessor TDD and source verification

The tests extract and execute production functions rather than wrapper-only substitutes.

- recurring-open structural RED: the previous head had non-bootstrap callers that could reach standard direct open; the new head permits it only for true first pod-0 bootstrap.
- post-response linearization RED: the previous head committed through syncer and then changed root/readiness state in addon; the new production harness injects an immediate next demotion and proves that commit publishes complete readiness, the next HA cycle retracts it, and addon performs no later visible transition.
- preStop RED: the previous five-second lock timeout continued marker/fence mutation through `|| true`; the new production harness holds acceptance beyond the old budget and proves timeout means zero marker/SQL mutation before process termination.
- focused acceptance/lock/static set: `96` examples, `0` failures.
- related acceptance + lock + r9 race + fence/startup set: `101` examples, `0` failures.
- all MariaDB ShellSpec files: `766` examples = `757` pass / `0` fail / `9` historical pending.
- switchover suite: `201` pass / `0` fail / `6` historical pending.
- addon `bash -n`, `sh -n`, ShellCheck severity=error, `helm template`, and `git diff --check`: PASS.
- syncer `go test ./... -count=1`, focused `go test -race`, and `go vet ./...`: PASS on the paired exact.

## CI, review, and runtime boundary

Current addon head `aa6ed6508c17febc312e4c2fef704433abc82ab5` is pushed, OPEN, non-draft, mergeable, and its official CI is terminal green. The cross-repository syncer references above document the predecessor integration boundary; this metadata refresh does not reassert their present CI state. Earlier review/checker results remain scoped to the exact paths and heads they covered.

Runtime for the corrected pair is `N=0`. This PR update is not a Test GO. After both official CIs, Magnus's new-head addon review, and Jack's independent production checker close, Dev must freshly enumerate every current weicao open PR touching MariaDB, build a new combined source, and publish a new exact manifest. Test independently owns package, render, runner, live identity, focused runtime evidence, cleanup, and any later full-suite decision.


## Current-head successor correction

Current addon exact: `aa6ed6508c17febc312e4c2fef704433abc82ab5` (tree `a177476dc28e3283c5308599942f5dd5df531d76`). This successor keeps the authority-linearization contract above and fixes one additional preStop SQL-literal contract gap: values now escape backslashes before doubling single quotes, matching the runtime SQL-quote contract for socket and TCP paths.

- old-source adversarial embedded/trailing backslash + quote cases: `3` failures
- current successor focused spec: `3` examples, `0` failures
- related runtime-race + semisync templates: `78` examples, `0` failures
- current exact GitHub Actions: terminal green
- runtime on this current exact remains `N=0`; these source tests do not replace Jack-owned product validation
