### PR TITLE
mariadb: log primary reconcile drift predicates

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_merged_semisync_startup_recovery_spec.sh
@@ -72,9 +72,28 @@ Describe "cmpd-replication.yaml semisync startup recovery"
   primary_reconcile_fast_path_requires_real_wildcard_listener() {
     awk '
       index($0, "reconcile_sql_listener_for_syncer_primary_once() {") { fn = 1 }
-      fn && index($0, ".primary-read-write-ready") && index($0, "mariadbd_listen_on_all_interfaces") { found = 1 }
-      fn && index($0, "runtime-primary-listener-reconcile-repair-begin") { exit(found ? 0 : 1) }
-      END { exit(found ? 0 : 1) }
+      fn && index($0, ".primary-read-write-ready") { primary_ready = 1 }
+      fn && index($0, "mariadbd_listen_on_all_interfaces") { listener = 1 }
+      fn && index($0, "runtime-primary-listener-reconcile-repair-begin") { exit(primary_ready && listener ? 0 : 1) }
+      END { exit(primary_ready && listener ? 0 : 1) }
+    ' "$(template_file)"
+  }
+
+  primary_reconcile_logs_each_drift_predicate_before_repair() {
+    awk '
+      index($0, "reconcile_sql_listener_for_syncer_primary_once() {") { fn = 1 }
+      fn && index($0, "runtime-primary-listener-reconcile-repair-begin") {
+        log_line = NR
+        primary_ready = index($0, "primary_ready=")
+        remote_fence = index($0, "remote_root_fence=")
+        master_info = index($0, "master_info=")
+        listener = index($0, "listener_wildcard=")
+      }
+      fn && index($0, "expose_sql_listener_for_primary_role \"syncer-promoted-primary-existing-listener-no-writecheck\"") {
+        repair = NR
+        exit(log_line && primary_ready && remote_fence && master_info && listener && log_line < repair ? 0 : 1)
+      }
+      END { exit(log_line && primary_ready && remote_fence && master_info && listener && repair && log_line < repair ? 0 : 1) }
     ' "$(template_file)"
   }
 
@@ -211,6 +230,11 @@ Describe "cmpd-replication.yaml semisync startup recovery"
 
   It "does not trust .sql-listener-ready without a real wildcard listener in syncer-primary fast path"
     When call primary_reconcile_fast_path_requires_real_wildcard_listener
+    The status should be success
+  End
+
+  It "records every primary publish predicate before a drift repair mutates markers"
+    When call primary_reconcile_logs_each_drift_predicate_before_repair
     The status should be success
   End
 

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -2105,7 +2105,7 @@ local_has_user_tables() {
   [ "${table_count}" -gt 0 ]
 }
 reconcile_sql_listener_for_syncer_primary_once() {
-  local now primary_sid role
+  local now primary_sid role primary_ready remote_root_fence master_info listener_wildcard
   [ ! -f "${DATA_DIR}/.prestop-fence-started" ] || return 0
   # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_is_fresh`
   # early-skip has been removed. alpha.79 v1 minimalist deleted the
@@ -2115,10 +2115,27 @@ reconcile_sql_listener_for_syncer_primary_once() {
   if [ -f "${DATA_DIR}/.sql-listener-ready" ]; then
     role="$(query_local_syncer_role || true)"
     [ "${role}" = "primary" ] || return 0
-    if [ -f "${DATA_DIR}/.primary-read-write-ready" ] && [ ! -f "${DATA_DIR}/.remote-root-fence-role" ] && [ ! -f "${DATA_DIR}/master.info" ] && mariadbd_listen_on_all_interfaces; then
+    primary_ready=absent
+    remote_root_fence=absent
+    master_info=absent
+    listener_wildcard=absent
+    [ -f "${DATA_DIR}/.primary-read-write-ready" ] && primary_ready=present
+    [ -f "${DATA_DIR}/.remote-root-fence-role" ] && remote_root_fence=present
+    [ -f "${DATA_DIR}/master.info" ] && master_info=present
+    if mariadbd_listen_on_all_interfaces; then
+      listener_wildcard=present
+    fi
+    if [ "${primary_ready}" = "present" ] && \
+       [ "${remote_root_fence}" = "absent" ] && \
+       [ "${master_info}" = "absent" ] && \
+       [ "${listener_wildcard}" = "present" ]; then
       return 0
     fi
-    prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role}"
+    # Record the last pre-mutation snapshot. expose_sql_listener_for_primary_role
+    # starts by STOP/RESET and set_primary_read_write starts by retracting both
+    # ready markers, so a post-repair snapshot cannot identify the first broken
+    # predicate that caused the repair.
+    prestop_watchdog_log "runtime-primary-listener-reconcile-repair-begin reason=primary-role-state-drift role=${role} primary_ready=${primary_ready} remote_root_fence=${remote_root_fence} master_info=${master_info} listener_wildcard=${listener_wildcard}"
     # Keep the historical suffix for log continuity.  The r9 acceptance
     # contract now uses the internal-admin, sql_log_bin=0 pre-open gate on all
     # paths, so neither this repair loop nor a normal promotion emits the old


### PR DESCRIPTION
## Problem

Fresh focused r11 on addon combined `73d05dcfd2a907b7bbcb292d2f0d8d3de7d7abf1` and syncer `7502b58f45efd4fe8f2b06e5313230d9aec69510` proved an addon-side marker oscillation. After an authoritative primary write commit succeeds, the runtime primary listener reconciler enters `primary-role-state-drift` and starts repair before the next HA promotion. Repair retracts the authority markers, but the current aggregate log does not identify which of its four predicates first failed.

Evidence:

- r11 first-red outer SHA256: `5ca8e2cc2a71c74d177ef3b8c4e0dd2633bab90e75a3320964494130ce6f579a`
- r11 first-red manifest SHA256: `cf3d4b219a8ad4416b9133b3a615f787a86d30389677bf88fa68c12bd83081fc` (14/14)
- supplemental addon-log outer SHA256: `83aabd76e9612f9291bdefae358f75e2bc4622a5b35955f69ed00299eee69096`
- supplemental manifest SHA256: `234e06383a2362f02bbd2a5fff82cab5a0c27177ec82dd10d7d5aae345a5ee60` (3/3)
- observed sequence: authority commit/reconcile complete at `03:22:20Z`; addon `runtime-primary-listener-reconcile-repair-begin` at `03:22:24Z`; only afterwards does the repair fail closed.

## Change

Capture and log the four primary-publish predicates before repair can mutate state:

- `primary_ready`
- `remote_root_fence`
- `master_info`
- `listener_wildcard`

The fast-path decision uses that same captured snapshot. This is diagnostic observability only; it does not change the repair policy or claim to fix the oscillation.

## TDD and source gates

- RED: focused ShellSpec `30 examples, 1 failure` before production instrumentation
- GREEN: focused ShellSpec `30 examples, 0 failures`
- full MariaDB ShellSpec: `768 examples, 0 failures, 9 historical pendings`
- `bash -n addons/mariadb/scripts/replication-entrypoint.sh`
- `shellcheck -S error addons/mariadb/scripts/replication-entrypoint.sh`
- `helm lint addons/mariadb`
- default `helm template` plus rendered predicate-log verification
- `git diff --check`

## Runtime boundary

The next focused round is diagnostic N=1 only. Its acceptance target is an unambiguous pre-mutation value for all four predicates across the commit-to-repair window. It is not release evidence, and the full suite remains NO-LAUNCH.
