### PR TITLE
fix(mariadb): make Galera preStop ordered and DNS-safe

### DIFF
--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.32
+version: 1.2.0-alpha.33
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ description: MariaDB is a high performance open source relational database manag
 
 type: application
 
-version: 1.2.0-alpha.33
+version: 1.2.0-alpha.34
 
 appVersion: "11.4.10"
 

--- a/addons/mariadb/scripts-ut-spec/galera_memberleave_removed_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/galera_memberleave_removed_spec.sh
@@ -4,9 +4,10 @@
 # kbagent execution face (no mariadb client), all SQL guarded with
 # `2>/dev/null || true`, so its claimed FLUSH TABLES / wsrep_desync=ON never
 # executed. Galera evicts a departed node natively (keepalive timeout) and
-# the shutdown-time graceful leave (final seqno + safe_to_bootstrap, clean
-# InnoDB flush) is handled by the mariadb container preStop, which runs
-# in-container against 127.0.0.1. The broken action + its script were removed.
+# the native container preStop orders peer termination and publishes the
+# watcher guard. Kubelet then signals mariadbd PID 1, which performs the
+# shutdown-time graceful leave (final seqno + safe_to_bootstrap, clean InnoDB
+# flush). The broken action + its script were removed.
 
 Describe "galera memberLeave removal (H10)"
   CMPD_GALERA="${SHELLSPEC_CWD:?}/addons/mariadb/templates/cmpd-galera.yaml"
@@ -37,20 +38,15 @@ Describe "galera memberLeave removal (H10)"
     The output should equal "GONE"
   End
 
-  It "graceful-leave intent is still covered by the galera preStop (in-container)"
-    # The shutdown-time graceful leave lives in the mariadb container preStop.
+  It "graceful-leave intent is still covered by the native container termination path"
+    # preStop orders the nodes; kubelet TERM drives the actual engine exit.
     When run sh -c "grep -c 'preStop:' '${CMPD_GALERA}'"
     The status should be success
     The output should equal "1"
   End
 
-  It "preStop performs the in-container graceful shutdown (inline SQL or dedicated prestop script)"
-    # Implementation-agnostic on purpose: the graceful shutdown may live as
-    # inline preStop SQL (current main) or be delegated to a dedicated
-    # galera-prestop.sh (PR #3108's bounded ordered shutdown). Pinning the
-    # inline SQL literal here made this spec fail when combined with #3108
-    # even though the behavior is preserved — assert the intent, not the form.
-    When run sh -c "grep -F 'SET GLOBAL wsrep_on=OFF' '${CMPD_GALERA}' || grep -E 'galera-prestop\.sh' '${CMPD_GALERA}'"
+  It "preStop delegates bounded ordering to the dedicated script"
+    When run sh -c "grep -E 'galera-prestop\.sh' '${CMPD_GALERA}'"
     The status should be success
     The output should not equal ""
   End

--- a/addons/mariadb/scripts-ut-spec/galera_prestop_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/galera_prestop_spec.sh
@@ -6,8 +6,6 @@ Describe "galera-prestop.sh"
     export DATA_DIR="${TEST_DIR}/data"
     export POD_NAME="mdb-galera-mariadb-0"
     export PEER_FQDNS="mdb-galera-mariadb-0.headless.demo.svc.cluster.local,mdb-galera-mariadb-1.headless.demo.svc.cluster.local,mdb-galera-mariadb-2.headless.demo.svc.cluster.local"
-    export MARIADB_ROOT_USER="root"
-    export MARIADB_ROOT_PASSWORD="secret"
     export GALERA_PRESTOP_CONTAINER_LOG_PATH="${TEST_DIR}/container.log"
     export GALERA_PRESTOP_DEGRADED_LOG="${DATA_DIR}/log/galera-prestop-degraded.log"
     mkdir -p "${DATA_DIR}"
@@ -16,12 +14,11 @@ Describe "galera-prestop.sh"
 
   cleanup() {
     rm -rf "${TEST_DIR}"
-    unset DATA_DIR POD_NAME PEER_FQDNS MARIADB_ROOT_USER MARIADB_ROOT_PASSWORD
+    unset DATA_DIR POD_NAME PEER_FQDNS
     unset GALERA_PRESTOP_ORDER_WAIT_SECONDS GALERA_PRESTOP_POLL_SECONDS
-    unset GALERA_PRESTOP_PROBE_TIMEOUT_SECONDS GALERA_PRESTOP_SQL_TIMEOUT_SECONDS
-    unset GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS GALERA_PRESTOP_CONTAINER_LOG_PATH
+    unset GALERA_PRESTOP_PROBE_TIMEOUT_SECONDS GALERA_PRESTOP_CONTAINER_LOG_PATH
     unset GALERA_PRESTOP_TERMINATION_GRACE_SECONDS GALERA_PRESTOP_SAFETY_MARGIN_SECONDS
-    unset GALERA_PRESTOP_DEGRADED_LOG VALIDATION_ERROR DEGRADED_EVIDENCE_WRITE_FAILED
+    unset GALERA_PRESTOP_DEGRADED_LOG VALIDATION_ERROR
   }
   AfterEach "cleanup"
 
@@ -81,9 +78,7 @@ Describe "galera-prestop.sh"
   End
 
   It "rejects timeout settings that consume the termination grace period"
-    GALERA_PRESTOP_ORDER_WAIT_SECONDS=70
-    GALERA_PRESTOP_SQL_TIMEOUT_SECONDS=5
-    GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS=40
+    GALERA_PRESTOP_ORDER_WAIT_SECONDS=116
     GALERA_PRESTOP_SAFETY_MARGIN_SECONDS=5
     GALERA_PRESTOP_TERMINATION_GRACE_SECONDS=120
 
@@ -180,43 +175,30 @@ Describe "galera-prestop.sh"
     The contents of file "${GALERA_PRESTOP_CONTAINER_LOG_PATH}" should include "ordered shutdown degraded: reason=test_degradation"
   End
 
-  It "keeps the preStop hook successful after invalid identity is recorded"
+  It "fails closed on invalid identity before publishing the shutdown marker"
     POD_NAME=""
-    local_sql() {
-      return 0
-    }
-    mysqladmin() {
-      return 0
-    }
-
-    When call main
-    The status should be success
-    The output should include "reason=invalid_pod_name"
-    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=invalid_pod_name"
-  End
-
-  It "finishes local shutdown then fails the hook when both degraded evidence sinks are unavailable"
-    POD_NAME=""
-    GALERA_PRESTOP_CONTAINER_LOG_PATH="/dev/null/container-log"
-    GALERA_PRESTOP_DEGRADED_LOG="/dev/null/degraded-log"
-    local_sql() {
-      printf '%s\n' "$1" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
-    mysqladmin() {
-      printf 'mysqladmin %s\n' "$*" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
 
     When call main
     The status should be failure
     The output should include "reason=invalid_pod_name"
-    The stderr should include "degraded evidence sinks unavailable"
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_desync=ON;"
-    The contents of file "${TEST_DIR}/sql.log" should include "mysqladmin"
+    The stderr should include "shutdown preparation failed: reason=invalid_pod_name"
+    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=invalid_pod_name"
+    The path "${DATA_DIR}/.galera-shutting-down" should not be exist
   End
 
-  It "degrades a stuck higher-ordinal peer but still shuts down locally and exits successfully"
+  It "fails the hook when both failure evidence sinks are unavailable"
+    POD_NAME=""
+    GALERA_PRESTOP_CONTAINER_LOG_PATH="/dev/null/container-log"
+    GALERA_PRESTOP_DEGRADED_LOG="/dev/null/degraded-log"
+
+    When call main
+    The status should be failure
+    The output should include "reason=invalid_pod_name"
+    The stderr should include "shutdown preparation failed"
+    The path "${DATA_DIR}/.galera-shutting-down" should not be exist
+  End
+
+  It "fails closed on a stuck higher-ordinal peer before publishing the shutdown marker"
     GALERA_PRESTOP_ORDER_WAIT_SECONDS=2
     GALERA_PRESTOP_POLL_SECONDS=30
     printf '0\n' > "${TEST_DIR}/clock"
@@ -229,98 +211,49 @@ Describe "galera-prestop.sh"
     peer_sql_port_state() {
       printf 'open'
     }
-    local_sql() {
-      printf '%s\n' "$1" >> "${TEST_DIR}/sql.log"
+    When call main
+    The status should be failure
+    The output should include "reason=order_wait_timeout"
+    The stderr should include "shutdown preparation failed: higher-ordinal peers did not stop"
+    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=order_wait_timeout"
+    The path "${DATA_DIR}/.galera-shutting-down" should not be exist
+  End
+
+  It "publishes the marker then lets kubelet signal PID 1"
+    mariadb() {
+      printf 'mariadb %s\n' "$*" >> "${TEST_DIR}/unexpected-client.log"
       return 0
     }
     mysqladmin() {
-      printf 'mysqladmin %s\n' "$*" >> "${TEST_DIR}/sql.log"
+      printf 'mysqladmin %s\n' "$*" >> "${TEST_DIR}/unexpected-client.log"
       return 0
+    }
+
+    When call prepare_ordered_shutdown
+    The status should be success
+    The path "${DATA_DIR}/.galera-shutting-down" should be exist
+    The output should include "kubelet may now signal mariadbd"
+    The path "${TEST_DIR}/unexpected-client.log" should not be exist
+  End
+
+  It "returns success only after order and marker preparation both close"
+    peer_sql_port_state() {
+      printf 'closed'
     }
 
     When call main
     The status should be success
-    The output should include "reason=order_wait_timeout"
-    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=order_wait_timeout"
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_desync=ON;"
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_on=OFF;"
-    The contents of file "${TEST_DIR}/sql.log" should include "mysqladmin -uroot -psecret -h127.0.0.1 shutdown"
-  End
-
-  It "runs desync, wsrep disable, and mysqladmin shutdown in order"
-    local_sql() {
-      printf '%s\n' "$1" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
-    mysqladmin() {
-      printf 'mysqladmin %s\n' "$*" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
-
-    When call graceful_shutdown
-    The status should be success
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_desync=ON;"
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_on=OFF;"
-    The contents of file "${TEST_DIR}/sql.log" should include "mysqladmin -uroot -psecret -h127.0.0.1 shutdown"
-  End
-
-  It "publishes the shutting-down marker before the first Galera desync mutation"
-    local_sql() {
-      if [ "$1" = "SET GLOBAL wsrep_desync=ON;" ] \
-        && [ ! -f "${DATA_DIR}/.galera-shutting-down" ]; then
-        printf 'desync-before-marker\n' >> "${TEST_DIR}/sql.log"
-        return 1
-      fi
-      printf '%s\n' "$1" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
-    mysqladmin() {
-      printf 'mysqladmin %s\n' "$*" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
-
-    When call graceful_shutdown
-    The status should be success
     The path "${DATA_DIR}/.galera-shutting-down" should be exist
-    The contents of file "${TEST_DIR}/sql.log" should not include "desync-before-marker"
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_desync=ON;"
-    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should not include "reason=wsrep_desync_failed"
+    The output should include "higher-ordinal peers have stopped"
+    The output should include "kubelet may now signal mariadbd"
   End
 
-  It "records a marker publication failure but still performs the local shutdown"
+  It "fails when the shutdown marker cannot be published"
     DATA_DIR="/dev/null/data"
-    local_sql() {
-      printf '%s\n' "$1" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
-    mysqladmin() {
-      printf 'mysqladmin %s\n' "$*" >> "${TEST_DIR}/sql.log"
-      return 0
-    }
 
-    When call graceful_shutdown
-    The status should be success
+    When call prepare_ordered_shutdown
+    The status should be failure
     The output should include "failed to publish .galera-shutting-down"
     The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=shutting_down_marker_failed"
-    The contents of file "${TEST_DIR}/sql.log" should include "SET GLOBAL wsrep_desync=ON;"
-    The contents of file "${TEST_DIR}/sql.log" should include "mysqladmin"
-  End
-
-  It "does not fail the hook when SQL cleanup commands fail"
-    local_sql() {
-      return 1
-    }
-    mysqladmin() {
-      return 1
-    }
-
-    When call graceful_shutdown
-    The status should be success
-    The output should include "failed to set wsrep_desync=ON"
-    The output should include "failed to set wsrep_on=OFF"
-    The output should include "mysqladmin shutdown failed"
-    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=wsrep_desync_failed"
-    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=wsrep_disable_failed"
-    The contents of file "${GALERA_PRESTOP_DEGRADED_LOG}" should include "reason=mysqladmin_shutdown_failed"
   End
 End

--- a/addons/mariadb/scripts-ut-spec/galera_prestop_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/galera_prestop_spec.sh
@@ -157,14 +157,188 @@ Describe "galera-prestop.sh"
     The output should equal "closed"
   End
 
-  It "classifies DNS failure as uncertain rather than stopped"
+  It "classifies authoritative name absence separately from transient DNS failure"
     timeout() {
       printf 'bash: example: Name or service not known\n' >&2
       return 1
     }
 
     When call peer_sql_port_state "missing.example" 2
-    The output should equal "dns-failure"
+    The output should equal "absent"
+  End
+
+  It "classifies no-address name absence as authoritative"
+    timeout() {
+      printf 'bash: example: No address associated with hostname\n' >&2
+      return 1
+    }
+
+    When call peer_sql_port_state "missing.example" 2
+    The output should equal "absent"
+  End
+
+  It "keeps temporary DNS failure uncertain"
+    timeout() {
+      printf 'bash: example: Temporary failure in name resolution\n' >&2
+      return 1
+    }
+
+    When call peer_sql_port_state "missing.example" 2
+    The output should equal "dns-transient"
+  End
+
+  It "requires two consecutive authoritative absences before closing a peer"
+    POD_NAME="mdb-galera-mariadb-1"
+    GALERA_PRESTOP_ORDER_WAIT_SECONDS=10
+    GALERA_PRESTOP_POLL_SECONDS=1
+    printf '0\n' > "${TEST_DIR}/clock"
+    monotonic_seconds() {
+      cat "${TEST_DIR}/clock"
+    }
+    sleep() {
+      local now
+      now="$(cat "${TEST_DIR}/clock")"
+      printf '%s\n' "$((now + 1))" > "${TEST_DIR}/clock"
+    }
+    peer_sql_port_state() {
+      local calls=0
+      [ -f "${TEST_DIR}/peer-calls" ] && calls="$(cat "${TEST_DIR}/peer-calls")"
+      calls=$((calls + 1))
+      printf '%s\n' "${calls}" > "${TEST_DIR}/peer-calls"
+      printf 'absent'
+    }
+
+    When call wait_for_higher_ordinals
+    The status should be success
+    The contents of file "${TEST_DIR}/peer-calls" should equal "2"
+    The output should include "higher-ordinal peers have stopped"
+  End
+
+  It "clears an absence streak after an uncertain observation"
+    POD_NAME="mdb-galera-mariadb-1"
+    GALERA_PRESTOP_ORDER_WAIT_SECONDS=10
+    GALERA_PRESTOP_POLL_SECONDS=1
+    printf '0\n' > "${TEST_DIR}/clock"
+    monotonic_seconds() {
+      cat "${TEST_DIR}/clock"
+    }
+    sleep() {
+      local now
+      now="$(cat "${TEST_DIR}/clock")"
+      printf '%s\n' "$((now + 1))" > "${TEST_DIR}/clock"
+    }
+    peer_sql_port_state() {
+      local calls=0
+      [ -f "${TEST_DIR}/peer-calls" ] && calls="$(cat "${TEST_DIR}/peer-calls")"
+      calls=$((calls + 1))
+      printf '%s\n' "${calls}" > "${TEST_DIR}/peer-calls"
+      case "${calls}" in
+        1|3|4) printf 'absent' ;;
+        2) printf 'dns-transient' ;;
+      esac
+    }
+
+    When call wait_for_higher_ordinals
+    The status should be success
+    The contents of file "${TEST_DIR}/peer-calls" should equal "4"
+    The output should include "higher-ordinal peers have stopped"
+  End
+
+  It "clears an absence streak across timeout unreachable and unknown states"
+    POD_NAME="mdb-galera-mariadb-1"
+    GALERA_PRESTOP_ORDER_WAIT_SECONDS=20
+    GALERA_PRESTOP_POLL_SECONDS=1
+    printf '0\n' > "${TEST_DIR}/clock"
+    monotonic_seconds() {
+      cat "${TEST_DIR}/clock"
+    }
+    sleep() {
+      local now
+      now="$(cat "${TEST_DIR}/clock")"
+      printf '%s\n' "$((now + 1))" > "${TEST_DIR}/clock"
+    }
+    peer_sql_port_state() {
+      local calls=0
+      [ -f "${TEST_DIR}/peer-calls" ] && calls="$(cat "${TEST_DIR}/peer-calls")"
+      calls=$((calls + 1))
+      printf '%s\n' "${calls}" > "${TEST_DIR}/peer-calls"
+      case "${calls}" in
+        1|3|5|7|8) printf 'absent' ;;
+        2) printf 'timeout' ;;
+        4) printf 'unreachable' ;;
+        6) printf 'unexpected-state' ;;
+      esac
+    }
+
+    When call wait_for_higher_ordinals
+    The status should be success
+    The contents of file "${TEST_DIR}/peer-calls" should equal "8"
+    The output should include "higher-ordinal peers have stopped"
+  End
+
+  It "tracks authoritative absence streaks independently per peer"
+    GALERA_PRESTOP_ORDER_WAIT_SECONDS=10
+    GALERA_PRESTOP_POLL_SECONDS=1
+    printf '0\n' > "${TEST_DIR}/clock"
+    monotonic_seconds() {
+      cat "${TEST_DIR}/clock"
+    }
+    sleep() {
+      local now
+      now="$(cat "${TEST_DIR}/clock")"
+      printf '%s\n' "$((now + 1))" > "${TEST_DIR}/clock"
+    }
+    peer_sql_port_state() {
+      local peer="$1"
+      local key="${peer%%.*}"
+      local counter="${TEST_DIR}/${key}.calls"
+      local calls=0
+      [ -f "${counter}" ] && calls="$(cat "${counter}")"
+      calls=$((calls + 1))
+      printf '%s\n' "${calls}" > "${counter}"
+      case "${key}" in
+        mdb-galera-mariadb-1) printf 'absent' ;;
+        mdb-galera-mariadb-2)
+          case "${calls}" in
+            1|3|4) printf 'absent' ;;
+            2) printf 'open' ;;
+          esac
+          ;;
+      esac
+    }
+
+    When call wait_for_higher_ordinals
+    The status should be success
+    The contents of file "${TEST_DIR}/mdb-galera-mariadb-1.calls" should equal "2"
+    The contents of file "${TEST_DIR}/mdb-galera-mariadb-2.calls" should equal "4"
+    The output should include "higher-ordinal peers have stopped"
+  End
+
+  It "does not close a peer after only one authoritative absence"
+    POD_NAME="mdb-galera-mariadb-1"
+    GALERA_PRESTOP_ORDER_WAIT_SECONDS=2
+    GALERA_PRESTOP_POLL_SECONDS=1
+    printf '0\n' > "${TEST_DIR}/clock"
+    monotonic_seconds() {
+      cat "${TEST_DIR}/clock"
+    }
+    sleep() {
+      local now
+      now="$(cat "${TEST_DIR}/clock")"
+      printf '%s\n' "$((now + 1))" > "${TEST_DIR}/clock"
+    }
+    peer_sql_port_state() {
+      if [ ! -f "${TEST_DIR}/observed-once" ]; then
+        : > "${TEST_DIR}/observed-once"
+        printf 'absent'
+      else
+        printf 'open'
+      fi
+    }
+
+    When call wait_for_higher_ordinals
+    The status should be failure
+    The output should include "reason=order_wait_timeout"
   End
 
   It "persists and mirrors degraded shutdown evidence"

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -1000,9 +1000,9 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is current (alpha.33 - combined MariaDB candidate)"
+    It "Chart.yaml literal version is current (alpha.34 - combined MariaDB candidate)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.33$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.34$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -3274,7 +3274,7 @@ EOF
       # kept in sync with latest chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.33"
+      The output should equal "version: 1.2.0-alpha.34"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -3335,7 +3335,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.33"
+        The output should equal "version: 1.2.0-alpha.34"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3551,7 +3551,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.33"
+        The output should equal "version: 1.2.0-alpha.34"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -1000,9 +1000,9 @@ EOF
       The output should equal "1"
     End
 
-    It "Chart.yaml literal version is current (alpha.32 - combined MariaDB candidate)"
+    It "Chart.yaml literal version is current (alpha.33 - combined MariaDB candidate)"
       chart_yaml="${SHELLSPEC_CWD:?}/addons/mariadb/Chart.yaml"
-      When call grep -c '^version: 1.2.0-alpha.32$' "${chart_yaml}"
+      When call grep -c '^version: 1.2.0-alpha.33$' "${chart_yaml}"
       The output should equal "1"
     End
 
@@ -3274,7 +3274,7 @@ EOF
       # kept in sync with latest chart version.
       When call grep -E "^version:" "${CHART_FILE}"
       The status should be success
-      The output should equal "version: 1.2.0-alpha.32"
+      The output should equal "version: 1.2.0-alpha.33"
     End
 
     It "alpha.65 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged; this bump is packaging-contract only)"
@@ -3335,7 +3335,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.32"
+        The output should equal "version: 1.2.0-alpha.33"
       End
 
       It "alpha.66 v1: Chart.yaml appVersion still 11.4.10 (mariadb engine version unchanged) [contract-no-regression]"
@@ -3551,7 +3551,7 @@ EOF
         # version.
         When call grep -E "^version:" "${CHART_FILE}"
         The status should be success
-        The output should equal "version: 1.2.0-alpha.32"
+        The output should equal "version: 1.2.0-alpha.33"
       End
     End
 

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -80,8 +80,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.32 (combined MariaDB candidate)"
-      When call grep -c '^version: 1.2.0-alpha.32$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.33 (combined MariaDB candidate)"
+      When call grep -c '^version: 1.2.0-alpha.33$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_user_convergence_spec.sh
@@ -80,8 +80,8 @@ Describe "alpha.72 v1 replication user path convergence (static gates)"
   MEMBER_JOIN="${ADDON_ROOT}/scripts/replication-member-join.sh"
 
   Describe "Gate 1: Chart.yaml literal version"
-    It "is exactly 1.2.0-alpha.33 (combined MariaDB candidate)"
-      When call grep -c '^version: 1.2.0-alpha.33$' "${CHART_YAML}"
+    It "is exactly 1.2.0-alpha.34 (combined MariaDB candidate)"
+      When call grep -c '^version: 1.2.0-alpha.34$' "${CHART_YAML}"
       The output should eq "1"
       The status should be success
     End

--- a/addons/mariadb/scripts/galera-prestop.sh
+++ b/addons/mariadb/scripts/galera-prestop.sh
@@ -5,8 +5,6 @@ DATA_DIR="${DATA_DIR:-/var/lib/mysql}"
 GALERA_PRESTOP_ORDER_WAIT_SECONDS="${GALERA_PRESTOP_ORDER_WAIT_SECONDS:-60}"
 GALERA_PRESTOP_POLL_SECONDS="${GALERA_PRESTOP_POLL_SECONDS:-3}"
 GALERA_PRESTOP_PROBE_TIMEOUT_SECONDS="${GALERA_PRESTOP_PROBE_TIMEOUT_SECONDS:-2}"
-GALERA_PRESTOP_SQL_TIMEOUT_SECONDS="${GALERA_PRESTOP_SQL_TIMEOUT_SECONDS:-3}"
-GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS="${GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS:-40}"
 GALERA_PRESTOP_TERMINATION_GRACE_SECONDS="${GALERA_PRESTOP_TERMINATION_GRACE_SECONDS:-120}"
 GALERA_PRESTOP_SAFETY_MARGIN_SECONDS="${GALERA_PRESTOP_SAFETY_MARGIN_SECONDS:-5}"
 GALERA_PRESTOP_CONTAINER_LOG_PATH="${GALERA_PRESTOP_CONTAINER_LOG_PATH:-/proc/1/fd/1}"
@@ -36,7 +34,6 @@ record_degraded() {
     mirrored=1
   fi
   if [ "${persisted}" -ne 1 ] && [ "${mirrored}" -ne 1 ]; then
-    DEGRADED_EVIDENCE_WRITE_FAILED=1
     return 1
   fi
   return 0
@@ -99,24 +96,21 @@ validate_inputs() {
   if ! is_uint "${GALERA_PRESTOP_ORDER_WAIT_SECONDS}" \
     || ! is_uint "${GALERA_PRESTOP_POLL_SECONDS}" \
     || ! is_uint "${GALERA_PRESTOP_PROBE_TIMEOUT_SECONDS}" \
-    || ! is_uint "${GALERA_PRESTOP_SQL_TIMEOUT_SECONDS}" \
-    || ! is_uint "${GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS}" \
     || ! is_uint "${GALERA_PRESTOP_TERMINATION_GRACE_SECONDS}" \
     || ! is_uint "${GALERA_PRESTOP_SAFETY_MARGIN_SECONDS}" \
     || [ "${GALERA_PRESTOP_POLL_SECONDS}" -eq 0 ] \
     || [ "${GALERA_PRESTOP_PROBE_TIMEOUT_SECONDS}" -eq 0 ] \
-    || [ "${GALERA_PRESTOP_SQL_TIMEOUT_SECONDS}" -eq 0 ] \
-    || [ "${GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS}" -eq 0 ] \
     || [ "${GALERA_PRESTOP_TERMINATION_GRACE_SECONDS}" -eq 0 ] \
     || [ "${GALERA_PRESTOP_SAFETY_MARGIN_SECONDS}" -eq 0 ]; then
     VALIDATION_ERROR="reason=invalid_timeout_configuration"
     return 1
   fi
 
+  # The hook only orders peers and publishes the watcher guard. Kubelet sends
+  # TERM to mariadbd after this hook returns, so the rest of the Pod grace
+  # period is deliberately reserved for the engine's own clean shutdown.
   local worst_case_seconds=$((
     GALERA_PRESTOP_ORDER_WAIT_SECONDS
-    + (2 * GALERA_PRESTOP_SQL_TIMEOUT_SECONDS)
-    + GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS
     + GALERA_PRESTOP_SAFETY_MARGIN_SECONDS
   ))
   if [ "${worst_case_seconds}" -gt "${GALERA_PRESTOP_TERMINATION_GRACE_SECONDS}" ]; then
@@ -265,48 +259,28 @@ wait_for_higher_ordinals() {
   done
 }
 
-local_sql() {
-  local statement="$1"
-  timeout "${GALERA_PRESTOP_SQL_TIMEOUT_SECONDS}" \
-    mariadb -u"${MARIADB_ROOT_USER:-}" -p"${MARIADB_ROOT_PASSWORD:-}" \
-    -P3306 -h127.0.0.1 \
-    -e "${statement}" >/dev/null 2>&1
-}
-
-graceful_shutdown() {
+prepare_ordered_shutdown() {
   if ! touch "${DATA_DIR}/.galera-shutting-down" 2>/dev/null; then
-    log "warning: failed to publish .galera-shutting-down before desync; continuing best-effort shutdown"
+    log "failed to publish .galera-shutting-down; refusing to report prepared"
     record_degraded "reason=shutting_down_marker_failed"
+    return 1
   fi
-
-  if ! local_sql "SET GLOBAL wsrep_desync=ON;"; then
-    log "warning: failed to set wsrep_desync=ON; continuing best-effort shutdown"
-    record_degraded "reason=wsrep_desync_failed"
-  fi
-
-  if ! local_sql "SET GLOBAL wsrep_on=OFF;"; then
-    log "warning: failed to set wsrep_on=OFF; continuing best-effort shutdown"
-    record_degraded "reason=wsrep_disable_failed"
-  fi
-
-  if ! timeout "${GALERA_PRESTOP_SHUTDOWN_TIMEOUT_SECONDS}" \
-    mysqladmin -u"${MARIADB_ROOT_USER:-}" -p"${MARIADB_ROOT_PASSWORD:-}" \
-    -h127.0.0.1 shutdown >/dev/null 2>&1; then
-    log "warning: mysqladmin shutdown failed; kubelet may terminate mariadbd"
-    record_degraded "reason=mysqladmin_shutdown_failed"
-  fi
+  log "ordered shutdown prepared; kubelet may now signal mariadbd"
+  return 0
 }
 
 main() {
-  DEGRADED_EVIDENCE_WRITE_FAILED=0
   if ! validate_inputs; then
     record_degraded "${VALIDATION_ERROR}"
-  else
-    wait_for_higher_ordinals || true
+    printf 'galera-prestop: shutdown preparation failed: %s\n' "${VALIDATION_ERROR}" >&2
+    return 1
   fi
-  graceful_shutdown || true
-  if [ "${DEGRADED_EVIDENCE_WRITE_FAILED}" -ne 0 ]; then
-    printf 'galera-prestop: degraded evidence sinks unavailable; emitting FailedPreStopHook\n' >&2
+  if ! wait_for_higher_ordinals; then
+    printf 'galera-prestop: shutdown preparation failed: higher-ordinal peers did not stop\n' >&2
+    return 1
+  fi
+  if ! prepare_ordered_shutdown; then
+    printf 'galera-prestop: shutdown preparation failed: watcher guard unavailable\n' >&2
     return 1
   fi
   return 0

--- a/addons/mariadb/scripts/galera-prestop.sh
+++ b/addons/mariadb/scripts/galera-prestop.sh
@@ -175,10 +175,20 @@ peer_sql_port_state() {
 
   case "${output}" in
     *"Connection refused"*) printf 'closed' ;;
-    *"Name or service not known"*|*"Temporary failure in name resolution"*|*"No address associated"*)
-      printf 'dns-failure'
+    *"Name or service not known"*|*"No address associated"*)
+      printf 'absent'
       ;;
+    *"Temporary failure in name resolution"*) printf 'dns-transient' ;;
     *) printf 'unreachable' ;;
+  esac
+}
+
+peer_in_list() {
+  local list="$1"
+  local peer="$2"
+  case " ${list} " in
+    *" ${peer} "*) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -194,6 +204,10 @@ wait_for_higher_ordinals() {
   local started_at
   started_at="$(monotonic_seconds)"
   local deadline=$((started_at + GALERA_PRESTOP_ORDER_WAIT_SECONDS))
+  # Bash 3 compatible, space-delimited sets. Peer FQDNs are validated to
+  # contain no whitespace before this function is called by main.
+  local absent_once=""
+  local confirmed_stopped=""
   while true; do
     local now
     now="$(monotonic_seconds)"
@@ -209,8 +223,13 @@ wait_for_higher_ordinals() {
     fi
 
     local still_waiting=""
+    local next_absent_once=""
     local peer
     for peer in ${peers}; do
+      if peer_in_list "${confirmed_stopped}" "${peer}"; then
+        continue
+      fi
+
       now="$(monotonic_seconds)"
       remaining=$((deadline - now))
       if [ "${remaining}" -le 0 ]; then
@@ -229,8 +248,23 @@ wait_for_higher_ordinals() {
           # A refused connection is only the local observation that the SQL
           # listener is down. It is the cleanest signal available to this
           # preStop hook, but it is not proof that the peer wrote grastate.dat.
+          confirmed_stopped="${confirmed_stopped} ${peer}"
           ;;
-        open|timeout|dns-failure|unreachable)
+        absent)
+          # A deleted higher-ordinal Pod may disappear from headless-Service
+          # DNS before this hook probes it. Require the same authoritative
+          # name-absence result in two consecutive polls so a one-off resolver
+          # anomaly cannot release the lower ordinal early.
+          if peer_in_list "${absent_once}" "${peer}"; then
+            confirmed_stopped="${confirmed_stopped} ${peer}"
+          else
+            next_absent_once="${next_absent_once} ${peer}"
+            still_waiting="${still_waiting} ${peer}(absent-1/2)"
+          fi
+          ;;
+        open|timeout|dns-transient|unreachable)
+          # Do not carry an authoritative-absence streak across any uncertain
+          # or live observation. The peer must start again at 1/2.
           still_waiting="${still_waiting} ${peer}(${state})"
           ;;
         *)
@@ -238,6 +272,7 @@ wait_for_higher_ordinals() {
           ;;
       esac
     done
+    absent_once="${next_absent_once}"
 
     if [ -z "${still_waiting}" ]; then
       log "higher-ordinal peers have stopped; proceeding with local shutdown"

--- a/addons/mariadb/templates/cmpd-galera.yaml
+++ b/addons/mariadb/templates/cmpd-galera.yaml
@@ -152,14 +152,15 @@ spec:
     # internal removal step is required. The previous memberLeave ran in the
     # kbagent execution face (no mariadb client, all SQL `2>/dev/null || true`),
     # so its claimed FLUSH TABLES / wsrep_desync=ON never executed — a silent
-    # no-op. The graceful-leave that does matter at shutdown (final seqno +
-    # safe_to_bootstrap, clean InnoDB flush) is handled by the mariadb
-    # container preStop below, which runs in-container against 127.0.0.1.
+    # no-op. The native preStop below orders the Pods and publishes a guard
+    # for the in-container watcher. After the hook returns, kubelet sends TERM
+    # to mariadbd (PID 1), which owns the actual graceful Galera leave and
+    # InnoDB flush.
   runtime:
-    # Allow enough time for Galera to write grastate.dat on clean shutdown.
-    # 30s (default) is insufficient when InnoDB has dirty pages to flush.
-    # preStop hook below triggers graceful shutdown; this grace period gives
-    # it time to complete before SIGKILL.
+    # The grace period covers both the bounded ordering hook and the clean
+    # mariadbd shutdown that starts only after kubelet sends TERM. Running
+    # mysqladmin inside preStop would consume this same budget before TERM and
+    # can collapse the intended high-to-low order when that client call stalls.
     terminationGracePeriodSeconds: 120
     containers:
       - name: mariadb


### PR DESCRIPTION
## Problems observed

This PR closes two evidence-backed failures in the same Galera native `preStop` path.

1. In the r21 frozen scene, Stop and Start OpsRequests both reported `Succeed`, but the data plane stayed failed. Every PVC recorded `mysqladmin_shutdown_failed`; pod-0 and pod-1 also exhausted the higher-ordinal wait. The hook had consumed the Pod grace budget with SQL and `mysqladmin shutdown` before kubelet could signal mariadbd PID 1.
2. After the first fix, the fresh r22 scene recovered to Primary/size3/all-Synced/rows9, but the hook contract still failed. pod-1 was deleted at 11:19:13Z and pod-2 at 11:19:20Z; pod-0 then waited the full 60 seconds, Kubernetes emitted `FailedPreStopHook` at 11:20:07Z, and pod-0's PVC persisted `reason=order_wait_timeout` with both deleted higher peers marked `budget-exhausted`. The hook treated their post-deletion DNS name absence as indefinite uncertainty.

The second result means r22 is **runtime FAIL/N=1 for preStop validation**, despite successful data-plane recovery.

## Root cause

`galera-prestop.sh` is a Kubernetes native container `preStop`, not a kbagent lifecycle action. Kubernetes starts the Pod termination grace countdown before the hook and sends TERM to container PID 1 only after the hook returns.

The old code had two separate contract violations:

- it ran client-side SQL/`mysqladmin shutdown` inside the hook and swallowed failures, delaying kubelet's real TERM;
- its bounded TCP probe only recognized `Connection refused` as stopped. Once a deleted higher Pod disappeared from headless-Service DNS, `Name or service not known` / `No address associated` could never close that peer, so the lower ordinal exhausted the 60-second wait.

Primary contracts:

- Kubernetes native hook ordering and shared grace budget: <https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/>
- MariaDB Galera orderly shutdown / last clean node safe-to-bootstrap contract: <https://mariadb.com/docs/galera-cluster/high-availability/resetting-the-quorum-cluster-bootstrap>

## Behavior fix

- Keep `preStop` responsible only for bounded high-to-low ordering and publishing `.galera-shutting-down` for the watcher guard.
- Let kubelet send TERM to the `exec`-owned mariadbd PID 1; do not run SQL or `mysqladmin` in the hook.
- Keep `Connection refused` as an immediate closed observation.
- Classify only authoritative name absence (`Name or service not known` / `No address associated`) as `absent`, and require the same peer to be absent in **two consecutive polls** before confirming it stopped.
- Clear that peer's absence streak on any live or uncertain observation (`open`, transient DNS failure, timeout, generic unreachable, or unknown) and continue fail-closed.
- Track peers independently, remember confirmed peers, preserve the existing wall-clock deadline, and return non-zero with persisted degraded evidence on unresolved peers.
- No K8s API, RBAC, sidecar, shared-volume coordination, or new engine shutdown mechanism is added.
- Bump the chart to `1.2.0-alpha.34` because the ComponentDefinition runtime contract changed.

The Chinese design document was published in the MariaDB team thread before this second code change. It covers the problem, alternatives, core flow, compatibility, and split Dev/Test plan.

## TDD and local source validation

First fix:

- Old parent focused RED: `22 examples / 6 failures`.
- Patched focused GREEN: `22 / 0`.

DNS/deleted-peer fix on exact `90434973494b6b8207b287e7ea5bbd2cc3292307`:

- Production RED with tests only: `28 examples / 6 failures`; failures covered authoritative absence classification, transient classification, two-poll confirmation, uncertain-state reset, and independent peer state.
- Current Bash 3.2 focused GREEN: `29 / 0`.
- Related Galera/switchover/version specs on Bash 5.3: `250 / 0 / 6 documented pending`.
- Full MariaDB ShellSpec on Bash 5.3: `777 / 0 / 9 documented pending`.
- `bash -n`, ShellCheck error gate, and `git diff --check`: PASS.
- Helm dependency build, lint, default render, and package: PASS.
- Offline package proof only: `mariadb-1.2.0-alpha.34.tgz` SHA256 `51af67d5c73bf32a8e2957f1faabc4b881d10a45a8a5d62f7b35d7e9a6e2dbac`; default render SHA256 `95890869b273f7d8eba1e29813028a426596f02b3c374971643ea4112246e447`.

## Current boundary

- Exact head: `c509f506861d21e88ce16f4498ac08ae3fce7e46`.
- CI: rerunning for this exact head; not yet terminal at the time of this update.
- Runtime: **no post-`c509f5068` runtime result**. The r22 scene remains frozen read-only and is not evidence for the new source.
- Merge order: this PR is stacked on PR #3216 and must follow it.
- A fresh Test-owned immutable package and Galera Stop/Start run must show no `FailedPreStopHook`, no new persisted degraded record, and the exact Primary/size3/Synced/rows oracle before any runtime-fixed claim.
