### PR TITLE
mariadb: align primary roleProbe marker contract

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -668,16 +668,32 @@ Last_SQL_Errno: 0"
       End
     End
 
-    Context "when publishing a primary with remote root access enabled"
-      setup_primary_remote_root() {
+    Context "when an already-accepted primary has no remote-root fence marker"
+      setup_primary_without_remote_fence_marker() {
+        export MARIADB_ROOT_HOST="%"
+        touch "${TEST_DIR}/.replication-ready"
+      }
+      Before "setup_primary_without_remote_fence_marker"
+
+      It "publishes primary without recreating the marker owned by secondary fencing"
+        When call check_role
+        The status should be success
+        The output should eq "primary"
+        The path "${TEST_DIR}/.remote-root-fence-role" should not be exist
+      End
+    End
+
+    Context "when a primary transitions from a persisted secondary remote-root fence"
+      setup_primary_remote_root_transition() {
         export MARIADB_ROOT_HOST="%"
         export MOCK_MARIADB_CAPTURE_FILE="${TEST_DIR}/mariadb-sql.log"
         touch "${TEST_DIR}/.replication-ready"
+        printf "secondary" > "${TEST_DIR}/.remote-root-fence-role"
         make_mariadb_cli
       }
-      Before "setup_primary_remote_root"
+      Before "setup_primary_remote_root_transition"
 
-      It "alpha.60: restores remote root grants WITHOUT admin bypass privileges and records primary fence marker"
+      It "restores primary grants without admin bypass privileges and clears the secondary fence marker"
         # alpha.60 (Jack 23:28 review): primary grant must NOT include
         # SUPER / READ_ONLY ADMIN / BINLOG ADMIN, because those let user-facing
         # root bypass @@global.read_only=ON during a future switchover and
@@ -694,7 +710,25 @@ Last_SQL_Errno: 0"
         The contents of file "${TEST_DIR}/mariadb-sql.log" should not include "READ_ONLY ADMIN"
         The contents of file "${TEST_DIR}/mariadb-sql.log" should not include "BINLOG ADMIN"
         The contents of file "${TEST_DIR}/mariadb-sql.log" should not include ", GRANT OPTION,"
-        The contents of file "${TEST_DIR}/.remote-root-fence-role" should eq "primary"
+        The path "${TEST_DIR}/.remote-root-fence-role" should not be exist
+      End
+    End
+
+    Context "when a primary cannot replace a persisted secondary remote-root fence"
+      setup_primary_remote_root_transition_failure() {
+        export MARIADB_ROOT_HOST="%"
+        export MOCK_MARIADB_SQL_RC=1
+        touch "${TEST_DIR}/.replication-ready"
+        printf "secondary" > "${TEST_DIR}/.remote-root-fence-role"
+        make_mariadb_cli
+      }
+      Before "setup_primary_remote_root_transition_failure"
+
+      It "fails closed and preserves the secondary fence marker"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+        The contents of file "${TEST_DIR}/.remote-root-fence-role" should eq "secondary"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_spec.sh
@@ -93,6 +93,22 @@ EOF
     chmod +x "${TEST_DIR}/mariadb"
   }
 
+  setup_secondary_remote_root_base() {
+    unset MARIADB_ROLEPROBE_SKIP_DB_READY
+    export MARIADB_ROOT_HOST="%"
+    export MOCK_MARIADB_SELECT1_RC=0
+    export MOCK_MARIADB_SELECT1_STDOUT="1"
+    export MOCK_MARIADB_SHOW_SLAVE_STATUS_RC=0
+    export MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT="Slave_IO_Running: Yes
+Slave_SQL_Running: Yes
+Last_IO_Errno: 0
+Last_SQL_Errno: 0"
+    export MOCK_MARIADB_CAPTURE_FILE="${TEST_DIR}/mariadb-sql.log"
+    touch "${TEST_DIR}/.replication-ready"
+    touch "${TEST_DIR}/master.info"
+    make_mariadb_cli
+  }
+
   Describe "check_role()"
     Context "when syncerctl returns stale secondary but local files say primary"
       setup_stale_syncer_secondary() {
@@ -734,19 +750,7 @@ Last_SQL_Errno: 0"
 
     Context "when publishing a secondary with remote root access enabled"
       setup_secondary_remote_root() {
-        unset MARIADB_ROLEPROBE_SKIP_DB_READY
-        export MARIADB_ROOT_HOST="%"
-        export MOCK_MARIADB_SELECT1_RC=0
-        export MOCK_MARIADB_SELECT1_STDOUT="1"
-        export MOCK_MARIADB_SHOW_SLAVE_STATUS_RC=0
-        export MOCK_MARIADB_SHOW_SLAVE_STATUS_STDOUT="Slave_IO_Running: Yes
-Slave_SQL_Running: Yes
-Last_IO_Errno: 0
-Last_SQL_Errno: 0"
-        export MOCK_MARIADB_CAPTURE_FILE="${TEST_DIR}/mariadb-sql.log"
-        touch "${TEST_DIR}/.replication-ready"
-        touch "${TEST_DIR}/master.info"
-        make_mariadb_cli
+        setup_secondary_remote_root_base
       }
       Before "setup_secondary_remote_root"
 
@@ -770,6 +774,63 @@ Last_SQL_Errno: 0"
         The contents of file "${TEST_DIR}/mariadb-sql.log" should not include "BINLOG ADMIN"
         The contents of file "${TEST_DIR}/mariadb-sql.log" should not include "CONNECTION ADMIN"
         The contents of file "${TEST_DIR}/.remote-root-fence-role" should eq "secondary"
+      End
+    End
+
+    Context "when the required secondary fence marker tmp write fails"
+      setup_secondary_fence_marker_write_failure() {
+        setup_secondary_remote_root_base
+        remote_root_fence_write_tmp() {
+          printf '%s' "$2" > "${TEST_DIR}/marker-write-attempted"
+          return 1
+        }
+      }
+      Before "setup_secondary_fence_marker_write_failure"
+
+      It "fails closed instead of publishing secondary"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+        The contents of file "${TEST_DIR}/marker-write-attempted" should include ".remote-root-fence-role.tmp."
+        The path "${TEST_DIR}/.remote-root-fence-role" should not be exist
+      End
+    End
+
+    Context "when the required secondary fence marker atomic rename fails"
+      setup_secondary_fence_marker_rename_failure() {
+        setup_secondary_remote_root_base
+        remote_root_fence_commit_tmp() {
+          printf '%s' "$1" > "${TEST_DIR}/marker-rename-attempted"
+          return 1
+        }
+      }
+      Before "setup_secondary_fence_marker_rename_failure"
+
+      It "fails closed and removes the uncommitted tmp marker"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+        The contents of file "${TEST_DIR}/marker-rename-attempted" should include ".remote-root-fence-role.tmp."
+        The path "${TEST_DIR}/.remote-root-fence-role" should not be exist
+      End
+    End
+
+    Context "when the committed secondary fence marker cannot be read back"
+      setup_secondary_fence_marker_readback_failure() {
+        setup_secondary_remote_root_base
+        remote_root_fence_readback() {
+          printf 'attempted' > "${TEST_DIR}/marker-readback-attempted"
+          return 1
+        }
+      }
+      Before "setup_secondary_fence_marker_readback_failure"
+
+      It "fails closed and removes the unverified marker"
+        When call check_role
+        The status should be failure
+        The output should eq "initializing"
+        The contents of file "${TEST_DIR}/marker-readback-attempted" should eq "attempted"
+        The path "${TEST_DIR}/.remote-root-fence-role" should not be exist
       End
     End
 

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -197,7 +197,15 @@ apply_remote_root_fence() {
 
   marker="$(remote_root_fence_file)"
   current="$(cat "${marker}" 2>/dev/null || true)"
-  if [ "${current}" = "${role}" ]; then
+  # The marker has one durable meaning: a secondary remote-root fence is
+  # active.  A fully accepted primary is represented by marker absence; the
+  # entrypoint clears it before publishing primary readiness and its runtime
+  # reconciler requires it to stay absent.  Do not recreate a synthetic
+  # "primary" fence on every roleProbe tick after that authoritative commit.
+  if [ "${role}" = "primary" ] && [ ! -f "${marker}" ]; then
+    return 0
+  fi
+  if [ "${role}" = "secondary" ] && [ "${current}" = "secondary" ]; then
     return 0
   fi
 
@@ -258,10 +266,22 @@ apply_remote_root_fence() {
       local_sql_best_effort -e "SET SESSION sql_log_bin=0; GRANT BINLOG MONITOR ON *.* TO '${user}'@'${host}'; SET SESSION sql_log_bin=1;"
       local_sql_best_effort -e "SET SESSION sql_log_bin=0; GRANT SLAVE MONITOR ON *.* TO '${user}'@'${host}'; SET SESSION sql_log_bin=1;"
     fi
-    printf "%s" "${role}" > "${marker}" 2>/dev/null || true
+    if [ "${role}" = "secondary" ]; then
+      printf "%s" "secondary" > "${marker}" 2>/dev/null || true
+    else
+      # Primary grants are now in place, so close the same marker contract the
+      # entrypoint uses for a committed healthy primary.  Removal failure must
+      # keep role publication fail-closed rather than hiding state drift.
+      rm -f "${marker}" 2>/dev/null || return 1
+    fi
     return 0
   fi
-  rm -f "${marker}" 2>/dev/null || true
+  # A failed primary transition must preserve an existing secondary fence so
+  # the entrypoint can observe and repair it.  Secondary transition failures
+  # retain the historical stale-marker cleanup behavior.
+  if [ "${role}" != "primary" ]; then
+    rm -f "${marker}" 2>/dev/null || true
+  fi
   return 1
 }
 

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -51,6 +51,46 @@ remote_root_fence_file() {
   printf "%s/.remote-root-fence-role" "$(data_dir)"
 }
 
+remote_root_fence_write_tmp() {
+  printf '%s' "$1" > "$2"
+}
+
+remote_root_fence_commit_tmp() {
+  mv -f "$1" "$2"
+}
+
+remote_root_fence_readback() {
+  cat "$1"
+}
+
+# The marker is durable evidence that the user-facing remote root account was
+# successfully reduced to the secondary privilege set. Publishing "secondary"
+# without positively committing and re-reading that evidence is fail-open: a
+# later primary transition cannot know that it must restore the account.
+write_secondary_remote_root_fence() {
+  marker="$1"
+  marker_tmp="${marker}.tmp.$$"
+  marker_value=""
+
+  rm -f "${marker_tmp}" 2>/dev/null || return 1
+  if ! remote_root_fence_write_tmp "secondary" "${marker_tmp}" 2>/dev/null; then
+    rm -f "${marker_tmp}" 2>/dev/null || true
+    return 1
+  fi
+  if ! remote_root_fence_commit_tmp "${marker_tmp}" "${marker}" 2>/dev/null; then
+    rm -f "${marker_tmp}" 2>/dev/null || true
+    return 1
+  fi
+  marker_value="$(remote_root_fence_readback "${marker}" 2>/dev/null)" || {
+    rm -f "${marker}" 2>/dev/null || true
+    return 1
+  }
+  if [ "${marker_value}" != "secondary" ]; then
+    rm -f "${marker}" 2>/dev/null || true
+    return 1
+  fi
+}
+
 # alpha.80 v1 (Helen): the alpha.76 `switchover_fence_active_file` +
 # `switchover_fence_active_is_fresh` + `SWITCHOVER_FENCE_MARKER_MAX_AGE_SECONDS`
 # helpers are removed. alpha.79 v1 minimalist refactor in switchover.sh
@@ -267,7 +307,7 @@ apply_remote_root_fence() {
       local_sql_best_effort -e "SET SESSION sql_log_bin=0; GRANT SLAVE MONITOR ON *.* TO '${user}'@'${host}'; SET SESSION sql_log_bin=1;"
     fi
     if [ "${role}" = "secondary" ]; then
-      printf "%s" "secondary" > "${marker}" 2>/dev/null || true
+      write_secondary_remote_root_fence "${marker}" || return 1
     else
       # Primary grants are now in place, so close the same marker contract the
       # entrypoint uses for a committed healthy primary.  Removal failure must


### PR DESCRIPTION
## Problem

Fresh diagnostic r12 on addon `3e51be9bebd950b26405399966243fba64d5596b` and syncer `7502b58f45efd4fe8f2b06e5313230d9aec69510` narrowed the post-commit repair loop to one directly conflicting predicate:

```text
2026-07-15T04:50:15Z primary-write-commit rc=0 authority=fresh-lease-cas
2026-07-15T04:50:18Z runtime-primary-listener-reconcile-repair-begin primary_ready=present remote_root_fence=present master_info=absent listener_wildcard=present
```

The entrypoint clears `.remote-root-fence-role` before authoritative commit and treats marker absence as part of the committed-primary invariant. The roleProbe then calls `apply_remote_root_fence "primary"` and writes `primary` back to that marker, causing the runtime repair path to retract readiness and fence the database.

Canonical evidence:

- outer SHA256: `f953215c36658cf9564294f8842b3dc4df915aaec60fca65856efcbccc4758a2`
- inner `SHA256SUMS` SHA256: `9bd27dc268c3a5338cfefdbb08f030f40e3e047b337b8057549ac064f57a56fd`
- 22/22 payload files verified; scene remains frozen, repair/cleanup 0

This is exact-source N=1 evidence. It proves the first observed conflicting predicate for this run, not fleet frequency.

## Change

Give `.remote-root-fence-role` one durable meaning:

- `secondary` present: secondary remote-root fence is active
- absent: committed primary remote-root state

An already-accepted primary with no marker no longer rewrites grants or recreates the marker. A secondary-to-primary transition still applies the primary grant set, then removes the marker. If that transition fails, it preserves the secondary marker so the entrypoint observes and repairs the drift instead of hiding it. Secondary behavior is otherwise unchanged.

## Predecessor TDD

Production RED on the old source: `50 examples, 3 failures, 1 historical pending`:

1. accepted primary with absent marker failed because roleProbe tried to recreate primary state;
2. successful secondary-to-primary transition left a `primary` marker;
3. failed transition erased the existing `secondary` fence marker.

GREEN:

- focused roleProbe: `50 examples, 0 failures, 1 historical pending`
- related roleProbe + merged recovery + semisync fence: `153 examples, 0 failures, 1 historical pending`
- full MariaDB ShellSpec: `770 examples, 0 failures, 9 historical pendings`
- POSIX `sh -n`
- ShellCheck error-level
- Helm lint and default render, including rendered marker-contract source
- `git diff --check`

## Runtime boundary

No patched runtime result exists yet. The diagnostic r12 scene remains frozen and the full suite remains NO-LAUNCH. The next runtime gate must use a newly audited current-head combined source and run focused initial-authority convergence before any full-suite decision.


## Current-head durable-marker successor

Current addon exact: `126aa24b48fbc43ee52fa13d1e17f98c1e423f60` (tree `2a351c910244b9037be661ba862c5db6f50e0a8c`). The marker meaning above is unchanged; this successor makes secondary marker persistence fail closed: same-directory temporary write, atomic rename, and exact readback must all succeed, otherwise roleProbe returns `1` and removes any unverified marker.

- old-source write/rename/readback failure cases: `3` failures
- current focused roleProbe: `53` examples, `0` failures, `1` historical pending
- `git diff --check`, POSIX `sh -n`, and ShellCheck error-level: pass
- current exact GitHub Actions: terminal green
- no patched runtime result exists for this current exact; product runtime remains `N=0`
