### PR TITLE
fix(redis): reject TLS for Redis 5

### DIFF
--- a/addons/redis/scripts-ut-spec/redis_tls_version_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_tls_version_contract_spec.sh
@@ -31,6 +31,13 @@ Describe "Redis TLS service-version contract"
           "redis-sentinel" => "redis-sentinel"
         }
         majors = %w[5 6 7 8]
+        expected_names = families.keys.product(majors).map do |family, major|
+          "#{family}-#{major}-#{version}"
+        end
+        definition_names = definitions.map { |definition| definition.dig("metadata", "name") }
+        abort "expected exactly 12 ComponentDefinitions, got #{definitions.size}" unless definitions.size == expected_names.size
+        abort "ComponentDefinition names differ: #{definition_names.sort.inspect}" unless definition_names.sort == expected_names.sort
+
         rows = []
         violations = []
 

--- a/addons/redis/scripts-ut-spec/redis_tls_version_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_tls_version_contract_spec.sh
@@ -1,0 +1,91 @@
+# shellcheck shell=bash
+
+Describe "Redis TLS service-version contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s" "${REDIS_TLS_CONTRACT_CHART_PATH:-$(repo_root)/addons/redis}"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  ruby_not_available() { ! command -v ruby >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+  Skip if "ruby not available" ruby_not_available
+
+  validate_tls_version_contract() {
+    helm template test "$(chart_path)" \
+      --dependency-update \
+      --show-only templates/cmpd-redis.yaml \
+      --show-only templates/cmpd-redis-cluster.yaml \
+      --show-only templates/cmpd-redis-sentinel.yaml | ruby -ryaml -e '
+        documents = YAML.load_stream($stdin.read).compact
+        chart = YAML.load_file(ARGV.fetch(0))
+        version = chart.fetch("version")
+        definitions = documents.select { |document| document["kind"] == "ComponentDefinition" }
+
+        families = {
+          "redis" => "redis",
+          "redis-cluster" => "redis-cluster",
+          "redis-sentinel" => "redis-sentinel"
+        }
+        majors = %w[5 6 7 8]
+        rows = []
+        violations = []
+
+        families.each_key do |family|
+          majors.each do |major|
+            name = "#{family}-#{major}-#{version}"
+            definition = definitions.find { |document| document.dig("metadata", "name") == name }
+            abort "missing ComponentDefinition #{name}" unless definition
+
+            tls = definition.dig("spec", "tls")
+            rows << "#{name}\ttls=#{tls ? "present" : "absent"}"
+            if major == "5"
+              violations << "Redis 5 must not advertise TLS: #{name}" if tls
+            else
+              expected_tls = {
+                "volumeName" => "tls",
+                "mountPath" => "/etc/pki/tls",
+                "caFile" => "ca.crt",
+                "certFile" => "tls.crt",
+                "keyFile" => "tls.key"
+              }
+              violations << "TLS contract differs for #{name}: #{tls.inspect}" unless tls == expected_tls
+            end
+          end
+        end
+
+        puts rows
+        abort violations.join("\n") unless violations.empty?
+
+        redis5 = definitions.find { |document| document.dig("metadata", "name") == "redis-5-#{version}" }
+        cluster5 = definitions.find { |document| document.dig("metadata", "name") == "redis-cluster-5-#{version}" }
+        sentinel5 = definitions.find { |document| document.dig("metadata", "name") == "redis-sentinel-5-#{version}" }
+
+        runtime_container = lambda do |definition, container_name|
+          containers = definition.dig("spec", "runtime", "containers") || []
+          container = containers.find { |entry| entry["name"] == container_name }
+          abort "missing runtime container #{container_name}" unless container
+          container
+        end
+
+        redis5_runtime = runtime_container.call(redis5, "redis")
+        cluster5_runtime = runtime_container.call(cluster5, "redis-cluster")
+        sentinel5_runtime = runtime_container.call(sentinel5, "redis-sentinel")
+        abort "Redis 5 data script route changed" unless redis5_runtime["command"] == ["/scripts/redis5-start.sh"]
+        abort "Redis 5 cluster script route changed" unless cluster5_runtime["command"] == ["/scripts/redis-cluster5-server-start.sh"]
+        sentinel5_command = [sentinel5_runtime["command"], sentinel5_runtime["args"]].flatten.compact.join("\n")
+        abort "Redis 5 sentinel script route changed" unless sentinel5_command.include?("/scripts/redis5-sentinel-start-v2.sh")
+
+        puts "Redis 5 rejects TLS while Redis 6/7/8 retain TLS"
+      ' "$(chart_path)/Chart.yaml"
+  }
+
+  It "does not advertise TLS for Redis 5 and preserves TLS for Redis 6/7/8"
+    When call validate_tls_version_contract
+    The status should be success
+    The output should include "Redis 5 rejects TLS while Redis 6/7/8 retain TLS"
+  End
+End

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -27,12 +27,14 @@ spec:
   serviceVersion: {{ .serviceVersion }}
   minReadySeconds: 10
   podUpgradePolicy: ReCreate
+  {{- if ne .major "5" }}
   tls:
     volumeName: tls
     mountPath: {{ $.Values.tlsMountPath }}
     caFile: ca.crt
     certFile: tls.crt
     keyFile: tls.key
+  {{- end }}
   services:
     - name: redis-advertised
       serviceName: redis-advertised

--- a/addons/redis/templates/cmpd-redis-sentinel.yaml
+++ b/addons/redis/templates/cmpd-redis-sentinel.yaml
@@ -78,12 +78,14 @@ spec:
       - container: redis-sentinel
         ports:
           - redis-sentinel
+  {{- if ne .major "5" }}
   tls:
     volumeName: tls
     mountPath: {{ $.Values.tlsMountPath }}
     caFile: ca.crt
     certFile: tls.crt
     keyFile: tls.key
+  {{- end }}
   vars:
     - name: TLS_ENABLED
       valueFrom:

--- a/addons/redis/templates/cmpd-redis.yaml
+++ b/addons/redis/templates/cmpd-redis.yaml
@@ -20,12 +20,14 @@ spec:
   podManagementPolicy: OrderedReady
   podUpgradePolicy: ReCreate
   minReadySeconds: 10
+  {{- if ne .major "5" }}
   tls:
     volumeName: tls
     mountPath: {{ $.Values.tlsMountPath }}
     caFile: ca.crt
     certFile: tls.crt
     keyFile: tls.key
+  {{- end }}
   services:
     - name: redis
       serviceName: redis


### PR DESCRIPTION
## Problem

Redis 5.0.12 does not provide the TLS server/client capability used by the addon, but all three Redis 5 ComponentDefinitions advertised `spec.tls`. With `tls: true`, KubeBlocks injected `REDIS_CLI_TLS_CMD=--tls --insecure` while the Redis 5 startup scripts launched a plaintext server. Exact runtime evidence showed all three shard Pods exhaust readiness attempts because `redis-cli` rejects `--tls`; plaintext password-auth PING remained healthy.

This failure happens before parent PR #3190 partial-join injection, so it is a separate capability-contract bug. See #3221.

## Solution

- omit `spec.tls` from Redis 5 data, cluster, and sentinel ComponentDefinitions;
- preserve the full TLS contract for Redis 6/7/8;
- rely on KubeBlocks fail-closed validation when a user requests TLS against a definition that does not support it; never downgrade silently to plaintext;
- inherit Chart `1.2.0-alpha.5` and Redis 5/6 slot-owner routing from parent PR #3190;
- keep a structured Helm/YAML contract over the exact Redis family/version definition set, cardinality, and startup-script routing.

This PR is stacked on PR #3190 exact `31e4a0950244e4ecc86c1b3d6bccd8bcd9b13df9`.

## TDD and validation

- Original RED showed all Redis family/version definitions advertising TLS and reported the three Redis 5 violations.
- Exact current head: `8f1a9cb53e265da321ac136b01ad80f51daadaa2`; tree `d50c6f4d45075b9f7b0200feda17035c5452a31d`.
- Rebase range-diff keeps both TLS commits patch-equivalent; the parent is exactly the new PR #3190 head and alpha.5 is preserved.
- TLS contract Bash 5: `1/0`; macOS Bash 3: `1/0`.
- Parent classifier + TLS + Redis 5 + replica-recovery focused set: `28/0`.
- Full Redis Bash 5 ShellSpec: `552/0`.
- Bash syntax, ShellCheck error severity, `git diff --check`, Helm lint, Helm template, alpha.5 render and routing: PASS.
- Focused review is terminal NO BLOCKER. The reviewer verified stable patch-id equivalence and exact parent ancestry.
- GitHub CI is terminal 7/7 PASS: ShellSpec, shell-check, four chart checks, and generate-files.

## Review focus

- the capability boundary: Redis 5 must expose no TLS contract, Redis 6/7/8 must remain unchanged;
- fail-closed behavior with no plaintext downgrade;
- exact definition-set/cardinality test so an extra or missing definition cannot false-green;
- stacked inheritance: only the two TLS commits sit above exact parent `31e4a095`.

## Runtime boundary

All older alpha.2/alpha.3/alpha.4 runtime evidence belongs to older source identities and does not transfer. Exact alpha.5 runtime is N=0. Max now owns fresh exact-head validation for Redis 5 `tls:true` rejection with Pod=0, Redis 5 password-only partial-join/restart, unchanged Redis 6/7/8 TLS+password/ACL behavior, and the shared shard-expansion contract. This source/render proof is not runtime PASS or release-ready.

Fixes #3221