### PR TITLE
fix: add mysql57 performance_schema parameter schema

### DIFF
--- a/addons/mysql/config/mysql5.7-config-constraint.cue
+++ b/addons/mysql/config/mysql5.7-config-constraint.cue
@@ -1099,6 +1099,9 @@
   // Enable parallel execution on the slave of all uncommitted threads already in the prepare phase, without violating consistency.
   slave_preserve_commit_order?: string & "0" | "1" | "OFF" | "ON"
 
+	// Enables or disables the Performance Schema
+	performance_schema: string & "OFF" | "ON" | *"OFF"
+
 	// The number of seconds the slave SQL thread waits for activity on the replication queue before checking for more events.
   performance_schema_digests_size?: int & >=-1 & <=1048576
 


### PR DESCRIPTION
## What changed
- add the missing `performance_schema` schema entry to the MySQL 5.7 parameter constraint

## Why
- `mysql5.7-config-effect-scope.yaml` already classifies `performance_schema` as a static parameter
- but `mysql5.7-config-constraint.cue` did not define the parameter itself
- that mismatch can break parameter API validation/rendering for MySQL 5.7 reconfiguration

## Impact
- the MySQL 5.7 parameter API can expose and validate `performance_schema` consistently
- the parameter remains restart-only rather than dynamic

## Root cause
- effect-scope and parameter schema drifted out of sync for MySQL 5.7

## Related issue
- Refs apecloud/apecloud#19172

## Validation
- checked the diff only
- ran `git diff --check` on the modified file
