### PR TITLE
fix(redis): bound shard scale-out reshard

### DIFF
--- a/addons/redis/Chart.yaml
+++ b/addons/redis/Chart.yaml
@@ -4,7 +4,7 @@ description: "Redis is an in-memory database that persists on disk. The data mod
 
 type: application
 
-version: 1.2.0-alpha.5
+version: 1.2.0-alpha.6
 
 appVersion: "7.2.7"
 

--- a/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-common.sh
@@ -398,31 +398,74 @@ check_redis_server_ready_with_retry() {
   return 0
 }
 
-# check redis cluster all slots are covered
-check_slots_covered() {
-  # cluster_node_endpoint_wth_port is the target node endpoint with port, for example 172.0.0.1:6379
-  local node_endpoint_wth_port="$1"
-  local cluster_service_port="$2"
-  unset_xtrace_when_ut_mode_false
-  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
-    check=$(redis-cli $REDIS_CLI_TLS_CMD --cluster check "$node_endpoint_wth_port" -p "$cluster_service_port")
-  else
-    check=$(redis-cli $REDIS_CLI_TLS_CMD --cluster check "$node_endpoint_wth_port" -p "$cluster_service_port" -a "$REDIS_DEFAULT_PASSWORD")
-  fi
-  set_xtrace_when_ut_mode_false
-  if contains "$check" "All 16384 slots covered"; then
-    if contains "$check" "[ERR]" || \
-       contains "$check" "[WARNING] The following slots are open" || \
-       contains "$check" "has slots in importing state" || \
-       contains "$check" "has slots in migrating state"; then
-      echo "Redis Cluster slots are covered but cluster check is not stable:" >&2
-      echo "$check" >&2
-      return 1
-    fi
+classify_redis_cluster_check_output() {
+  local check_rc="$1"
+  local check_output="$2"
+
+  if contains "$check_output" "[WARNING] The following slots are open" || \
+     contains "$check_output" "has slots in importing state" || \
+     contains "$check_output" "has slots in migrating state" || \
+     contains "$check_output" "Not all 16384 slots are covered by nodes"; then
+    echo "open-or-uncovered"
     return 0
   fi
-  echo "Redis Cluster slots are not fully covered:" >&2
-  echo "$check" >&2
+
+  if contains "$check_output" "All 16384 slots covered" && \
+     contains "$check_output" "Nodes don't agree about configuration"; then
+    echo "views-disagreement"
+    return 0
+  fi
+
+  if [ "$check_rc" -eq 0 ] && \
+     contains "$check_output" "All 16384 slots covered" && \
+     ! contains "$check_output" "[ERR]"; then
+    echo "stable"
+    return 0
+  fi
+
+  echo "probe-error"
+}
+
+inspect_redis_cluster_check() {
+  # node_endpoint_with_port is the target node endpoint with port, for example 172.0.0.1:6379
+  local node_endpoint_with_port="$1"
+  local cluster_service_port="$2"
+  local output
+  local check_rc
+
+  unset_xtrace_when_ut_mode_false
+  if is_empty "$REDIS_DEFAULT_PASSWORD"; then
+    if output=$(redis-cli $REDIS_CLI_TLS_CMD --cluster check "$node_endpoint_with_port" -p "$cluster_service_port" 2>&1); then
+      check_rc=0
+    else
+      check_rc=$?
+    fi
+  else
+    if output=$(redis-cli $REDIS_CLI_TLS_CMD --cluster check "$node_endpoint_with_port" -p "$cluster_service_port" -a "$REDIS_DEFAULT_PASSWORD" 2>&1); then
+      check_rc=0
+    else
+      check_rc=$?
+    fi
+  fi
+  set_xtrace_when_ut_mode_false
+
+  redis_cluster_check_output="$output"
+  redis_cluster_check_rc="$check_rc"
+  redis_cluster_check_state=$(classify_redis_cluster_check_output "$check_rc" "$output")
+}
+
+# check redis cluster all slots are covered and every node view is stable
+check_slots_covered() {
+  local node_endpoint_with_port="$1"
+  local cluster_service_port="$2"
+
+  inspect_redis_cluster_check "$node_endpoint_with_port" "$cluster_service_port"
+  if [ "$redis_cluster_check_state" = "stable" ]; then
+    return 0
+  fi
+
+  echo "Redis Cluster check is not stable (state=$redis_cluster_check_state, rc=$redis_cluster_check_rc):" >&2
+  echo "$redis_cluster_check_output" >&2
   return 1
 }
 

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -160,6 +160,57 @@ fix_unstable_cluster_and_defer() {
   return 1
 }
 
+scale_out_diagnose_not_ready() {
+  local phase="$1"
+  local context="$2"
+  local retry_safe="$3"
+  {
+    echo "Redis Cluster lifecycle diagnosis:"
+    echo "  action: scale_out_redis_cluster_shard"
+    echo "  phase: $phase"
+    echo "  cluster: ${KB_CLUSTER_NAME:-<unset>}"
+    echo "  component: ${CURRENT_SHARD_COMPONENT_NAME:-<unset>}"
+    echo "$context"
+    echo "  next-retry-safe: $retry_safe"
+  } >&2
+}
+
+ensure_scale_out_cluster_stable_or_defer() {
+  local node_with_port="$1"
+  local node_port
+  local context
+  node_port=$(echo "$node_with_port" | cut -d':' -f2)
+
+  inspect_redis_cluster_check "$node_with_port" "$node_port"
+  case "$redis_cluster_check_state" in
+    stable)
+      return 0
+      ;;
+    views-disagreement)
+      context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s' \
+        "$redis_cluster_check_rc" "$redis_cluster_check_state")
+      scale_out_diagnose_not_ready "cluster-views-not-converged" "$context" "yes"
+      ;;
+    open-or-uncovered)
+      if fix_cluster_slots "$node_with_port" "$node_port"; then
+        context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s\n  repair_applied: yes' \
+          "$redis_cluster_check_rc" "$redis_cluster_check_state")
+        scale_out_diagnose_not_ready "cluster-slots-repair-applied" "$context" "yes"
+      else
+        context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s\n  repair_applied: no' \
+          "$redis_cluster_check_rc" "$redis_cluster_check_state")
+        scale_out_diagnose_not_ready "cluster-slots-repair-failed" "$context" "no"
+      fi
+      ;;
+    *)
+      context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s' \
+        "$redis_cluster_check_rc" "$redis_cluster_check_state")
+      scale_out_diagnose_not_ready "cluster-check-failed" "$context" "no"
+      ;;
+  esac
+  return 1
+}
+
 extract_pod_name_prefix() {
   local pod_name="$1"
   # shellcheck disable=SC2001
@@ -799,7 +850,7 @@ scale_out_redis_cluster_shard() {
   fi
 
   if [ ${#other_component_nodes[@]} -gt 0 ]; then
-    fix_unstable_cluster_and_defer "${other_component_nodes[0]}" || return 1
+    ensure_scale_out_cluster_stable_or_defer "${other_component_nodes[0]}" || return 1
   fi
 
   # check the current component shard whether is already scaled out
@@ -877,6 +928,9 @@ scale_out_redis_cluster_shard() {
   local slots_per_shard
   local current_slots
   local remaining_slots
+  local batch_size
+  local batch_slots
+  local context
   total_slots=16384
   current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
   all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
@@ -890,21 +944,53 @@ scale_out_redis_cluster_shard() {
   fi
   remaining_slots=$((slots_per_shard - current_slots))
   if [ "$remaining_slots" -le 0 ]; then
-    if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
+    if ensure_scale_out_cluster_stable_or_defer "$primary_node_with_port"; then
       echo "Redis cluster scale out shard already owns $current_slots slots and cluster is stable"
       return 0
     fi
-    fix_unstable_cluster_and_defer "$primary_node_with_port" || return 1
-  fi
-
-  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$remaining_slots"; then
-    echo "Redis cluster scale out shard reshard successfully"
-  else
-    echo "Failed to scale out shard reshard" >&2
     return 1
   fi
 
-  check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"
+  batch_size=${REDIS_CLUSTER_RESHARD_BATCH_SIZE:-128}
+  if ! [[ "$batch_size" =~ ^[1-9][0-9]*$ ]]; then
+    context=$(printf '  batch_size: %s\n  current_slots: %s\n  target_slots: %s\n  remaining_slots: %s' \
+      "$batch_size" "$current_slots" "$slots_per_shard" "$remaining_slots")
+    scale_out_diagnose_not_ready "invalid-reshard-batch-size" "$context" "no"
+    return 1
+  fi
+  batch_slots=$remaining_slots
+  if [ "$batch_slots" -gt "$batch_size" ]; then
+    batch_slots=$batch_size
+  fi
+
+  if ! scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$batch_slots"; then
+    echo "Failed to scale out shard reshard" >&2
+    context=$(printf '  batch_slots: %s\n  current_slots: %s\n  target_slots: %s\n  remaining_slots: %s' \
+      "$batch_slots" "$current_slots" "$slots_per_shard" "$remaining_slots")
+    scale_out_diagnose_not_ready "reshard-command-failed" "$context" "no"
+    return 1
+  fi
+
+  ensure_scale_out_cluster_stable_or_defer "$primary_node_with_port" || return 1
+  current_slots=$(count_node_slots "$primary_node_fqdn" "$primary_node_port" "$mapping_primary_cluster_id")
+  status=$?
+  if [ $status -ne 0 ] || ! [[ "$current_slots" =~ ^[0-9]+$ ]]; then
+    context=$(printf '  batch_slots: %s\n  current_slots: %s\n  target_slots: %s' \
+      "$batch_slots" "$current_slots" "$slots_per_shard")
+    scale_out_diagnose_not_ready "post-reshard-slot-count-failed" "$context" "no"
+    return 1
+  fi
+
+  remaining_slots=$((slots_per_shard - current_slots))
+  if [ "$remaining_slots" -le 0 ]; then
+    echo "Redis cluster scale out shard owns $current_slots slots and cluster is stable"
+    return 0
+  fi
+
+  context=$(printf '  batch_slots: %s\n  current_slots: %s\n  target_slots: %s\n  remaining_slots: %s' \
+    "$batch_slots" "$current_slots" "$slots_per_shard" "$remaining_slots")
+  scale_out_diagnose_not_ready "reshard-progress" "$context" "yes"
+  return 1
 }
 
 sync_acl_for_redis_cluster_shard() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
@@ -178,6 +178,57 @@ fix_unstable_cluster_and_defer() {
   return 1
 }
 
+scale_out_diagnose_not_ready() {
+  local phase="$1"
+  local context="$2"
+  local retry_safe="$3"
+  {
+    echo "Redis Cluster lifecycle diagnosis:"
+    echo "  action: scale_out_redis_cluster_shard"
+    echo "  phase: $phase"
+    echo "  cluster: ${KB_CLUSTER_NAME:-<unset>}"
+    echo "  component: ${CURRENT_SHARD_COMPONENT_NAME:-<unset>}"
+    echo "$context"
+    echo "  next-retry-safe: $retry_safe"
+  } >&2
+}
+
+ensure_scale_out_cluster_stable_or_defer() {
+  local node_with_port="$1"
+  local node_port
+  local context
+  node_port=$(echo "$node_with_port" | cut -d':' -f2)
+
+  inspect_redis_cluster_check "$node_with_port" "$node_port"
+  case "$redis_cluster_check_state" in
+    stable)
+      return 0
+      ;;
+    views-disagreement)
+      context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s' \
+        "$redis_cluster_check_rc" "$redis_cluster_check_state")
+      scale_out_diagnose_not_ready "cluster-views-not-converged" "$context" "yes"
+      ;;
+    open-or-uncovered)
+      if fix_cluster_slots "$node_with_port" "$node_port"; then
+        context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s\n  repair_applied: yes' \
+          "$redis_cluster_check_rc" "$redis_cluster_check_state")
+        scale_out_diagnose_not_ready "cluster-slots-repair-applied" "$context" "yes"
+      else
+        context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s\n  repair_applied: no' \
+          "$redis_cluster_check_rc" "$redis_cluster_check_state")
+        scale_out_diagnose_not_ready "cluster-slots-repair-failed" "$context" "no"
+      fi
+      ;;
+    *)
+      context=$(printf '  cluster_check_rc: %s\n  cluster_check_state: %s' \
+        "$redis_cluster_check_rc" "$redis_cluster_check_state")
+      scale_out_diagnose_not_ready "cluster-check-failed" "$context" "no"
+      ;;
+  esac
+  return 1
+}
+
 extract_pod_name_prefix() {
   local pod_name="$1"
   # shellcheck disable=SC2001
@@ -797,7 +848,7 @@ scale_out_redis_cluster_shard() {
   fi
 
   if [ ${#other_component_nodes[@]} -gt 0 ]; then
-    fix_unstable_cluster_and_defer "${other_component_nodes[0]}" || return 1
+    ensure_scale_out_cluster_stable_or_defer "${other_component_nodes[0]}" || return 1
   fi
 
   # check the current component shard whether is already scaled out
@@ -872,6 +923,9 @@ scale_out_redis_cluster_shard() {
   local slots_per_shard
   local current_slots
   local remaining_slots
+  local batch_size
+  local batch_slots
+  local context
   total_slots=16384
   current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
   all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
@@ -885,21 +939,53 @@ scale_out_redis_cluster_shard() {
   fi
   remaining_slots=$((slots_per_shard - current_slots))
   if [ "$remaining_slots" -le 0 ]; then
-    if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
+    if ensure_scale_out_cluster_stable_or_defer "$primary_node_with_port"; then
       echo "Redis cluster scale out shard already owns $current_slots slots and cluster is stable"
       return 0
     fi
-    fix_unstable_cluster_and_defer "$primary_node_with_port" || return 1
-  fi
-
-  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$remaining_slots"; then
-    echo "Redis cluster scale out shard reshard successfully"
-  else
-    echo "Failed to scale out shard reshard" >&2
     return 1
   fi
 
-  check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"
+  batch_size=${REDIS_CLUSTER_RESHARD_BATCH_SIZE:-128}
+  if ! [[ "$batch_size" =~ ^[1-9][0-9]*$ ]]; then
+    context=$(printf '  batch_size: %s\n  current_slots: %s\n  target_slots: %s\n  remaining_slots: %s' \
+      "$batch_size" "$current_slots" "$slots_per_shard" "$remaining_slots")
+    scale_out_diagnose_not_ready "invalid-reshard-batch-size" "$context" "no"
+    return 1
+  fi
+  batch_slots=$remaining_slots
+  if [ "$batch_slots" -gt "$batch_size" ]; then
+    batch_slots=$batch_size
+  fi
+
+  if ! scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$batch_slots"; then
+    echo "Failed to scale out shard reshard" >&2
+    context=$(printf '  batch_slots: %s\n  current_slots: %s\n  target_slots: %s\n  remaining_slots: %s' \
+      "$batch_slots" "$current_slots" "$slots_per_shard" "$remaining_slots")
+    scale_out_diagnose_not_ready "reshard-command-failed" "$context" "no"
+    return 1
+  fi
+
+  ensure_scale_out_cluster_stable_or_defer "$primary_node_with_port" || return 1
+  current_slots=$(count_node_slots "$primary_node_fqdn" "$primary_node_port" "$mapping_primary_cluster_id")
+  status=$?
+  if [ $status -ne 0 ] || ! [[ "$current_slots" =~ ^[0-9]+$ ]]; then
+    context=$(printf '  batch_slots: %s\n  current_slots: %s\n  target_slots: %s' \
+      "$batch_slots" "$current_slots" "$slots_per_shard")
+    scale_out_diagnose_not_ready "post-reshard-slot-count-failed" "$context" "no"
+    return 1
+  fi
+
+  remaining_slots=$((slots_per_shard - current_slots))
+  if [ "$remaining_slots" -le 0 ]; then
+    echo "Redis cluster scale out shard owns $current_slots slots and cluster is stable"
+    return 0
+  fi
+
+  context=$(printf '  batch_slots: %s\n  current_slots: %s\n  target_slots: %s\n  remaining_slots: %s' \
+    "$batch_slots" "$current_slots" "$slots_per_shard" "$remaining_slots")
+  scale_out_diagnose_not_ready "reshard-progress" "$context" "yes"
+  return 1
 }
 
 sync_acl_for_redis_cluster_shard() {

--- a/addons/redis/scripts-ut-spec/fixtures/redis_cluster_scaleout_batch_fixture.sh
+++ b/addons/redis/scripts-ut-spec/fixtures/redis_cluster_scaleout_batch_fixture.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+script=$1
+family=$2
+scenario=$3
+
+# shellcheck source=/dev/null
+source "$script"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+count_file="$tmp_dir/count"
+fix_file="$tmp_dir/fix"
+mutation_file="$tmp_dir/mutation"
+printf '0\n' >"$count_file"
+printf '0\n' >"$fix_file"
+printf '0\n' >"$mutation_file"
+
+ut_mode=true
+network_mode=default
+CURRENT_SHARD_COMPONENT_SHORT_NAME=shard-new
+CURRENT_SHARD_COMPONENT_NAME=redis-shard-new
+CURRENT_SHARD_POD_NAME_LIST=redis-shard-new-0,redis-shard-new-1
+KB_CLUSTER_POD_NAME_LIST=redis-shard-a-0,redis-shard-a-1,redis-shard-b-0,redis-shard-b-1,redis-shard-c-0,redis-shard-c-1,redis-shard-new-0,redis-shard-new-1
+KB_CLUSTER_POD_FQDN_LIST=$KB_CLUSTER_POD_NAME_LIST
+KB_CLUSTER_COMPONENT_LIST=shard-a,shard-b,shard-c,shard-new
+SERVICE_PORT=6379
+REDIS_CLUSTER_RESHARD_BATCH_SIZE=128
+[[ $scenario == invalid-batch ]] && REDIS_CLUSTER_RESHARD_BATCH_SIZE=0
+
+is_empty() { [[ -z $1 ]]; }
+sleep_when_ut_mode_false() { :; }
+
+init_other_components_and_pods_info() {
+  other_component_nodes=(10.42.0.10:6379)
+  other_components=(shard-a shard-b shard-c)
+  other_component_pod_names=(redis-shard-a-0)
+}
+
+init_current_comp_default_nodes_for_scale_out() {
+  declare -gA scale_out_shard_default_primary_node
+  declare -gA scale_out_shard_default_other_nodes
+  scale_out_shard_default_primary_node=([redis-shard-new-0]=10.42.0.20:6379)
+  scale_out_shard_default_other_nodes=()
+}
+
+get_cluster_id() { printf 'new-primary-id\n'; }
+check_current_shard_other_nodes_are_joined() { return 0; }
+check_node_in_cluster() { return 0; }
+find_exist_available_node() { printf '10.42.0.10:6379\n'; }
+scale_out_shard_primary_join_cluster() { return 0; }
+secondary_replicated_to_primary() { return 0; }
+
+inspect_redis_cluster_check() {
+  case $scenario in
+    views)
+      redis_cluster_check_state=views-disagreement
+      redis_cluster_check_output='[ERR] Nodes do not agree about configuration! All 16384 slots covered.'
+      redis_cluster_check_rc=1
+      ;;
+    probe-error)
+      redis_cluster_check_state=probe-error
+      redis_cluster_check_output='Could not connect to Redis'
+      redis_cluster_check_rc=1
+      ;;
+    open|repair-failure)
+      redis_cluster_check_state=open-or-uncovered
+      redis_cluster_check_output='[WARNING] The following slots are open: 12043. Not all 16384 slots are covered by nodes.'
+      redis_cluster_check_rc=1
+      ;;
+    *)
+      redis_cluster_check_state=stable
+      redis_cluster_check_output='[OK] All 16384 slots covered.'
+      redis_cluster_check_rc=0
+      ;;
+  esac
+  return 0
+}
+
+fix_cluster_slots() {
+  local count
+  count=$(cat "$fix_file")
+  printf '%s\n' "$((count + 1))" >"$fix_file"
+  [[ $scenario == repair-failure ]] && return 1
+  return 0
+}
+
+count_node_slots() {
+  local count value
+  count=$(cat "$count_file")
+  printf '%s\n' "$((count + 1))" >"$count_file"
+  case $scenario in
+    large) [[ $count -eq 0 ]] && value=0 || value=128 ;;
+    reentry) [[ $count -eq 0 ]] && value=128 || value=256 ;;
+    final) [[ $count -eq 0 ]] && value=4000 || value=4096 ;;
+    post-count-error)
+      if [[ $count -eq 0 ]]; then
+        value=0
+      else
+        printf 'count failed\n' >&2
+        return 1
+      fi
+      ;;
+    *) value=0 ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+scale_out_shard_reshard() {
+  local count
+  count=$(cat "$mutation_file")
+  printf '%s\n' "$((count + 1))" >"$mutation_file"
+  printf 'reshard_slots=%s\n' "$3"
+  [[ $scenario == mutation-failure ]] && return 1
+  return 0
+}
+
+set +e
+output=$(scale_out_redis_cluster_shard 2>&1)
+status=$?
+set -e
+
+printf 'family=%s scenario=%s status=%s mutation=%s fix=%s\n' \
+  "$family" "$scenario" "$status" "$(cat "$mutation_file")" "$(cat "$fix_file")"
+printf '%s\n' "$output"

--- a/addons/redis/scripts-ut-spec/redis_cluster6_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster6_manage_spec.sh
@@ -21,6 +21,18 @@ Describe "Redis Cluster6 Manage Script Tests"
   }
   BeforeAll "init"
 
+  inspect_redis_cluster_check() {
+    if check_slots_covered "$1" "$2"; then
+      redis_cluster_check_state="stable"
+      redis_cluster_check_output="[OK] All 16384 slots covered."
+      redis_cluster_check_rc=0
+    else
+      redis_cluster_check_state="probe-error"
+      redis_cluster_check_output="mocked cluster check failure"
+      redis_cluster_check_rc=1
+    fi
+  }
+
   cleanup() {
     rm -f $common_library_file
   }

--- a/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_common_spec.sh
@@ -139,6 +139,24 @@ Describe "Redis Cluster Common Bash Script Tests"
     End
   End
 
+  Describe "classify_redis_cluster_check_output()"
+    Parameters
+      "stable"             "0"  "[OK] All 16384 slots covered."
+      "views-disagreement" "1"  "[ERR] Nodes don't agree about configuration! All 16384 slots covered."
+      "open-or-uncovered"  "1"  "[WARNING] The following slots are open: 12043. Not all 16384 slots are covered by nodes."
+      "open-or-uncovered"  "1"  "node has slots in migrating state. All 16384 slots covered."
+      "open-or-uncovered"  "1"  "[ERR] Nodes don't agree about configuration! [WARNING] The following slots are open: 12043. All 16384 slots covered."
+      "probe-error"        "1"  "Could not connect to Redis at redis-0:6379"
+      "probe-error"        "1"  "[ERR] Unknown cluster check failure. All 16384 slots covered."
+    End
+
+    It "classifies $1 without treating every rc1 as repairable"
+      When call classify_redis_cluster_check_output "$2" "$3"
+      The status should be success
+      The output should eq "$1"
+    End
+  End
+
   Describe "fix_cluster_slots()"
     setup() {
       export REDIS_DEFAULT_PASSWORD=""

--- a/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
@@ -77,6 +77,8 @@ Describe "Redis Cluster lifecycle action contract"
       abort "expected four Redis Cluster postProvision actions, got #{post_provision.length}" unless post_provision.length == 4
       post_timeouts = post_provision.map { |action| action.fetch("timeoutSeconds") }
       abort "postProvision timeoutSeconds must all be 50, got #{post_timeouts.inspect}" unless post_timeouts == [50, 50, 50, 50]
+      post_retries = post_provision.map { |action| action.dig("retryPolicy", "maxRetries") }
+      abort "postProvision maxRetries must cover the 32-batch worst-case scale-out, got #{post_retries.inspect}" unless post_retries == [64, 64, 64, 64]
 
       sharding = documents.select { |document| document["kind"] == "ShardingDefinition" }
       abort "expected one ShardingDefinition, got #{sharding.length}" unless sharding.length == 1

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -26,6 +26,18 @@ Describe "Redis Cluster Manage Bash Script Tests"
   }
   BeforeAll "init"
 
+  inspect_redis_cluster_check() {
+    if check_slots_covered "$1" "$2"; then
+      redis_cluster_check_state="stable"
+      redis_cluster_check_output="[OK] All 16384 slots covered."
+      redis_cluster_check_rc=0
+    else
+      redis_cluster_check_state="probe-error"
+      redis_cluster_check_output="mocked cluster check failure"
+      redis_cluster_check_rc=1
+    fi
+  }
+
   cleanup() {
     rm -f $common_library_file;
   }
@@ -1191,6 +1203,12 @@ Describe "Redis Cluster Manage Bash Script Tests"
 
       check_slots_covered() {
         return 1
+      }
+
+      inspect_redis_cluster_check() {
+        redis_cluster_check_state="stable"
+        redis_cluster_check_output="[OK] All 16384 slots covered."
+        redis_cluster_check_rc=0
       }
 
       fix_unstable_cluster_and_defer() {

--- a/addons/redis/scripts-ut-spec/redis_cluster_scaleout_batch_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_scaleout_batch_contract_spec.sh
@@ -1,0 +1,103 @@
+# shellcheck shell=bash
+
+if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
+  echo "redis_cluster_scaleout_batch_contract_spec.sh skip cases because dependency bash version 4 or higher is not installed."
+  exit 0
+fi
+
+Describe "Redis Cluster scale-out bounded batch contract"
+  contract_fixture=./fixtures/redis_cluster_scaleout_batch_fixture.sh
+
+  Parameters
+    "redis5"   "../redis-cluster-scripts/redis-cluster-manage.sh"
+    "redis6+"  "../redis-cluster-scripts/redis-cluster6-manage.sh"
+  End
+
+  It "moves only one bounded batch for a new shard on ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" large
+    The status should be success
+    The stdout should include "family=$1 scenario=large status=1 mutation=1 fix=0"
+    The stdout should include "reshard_slots=128"
+    The stdout should include "action: scale_out_redis_cluster_shard"
+    The stdout should include "phase: reshard-progress"
+    The stdout should include "current_slots: 128"
+    The stdout should include "target_slots: 4096"
+    The stdout should include "next-retry-safe: yes"
+    The stdout should not include "reshard_slots=4096"
+  End
+
+  It "recomputes progress on every invocation for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" reentry
+    The status should be success
+    The stdout should include "family=$1 scenario=reentry status=1 mutation=1 fix=0"
+    The stdout should include "reshard_slots=128"
+    The stdout should include "current_slots: 256"
+    The stdout should include "remaining_slots: 3840"
+  End
+
+  It "moves the exact final remainder and positively closes for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" final
+    The status should be success
+    The stdout should include "family=$1 scenario=final status=0 mutation=1 fix=0"
+    The stdout should include "reshard_slots=96"
+    The stdout should include "Redis cluster scale out shard owns 4096 slots and cluster is stable"
+  End
+
+  It "defers full-coverage view disagreement without mutation or fix on ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" views
+    The status should be success
+    The stdout should include "family=$1 scenario=views status=1 mutation=0 fix=0"
+    The stdout should include "phase: cluster-views-not-converged"
+    The stdout should include "next-retry-safe: yes"
+  End
+
+  It "fails closed on an unknown cluster-check failure for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" probe-error
+    The status should be success
+    The stdout should include "family=$1 scenario=probe-error status=1 mutation=0 fix=0"
+    The stdout should include "phase: cluster-check-failed"
+    The stdout should include "next-retry-safe: no"
+  End
+
+  It "keeps the existing open-slot repair-and-defer behavior for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" open
+    The status should be success
+    The stdout should include "family=$1 scenario=open status=1 mutation=0 fix=1"
+    The stdout should include "phase: cluster-slots-repair-applied"
+    The stdout should include "next-retry-safe: yes"
+  End
+
+  It "fails closed when the batch size is invalid for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" invalid-batch
+    The status should be success
+    The stdout should include "family=$1 scenario=invalid-batch status=1 mutation=0 fix=0"
+    The stdout should include "phase: invalid-reshard-batch-size"
+    The stdout should include "batch_size: 0"
+    The stdout should include "next-retry-safe: no"
+  End
+
+  It "fails closed when the bounded reshard command is rejected for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" mutation-failure
+    The status should be success
+    The stdout should include "family=$1 scenario=mutation-failure status=1 mutation=1 fix=0"
+    The stdout should include "phase: reshard-command-failed"
+    The stdout should include "batch_slots: 128"
+    The stdout should include "next-retry-safe: no"
+  End
+
+  It "fails closed when the post-reshard slot count cannot be observed for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" post-count-error
+    The status should be success
+    The stdout should include "family=$1 scenario=post-count-error status=1 mutation=1 fix=0"
+    The stdout should include "phase: post-reshard-slot-count-failed"
+    The stdout should include "next-retry-safe: no"
+  End
+
+  It "surfaces an unsuccessful open-slot repair as operator attention for ${1}"
+    When run "$SHELLSPEC_SHELL" "$contract_fixture" "$2" "$1" repair-failure
+    The status should be success
+    The stdout should include "family=$1 scenario=repair-failure status=1 mutation=0 fix=1"
+    The stdout should include "phase: cluster-slots-repair-failed"
+    The stdout should include "next-retry-safe: no"
+  End
+End

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -503,7 +503,7 @@ spec:
                 fieldPath: status.hostIP
       preCondition: RuntimeReady
       retryPolicy:
-        maxRetries: 10
+        maxRetries: 64
     memberLeave:
       exec:
         container: redis-cluster


### PR DESCRIPTION
## 问题

Redis Cluster 从 3 个 shard 扩到 4 个 shard 时，新 shard 需要接收 4096 个 slots。现有 postProvision 在一次 50 秒生命周期调用里执行完整 4096-slot reshard，没有把工作拆成可重入步骤。

现场中，拓扑已经出现 8 个 Pod、4 master + 4 replica、16384 slots 全覆盖，但连续 420 秒、29 次 `redis-cli --cluster check` 都返回 rc=1：`Nodes don't agree about configuration`。slots 12043/12044 在 8 个 Pod 的视图中是 7:1 owner 分裂，Component 一直停在 Creating/postProvision。现场包已归档；初始调用日志已轮转，因此不把它写成“已直接证明恰好 50 秒超时”。

## 修改

- 每次 postProvision 最多移动 128 个 slots；每次调用从 live cluster 重新计算当前 slots 和剩余量，最后一批只移动实际 remainder。
- 只有目标 slots 达成且 cluster check 正向稳定才 rc=0；中间进度输出 retry-safe diagnosis 并 rc=1，让下一次调用继续。
- 把 cluster-check 结果分为 stable、全覆盖但视图不一致、open/uncovered、probe error：
  - 全覆盖但视图不一致只等待传播，不运行 `--cluster fix`；
  - open/uncovered 保留已有 repair-and-defer；
  - 未知 probe/mutation/count 失败 fail closed。
- Redis 5 与 Redis 6+ 两条脚本保持同一行为。
- postProvision `maxRetries` 从 10 提到 64：128 slots/batch 的 3→4 最坏需要 32 个批次，原 10 次预算无法覆盖正向收敛。
- Chart 版本推进到 `1.2.0-alpha.6`，避免复用不可变 definition 名称。

## 测试

TDD 证据：
- 新共享矩阵在实现前 RED：18/18 failures；retry-budget 渲染合同 RED 显示四个版本都是 `[10, 10, 10, 10]`。
- Redis 5 / Redis 6+ 共享 batch contract 覆盖大批次、重入、最终 remainder、视图分裂、open repair、probe/mutation/count 失败和非法 batch。
- 完整 Redis ShellSpec：579 examples, 0 failures（bash 5.3.9）。
- `bash -n`、ShellCheck error severity、`git diff --check`：PASS。
- `helm lint addons/redis`：1 chart, 0 failed。
- Helm render：Redis 5/6/7/8 ComponentDefinition 均为 timeout 50s、maxRetries 64，chart/sharding definition 为 `1.2.0-alpha.6`。

## 当前边界

- 这是 stacked draft PR，base 是 PR #3218 exact head `8f1a9cb5`；必须按父 PR 顺序合并。
- GitHub CI 尚未终态。
- 当前 exact head `caf53d84` 还没有 runtime PASS；旧 alpha5 现场只证明修复前 first-red，不能外推为本 PR PASS。
- runtime gate 将由 Redis 测试 owner 使用 exact head 做 fresh Redis 5 3→4 data-bearing scale-out，并验证所有节点视图稳定、Component/Cluster 收敛、数据/认证健康与清理。

