### PR TITLE
feat(mysql): classify removed 8.4 parameters

### DIFF
--- a/addons/mysql/scripts-ut-spec/update_parameter_result_policy_spec.sh
+++ b/addons/mysql/scripts-ut-spec/update_parameter_result_policy_spec.sh
@@ -1,0 +1,30 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "MySQL update-parameter result policy"
+  render_reconfigure_policy_summary() {
+    local work_dir rendered
+    work_dir=$(mktemp -d)
+    rendered="${work_dir}/rendered.yaml"
+
+    cp -R .. "${work_dir}/mysql"
+    cp -R ../../kblib "${work_dir}/kblib"
+    helm dependency build "${work_dir}/mysql" >/dev/null
+    helm template mysql "${work_dir}/mysql" > "${rendered}"
+
+    printf 'reconfigure=%s exit64=%s invalid=%s no_retry=%s exit1=%s\n' \
+      "$(grep -c '^      reconfigure:$' "${rendered}")" \
+      "$(grep -c '^[[:space:]]*- execExitCode: 64$' "${rendered}")" \
+      "$(grep -c '^[[:space:]]*code: InvalidParameter$' "${rendered}")" \
+      "$(grep -c '^[[:space:]]*retry: false$' "${rendered}")" \
+      "$(grep -c '^[[:space:]]*- execExitCode: 1$' "${rendered}" || true)"
+
+    rm -rf "${work_dir}"
+  }
+
+  It "renders one dedicated non-retryable InvalidParameter mapping per reconfigure action"
+    When call render_reconfigure_policy_summary
+    The status should be success
+    The output should equal "reconfigure=7 exit64=7 invalid=7 no_retry=7 exit1=0"
+  End
+End

--- a/addons/mysql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/mysql/scripts-ut-spec/update_parameter_spec.sh
@@ -114,4 +114,49 @@ Describe "MySQL update-parameter Script Tests"
       The stderr should include "Failed to set parameter"
     End
   End
+
+  Describe "MySQL 8.4 removed-variable rejection"
+    # mysql mock that answers SELECT VERSION() with the configured version and
+    # records / succeeds any SET GLOBAL. The tail argument is the SQL query.
+    mock_mysql_version() {
+      local version="$1"; shift
+      local q; eval "q=\"\${$#}\""
+      case "$q" in
+        *VERSION*) printf '%s\n' "$version" ;;
+        *) printf '%s' "$q" > "${MOCK_QUERY_FILE}"; return 0 ;;
+      esac
+    }
+
+    It "rejects a removed variable on MySQL 8.4 before SET GLOBAL"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh expire_logs_days 1
+      The status should be failure
+      The stderr should include "removed in MySQL 8.4"
+      # SET GLOBAL must not have been attempted for the removed variable.
+      The contents of file "${MOCK_QUERY_FILE}" should not include "SET GLOBAL expire_logs_days"
+    End
+
+    It "rejects another removed variable (master_info_repository) on 8.4"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh master_info_repository TABLE
+      The status should be failure
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "accepts a non-removed variable on MySQL 8.4"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh max_connections 500
+      The status should be success
+      The stdout should include "Set parameter max_connections"
+      The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL max_connections = 500;"
+    End
+
+    It "does not reject the removed name on MySQL 8.0 (still a legal 8.0 variable)"
+      mysql() { mock_mysql_version "8.0.33" "$@"; }
+      When run source ../scripts/update-parameter.sh expire_logs_days 1
+      The status should be success
+      The stdout should include "Set parameter expire_logs_days"
+      The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL expire_logs_days = 1;"
+    End
+  End
 End

--- a/addons/mysql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/mysql/scripts-ut-spec/update_parameter_spec.sh
@@ -1,0 +1,117 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+Describe "MySQL update-parameter Script Tests"
+
+  setup() {
+    MYSQL_ADMIN_USER="kbadmin"
+    MYSQL_ADMIN_PASSWORD="secret"
+    MOCK_QUERY_FILE=$(mktemp)
+  }
+  cleanup() {
+    rm -f "${MOCK_QUERY_FILE}"
+  }
+  BeforeEach "setup"
+  AfterEach "cleanup"
+
+  Describe "success path"
+    mysql() {
+      # last argument is the query
+      eval "printf '%s' \"\${$#}\"" > "${MOCK_QUERY_FILE}"
+      return 0
+    }
+
+    It "applies a plain numeric value and reports success"
+      When run source ../scripts/update-parameter.sh max_connections 500
+      The status should be success
+      The stdout should include "Set parameter max_connections to value 500"
+      The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL max_connections = 500;"
+    End
+
+    It "converts size suffixes to bytes"
+      When run source ../scripts/update-parameter.sh innodb_buffer_pool_size 128M
+      The status should be success
+      The stdout should include "Set parameter"
+      The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL innodb_buffer_pool_size = 134217728;"
+    End
+
+    It "quotes non-numeric values"
+      When run source ../scripts/update-parameter.sh sql_mode NO_ENGINE_SUBSTITUTION
+      The status should be success
+      The stdout should include "Set parameter"
+      The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';"
+    End
+
+    It "normalizes dashes to underscores"
+      When run source ../scripts/update-parameter.sh max-connections 500
+      The status should be success
+      The stdout should include "Set parameter max_connections"
+      The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL max_connections = 500;"
+    End
+  End
+
+  Describe "tolerated cannot-apply-online errors"
+    It "tolerates ERROR 1238 (read-only variable) and says it applies after restart"
+      mysql() {
+        echo "ERROR 1238 (HY000) at line 1: Variable 'gtid_mode' is a read-only variable" >&2
+        return 1
+      }
+      When run source ../scripts/update-parameter.sh gtid_mode ON
+      The status should be success
+      The stdout should include "read-only"
+      The stdout should include "after the next restart"
+    End
+
+    It "tolerates ERROR 1193 for loose_-prefixed parameters (plugin not loaded)"
+      mysql() {
+        echo "ERROR 1193 (HY000): Unknown system variable 'audit_log_policy'" >&2
+        return 1
+      }
+      When run source ../scripts/update-parameter.sh loose_audit_log_policy ALL
+      The status should be success
+      The stdout should include "skipped"
+    End
+  End
+
+  Describe "real errors fail the action"
+    It "fails on ERROR 1193 for a parameter without the loose_ prefix"
+      mysql() {
+        echo "ERROR 1193 (HY000): Unknown system variable 'no_such_variable'" >&2
+        return 1
+      }
+      When run source ../scripts/update-parameter.sh no_such_variable 1
+      The status should be failure
+      The stderr should include "Failed to set parameter no_such_variable"
+    End
+
+    It "fails on ERROR 1231 (wrong value)"
+      mysql() {
+        echo "ERROR 1231 (42000): Variable 'innodb_flush_log_at_trx_commit' can't be set to the value of '9'" >&2
+        return 1
+      }
+      When run source ../scripts/update-parameter.sh innodb_flush_log_at_trx_commit 9
+      The status should be failure
+      The stderr should include "Failed to set parameter"
+    End
+
+    It "fails on authentication error (ERROR 1045)"
+      mysql() {
+        echo "ERROR 1045 (28000): Access denied for user 'kbadmin'@'localhost'" >&2
+        return 1
+      }
+      When run source ../scripts/update-parameter.sh max_connections 500
+      The status should be failure
+      The stderr should include "Failed to set parameter"
+    End
+
+    It "fails when the server is unreachable"
+      mysql() {
+        echo "ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1:3306'" >&2
+        return 1
+      }
+      When run source ../scripts/update-parameter.sh max_connections 500
+      The status should be failure
+      The stderr should include "Failed to set parameter"
+    End
+  End
+End

--- a/addons/mysql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/mysql/scripts-ut-spec/update_parameter_spec.sh
@@ -80,7 +80,7 @@ Describe "MySQL update-parameter Script Tests"
         return 1
       }
       When run source ../scripts/update-parameter.sh no_such_variable 1
-      The status should be failure
+      The status should equal 1
       The stderr should include "Failed to set parameter no_such_variable"
     End
 
@@ -90,7 +90,7 @@ Describe "MySQL update-parameter Script Tests"
         return 1
       }
       When run source ../scripts/update-parameter.sh innodb_flush_log_at_trx_commit 9
-      The status should be failure
+      The status should equal 1
       The stderr should include "Failed to set parameter"
     End
 
@@ -100,7 +100,7 @@ Describe "MySQL update-parameter Script Tests"
         return 1
       }
       When run source ../scripts/update-parameter.sh max_connections 500
-      The status should be failure
+      The status should equal 1
       The stderr should include "Failed to set parameter"
     End
 
@@ -110,7 +110,7 @@ Describe "MySQL update-parameter Script Tests"
         return 1
       }
       When run source ../scripts/update-parameter.sh max_connections 500
-      The status should be failure
+      The status should equal 1
       The stderr should include "Failed to set parameter"
     End
   End
@@ -127,19 +127,61 @@ Describe "MySQL update-parameter Script Tests"
       esac
     }
 
-    It "rejects a removed variable on MySQL 8.4 before SET GLOBAL"
+    It "rejects expire_logs_days with the dedicated exit code before SET GLOBAL"
       mysql() { mock_mysql_version "8.4.8" "$@"; }
       When run source ../scripts/update-parameter.sh expire_logs_days 1
-      The status should be failure
+      The status should equal 64
       The stderr should include "removed in MySQL 8.4"
       # SET GLOBAL must not have been attempted for the removed variable.
       The contents of file "${MOCK_QUERY_FILE}" should not include "SET GLOBAL expire_logs_days"
     End
 
-    It "rejects another removed variable (master_info_repository) on 8.4"
+    It "rejects default_authentication_plugin with the dedicated exit code"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh default_authentication_plugin mysql_native_password
+      The status should equal 64
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "rejects binlog_transaction_dependency_tracking with the dedicated exit code"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh binlog_transaction_dependency_tracking WRITESET
+      The status should equal 64
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "rejects transaction_write_set_extraction with the dedicated exit code"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh transaction_write_set_extraction XXHASH64
+      The status should equal 64
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "rejects slave_rows_search_algorithms with the dedicated exit code"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh slave_rows_search_algorithms INDEX_SCAN,HASH_SCAN
+      The status should equal 64
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "rejects master_info_repository with the dedicated exit code"
       mysql() { mock_mysql_version "8.4.8" "$@"; }
       When run source ../scripts/update-parameter.sh master_info_repository TABLE
-      The status should be failure
+      The status should equal 64
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "rejects relay_log_info_repository with the dedicated exit code"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh relay_log_info_repository TABLE
+      The status should equal 64
+      The stderr should include "removed in MySQL 8.4"
+    End
+
+    It "rejects log_bin_use_v1_row_events with the dedicated exit code"
+      mysql() { mock_mysql_version "8.4.8" "$@"; }
+      When run source ../scripts/update-parameter.sh log_bin_use_v1_row_events ON
+      The status should equal 64
       The stderr should include "removed in MySQL 8.4"
     End
 
@@ -151,12 +193,38 @@ Describe "MySQL update-parameter Script Tests"
       The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL max_connections = 500;"
     End
 
+    It "keeps an unlisted unknown variable on the generic exit-code path on MySQL 8.4"
+      mysql() {
+        local q; eval "q=\"\${$#}\""
+        case "$q" in
+          *VERSION*) printf '%s\n' "8.4.8" ;;
+          *) echo "ERROR 1193 (HY000): Unknown system variable 'no_such_variable'" >&2; return 1 ;;
+        esac
+      }
+      When run source ../scripts/update-parameter.sh no_such_variable 1
+      The status should equal 1
+      The stderr should include "Failed to set parameter no_such_variable"
+    End
+
     It "does not reject the removed name on MySQL 8.0 (still a legal 8.0 variable)"
       mysql() { mock_mysql_version "8.0.33" "$@"; }
       When run source ../scripts/update-parameter.sh expire_logs_days 1
       The status should be success
       The stdout should include "Set parameter expire_logs_days"
       The contents of file "${MOCK_QUERY_FILE}" should equal "SET GLOBAL expire_logs_days = 1;"
+    End
+
+    It "keeps a version-probe failure on the generic exit-code path"
+      mysql() {
+        local q; eval "q=\"\${$#}\""
+        case "$q" in
+          *VERSION*) return 1 ;;
+          *) echo "ERROR 1193 (HY000): Unknown system variable 'expire_logs_days'" >&2; return 1 ;;
+        esac
+      }
+      When run source ../scripts/update-parameter.sh expire_logs_days 1
+      The status should equal 1
+      The stderr should include "Failed to set parameter expire_logs_days"
     End
   End
 End

--- a/addons/mysql/scripts/update-parameter.sh
+++ b/addons/mysql/scripts/update-parameter.sh
@@ -17,11 +17,16 @@ if echo "${paramName}" | grep -q "^loose_"; then
 fi
 paramName=$(echo "${paramName}" | tr '-' '_')
 
-# MySQL 8.4 removed several system variables. Reject a reconfigure of any of
-# them BEFORE the SET GLOBAL / config write, so it fails explicitly with a
-# clear reason instead of silently landing in my.cnf and crash-looping the
-# instance on the next restart. The SET GLOBAL unknown-variable error below is
-# a backstop; this by-name check makes the rejection deterministic and visible.
+# This list is the sole authority for the dedicated InvalidParameter exit code.
+# MySQL documents every member in its 8.4 removed-features table:
+# https://dev.mysql.com/doc/refman/8.4/en/added-deprecated-removed.html
+# expire_logs_days was removed in 8.2; transaction_write_set_extraction,
+# slave_rows_search_algorithms, master_info_repository,
+# relay_log_info_repository, and log_bin_use_v1_row_events in 8.3; and
+# default_authentication_plugin and binlog_transaction_dependency_tracking in
+# 8.4. Changing the list changes the result-policy contract and requires a
+# dedicated rejection test for every added or removed member.
+readonly INVALID_PARAMETER_EXIT_CODE=64
 mysql_84_removed_vars="expire_logs_days default_authentication_plugin binlog_transaction_dependency_tracking transaction_write_set_extraction slave_rows_search_algorithms master_info_repository relay_log_info_repository log_bin_use_v1_row_events"
 server_version=$(mysql_exec "SELECT VERSION();" 2>/dev/null | head -n1)
 server_major=$(echo "${server_version}" | cut -d. -f1)
@@ -31,7 +36,7 @@ if [[ "${server_major}" =~ ^[0-9]+$ ]] && [[ "${server_minor}" =~ ^[0-9]+$ ]]; t
         for removed in ${mysql_84_removed_vars}; do
             if [ "${paramName}" = "${removed}" ]; then
                 echo "Parameter ${paramName} was removed in MySQL 8.4 and cannot be set on server version ${server_version}; rejecting reconfigure." >&2
-                exit 1
+                exit "${INVALID_PARAMETER_EXIT_CODE}"
             fi
         done
     fi
@@ -84,4 +89,3 @@ if [ $status -ne 0 ]; then
     exit 1
 fi
 echo "Set parameter ${paramName} to value ${paramValue}"
-

--- a/addons/mysql/scripts/update-parameter.sh
+++ b/addons/mysql/scripts/update-parameter.sh
@@ -8,8 +8,12 @@ function mysql_exec() {
 paramName="${1:?missing param name}"
 paramValue="${2:?missing value}"
 
+# loose_-prefixed parameters keep MySQL's loose semantics: absence of the
+# variable (plugin not loaded) is tolerated, any other failure is not.
+is_loose=false
 if echo "${paramName}" | grep -q "^loose_"; then
-    paramName=${paramName//"loose_"/}
+    paramName=${paramName#loose_}
+    is_loose=true
 fi
 paramName=$(echo "${paramName}" | tr '-' '_')
 
@@ -39,12 +43,25 @@ else
 fi
 
 if [ $status -ne 0 ]; then
-    if echo "${ret}" | grep -q "ERROR 1045 (28000)"; then
-        echo "Failed to set parameter ${paramName} to value ${paramValue}, result: ${ret}"
-        exit 1
+    # Reconfigure must not judge success by this single SET GLOBAL alone:
+    # some parameters cannot be applied online and legitimately land here.
+    # Tolerate exactly those, loudly; fail everything else so the Ops does
+    # not report success for a value that was never applied.
+    if echo "${ret}" | grep -q "ERROR 1238 "; then
+        # Read-only variable: it cannot change online. The framework has
+        # already persisted it into the rendered my.cnf, so it takes effect
+        # on the next restart.
+        echo "Parameter ${paramName} is read-only (ERROR 1238); it will take effect after the next restart."
+        exit 0
     fi
-    # Ignore other errors
-else
-    echo "Set parameter ${paramName} to value ${paramValue}, result: ${ret}"
+    if [ "${is_loose}" = "true" ] && echo "${ret}" | grep -q "ERROR 1193 "; then
+        # loose_ parameter whose plugin is not loaded: absence is tolerated
+        # by MySQL's loose semantics, mirror that here.
+        echo "Parameter loose_${paramName} is unknown on this instance (plugin not loaded); skipped."
+        exit 0
+    fi
+    echo "Failed to set parameter ${paramName} to value ${paramValue}, result: ${ret}" >&2
+    exit 1
 fi
+echo "Set parameter ${paramName} to value ${paramValue}"
 

--- a/addons/mysql/scripts/update-parameter.sh
+++ b/addons/mysql/scripts/update-parameter.sh
@@ -17,6 +17,26 @@ if echo "${paramName}" | grep -q "^loose_"; then
 fi
 paramName=$(echo "${paramName}" | tr '-' '_')
 
+# MySQL 8.4 removed several system variables. Reject a reconfigure of any of
+# them BEFORE the SET GLOBAL / config write, so it fails explicitly with a
+# clear reason instead of silently landing in my.cnf and crash-looping the
+# instance on the next restart. The SET GLOBAL unknown-variable error below is
+# a backstop; this by-name check makes the rejection deterministic and visible.
+mysql_84_removed_vars="expire_logs_days default_authentication_plugin binlog_transaction_dependency_tracking transaction_write_set_extraction slave_rows_search_algorithms master_info_repository relay_log_info_repository log_bin_use_v1_row_events"
+server_version=$(mysql_exec "SELECT VERSION();" 2>/dev/null | head -n1)
+server_major=$(echo "${server_version}" | cut -d. -f1)
+server_minor=$(echo "${server_version}" | cut -d. -f2)
+if [[ "${server_major}" =~ ^[0-9]+$ ]] && [[ "${server_minor}" =~ ^[0-9]+$ ]]; then
+    if [ "${server_major}" -gt 8 ] || { [ "${server_major}" -eq 8 ] && [ "${server_minor}" -ge 4 ]; }; then
+        for removed in ${mysql_84_removed_vars}; do
+            if [ "${paramName}" = "${removed}" ]; then
+                echo "Parameter ${paramName} was removed in MySQL 8.4 and cannot be set on server version ${server_version}; rejecting reconfigure." >&2
+                exit 1
+            fi
+        done
+    fi
+fi
+
 var_int=-1
 if [[ "${paramValue}" =~ ^[0-9]+$ ]]; then
     var_int="${paramValue}"

--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -341,6 +341,11 @@ reconfigure:
 
         /scripts/update-parameter.sh "$1" "$2"
       - --
+  resultPolicy:
+    failureCodes:
+      - execExitCode: 64
+        code: InvalidParameter
+        retry: false
 {{- end -}}
 
 {{- define "mysql.mydumper.image" -}}


### PR DESCRIPTION
## Problem

KubeBlocks controller PR #10684 adds an opt-in action result policy for deterministic rejected parameters. MySQL 8.4 already rejects a fixed set of removed variables before `SET GLOBAL`, but that path currently shares generic exit code 1 with authentication, connection, probe, unknown-variable, and other execution failures. Mapping exit 1 would therefore misclassify infrastructure or engine errors as `InvalidParameter`.

## Change

- return dedicated exit code 64 only when the server version is parseable as MySQL 8.4+ and the normalized parameter is in the fixed eight-member removed-variable list
- map only exit code 64 to `InvalidParameter` with `retry: false` in the shared reconfigure action
- retain generic exit code 1 for all other failures
- cite the upstream MySQL removed-features source and require a dedicated test for each list member
- render-test all seven MySQL reconfigure actions and assert no exit-code-1 mapping

This PR is stacked on #3086 (`helios/mysql-84-paramsdef`) and includes the three commits from #3080 that provide the generic error and removed-variable foundation.

## TDD evidence

Before the product patch, the focused suite was `22 examples / 9 failures`: all eight removed-variable cases returned 1 instead of 64 and the seven rendered actions had no result mapping.

After the patch:

- focused ShellSpec: `23 examples / 0 failures`
- all MySQL ShellSpec: `29 examples / 0 failures`
- Bash syntax: PASS
- ShellCheck severity error: PASS
- Helm lint: PASS
- Helm render + structured parse: seven reconfigure actions, each with exactly `[{execExitCode: 64, code: InvalidParameter, retry: false}]`
- `git diff --check`: PASS
- isolated implementation review: no blocking finding

## Runtime boundary

Runtime is `N=0 / NOT_RUN`. Acceptance requires controller manager and Pod kbagent sidecar built from the exact same #10684 head, then the focused MySQL 8.4 rejected-parameter rollback and subsequent valid reconfigure checks.
