### PR TITLE
mariadb: preserve secondary fence marker while pending

### DIFF
--- a/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/semisync_rejoin_fence_template_spec.sh
@@ -25,6 +25,53 @@ Describe "cmpd-replication.yaml rejoin fence template"
     ' "$(template_file)"
   }
 
+  extract_function_definition() {
+    function_name="$1"
+    awk -v function_name="${function_name}" '
+      index($0, function_name "() {") == 1 { inside = 1; start = NR }
+      inside && NR > start && /^[[:alnum:]_]+\(\) \{$/ { exit }
+      inside { print }
+    ' "$(template_file)"
+  }
+
+  runtime_secondary_pending_preserves_remote_root_fence() {
+    tmpdir="$(mktemp -d)" || return 1
+    DATA_DIR="${tmpdir}"
+    mkdir -p "${DATA_DIR}" || return 1
+    touch "${DATA_DIR}/.replication-ready" "${DATA_DIR}/.primary-read-write-ready"
+    printf '%s' secondary > "${DATA_DIR}/.remote-root-fence-role"
+
+    eval "$(extract_function_definition mark_replication_pending)"
+    eval "$(extract_function_definition configure_replication_from_primary_service_once)"
+
+    observed_marker=unobserved
+    set_replica_read_only() {
+      if [ -f "${DATA_DIR}/.remote-root-fence-role" ]; then
+        observed_marker="$(cat "${DATA_DIR}/.remote-root-fence-role")"
+      else
+        observed_marker=absent
+      fi
+      return 1
+    }
+    prestop_watchdog_log() { :; }
+
+    configure_replication_from_primary_service_once "runtime-secondary-reconcile"
+    reconcile_rc=$?
+    marker_after=absent
+    [ ! -f "${DATA_DIR}/.remote-root-fence-role" ] || marker_after="$(cat "${DATA_DIR}/.remote-root-fence-role")"
+    ready_removed=false
+    pending_present=false
+    [ ! -f "${DATA_DIR}/.replication-ready" ] && [ ! -f "${DATA_DIR}/.primary-read-write-ready" ] && ready_removed=true
+    [ -f "${DATA_DIR}/.replication-pending" ] && pending_present=true
+    rm -rf "${tmpdir}"
+
+    [ "${reconcile_rc}" -eq 1 ] &&
+      [ "${observed_marker}" = secondary ] &&
+      [ "${marker_after}" = secondary ] &&
+      [ "${ready_removed}" = true ] &&
+      [ "${pending_present}" = true ]
+  }
+
   fenced_primary_commit_is_last_visible_step() {
     awk '
       index($0, "set_primary_read_write() {") { fn = 1 }
@@ -325,8 +372,13 @@ Describe "cmpd-replication.yaml rejoin fence template"
     The status should be success
   End
 
-  It "clears stale remote-root fence markers when replication becomes pending"
+  It "does not let generic pending state erase the durable secondary fence marker"
     When call function_contains "mark_replication_pending" ".remote-root-fence-role"
+    The status should be failure
+  End
+
+  It "keeps the secondary fence marker throughout the first runtime-secondary reconcile step"
+    When call runtime_secondary_pending_preserves_remote_root_fence
     The status should be success
   End
 

--- a/addons/mariadb/scripts/replication-entrypoint.sh
+++ b/addons/mariadb/scripts/replication-entrypoint.sh
@@ -671,7 +671,12 @@ mark_replication_pending() {
   # demoted peer to re-acquire leader and write orphan events.
   # Bind-state is only reset by the bootstrap start_mariadbd_process
   # at line 1901 (a fresh container restart will rebuild it).
-  rm -f ${DATA_DIR}/.remote-root-fence-role
+  # The remote-root marker is durable fence state, not a readiness marker:
+  # `secondary` means the secondary root fence is active, while absence is the
+  # committed-primary state.  Generic pending transitions must not erase an
+  # already-proven secondary fence.  The role-specific owner removes it only
+  # after a primary transition has repaired grants successfully, and writes it
+  # only after the secondary fence is actually in place.
   touch ${DATA_DIR}/.replication-pending
 }
 mark_replication_ready() {


### PR DESCRIPTION
## Problem

Fresh focused r18 on addon `ccd5c0e81ffaafa9b71c9f38c09b00a46246465c` and syncer `7502b58f45efd4fe8f2b06e5313230d9aec69510` showed the primary staying converged, but a healthy secondary's durable remote-root fence marker oscillating between `secondary` and absent.

The exact cross-script cause is in `replication-entrypoint.sh`: every `configure_replication_from_primary_service_once()` iteration begins with `mark_replication_pending()`, and that generic readiness helper unconditionally removed `.remote-root-fence-role`. The roleProbe later recreated `secondary` only after its successful grant/fence tick. A recurring runtime-secondary reconcile therefore exposed an absent-marker window even though the secondary remained `read_only=1` and otherwise healthy.

Evidence scope is one focused run (`N=1`), not a frequency claim:

- official seven-sample window: secondary marker `secondary` in 6 samples, absent in sample 7;
- independent read-only post-red window: `secondary` 18 times, absent twice;
- watchdog shows a new runtime-secondary reconcile beginning before the absent observation;
- primary was stable in 7/7 samples with `read_only=0`, all real ready markers, no pending/master.info/remote marker, and no new repair or authority commit;
- full/Ops/fault were not launched and every product scene remains frozen.

Evidence archive outer SHA-256: `f74b470331c40f075f366a59bd9fc0a35a7388ac045a50b9f04ae15a9d6ddd73`; inner manifest SHA-256: `7a86cfcdeed8fa9cef2c47fd53fb286f5c70b965592a58c9e446b366c400961a`; 93/93 files independently verified.

## Fix

Remove `.remote-root-fence-role` mutation from generic `mark_replication_pending()`.

This keeps ownership aligned with the durable contract introduced by the parent PR:

- `secondary` means a secondary remote-root fence is active;
- marker absence means committed-primary state;
- generic readiness/pending transitions retract ready markers and publish `.replication-pending`, but do not rewrite durable fence state;
- role-specific code removes the marker only after a primary transition has repaired grants successfully, and writes `secondary` only after the secondary fence is actually in place.

No read-only, root-account, listener, authority acquisition/commit, switchover, error rollback, or ready-publication operation is removed or reordered.

## TDD and gates

Before the production change, the exact-source test was deterministically RED:

- `74 examples, 2 failures`;
- static ownership check proved generic pending still referenced the marker;
- a production-function harness extracted the real `mark_replication_pending()` and `configure_replication_from_primary_service_once()` functions, entered with marker=`secondary`, and observed marker=absent at the first secondary-reconcile step.

After the change:

- focused secondary-marker suite: `74 examples, 0 failures`;
- related roleProbe, primary acceptance, linearization, role-race, and recovery suites: `182 examples, 0 failures, 1 historical pending`;
- complete MariaDB ShellSpec: `771 examples, 0 failures, 9 historical pendings`;
- POSIX `sh -n`, ShellCheck error severity, Helm dependency/lint/default render, rendered contract, and `git diff --check`: PASS.

## Runtime boundary

This PR has no post-fix runtime result yet (`N=0`). The r18 product FAIL remains frozen. A new Test round is forbidden until official CI, exact Magnus review, and a fresh manifest containing current main plus every current weicao open MariaDB PR head are all complete.
