### PR TITLE
fix(milvus): report recovery helper command failures

### DIFF
--- a/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
+++ b/addons/milvus/scripts-ut-spec/recover_embedded_minio_credential_spec.sh
@@ -60,6 +60,9 @@ case "${1:-} ${2:-}" in
   "delete pod")
     touch "${FAKE_STATE_DIR}/deleted"
     printf '%s\n' 'pod "demo-minio-0" deleted'
+    if [[ -n "${FAKE_DELETE_RC:-}" ]]; then
+      exit "${FAKE_DELETE_RC}"
+    fi
     ;;
   "get opsrequest")
     output="${*: -1}"
@@ -136,6 +139,10 @@ EOF
 
   run_aborted_after_replacement() {
     FAKE_FINAL_OPS_PHASE=Aborted run_recovery
+  }
+
+  run_delete_nonzero_after_success_output() {
+    FAKE_DELETE_RC=1 run_recovery
   }
 
   It "replaces only the stale failed MinIO Pod after the desired alpha.1 contract is visible"
@@ -220,6 +227,16 @@ EOF
     The output should include "replacement-pod=demo-minio-0,uid-new,Ready"
     The stderr should include "OpsRequest reached Aborted"
     The stderr should not include "recovery did not converge"
+    The contents of file "${calls_file}" should include "delete pod demo-minio-0 --wait=false"
+  End
+
+  It "reports the phase and rc when a bare delete command exits nonzero without stderr"
+    When call run_delete_nonzero_after_success_output
+    The status should be failure
+    The output should include 'pod "demo-minio-0" deleted'
+    The output should not include "replacement-pod="
+    The stderr should include "unexpected-command-failure phase=replace-stale-pod rc=1"
+    The stderr should include "command="
     The contents of file "${calls_file}" should include "delete pod demo-minio-0 --wait=false"
   End
 End

--- a/addons/milvus/scripts/recover-embedded-minio-credential.sh
+++ b/addons/milvus/scripts/recover-embedded-minio-credential.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -Eeuo pipefail
 
 TARGET_MINIO_DEF="milvus-minio-1.2.0-alpha.1"
 TARGET_MILVUS_DEF="milvus-standalone-1.2.0-alpha.1"
@@ -10,6 +10,20 @@ KUBECTL="${KUBECTL:-kubectl}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-3}"
 DESIRED_TIMEOUT_SECONDS="${DESIRED_TIMEOUT_SECONDS:-900}"
 READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-600}"
+phase="bootstrap"
+
+unexpected_error() {
+  local rc=$?
+  local line="${BASH_LINENO[0]:-${LINENO}}"
+  local command="${BASH_COMMAND:-unknown}"
+
+  trap - ERR
+  printf 'ERROR: unexpected-command-failure phase=%s rc=%s line=%s command=%q\n' \
+    "${phase}" "${rc}" "${line}" "${command}" >&2
+  exit "${rc}"
+}
+
+trap unexpected_error ERR
 
 usage() {
   cat >&2 <<'EOF'
@@ -211,9 +225,12 @@ wait_for_operation_and_cluster() {
   fail "recovery did not converge within ${READY_TIMEOUT_SECONDS}s; first=${first}; last=${last}"
 }
 
+phase="validate-migration-contract"
 validate_migration_contract
+phase="wait-desired-contract"
 wait_for_desired_contract
 
+phase="inspect-minio-pod"
 pod=$(one_minio_pod)
 old_uid=$(pod_uid "${pod}")
 definition=$(pod_definition "${pod}")
@@ -222,6 +239,7 @@ if [[ "${definition}" == "${TARGET_MINIO_DEF}" ]]; then
   printf 'replacement=not-needed,pod=%s,uid=%s\n' "${pod}" "${old_uid}"
   require_new_uid=false
 else
+  phase="replace-stale-pod"
   [[ "${definition}" == "${AFFECTED_MINIO_DEF}" ]] ||
     fail "refusing to replace Pod with unsupported definition: ${definition:-missing}"
   owner=$(pod_controller_owner "${pod}")
@@ -232,5 +250,7 @@ else
   require_new_uid=true
 fi
 
+phase="wait-replacement"
 wait_for_replacement "${old_uid}" "${require_new_uid}"
+phase="wait-operation-and-cluster"
 wait_for_operation_and_cluster


### PR DESCRIPTION
## Why

An affected Milvus alpha.0 -> alpha.1 recovery run on exact `main` commit `80dfb2bc16bb3aabe13ed8d77d6e1d9f566d05ef` exercised a normal KubeBlocks controller Pod restart, then the shipped recovery helper returned `rc=1` after 12 seconds with an empty stderr. Its stdout ended after the stale MinIO Pod delete; the test harness was independently verified to persist the child Bash rc without timeout, traps, pipelines, or rewriting. The scene later converged, so this does **not** claim a KubeBlocks or MinIO functional defect. The exact command that returned nonzero remains unbound because bare `set -e` exits had no diagnostic.

The addon troubleshooting contract in `kubeblocks-addon-docs/docs/addon-api/11-troubleshooting.md` treats stdout/stderr and exit code as the evidence boundary for scripts. A shipped helper must not return an unattributable nonzero status.

## What changes

- inherit `ERR` into recovery helper functions with `set -E`;
- emit a fail-closed stderr record with stable phase, source line, original rc, and failing command for unexpected command failures;
- label the helper's validation, desired-state wait, Pod inspection/replacement, and terminal wait phases;
- add a deterministic ShellSpec regression where fake `kubectl delete pod` prints the normal success line and then exits 1 with no stderr.

The patch changes diagnostics only. It does not treat the earlier run as PASS, does not weaken `set -euo pipefail`, and does not retry or hide a failed mutation.

## Candidate pin and PR audit

- target branch/head: `main` / `80dfb2bc16bb3aabe13ed8d77d6e1d9f566d05ef`
- patch commit: `7d24f7c0`
- relevant merged baseline: #3194
- open Milvus PR #3180 is omitted because its credential-generation scope was superseded by #3194; other open PRs by `weicao` target unrelated addons.

## Tests

- RED first: new regression failed because stderr was empty.
- focused ShellSpec, Bash 3.2.57: `11 examples, 0 failures`.
- all Milvus ShellSpec after chart dependency build, Bash 3.2.57: `13 examples, 0 failures`.
- `bash -n`: PASS.
- ShellCheck warning-or-higher: 0.
- `git diff --check`: PASS.
