### PR TITLE
feat(redis): manage shardAdd rebalance with a Job

### DIFF
--- a/addons/redis/Chart.yaml
+++ b/addons/redis/Chart.yaml
@@ -4,7 +4,7 @@ description: "Redis is an in-memory database that persists on disk. The data mod
 
 type: application
 
-version: 1.2.0-alpha.5
+version: 1.2.0-alpha.7
 
 appVersion: "7.2.7"
 

--- a/addons/redis/Chart.yaml
+++ b/addons/redis/Chart.yaml
@@ -4,7 +4,7 @@ description: "Redis is an in-memory database that persists on disk. The data mod
 
 type: application
 
-version: 1.2.0-alpha.7
+version: 1.2.0-alpha.8
 
 appVersion: "7.2.7"
 

--- a/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-manage.sh
@@ -868,43 +868,16 @@ scale_out_redis_cluster_shard() {
     fi
   done
 
-  # do the reshard
-  # TODO: optimize the number of reshard slots according to the cluster status
-  local total_slots
-  local current_comp_pod_count
-  local all_comp_pod_count
-  local shard_count
-  local slots_per_shard
-  local current_slots
-  local remaining_slots
-  total_slots=16384
-  current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
-  all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
-  shard_count=$((all_comp_pod_count / current_comp_pod_count))
-  slots_per_shard=$((total_slots / shard_count))
-  current_slots=$(count_node_slots "$primary_node_fqdn" "$primary_node_port" "$mapping_primary_cluster_id")
-  status=$?
-  if [ $status -ne 0 ]; then
-    echo "Failed to count current shard primary slots before scale out reshard" >&2
+  if ! check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
+    echo "Redis cluster slots are not fully covered after shard membership convergence" >&2
     return 1
   fi
-  remaining_slots=$((slots_per_shard - current_slots))
-  if [ "$remaining_slots" -le 0 ]; then
-    if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
-      echo "Redis cluster scale out shard already owns $current_slots slots and cluster is stable"
-      return 0
-    fi
-    fix_unstable_cluster_and_defer "$primary_node_with_port" || return 1
-  fi
-
-  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$remaining_slots"; then
-    echo "Redis cluster scale out shard reshard successfully"
-  else
-    echo "Failed to scale out shard reshard" >&2
+  if ! check_current_shard_other_nodes_are_joined "$primary_node_fqdn" "$primary_node_port"; then
+    echo "Redis cluster shard membership did not converge after node joins" >&2
     return 1
   fi
 
-  check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"
+  echo "Redis cluster shard membership converged; slot migration is delegated to the managed shardAdd Job"
 }
 
 sync_acl_for_redis_cluster_shard() {

--- a/addons/redis/redis-cluster-scripts/redis-cluster-shardadd-worker.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-shardadd-worker.sh
@@ -12,9 +12,61 @@ require_env() {
   fi
 }
 
+managed_shardadd_inputs=false
+prepare_managed_shardadd_inputs() {
+  if [ -n "${REDIS_CLUSTER_ENDPOINT:-}" ] &&
+     [ -n "${REDIS_TARGET_SHARD_COUNT:-}" ] &&
+     [ -n "${REDIS_NEW_MASTER_IDS:-}" ]; then
+    return 0
+  fi
+  if [ -z "${KB_SHARD_ADD_TOKEN:-}${KB_SHARDING_NAME:-}${KB_SHARD_ADD_SHARDS:-}${KB_SHARD_COUNT:-}" ]; then
+    return 0
+  fi
+
+  require_env KB_SHARD_ADD_TOKEN
+  require_env KB_SHARDING_NAME
+  require_env KB_SHARD_ADD_SHARDS
+  require_env KB_SHARD_COUNT
+  require_env REDIS_SOURCE_POD_NAME
+  require_env REDIS_SOURCE_COMPONENT_NAME
+  require_env REDIS_CLUSTER_NAMESPACE
+  require_env REDIS_CLUSTER_DOMAIN
+  require_env REDIS_SERVICE_PORT
+
+  if [[ "$KB_SHARD_ADD_SHARDS" == ,* ]] ||
+     [[ "$KB_SHARD_ADD_SHARDS" == *, ]] ||
+     [[ "$KB_SHARD_ADD_SHARDS" == *,,* ]]; then
+    printf 'KB_SHARD_ADD_SHARDS contains an empty component name\n' >&2
+    return 1
+  fi
+
+  local component
+  local normalized_components
+  normalized_components=$(printf '%s\n' "$KB_SHARD_ADD_SHARDS" | tr ',' '\n')
+  while IFS= read -r component; do
+    if ! [[ "$component" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+      printf 'KB_SHARD_ADD_SHARDS contains an invalid component name\n' >&2
+      return 1
+    fi
+  done <<<"$normalized_components"
+  if [ "$(printf '%s\n' "$normalized_components" | LC_ALL=C sort | uniq -d | wc -l | tr -d ' ')" != "0" ]; then
+    printf 'KB_SHARD_ADD_SHARDS contains duplicate component names\n' >&2
+    return 1
+  fi
+  if ! [[ "$REDIS_SERVICE_PORT" =~ ^[1-9][0-9]*$ ]] || [ "$REDIS_SERVICE_PORT" -gt 65535 ]; then
+    printf 'REDIS_SERVICE_PORT must be a valid TCP port\n' >&2
+    return 1
+  fi
+
+  REDIS_CLUSTER_ENDPOINT="${REDIS_SOURCE_POD_NAME}.${REDIS_SOURCE_COMPONENT_NAME}-headless.${REDIS_CLUSTER_NAMESPACE}.svc.${REDIS_CLUSTER_DOMAIN}:${REDIS_SERVICE_PORT}"
+  REDIS_TARGET_SHARD_COUNT=$KB_SHARD_COUNT
+  managed_shardadd_inputs=true
+}
+
+prepare_managed_shardadd_inputs
+
 require_env REDIS_CLUSTER_ENDPOINT
 require_env REDIS_TARGET_SHARD_COUNT
-require_env REDIS_NEW_MASTER_IDS
 
 if ! [[ "$REDIS_TARGET_SHARD_COUNT" =~ ^[1-9][0-9]*$ ]]; then
   printf 'REDIS_TARGET_SHARD_COUNT must be a positive integer\n' >&2
@@ -39,7 +91,10 @@ validate_new_master_ids() {
   fi
 }
 
-validate_new_master_ids
+if [ "$managed_shardadd_inputs" = false ]; then
+  require_env REDIS_NEW_MASTER_IDS
+  validate_new_master_ids
+fi
 
 REDIS_COMMAND_TIMEOUT_SECONDS=${REDIS_COMMAND_TIMEOUT_SECONDS:-300}
 REDIS_COMMAND_KILL_GRACE_SECONDS=${REDIS_COMMAND_KILL_GRACE_SECONDS:-10}
@@ -169,6 +224,86 @@ cluster_info_for_endpoint() {
   parse_endpoint "$endpoint"
   run_redis_cli -h "$PARSED_HOST" -p "$PARSED_PORT" cluster info
 }
+
+healthy_master_ids_for_component() {
+  local nodes=$1
+  local component=$2
+  local service_fqdn
+  local ids
+
+  ids=$(printf '%s\n' "$nodes" | awk -v component="$component" '
+    function node_host(raw, parts, base, announced) {
+      split(raw, parts, ",")
+      announced = parts[2]
+      if (announced != "") {
+        return announced
+      }
+      base = parts[1]
+      sub(/@.*/, "", base)
+      sub(/:[0-9]+$/, "", base)
+      return base
+    }
+    NF >= 8 && $3 ~ /master/ && $3 !~ /(fail|handshake|noaddr)/ {
+      host = node_host($2)
+      if (index(host, "." component "-headless.") > 0) {
+        print $1
+      }
+    }
+  ' | LC_ALL=C sort -u)
+  if [ -n "$ids" ]; then
+    printf '%s\n' "$ids"
+    return 0
+  fi
+
+  command -v getent >/dev/null 2>&1 || return 0
+  service_fqdn="${component}-headless.${REDIS_CLUSTER_NAMESPACE}.svc.${REDIS_CLUSTER_DOMAIN}"
+  local service_ips
+  service_ips=$(getent ahostsv4 "$service_fqdn" 2>/dev/null | awk '{print $1}' | LC_ALL=C sort -u)
+  [ -n "$service_ips" ] || return 0
+  printf '%s\n' "$nodes" | awk -v service_ips="$service_ips" '
+    BEGIN {
+      count = split(service_ips, entries, "\n")
+      for (i = 1; i <= count; i++) {
+        ips[entries[i]] = 1
+      }
+    }
+    NF >= 8 && $3 ~ /master/ && $3 !~ /(fail|handshake|noaddr)/ {
+      split($2, address_parts, ",")
+      address = address_parts[1]
+      sub(/@.*/, "", address)
+      sub(/:[0-9]+$/, "", address)
+      if (ips[address]) {
+        print $1
+      }
+    }
+  ' | LC_ALL=C sort -u
+}
+
+derive_new_master_ids() {
+  local nodes
+  local component
+  local component_ids
+  local component_id
+  local derived_ids=""
+
+  nodes=$(cluster_nodes_for_endpoint "$REDIS_CLUSTER_ENDPOINT")
+  while IFS= read -r component; do
+    [ -n "$component" ] || continue
+    component_ids=$(healthy_master_ids_for_component "$nodes" "$component")
+    if [ "$(printf '%s\n' "$component_ids" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]; then
+      printf 'KB_SHARD_ADD_SHARDS component %s does not map to exactly one healthy Redis master\n' "$component" >&2
+      return 1
+    fi
+    component_id=$(printf '%s\n' "$component_ids" | sed -n '1p')
+    derived_ids="${derived_ids}${derived_ids:+,}${component_id}"
+  done < <(printf '%s\n' "$KB_SHARD_ADD_SHARDS" | tr ',' '\n')
+  REDIS_NEW_MASTER_IDS=$derived_ids
+}
+
+if [ "$managed_shardadd_inputs" = true ]; then
+  derive_new_master_ids
+  validate_new_master_ids
+fi
 
 normalize_cluster_nodes() {
   awk '

--- a/addons/redis/redis-cluster-scripts/redis-cluster-shardadd-worker.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster-shardadd-worker.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+require_env() {
+  local name=$1
+  if [ -z "${!name:-}" ]; then
+    printf 'missing %s\n' "$name" >&2
+    return 1
+  fi
+}
+
+require_env REDIS_CLUSTER_ENDPOINT
+require_env REDIS_TARGET_SHARD_COUNT
+require_env REDIS_NEW_MASTER_IDS
+
+if ! [[ "$REDIS_TARGET_SHARD_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'REDIS_TARGET_SHARD_COUNT must be a positive integer\n' >&2
+  exit 1
+fi
+
+validate_new_master_ids() {
+  local master_id
+  local normalized_ids
+
+  normalized_ids=$(printf '%s\n' "$REDIS_NEW_MASTER_IDS" | tr ',' '\n')
+  while IFS= read -r master_id; do
+    if ! [[ "$master_id" =~ ^[[:xdigit:]]{40}$ ]]; then
+      printf 'REDIS_NEW_MASTER_IDS contains an invalid Redis node ID\n' >&2
+      return 1
+    fi
+  done <<<"$normalized_ids"
+
+  if [ "$(printf '%s\n' "$normalized_ids" | LC_ALL=C sort | uniq -d | wc -l | tr -d ' ')" != "0" ]; then
+    printf 'REDIS_NEW_MASTER_IDS contains duplicate Redis node IDs\n' >&2
+    return 1
+  fi
+}
+
+validate_new_master_ids
+
+REDIS_COMMAND_TIMEOUT_SECONDS=${REDIS_COMMAND_TIMEOUT_SECONDS:-300}
+REDIS_COMMAND_KILL_GRACE_SECONDS=${REDIS_COMMAND_KILL_GRACE_SECONDS:-10}
+for timeout_value in "$REDIS_COMMAND_TIMEOUT_SECONDS" "$REDIS_COMMAND_KILL_GRACE_SECONDS"; do
+  if ! [[ "$timeout_value" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'Redis command timeout values must be positive integers\n' >&2
+    exit 1
+  fi
+done
+
+if ! command -v timeout >/dev/null 2>&1; then
+  printf 'timeout command is required for bounded Redis operations\n' >&2
+  exit 1
+fi
+
+parse_endpoint() {
+  local endpoint=$1
+  if [[ "$endpoint" =~ ^\[([^]]+)\]:([0-9]+)$ ]]; then
+    PARSED_HOST=${BASH_REMATCH[1]}
+    PARSED_PORT=${BASH_REMATCH[2]}
+  elif [[ "$endpoint" =~ ^([^:]+):([0-9]+)$ ]]; then
+    PARSED_HOST=${BASH_REMATCH[1]}
+    PARSED_PORT=${BASH_REMATCH[2]}
+  else
+    printf 'invalid Redis endpoint: %s\n' "$endpoint" >&2
+    return 1
+  fi
+}
+
+if redis_cli_version=$(timeout \
+  -s TERM -k "${REDIS_COMMAND_KILL_GRACE_SECONDS}s" \
+  "${REDIS_COMMAND_TIMEOUT_SECONDS}s" redis-cli --version); then
+  :
+else
+  version_rc=$?
+  if [ "$version_rc" -eq 124 ] || [ "$version_rc" -eq 137 ]; then
+    printf 'redis-cli version probe timed out after %s seconds\n' "$REDIS_COMMAND_TIMEOUT_SECONDS" >&2
+  else
+    printf 'unable to execute redis-cli version probe\n' >&2
+  fi
+  exit "$version_rc"
+fi
+if ! [[ "$redis_cli_version" =~ redis-cli[[:space:]]+([0-9]+)\. ]]; then
+  printf 'unable to determine redis-cli major version\n' >&2
+  exit 1
+fi
+redis_cli_major=${BASH_REMATCH[1]}
+case "$redis_cli_major" in
+  5|6|7|8) ;;
+  *)
+    printf 'unsupported redis-cli major version: %s\n' "$redis_cli_major" >&2
+    exit 1
+    ;;
+esac
+
+declare -a redis_cli_common_args=()
+if [ "$redis_cli_major" -ge 6 ] && [ -n "${REDIS_DEFAULT_USER:-}" ] && [ "$REDIS_DEFAULT_USER" != "default" ]; then
+  redis_cli_common_args+=(--user "$REDIS_DEFAULT_USER")
+fi
+
+case "${REDIS_TLS_ENABLED:-false}" in
+  false|FALSE|0|"") ;;
+  true|TRUE|1)
+    require_env REDIS_TLS_CA_FILE
+    require_env REDIS_TLS_CERT_FILE
+    require_env REDIS_TLS_KEY_FILE
+    for tls_file in "$REDIS_TLS_CA_FILE" "$REDIS_TLS_CERT_FILE" "$REDIS_TLS_KEY_FILE"; do
+      if [ ! -r "$tls_file" ]; then
+        printf 'Redis TLS file is not readable: %s\n' "$tls_file" >&2
+        exit 1
+      fi
+    done
+    redis_cli_common_args+=(
+      --tls
+      --cacert "$REDIS_TLS_CA_FILE"
+      --cert "$REDIS_TLS_CERT_FILE"
+      --key "$REDIS_TLS_KEY_FILE"
+    )
+    ;;
+  *)
+    printf 'REDIS_TLS_ENABLED must be true or false\n' >&2
+    exit 1
+    ;;
+esac
+
+run_redis_cli() {
+  local command_rc
+  local -a command_args=(
+    timeout
+    -s TERM
+    -k "${REDIS_COMMAND_KILL_GRACE_SECONDS}s"
+    "${REDIS_COMMAND_TIMEOUT_SECONDS}s"
+    redis-cli
+  )
+
+  if [ "${#redis_cli_common_args[@]}" -gt 0 ]; then
+    command_args+=("${redis_cli_common_args[@]}")
+  fi
+  command_args+=("$@")
+
+  if [ -n "${REDIS_DEFAULT_PASSWORD:-}" ]; then
+    if REDISCLI_AUTH="$REDIS_DEFAULT_PASSWORD" "${command_args[@]}"; then
+      return 0
+    else
+      command_rc=$?
+    fi
+  elif "${command_args[@]}"; then
+    return 0
+  else
+    command_rc=$?
+  fi
+
+  if [ "$command_rc" -eq 124 ] || [ "$command_rc" -eq 137 ]; then
+    printf 'redis-cli command timed out after %s seconds\n' "$REDIS_COMMAND_TIMEOUT_SECONDS" >&2
+  fi
+  return "$command_rc"
+}
+
+cluster_nodes_for_endpoint() {
+  local endpoint=$1
+  parse_endpoint "$endpoint"
+  run_redis_cli -h "$PARSED_HOST" -p "$PARSED_PORT" cluster nodes
+}
+
+cluster_info_for_endpoint() {
+  local endpoint=$1
+  parse_endpoint "$endpoint"
+  run_redis_cli -h "$PARSED_HOST" -p "$PARSED_PORT" cluster info
+}
+
+normalize_cluster_nodes() {
+  awk '
+    function canonical_address(raw, parts, base, announced, port) {
+      split(raw, parts, ",")
+      base = parts[1]
+      sub(/@.*/, "", base)
+      port = base
+      sub(/^.*:/, "", port)
+      announced = parts[2]
+      if (announced != "") {
+        return announced ":" port
+      }
+      return base
+    }
+    NF >= 8 {
+      address = canonical_address($2)
+      flags = ""
+      flag_count = split($3, flag_parts, ",")
+      for (flag = 1; flag <= flag_count; flag++) {
+        if (flag_parts[flag] != "myself") {
+          flags = flags (flags == "" ? "" : ",") flag_parts[flag]
+        }
+      }
+      slots = ""
+      for (field = 9; field <= NF; field++) {
+        slots = slots (slots == "" ? "" : " ") $field
+      }
+      print $1 "|" address "|" flags "|" $4 "|" $7 "|" $8 "|" slots
+    }
+  ' | LC_ALL=C sort
+}
+
+cluster_endpoints_from_nodes() {
+  awk '
+    function canonical_address(raw, parts, base, announced, port) {
+      split(raw, parts, ",")
+      base = parts[1]
+      sub(/@.*/, "", base)
+      port = base
+      sub(/^.*:/, "", port)
+      announced = parts[2]
+      if (announced != "") {
+        return announced ":" port
+      }
+      return base
+    }
+    NF >= 8 && $3 !~ /(fail|handshake|noaddr)/ {
+      print canonical_address($2)
+    }
+  ' | LC_ALL=C sort -u
+}
+
+assert_node_views_agree() {
+  local seed_nodes=$1
+  local expected_view
+  local endpoint
+  local actual_view
+
+  expected_view=$(printf '%s\n' "$seed_nodes" | normalize_cluster_nodes)
+  while IFS= read -r endpoint; do
+    [ -n "$endpoint" ] || continue
+    actual_view=$(cluster_nodes_for_endpoint "$endpoint" | normalize_cluster_nodes)
+    if [ "$actual_view" != "$expected_view" ]; then
+      printf 'Redis Cluster node views do not agree: %s differs from %s\n' \
+        "$endpoint" "$REDIS_CLUSTER_ENDPOINT" >&2
+      return 1
+    fi
+  done < <(printf '%s\n' "$seed_nodes" | cluster_endpoints_from_nodes)
+}
+
+cluster_check_output() {
+  run_redis_cli --cluster check "$REDIS_CLUSTER_ENDPOINT"
+}
+
+cluster_check_is_stable() {
+  local output=$1
+  printf '%s\n' "$output" | grep -q 'All 16384 slots covered' || return 1
+  if printf '%s\n' "$output" | grep -Eq '\[ERR\]|slots are open|importing state|migrating state'; then
+    return 1
+  fi
+}
+
+cluster_info_value() {
+  local info=$1
+  local key=$2
+  printf '%s\n' "$info" | awk -F: -v key="$key" '$1 == key { gsub(/\r/, "", $2); print $2; exit }'
+}
+
+new_masters_own_slots() {
+  local nodes=$1
+  local master_id
+  local node_line
+
+  while IFS= read -r master_id; do
+    [ -n "$master_id" ] || continue
+    node_line=$(printf '%s\n' "$nodes" | awk -v id="$master_id" '$1 == id { print; exit }')
+    [ -n "$node_line" ] || return 1
+    printf '%s\n' "$node_line" | awk 'NF >= 9 && $3 ~ /master/ && $3 !~ /(fail|handshake|noaddr)/ { found = 1 } END { exit(found ? 0 : 1) }' || return 1
+  done < <(printf '%s\n' "$REDIS_NEW_MASTER_IDS" | tr ',' '\n')
+}
+
+new_masters_are_healthy_masters() {
+  local nodes=$1
+  local master_id
+  local matches
+
+  while IFS= read -r master_id; do
+    [ -n "$master_id" ] || continue
+    matches=$(printf '%s\n' "$nodes" | awk -v id="$master_id" '$1 == id { count++ } END { print count + 0 }')
+    [ "$matches" = "1" ] || return 1
+    printf '%s\n' "$nodes" | awk -v id="$master_id" '
+      $1 == id && $3 ~ /master/ && $3 !~ /(fail|handshake|noaddr)/ { healthy = 1 }
+      END { exit(healthy ? 0 : 1) }
+    ' || return 1
+  done < <(printf '%s\n' "$REDIS_NEW_MASTER_IDS" | tr ',' '\n')
+}
+
+topology_is_converged() {
+  local nodes=$1
+  local info=$2
+  local check=$3
+  local master_count
+
+  [ "$(cluster_info_value "$info" cluster_state)" = "ok" ] || return 1
+  [ "$(cluster_info_value "$info" cluster_slots_assigned)" = "16384" ] || return 1
+  [ "$(cluster_info_value "$info" cluster_slots_ok)" = "16384" ] || return 1
+  [ "$(cluster_info_value "$info" cluster_slots_pfail)" = "0" ] || return 1
+  [ "$(cluster_info_value "$info" cluster_slots_fail)" = "0" ] || return 1
+  [ "$(cluster_info_value "$info" cluster_size)" = "$REDIS_TARGET_SHARD_COUNT" ] || return 1
+  cluster_check_is_stable "$check" || return 1
+
+  master_count=$(printf '%s\n' "$nodes" | awk '$3 ~ /master/ && $3 !~ /(fail|handshake|noaddr)/ { count++ } END { print count + 0 }')
+  [ "$master_count" = "$REDIS_TARGET_SHARD_COUNT" ] || return 1
+  new_masters_own_slots "$nodes"
+}
+
+seed_nodes=$(cluster_nodes_for_endpoint "$REDIS_CLUSTER_ENDPOINT")
+assert_node_views_agree "$seed_nodes"
+if ! new_masters_are_healthy_masters "$seed_nodes"; then
+  printf 'Supplied new Redis master IDs are not unique healthy masters\n' >&2
+  exit 1
+fi
+seed_info=$(cluster_info_for_endpoint "$REDIS_CLUSTER_ENDPOINT")
+seed_check=$(cluster_check_output)
+
+if topology_is_converged "$seed_nodes" "$seed_info" "$seed_check"; then
+  printf 'Redis Cluster shardAdd topology already converged\n'
+  exit 0
+fi
+
+if printf '%s\n' "$seed_check" | grep -Eq 'slots are open|importing state|migrating state'; then
+  run_redis_cli --cluster fix "$REDIS_CLUSTER_ENDPOINT" --cluster-yes
+  seed_nodes=$(cluster_nodes_for_endpoint "$REDIS_CLUSTER_ENDPOINT")
+  assert_node_views_agree "$seed_nodes"
+elif printf '%s\n' "$seed_check" | grep -q '\[ERR\]'; then
+  printf 'Redis Cluster check reported an unrecoverable error before rebalance\n' >&2
+  exit 1
+fi
+
+run_redis_cli --cluster rebalance "$REDIS_CLUSTER_ENDPOINT" \
+  --cluster-use-empty-masters --cluster-yes
+
+final_nodes=$(cluster_nodes_for_endpoint "$REDIS_CLUSTER_ENDPOINT")
+assert_node_views_agree "$final_nodes"
+final_info=$(cluster_info_for_endpoint "$REDIS_CLUSTER_ENDPOINT")
+final_check=$(cluster_check_output)
+
+if ! topology_is_converged "$final_nodes" "$final_info" "$final_check"; then
+  printf 'Redis Cluster shardAdd rebalance finished without topology convergence\n' >&2
+  exit 1
+fi
+
+printf 'Redis Cluster shardAdd rebalance completed and topology converged\n'

--- a/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
+++ b/addons/redis/redis-cluster-scripts/redis-cluster6-manage.sh
@@ -863,43 +863,16 @@ scale_out_redis_cluster_shard() {
     fi
   done
 
-  # do the reshard
-  # TODO: optimize the number of reshard slots according to the cluster status
-  local total_slots
-  local current_comp_pod_count
-  local all_comp_pod_count
-  local shard_count
-  local slots_per_shard
-  local current_slots
-  local remaining_slots
-  total_slots=16384
-  current_comp_pod_count=$(echo "$CURRENT_SHARD_POD_NAME_LIST" | tr ',' '\n' | grep -c "^$CURRENT_SHARD_COMPONENT_NAME-")
-  all_comp_pod_count=$(echo "$KB_CLUSTER_POD_NAME_LIST" | tr ',' '\n' | grep -c ".*")
-  shard_count=$((all_comp_pod_count / current_comp_pod_count))
-  slots_per_shard=$((total_slots / shard_count))
-  current_slots=$(count_node_slots "$primary_node_fqdn" "$primary_node_port" "$mapping_primary_cluster_id")
-  status=$?
-  if [ $status -ne 0 ]; then
-    echo "Failed to count current shard primary slots before scale out reshard" >&2
+  if ! check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
+    echo "Redis cluster slots are not fully covered after shard membership convergence" >&2
     return 1
   fi
-  remaining_slots=$((slots_per_shard - current_slots))
-  if [ "$remaining_slots" -le 0 ]; then
-    if check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"; then
-      echo "Redis cluster scale out shard already owns $current_slots slots and cluster is stable"
-      return 0
-    fi
-    fix_unstable_cluster_and_defer "$primary_node_with_port" || return 1
-  fi
-
-  if scale_out_shard_reshard "$primary_node_with_port" "$mapping_primary_cluster_id" "$remaining_slots"; then
-    echo "Redis cluster scale out shard reshard successfully"
-  else
-    echo "Failed to scale out shard reshard" >&2
+  if ! check_current_shard_other_nodes_are_joined "$primary_node_fqdn" "$primary_node_port"; then
+    echo "Redis cluster shard membership did not converge after node joins" >&2
     return 1
   fi
 
-  check_slots_covered "$primary_node_with_port" "$SERVICE_PORT"
+  echo "Redis cluster shard membership converged; slot migration is delegated to the managed shardAdd Job"
 }
 
 sync_acl_for_redis_cluster_shard() {

--- a/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_getent.sh
+++ b/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_getent.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ "${1:-}" = "ahostsv4" ] &&
+   [ "${2:-}" = "redis-shard-new-headless.default.svc.cluster.local" ]; then
+  printf '10.0.0.2 STREAM redis-shard-new-headless.default.svc.cluster.local\n'
+  printf '10.0.0.2 DGRAM  redis-shard-new-headless.default.svc.cluster.local\n'
+  exit 0
+fi
+
+exit 2

--- a/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_redis_cli.sh
+++ b/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_redis_cli.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -u
+
+scenario=${FAKE_SCENARIO:-stable}
+state_file=${FAKE_STATE_FILE:?missing FAKE_STATE_FILE}
+log_file=${FAKE_REDIS_CLI_LOG:?missing FAKE_REDIS_CLI_LOG}
+major=${FAKE_REDIS_MAJOR:-7}
+
+printf '%q ' "$@" >>"$log_file"
+printf '\n' >>"$log_file"
+
+if [ "${1:-}" = "--version" ]; then
+  if [ "$scenario" = "hang_version" ]; then
+    trap 'printf "version-terminated\n" >>"$log_file"; exit 143' TERM INT
+    sleep 30
+  fi
+  printf 'redis-cli %s.0.0\n' "$major"
+  exit 0
+fi
+
+host=host1
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "-h" ]; then
+    host=$argument
+  fi
+  previous=$argument
+done
+
+command_line=" $* "
+new_master=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+old_master=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+old_replica=cccccccccccccccccccccccccccccccccccccccc
+new_replica=dddddddddddddddddddddddddddddddddddddddd
+
+emit_nodes() {
+  old_flags=master
+  new_flags=master
+  new_master_parent=-
+  if [ "$scenario" = "replica_new" ]; then
+    new_flags=slave
+    new_master_parent=$old_master
+  fi
+  if [ "$host" = "host1" ]; then
+    old_flags=myself,master
+  elif [ "$host" = "host2" ]; then
+    new_flags=myself,$new_flags
+  fi
+
+  old_replica_flags=slave
+  new_replica_flags=slave
+  if [ "$host" = "host3" ]; then
+    old_replica_flags=myself,slave
+  elif [ "$host" = "host4" ]; then
+    new_replica_flags=myself,slave
+  fi
+
+  if [ "$scenario" = "inconsistent" ] && [ "$host" = "host2" ]; then
+    printf '%s 10.0.0.1:6379@16379,host1 %s - 0 0 1 connected 0-8190\n' "$old_master" "$old_flags"
+    printf '%s 10.0.0.2:6379@16379,host2 %s - 0 0 2 connected 8191-16383\n' "$new_master" "$new_flags"
+    printf '%s 10.0.0.3:6379@16379,host3 %s %s 0 0 3 connected\n' "$old_replica" "$old_replica_flags" "$old_master"
+    printf '%s 10.0.0.4:6379@16379,host4 %s %s 0 0 4 connected\n' "$new_replica" "$new_replica_flags" "$new_master"
+    return
+  fi
+
+  if { [ "$scenario" = "empty" ] && [ ! -s "$state_file" ]; } ||
+     { [ "$scenario" = "partial_open" ] && ! grep -q '^rebalanced$' "$state_file" 2>/dev/null; } ||
+     { [ "$scenario" = "interrupted" ] && ! grep -q '^rebalanced$' "$state_file" 2>/dev/null; }; then
+    printf '%s 10.0.0.1:6379@16379,host1 %s - 0 0 1 connected 0-16383\n' "$old_master" "$old_flags"
+    if [ "$scenario" != "missing_new" ]; then
+      printf '%s 10.0.0.2:6379@16379,host2 %s %s 0 0 2 connected\n' "$new_master" "$new_flags" "$new_master_parent"
+    fi
+    printf '%s 10.0.0.3:6379@16379,host3 %s %s 0 0 3 connected\n' "$old_replica" "$old_replica_flags" "$old_master"
+    if [ "$scenario" != "missing_new" ]; then
+      printf '%s 10.0.0.4:6379@16379,host4 %s %s 0 0 4 connected\n' "$new_replica" "$new_replica_flags" "$new_master"
+    fi
+    return
+  fi
+
+  printf '%s 10.0.0.1:6379@16379,host1 %s - 0 0 1 connected 0-8191\n' "$old_master" "$old_flags"
+  if [ "$scenario" != "missing_new" ]; then
+    printf '%s 10.0.0.2:6379@16379,host2 %s %s 0 0 2 connected 8192-16383\n' "$new_master" "$new_flags" "$new_master_parent"
+  fi
+  printf '%s 10.0.0.3:6379@16379,host3 %s %s 0 0 3 connected\n' "$old_replica" "$old_replica_flags" "$old_master"
+  if [ "$scenario" != "missing_new" ]; then
+    printf '%s 10.0.0.4:6379@16379,host4 %s %s 0 0 4 connected\n' "$new_replica" "$new_replica_flags" "$new_master"
+  fi
+}
+
+if [[ "$command_line" == *" cluster nodes "* ]]; then
+  if [ "$scenario" = "hang" ]; then
+    trap 'printf "terminated\n" >>"$log_file"; exit 143' TERM INT
+    sleep 30
+  fi
+  emit_nodes
+  exit 0
+fi
+
+if [[ "$command_line" == *" cluster info "* ]]; then
+  cluster_size=2
+  if { [ "$scenario" = "empty" ] && [ ! -s "$state_file" ]; } ||
+     { [ "$scenario" = "partial_open" ] && ! grep -q '^rebalanced$' "$state_file" 2>/dev/null; } ||
+     { [ "$scenario" = "interrupted" ] && ! grep -q '^rebalanced$' "$state_file" 2>/dev/null; }; then
+    cluster_size=1
+  fi
+  printf 'cluster_state:ok\n'
+  printf 'cluster_slots_assigned:16384\n'
+  printf 'cluster_slots_ok:16384\n'
+  printf 'cluster_slots_pfail:0\n'
+  printf 'cluster_slots_fail:0\n'
+  printf 'cluster_size:%s\n' "$cluster_size"
+  exit 0
+fi
+
+if [[ "$command_line" == *" --cluster check "* ]]; then
+  if [ "$scenario" = "partial_open" ] && [ ! -s "$state_file" ]; then
+    printf '[WARNING] The following slots are open: 8192\n'
+    printf '[WARNING] Node has slots in importing state\n'
+    exit 0
+  fi
+  if [ "$scenario" = "interrupted" ] && grep -q '^interrupted$' "$state_file" 2>/dev/null; then
+    printf '[WARNING] The following slots are open: 8192\n'
+    printf '[WARNING] Node has slots in migrating state\n'
+    exit 0
+  fi
+  if [ "$scenario" = "unknown" ]; then
+    printf '[ERR] cluster metadata could not be classified\n'
+    exit 0
+  fi
+  printf '[OK] All 16384 slots covered.\n'
+  exit 0
+fi
+
+if [[ "$command_line" == *" --cluster fix "* ]]; then
+  printf 'fixed\n' >"$state_file"
+  printf 'fix complete\n'
+  exit 0
+fi
+
+if [[ "$command_line" == *" --cluster rebalance "* ]]; then
+  if [ "$scenario" = "interrupted" ] && [ ! -s "$state_file" ]; then
+    printf 'interrupted\n' >"$state_file"
+    printf 'rebalance interrupted\n' >&2
+    exit 70
+  fi
+  printf 'rebalanced\n' >"$state_file"
+  printf 'rebalance complete\n'
+  exit 0
+fi
+
+printf 'unexpected redis-cli invocation: %s\n' "$*" >&2
+exit 64

--- a/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_redis_cli.sh
+++ b/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_redis_cli.sh
@@ -78,13 +78,24 @@ emit_nodes() {
     return
   fi
 
-  printf '%s 10.0.0.1:6379@16379,host1 %s - 0 0 1 connected 0-8191\n' "$old_master" "$old_flags"
-  if [ "$scenario" != "missing_new" ]; then
-    printf '%s 10.0.0.2:6379@16379,host2 %s %s 0 0 2 connected 8192-16383\n' "$new_master" "$new_flags" "$new_master_parent"
+  old_hostname=host1
+  new_hostname=host2
+  old_replica_hostname=host3
+  new_replica_hostname=host4
+  if [ "$scenario" = "managed_stable" ]; then
+    old_hostname=redis-shard-old-0.redis-shard-old-headless.default.svc.cluster.local
+    new_hostname=redis-shard-new-0.redis-shard-new-headless.default.svc.cluster.local
+    old_replica_hostname=redis-shard-old-1.redis-shard-old-headless.default.svc.cluster.local
+    new_replica_hostname=redis-shard-new-1.redis-shard-new-headless.default.svc.cluster.local
   fi
-  printf '%s 10.0.0.3:6379@16379,host3 %s %s 0 0 3 connected\n' "$old_replica" "$old_replica_flags" "$old_master"
+
+  printf '%s 10.0.0.1:6379@16379,%s %s - 0 0 1 connected 0-8191\n' "$old_master" "$old_hostname" "$old_flags"
   if [ "$scenario" != "missing_new" ]; then
-    printf '%s 10.0.0.4:6379@16379,host4 %s %s 0 0 4 connected\n' "$new_replica" "$new_replica_flags" "$new_master"
+    printf '%s 10.0.0.2:6379@16379,%s %s %s 0 0 2 connected 8192-16383\n' "$new_master" "$new_hostname" "$new_flags" "$new_master_parent"
+  fi
+  printf '%s 10.0.0.3:6379@16379,%s %s %s 0 0 3 connected\n' "$old_replica" "$old_replica_hostname" "$old_replica_flags" "$old_master"
+  if [ "$scenario" != "missing_new" ]; then
+    printf '%s 10.0.0.4:6379@16379,%s %s %s 0 0 4 connected\n' "$new_replica" "$new_replica_hostname" "$new_replica_flags" "$new_master"
   fi
 }
 

--- a/addons/redis/scripts-ut-spec/redis_cluster6_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster6_manage_spec.sh
@@ -99,7 +99,10 @@ Describe "Redis Cluster6 Manage Script Tests"
 
       check_slots_covered() { return 0; }
 
-      check_current_shard_other_nodes_are_joined() { return 1; }
+      check_current_shard_other_nodes_are_joined() {
+        membership_checks=$((membership_checks + 1))
+        [ "$membership_checks" -gt 1 ]
+      }
 
       check_node_in_cluster() { return 1; }
 
@@ -113,6 +116,7 @@ Describe "Redis Cluster6 Manage Script Tests"
       count_node_slots() { echo "16384"; }
 
       setup() {
+        membership_checks=0
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="redis-shard-98x"
         export CURRENT_SHARD_POD_NAME_LIST="redis-shard-98x-0,redis-shard-98x-1"
@@ -155,7 +159,10 @@ Describe "Redis Cluster6 Manage Script Tests"
         if [ "$1" = "10.42.0.1:6379" ]; then return 0; else return 1; fi
       }
 
-      check_current_shard_other_nodes_are_joined() { return 1; }
+      check_current_shard_other_nodes_are_joined() {
+        membership_checks=$((membership_checks + 1))
+        [ "$membership_checks" -gt 1 ]
+      }
 
       count_node_slots() { echo "16384"; }
 
@@ -169,6 +176,7 @@ Describe "Redis Cluster6 Manage Script Tests"
       }
 
       setup() {
+        membership_checks=0
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="redis-shard-98x"
         export CURRENT_SHARD_POD_NAME_LIST="redis-shard-98x-0,redis-shard-98x-1"

--- a/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
@@ -21,6 +21,7 @@ Describe "Redis Cluster lifecycle action contract"
       --show-only templates/clusterdefinition.yaml \
       --show-only templates/cmpd-redis-cluster.yaml \
       --show-only templates/paramsdef-redis-cluster.yaml \
+      --show-only templates/opsdefinition-shardadd.yaml \
       --show-only templates/redis-cluster-scripts-template.yaml \
       --show-only templates/shardingdefinition.yaml >"$tmp_render"
   }
@@ -31,7 +32,7 @@ Describe "Redis Cluster lifecycle action contract"
       documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
       chart = YAML.load_file(ARGV.fetch(1))
       version = chart.fetch("version")
-      expected_version = "1.2.0-alpha.7"
+      expected_version = "1.2.0-alpha.8"
       abort "expected Redis chart version #{expected_version}, got #{version}" unless version == expected_version
 
       expected_cmpds = %w[5 6 7 8].map { |major| "redis-cluster-#{major}-#{version}" }
@@ -72,6 +73,157 @@ Describe "Redis Cluster lifecycle action contract"
       abort "missing managed shardAdd worker in versioned scripts ConfigMap" unless worker&.include?("topology_is_converged")
 
       puts "versioned immutable definition contract passed"
+    ' "$tmp_render" "$(chart_path)/Chart.yaml"
+  }
+
+  validate_managed_shardadd_contract() {
+    render_lifecycle_templates || return $?
+    ruby -ryaml -e '
+      documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
+      chart = YAML.load_file(ARGV.fetch(1))
+      version = chart.fetch("version")
+
+      sharding = documents.find { |document| document["kind"] == "ShardingDefinition" }
+      abort "missing Redis ShardingDefinition" unless sharding
+      annotations = sharding.dig("metadata", "annotations") || {}
+      abort "managed shardAdd migration must skip the one-time immutable check" unless
+        annotations["apps.kubeblocks.io/skip-immutable-check"] == "true"
+      shard_add = sharding.dig("spec", "lifecycleActions", "shardAdd")
+      expected_name = "redis-cluster-shardadd-#{version}"
+      abort "expected shardAdd to reference #{expected_name}, got #{shard_add.inspect}" unless
+        shard_add == {"opsDefinitionName" => expected_name}
+
+      definition = documents.find do |document|
+        document["kind"] == "OpsDefinition" && document.dig("metadata", "name") == expected_name
+      end
+      abort "missing managed shardAdd OpsDefinition #{expected_name}" unless definition
+      spec = definition.fetch("spec")
+      %w[preConditions componentInfos].each do |field|
+        abort "managed shardAdd OpsDefinition must not define #{field}" if spec.key?(field)
+      end
+      extractors = spec.fetch("podInfoExtractors")
+      abort "managed shardAdd requires exactly one PodInfoExtractor" unless extractors.length == 1
+      extractor = extractors.first
+      extractor_name = "redis-cluster-shardadd-inputs"
+      abort "unexpected managed shardAdd PodInfoExtractor name" unless extractor["name"] == extractor_name
+      abort "managed shardAdd must select any stable shard Pod" unless
+        extractor.dig("podSelector", "multiPodSelectionPolicy") == "Any" &&
+        extractor.dig("podSelector").keys == ["multiPodSelectionPolicy"]
+
+      env_ref = lambda do |name, source_name, optional = false|
+        value = {
+          "name" => name,
+          "valueFrom" => {
+            "envRef" => {
+              "targetContainerName" => "redis-cluster",
+              "envName" => source_name
+            }
+          }
+        }
+        value["optional"] = true if optional
+        value
+      end
+      expected_env = [
+        env_ref.call("REDIS_DEFAULT_USER", "REDIS_DEFAULT_USER"),
+        env_ref.call("REDIS_DEFAULT_PASSWORD", "REDIS_DEFAULT_PASSWORD"),
+        env_ref.call("REDIS_TLS_ENABLED", "TLS_ENABLED", true),
+        {
+          "name" => "REDIS_SOURCE_POD_NAME",
+          "valueFrom" => {"fieldPath" => {"fieldPath" => "metadata.name"}}
+        },
+        env_ref.call("REDIS_SOURCE_COMPONENT_NAME", "CURRENT_SHARD_COMPONENT_NAME"),
+        env_ref.call("REDIS_CLUSTER_NAMESPACE", "CLUSTER_NAMESPACE"),
+        env_ref.call("REDIS_CLUSTER_DOMAIN", "CLUSTER_DOMAIN"),
+        env_ref.call("REDIS_SERVICE_PORT", "SERVICE_PORT")
+      ]
+      abort "managed shardAdd extracted env contract differs: #{extractor["env"].inspect}" unless
+        extractor["env"] == expected_env
+      expected_mounts = [{"name" => "tls", "mountPath" => "/etc/pki/tls", "readOnly" => true}]
+      abort "managed shardAdd TLS mount contract differs: #{extractor["volumeMounts"].inspect}" unless
+        extractor["volumeMounts"] == expected_mounts
+      expected_parameters = %w[KB_SHARD_ADD_TOKEN KB_SHARDING_NAME KB_SHARD_ADD_SHARDS KB_SHARD_COUNT]
+      parameter_schema = spec.dig("parametersSchema", "openAPIV3Schema")
+      abort "managed shardAdd parameter schema must be an object" unless parameter_schema["type"] == "object"
+      abort "managed shardAdd required parameters differ: #{parameter_schema["required"].inspect}" unless
+        parameter_schema["required"] == expected_parameters
+      properties = parameter_schema.fetch("properties")
+      abort "managed shardAdd parameter properties differ: #{properties.keys.inspect}" unless
+        properties.keys == expected_parameters
+      expected_parameters.first(3).each do |parameter|
+        abort "#{parameter} must be a non-empty string" unless
+          properties[parameter] == {"type" => "string", "minLength" => 1}
+      end
+      abort "KB_SHARD_COUNT must be a positive integer" unless
+        properties["KB_SHARD_COUNT"] == {"type" => "integer", "minimum" => 1}
+      actions = spec.fetch("actions")
+      abort "managed shardAdd requires exactly one action" unless actions.length == 1
+      action = actions.first
+      abort "managed shardAdd requires failurePolicy=Fail" unless action["failurePolicy"] == "Fail"
+      abort "managed shardAdd must not define exec/resourceModifier" if
+        action.key?("exec") || action.key?("resourceModifier")
+      abort "managed shardAdd parameters differ: #{action["parameters"].inspect}" unless
+        action["parameters"] == expected_parameters
+      legacy_parameters = %w[shardAddToken shardingName newShardComponentNames targetShardCount]
+      rendered = File.read(ARGV.fetch(0))
+      leaked_legacy_parameters = legacy_parameters.select { |parameter| rendered.include?(parameter) }
+      abort "managed shardAdd render still contains legacy parameters: #{leaked_legacy_parameters.inspect}" unless
+        leaked_legacy_parameters.empty?
+      workload = action.fetch("workload")
+      abort "managed shardAdd requires ManagedJob" unless workload["type"] == "ManagedJob"
+      abort "managed shardAdd requires backoffLimit=0" unless workload["backoffLimit"] == 0
+      abort "managed shardAdd Job must use the exact PodInfoExtractor" unless
+        workload["podInfoExtractorName"] == extractor_name
+      pod_spec = workload.fetch("podSpec")
+      abort "managed shardAdd Job must never restart its worker Pod" unless
+        pod_spec["restartPolicy"] == "Never"
+      abort "managed shardAdd Job must have a bounded 3-hour deadline" unless
+        pod_spec["activeDeadlineSeconds"] == 10800
+      expected_scripts_volume = {
+        "name" => "scripts",
+        "configMap" => {
+          "name" => "redis-cluster-scripts-template-#{version}",
+          "defaultMode" => 365
+        }
+      }
+      abort "managed shardAdd Job must mount the versioned scripts ConfigMap" unless
+        pod_spec.fetch("volumes") == [expected_scripts_volume]
+      containers = workload.dig("podSpec", "containers") || []
+      abort "managed shardAdd requires exactly one worker container" unless containers.length == 1
+      worker_container = containers.first
+      command = Array(worker_container["command"]) + Array(worker_container["args"])
+      abort "managed shardAdd Job does not invoke the versioned worker" unless
+        command.join(" ").include?("/scripts/redis-cluster-shardadd-worker.sh")
+      abort "managed shardAdd worker must mount only the scripts volume directly" unless
+        worker_container.fetch("volumeMounts") == [
+          {"name" => "scripts", "mountPath" => "/scripts", "readOnly" => true}
+        ]
+      worker_env = worker_container.fetch("env").to_h { |item| [item.fetch("name"), item.fetch("value")] }
+      expected_worker_env = {
+        "REDIS_TLS_CA_FILE" => "/etc/pki/tls/ca.crt",
+        "REDIS_TLS_CERT_FILE" => "/etc/pki/tls/tls.crt",
+        "REDIS_TLS_KEY_FILE" => "/etc/pki/tls/tls.key",
+        "REDIS_COMMAND_TIMEOUT_SECONDS" => "7200",
+        "REDIS_COMMAND_KILL_GRACE_SECONDS" => "30"
+      }
+      abort "managed shardAdd worker static env differs: #{worker_env.inspect}" unless
+        worker_env == expected_worker_env
+
+      scripts = documents.find do |document|
+        document["kind"] == "ConfigMap" &&
+          document.dig("metadata", "name") == "redis-cluster-scripts-template-#{version}"
+      end
+      abort "missing versioned Redis Cluster scripts ConfigMap" unless scripts
+      %w[redis-cluster-manage.sh redis-cluster6-manage.sh].each do |script_name|
+        source = scripts.fetch("data").fetch(script_name)
+        scale_out_body = source.split("scale_out_redis_cluster_shard() {", 2).fetch(1)
+          .split("sync_acl_for_redis_cluster_shard() {", 2).fetch(0)
+        abort "#{script_name} still owns shardAdd slot migration" if
+          scale_out_body.include?("scale_out_shard_reshard")
+        abort "#{script_name} does not positively close membership" unless
+          scale_out_body.include?("membership converged; slot migration is delegated to the managed shardAdd Job")
+      end
+
+      puts "managed shardAdd rendered contract passed"
     ' "$tmp_render" "$(chart_path)/Chart.yaml"
   }
 
@@ -164,6 +316,12 @@ Describe "Redis Cluster lifecycle action contract"
     When call validate_versioned_definition_contract
     The status should be success
     The output should include "versioned immutable definition contract passed"
+  End
+
+  It "renders the exact managed shardAdd bridge and Job contract"
+    When call validate_managed_shardadd_contract
+    The status should be success
+    The output should include "managed shardAdd rendered contract passed"
   End
 
   It "replays postProvision failure diagnostics and preserves the manage rc"

--- a/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_lifecycle_contract_spec.sh
@@ -21,6 +21,7 @@ Describe "Redis Cluster lifecycle action contract"
       --show-only templates/clusterdefinition.yaml \
       --show-only templates/cmpd-redis-cluster.yaml \
       --show-only templates/paramsdef-redis-cluster.yaml \
+      --show-only templates/redis-cluster-scripts-template.yaml \
       --show-only templates/shardingdefinition.yaml >"$tmp_render"
   }
 
@@ -30,7 +31,8 @@ Describe "Redis Cluster lifecycle action contract"
       documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
       chart = YAML.load_file(ARGV.fetch(1))
       version = chart.fetch("version")
-      abort "Redis chart version must advance past immutable baseline 1.2.0-alpha.0" if version == "1.2.0-alpha.0"
+      expected_version = "1.2.0-alpha.7"
+      abort "expected Redis chart version #{expected_version}, got #{version}" unless version == expected_version
 
       expected_cmpds = %w[5 6 7 8].map { |major| "redis-cluster-#{major}-#{version}" }
       actual_cmpds = documents.map do |document|
@@ -60,6 +62,14 @@ Describe "Redis Cluster lifecycle action contract"
       abort "missing Redis cluster topology" unless cluster_topology
       actual_reference = cluster_topology.fetch("shardings").first.fetch("shardingDef")
       abort "expected cluster topology to reference #{expected_sharding}, got #{actual_reference}" unless actual_reference == expected_sharding
+
+      scripts = documents.find do |document|
+        document["kind"] == "ConfigMap" &&
+          document.dig("metadata", "name") == "redis-cluster-scripts-template-#{version}"
+      end
+      abort "missing versioned Redis Cluster scripts ConfigMap" unless scripts
+      worker = scripts.fetch("data")["redis-cluster-shardadd-worker.sh"]
+      abort "missing managed shardAdd worker in versioned scripts ConfigMap" unless worker&.include?("topology_is_converged")
 
       puts "versioned immutable definition contract passed"
     ' "$tmp_render" "$(chart_path)/Chart.yaml"

--- a/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_manage_spec.sh
@@ -1030,7 +1030,7 @@ Describe "Redis Cluster Manage Bash Script Tests"
         When call scale_out_redis_cluster_shard
         The status should be success
         The output should include "The current component shard primary and replicas already joined the cluster."
-        The output should include "Redis cluster scale out shard already owns 16384 slots and cluster is stable"
+        The output should include "membership converged; slot migration is delegated to the managed shardAdd Job"
       End
     End
 
@@ -1177,7 +1177,7 @@ Describe "Redis Cluster Manage Bash Script Tests"
       End
     End
 
-    Context "when failed to scale out shard reshard"
+    Context "when managed shardAdd owns slot migration after membership converges"
       init_current_comp_default_nodes_for_scale_out() {
         declare -gA scale_out_shard_default_primary_node
         scale_out_shard_default_primary_node["redis-shard-98x-0"]="10.42.0.1:6379"
@@ -1190,7 +1190,11 @@ Describe "Redis Cluster Manage Bash Script Tests"
       }
 
       check_slots_covered() {
-        return 1
+        check_slots_covered_calls=$((check_slots_covered_calls + 1))
+        if [ "$check_slots_covered_calls" -eq 1 ]; then
+          return 1
+        fi
+        return 0
       }
 
       fix_unstable_cluster_and_defer() {
@@ -1221,15 +1225,19 @@ Describe "Redis Cluster Manage Bash Script Tests"
       }
 
       scale_out_shard_reshard() {
-        return 1
+        printf 'unexpected reshard\n' >"$reshard_marker"
+        return 0
       }
 
       get_cluster_nodes_info() {
-         cluster_nodes_info="4958e6dca033cd1b321922508553fab869a29d 10.42.0.227:6379@16379,redis-shard-98x-0.redis-shard-98x-headless.default.svc master - 0 1711958289570 4 connected 0-1364 5461-6826 10923-12287"$'\n'"7381c6dca033cd1b321922508553fab869a29e 10.42.0.228:6379@16379,redis-shard-7hy-1.redis-shard-7hy-headless.default.svc slave 4958e6dca033cd1b321922508553fab869a29d 0 1711958289570 4 connected"
+         cluster_nodes_info="4958e6dca033cd1b321922508553fab869a29d 10.42.0.227:6379@16379,redis-shard-98x-0.redis-shard-98x-headless.default.svc master - 0 1711958289570 4 connected 0-1364 5461-6826 10923-12287"$'\n'"6381c6dca033cd1b321922508553fab869a29f 10.42.0.229:6379@16379,redis-shard-98x-1.redis-shard-98x-headless.default.svc slave 4958e6dca033cd1b321922508553fab869a29d 0 1711958289570 4 connected"$'\n'"7381c6dca033cd1b321922508553fab869a29e 10.42.0.228:6379@16379,redis-shard-7hy-1.redis-shard-7hy-headless.default.svc slave 4958e6dca033cd1b321922508553fab869a29d 0 1711958289570 4 connected"
          echo "$cluster_nodes_info"
       }
 
       setup() {
+        check_slots_covered_calls=0
+        reshard_marker=$(mktemp -t redis-reshard-marker-XXXXXX)
+        rm -f "$reshard_marker"
         export CURRENT_SHARD_COMPONENT_SHORT_NAME="shard-98x"
         export CURRENT_SHARD_COMPONENT_NAME="redis-shard-98x"
         export CURRENT_SHARD_POD_NAME_LIST="redis-shard-98x-0,redis-shard-98x-1"
@@ -1240,18 +1248,20 @@ Describe "Redis Cluster Manage Bash Script Tests"
       Before "setup"
 
       un_setup() {
+        rm -f "$reshard_marker"
         unset CURRENT_SHARD_COMPONENT_SHORT_NAME
         unset KB_CLUSTER_POD_NAME_LIST
         unset SERVICE_PORT
       }
       After "un_setup"
 
-      It "returns error when failed to scale out shard reshard"
+      It "returns after positive membership closure without reshard mutation"
         When call scale_out_redis_cluster_shard
-        The status should be failure
-        The error should include "Failed to scale out shard reshard"
+        The status should be success
         The error should not include "unexpected check_node_in_cluster port"
         The stdout should include "Redis cluster scale out shard secondary node redis-shard-98x-1 successfully"
+        The stdout should include "membership converged; slot migration is delegated to the managed shardAdd Job"
+        The path "$reshard_marker" should not be exist
       End
     End
   End

--- a/addons/redis/scripts-ut-spec/redis_cluster_shardadd_worker_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_shardadd_worker_spec.sh
@@ -1,0 +1,177 @@
+# shellcheck shell=bash
+
+Describe "Redis Cluster shardAdd managed-operation worker"
+  worker_path() {
+    printf '%s/addons/redis/redis-cluster-scripts/redis-cluster-shardadd-worker.sh' "${SHELLSPEC_CWD:?}"
+  }
+
+  setup_worker() {
+    fake_bin=$(mktemp -d -t redis-shardadd-bin-XXXXXX)
+    fake_state=$(mktemp -t redis-shardadd-state-XXXXXX)
+    fake_log=$(mktemp -t redis-shardadd-log-XXXXXX)
+    rm -f "$fake_state"
+    cp "${SHELLSPEC_CWD:?}/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_redis_cli.sh" "$fake_bin/redis-cli"
+    chmod +x "$fake_bin/redis-cli"
+
+    export PATH="$fake_bin:$PATH"
+    export FAKE_STATE_FILE="$fake_state"
+    export FAKE_REDIS_CLI_LOG="$fake_log"
+    export REDIS_CLUSTER_ENDPOINT="host1:6379"
+    export REDIS_TARGET_SHARD_COUNT="2"
+    export REDIS_NEW_MASTER_IDS="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    export REDIS_DEFAULT_USER="default"
+    export REDIS_COMMAND_TIMEOUT_SECONDS="5"
+    export REDIS_COMMAND_KILL_GRACE_SECONDS="1"
+  }
+  Before 'setup_worker'
+
+  cleanup_worker() {
+    rm -rf "$fake_bin"
+    rm -f "$fake_state" "$fake_log"
+    unset FAKE_SCENARIO FAKE_STATE_FILE FAKE_REDIS_CLI_LOG FAKE_REDIS_MAJOR
+    unset REDIS_CLUSTER_ENDPOINT REDIS_TARGET_SHARD_COUNT REDIS_NEW_MASTER_IDS
+    unset REDIS_DEFAULT_USER REDIS_DEFAULT_PASSWORD
+    unset REDIS_TLS_ENABLED REDIS_TLS_CA_FILE REDIS_TLS_CERT_FILE REDIS_TLS_KEY_FILE
+    unset REDIS_COMMAND_TIMEOUT_SECONDS REDIS_COMMAND_KILL_GRACE_SECONDS
+  }
+  After 'cleanup_worker'
+
+  run_worker() {
+    bash "$(worker_path)"
+  }
+
+  It "fails closed before redis-cli when required lifecycle inputs are missing"
+    unset REDIS_TARGET_SHARD_COUNT
+    When call run_worker
+    The status should be failure
+    The stderr should include "missing REDIS_TARGET_SHARD_COUNT"
+    The contents of file "$fake_log" should be blank
+  End
+
+  It "is a no-op when the requested topology is already converged"
+    export FAKE_SCENARIO=stable
+    When call run_worker
+    The status should be success
+    The output should include "already converged"
+    The contents of file "$fake_log" should not include "--cluster rebalance"
+    The contents of file "$fake_log" should include "-h host3"
+  End
+
+  It "rejects malformed or duplicate new-master IDs before redis-cli"
+    export REDIS_NEW_MASTER_IDS="not-a-node-id"
+    bash "$(worker_path)" 2>/dev/null && return 1
+    export REDIS_NEW_MASTER_IDS="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    When call run_worker
+    The status should be failure
+    The stderr should include "duplicate Redis node IDs"
+    The contents of file "$fake_log" should be blank
+  End
+
+
+  It "fails before mutation when a supplied new-master ID is absent"
+    export FAKE_SCENARIO=missing_new
+    When call run_worker
+    The status should be failure
+    The stderr should include "not unique healthy masters"
+    The contents of file "$fake_log" should not include "--cluster rebalance"
+  End
+
+  It "fails before mutation when a supplied new-master ID is a replica"
+    export FAKE_SCENARIO=replica_new
+    When call run_worker
+    The status should be failure
+    The stderr should include "not unique healthy masters"
+    The contents of file "$fake_log" should not include "--cluster rebalance"
+  End
+
+  It "runs one global rebalance for an empty new master and verifies convergence"
+    export FAKE_SCENARIO=empty
+    When call run_worker
+    The status should be success
+    The output should include "rebalance completed and topology converged"
+    The contents of file "$fake_log" should include "--cluster rebalance"
+    The contents of file "$fake_log" should include "--cluster-use-empty-masters"
+  End
+
+  It "fails closed when Redis nodes expose different slot-owner views"
+    export FAKE_SCENARIO=inconsistent
+    When call run_worker
+    The status should be failure
+    The stderr should include "Redis Cluster node views do not agree"
+  End
+
+  It "repairs an explicit open-slot state before the single rebalance"
+    export FAKE_SCENARIO=partial_open
+    When call run_worker
+    The status should be success
+    The output should include "rebalance completed and topology converged"
+    The contents of file "$fake_log" should include "--cluster fix"
+    The contents of file "$fake_log" should include "--cluster rebalance"
+  End
+
+  It "fails an interrupted rebalance and safely converges on retry"
+    export FAKE_SCENARIO=interrupted
+    bash "$(worker_path)" >/dev/null 2>&1 && return 1
+    When call run_worker
+    The status should be success
+    The output should include "rebalance completed and topology converged"
+    The contents of file "$fake_log" should include "--cluster fix"
+  End
+
+
+  It "bounds a stalled redis-cli command and reaps it"
+    export FAKE_SCENARIO=hang
+    export REDIS_COMMAND_TIMEOUT_SECONDS=1
+    When call run_worker
+    The status should be failure
+    The stderr should include "redis-cli command timed out after 1 seconds"
+    The contents of file "$fake_log" should include "terminated"
+  End
+
+
+  It "also bounds and reaps a stalled redis-cli version probe"
+    export FAKE_SCENARIO=hang_version
+    export REDIS_COMMAND_TIMEOUT_SECONDS=1
+    When call run_worker
+    The status should be failure
+    The stderr should include "redis-cli version probe timed out after 1 seconds"
+    The contents of file "$fake_log" should include "version-terminated"
+  End
+
+  It "does not mutate when cluster-check returns an unknown error"
+    export FAKE_SCENARIO=unknown
+    When call run_worker
+    The status should be failure
+    The stderr should include "unrecoverable error before rebalance"
+    The contents of file "$fake_log" should not include "--cluster fix"
+    The contents of file "$fake_log" should not include "--cluster rebalance"
+  End
+
+  It "uses one worker contract for Redis 5, 6, 7, and 8 without exposing the password"
+    export FAKE_SCENARIO=stable
+    export REDIS_DEFAULT_PASSWORD='worker-secret-value'
+    for major in 5 6 7 8; do
+      export FAKE_REDIS_MAJOR=$major
+      bash "$(worker_path)" || return $?
+    done
+    When call grep -F 'worker-secret-value' "$fake_log"
+    The status should be failure
+  End
+
+
+  It "requires readable TLS material and passes only file paths to redis-cli"
+    export FAKE_SCENARIO=stable
+    export REDIS_TLS_ENABLED=true
+    export REDIS_TLS_CA_FILE="$fake_bin/ca.crt"
+    export REDIS_TLS_CERT_FILE="$fake_bin/tls.crt"
+    export REDIS_TLS_KEY_FILE="$fake_bin/tls.key"
+    touch "$REDIS_TLS_CA_FILE" "$REDIS_TLS_CERT_FILE"
+    bash "$(worker_path)" >/dev/null 2>&1 && return 1
+    touch "$REDIS_TLS_KEY_FILE"
+    When call run_worker
+    The status should be success
+    The output should include "already converged"
+    The contents of file "$fake_log" should include "--tls"
+    The contents of file "$fake_log" should include "$fake_bin/tls.key"
+  End
+End

--- a/addons/redis/scripts-ut-spec/redis_cluster_shardadd_worker_spec.sh
+++ b/addons/redis/scripts-ut-spec/redis_cluster_shardadd_worker_spec.sh
@@ -12,6 +12,8 @@ Describe "Redis Cluster shardAdd managed-operation worker"
     rm -f "$fake_state"
     cp "${SHELLSPEC_CWD:?}/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_redis_cli.sh" "$fake_bin/redis-cli"
     chmod +x "$fake_bin/redis-cli"
+    cp "${SHELLSPEC_CWD:?}/addons/redis/scripts-ut-spec/fixtures/redis_cluster_shardadd_worker_getent.sh" "$fake_bin/getent"
+    chmod +x "$fake_bin/getent"
 
     export PATH="$fake_bin:$PATH"
     export FAKE_STATE_FILE="$fake_state"
@@ -30,6 +32,9 @@ Describe "Redis Cluster shardAdd managed-operation worker"
     rm -f "$fake_state" "$fake_log"
     unset FAKE_SCENARIO FAKE_STATE_FILE FAKE_REDIS_CLI_LOG FAKE_REDIS_MAJOR
     unset REDIS_CLUSTER_ENDPOINT REDIS_TARGET_SHARD_COUNT REDIS_NEW_MASTER_IDS
+    unset KB_SHARD_ADD_TOKEN KB_SHARDING_NAME KB_SHARD_ADD_SHARDS KB_SHARD_COUNT
+    unset REDIS_SOURCE_POD_NAME REDIS_SOURCE_COMPONENT_NAME
+    unset REDIS_CLUSTER_NAMESPACE REDIS_CLUSTER_DOMAIN REDIS_SERVICE_PORT
     unset REDIS_DEFAULT_USER REDIS_DEFAULT_PASSWORD
     unset REDIS_TLS_ENABLED REDIS_TLS_CA_FILE REDIS_TLS_CERT_FILE REDIS_TLS_KEY_FILE
     unset REDIS_COMMAND_TIMEOUT_SECONDS REDIS_COMMAND_KILL_GRACE_SECONDS
@@ -45,6 +50,59 @@ Describe "Redis Cluster shardAdd managed-operation worker"
     When call run_worker
     The status should be failure
     The stderr should include "missing REDIS_TARGET_SHARD_COUNT"
+    The contents of file "$fake_log" should be blank
+  End
+
+  It "derives the exact endpoint and new master ID from managed shardAdd inputs"
+    unset REDIS_CLUSTER_ENDPOINT REDIS_TARGET_SHARD_COUNT REDIS_NEW_MASTER_IDS
+    export KB_SHARD_ADD_TOKEN="token-1"
+    export KB_SHARDING_NAME="shard"
+    export KB_SHARD_ADD_SHARDS="redis-shard-new"
+    export KB_SHARD_COUNT="2"
+    export REDIS_SOURCE_POD_NAME="redis-shard-old-0"
+    export REDIS_SOURCE_COMPONENT_NAME="redis-shard-old"
+    export REDIS_CLUSTER_NAMESPACE="default"
+    export REDIS_CLUSTER_DOMAIN="cluster.local"
+    export REDIS_SERVICE_PORT="6379"
+    export FAKE_SCENARIO=managed_stable
+    When call run_worker
+    The status should be success
+    The output should include "already converged"
+    The contents of file "$fake_log" should include "-h redis-shard-old-0.redis-shard-old-headless.default.svc.cluster.local"
+  End
+
+  It "derives the new master ID from headless DNS when Redis 5 reports IP-only nodes"
+    unset REDIS_CLUSTER_ENDPOINT REDIS_TARGET_SHARD_COUNT REDIS_NEW_MASTER_IDS
+    export KB_SHARD_ADD_TOKEN="token-redis5"
+    export KB_SHARDING_NAME="shard"
+    export KB_SHARD_ADD_SHARDS="redis-shard-new"
+    export KB_SHARD_COUNT="2"
+    export REDIS_SOURCE_POD_NAME="redis-shard-old-0"
+    export REDIS_SOURCE_COMPONENT_NAME="redis-shard-old"
+    export REDIS_CLUSTER_NAMESPACE="default"
+    export REDIS_CLUSTER_DOMAIN="cluster.local"
+    export REDIS_SERVICE_PORT="6379"
+    export FAKE_SCENARIO=managed_ip
+    When call run_worker
+    The status should be success
+    The output should include "already converged"
+    The contents of file "$fake_log" should include "-h redis-shard-old-0.redis-shard-old-headless.default.svc.cluster.local"
+  End
+
+  It "rejects malformed managed component lists before redis-cli"
+    unset REDIS_CLUSTER_ENDPOINT REDIS_TARGET_SHARD_COUNT REDIS_NEW_MASTER_IDS
+    export KB_SHARD_ADD_TOKEN="token-1"
+    export KB_SHARDING_NAME="shard"
+    export KB_SHARD_ADD_SHARDS="redis-shard-new,,redis-shard-new"
+    export KB_SHARD_COUNT="3"
+    export REDIS_SOURCE_POD_NAME="redis-shard-old-0"
+    export REDIS_SOURCE_COMPONENT_NAME="redis-shard-old"
+    export REDIS_CLUSTER_NAMESPACE="default"
+    export REDIS_CLUSTER_DOMAIN="cluster.local"
+    export REDIS_SERVICE_PORT="6379"
+    When call run_worker
+    The status should be failure
+    The stderr should include "KB_SHARD_ADD_SHARDS"
     The contents of file "$fake_log" should be blank
   End
 

--- a/addons/redis/templates/opsdefinition-shardadd.yaml
+++ b/addons/redis/templates/opsdefinition-shardadd.yaml
@@ -1,0 +1,120 @@
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsDefinition
+metadata:
+  name: {{ printf "redis-cluster-shardadd-%s" .Chart.Version }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  podInfoExtractors:
+    - name: redis-cluster-shardadd-inputs
+      podSelector:
+        multiPodSelectionPolicy: Any
+      env:
+        - name: REDIS_DEFAULT_USER
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: REDIS_DEFAULT_USER
+        - name: REDIS_DEFAULT_PASSWORD
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: REDIS_DEFAULT_PASSWORD
+        - name: REDIS_TLS_ENABLED
+          optional: true
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: TLS_ENABLED
+        - name: REDIS_SOURCE_POD_NAME
+          valueFrom:
+            fieldPath:
+              fieldPath: metadata.name
+        - name: REDIS_SOURCE_COMPONENT_NAME
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: CURRENT_SHARD_COMPONENT_NAME
+        - name: REDIS_CLUSTER_NAMESPACE
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: CLUSTER_NAMESPACE
+        - name: REDIS_CLUSTER_DOMAIN
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: CLUSTER_DOMAIN
+        - name: REDIS_SERVICE_PORT
+          valueFrom:
+            envRef:
+              targetContainerName: redis-cluster
+              envName: SERVICE_PORT
+      volumeMounts:
+        - name: tls
+          mountPath: /etc/pki/tls
+          readOnly: true
+  parametersSchema:
+    openAPIV3Schema:
+      type: object
+      required:
+        - KB_SHARD_ADD_TOKEN
+        - KB_SHARDING_NAME
+        - KB_SHARD_ADD_SHARDS
+        - KB_SHARD_COUNT
+      properties:
+        KB_SHARD_ADD_TOKEN:
+          type: string
+          minLength: 1
+        KB_SHARDING_NAME:
+          type: string
+          minLength: 1
+        KB_SHARD_ADD_SHARDS:
+          type: string
+          minLength: 1
+        KB_SHARD_COUNT:
+          type: integer
+          minimum: 1
+  actions:
+    - name: shardadd-rebalance
+      failurePolicy: Fail
+      parameters:
+        - KB_SHARD_ADD_TOKEN
+        - KB_SHARDING_NAME
+        - KB_SHARD_ADD_SHARDS
+        - KB_SHARD_COUNT
+      workload:
+        type: ManagedJob
+        podInfoExtractorName: redis-cluster-shardadd-inputs
+        backoffLimit: 0
+        podSpec:
+          restartPolicy: Never
+          activeDeadlineSeconds: 10800
+          terminationGracePeriodSeconds: 30
+          containers:
+            - name: redis-cluster-shardadd-worker
+              image: {{ include "redis7.image" . }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - /scripts/redis-cluster-shardadd-worker.sh
+              env:
+                - name: REDIS_TLS_CA_FILE
+                  value: /etc/pki/tls/ca.crt
+                - name: REDIS_TLS_CERT_FILE
+                  value: /etc/pki/tls/tls.crt
+                - name: REDIS_TLS_KEY_FILE
+                  value: /etc/pki/tls/tls.key
+                - name: REDIS_COMMAND_TIMEOUT_SECONDS
+                  value: "7200"
+                - name: REDIS_COMMAND_KILL_GRACE_SECONDS
+                  value: "30"
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "redisCluster.scriptsTemplate" . }}
+                defaultMode: 0555

--- a/addons/redis/templates/shardingdefinition.yaml
+++ b/addons/redis/templates/shardingdefinition.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "redis.labels" . | nindent 4 }}
   annotations:
     {{- include "redis.apiVersion" . | nindent 4 }}
+    apps.kubeblocks.io/skip-immutable-check: "true"
 spec:
   template:
     compDef: {{ include "redisCluster.cmpdRegexpPattern" . }}
@@ -18,6 +19,8 @@ spec:
     - name: default
       shared: true
   lifecycleActions:
+    shardAdd:
+      opsDefinitionName: {{ printf "redis-cluster-shardadd-%s" .Chart.Version }}
     shardRemove:
       timeoutSeconds: 50
       exec:


### PR DESCRIPTION
## Problem facts

Redis Cluster data-bearing shard expansion needs a long-running, globally observed slot rebalance. The previous synchronous postProvision path made every new shard Pod a potential executor and ran inside a lifecycle action with a bounded execution window. That shape could overlap rebalance attempts and could not safely own a multi-minute operation.

The controller/API work now defines shardAdd as a ManagedJob operation. This PR supplies the addon side of that contract atomically: the chart advertises the OpsDefinition, the worker accepts the controller's final inputs, and postProvision stops owning slot rebalance.

## Changes

- Adds a versioned shardAdd OpsDefinition and references it from the Redis ShardingDefinition.
- Uses one `ManagedJob` action with one `Any` PodInfoExtractor and the eight approved source inputs.
- Exposes the exact operation parameters `KB_SHARD_ADD_TOKEN`, `KB_SHARDING_NAME`, `KB_SHARD_ADD_SHARDS`, and `KB_SHARD_COUNT` directly to the Job.
- Mounts the optional source `tls` volume read-only at `/etc/pki/tls`; TLS-disabled sources render no dangling Job volume or mount.
- Advances the immutable Redis chart identity to `1.2.0-alpha.8` and adds the one-time immutable-check migration annotation.
- Extends the shardAdd worker to consume the managed inputs, validate all inputs before mutation, resolve new masters by announced hostname, and use an IP-only DNS fallback for Redis 5.
- Removes scale-out reshard ownership from Redis 5/6+ postProvision. Those scripts now positively verify slot coverage and current-shard membership after node join; initial creation, ACL, and shardRemove behavior remains unchanged.

## Contract boundary

This PR is stacked on PR #3218 exact `8f1a9cb53e265da321ac136b01ad80f51daadaa2`.

Addon exact source: `f7c53e36298f0da5f4ef5e240eac3d32c7968d59`, tree `2e78bf4a61b721c02da6451549c326f1a6446fdd`.

The final controller source/image is still pending. Managed-operation runtime is therefore `N=0/PASS0/FAIL0`; no old controller image or alpha6 runtime evidence transfers to this candidate. This PR is not release-ready.

## Verification

- Focused bridge/worker/manage ShellSpec with Bash 5: `80 examples, 0 failures`
- Full Redis ShellSpec with Bash 5: `570 examples, 0 failures`
- `make scripts-test` with macOS Bash 3: `149 examples, 0 failures, 39 skips`
- Lifecycle render contract, including zero old lower-camel parameter names: `9 examples, 0 failures`
- Helm lint/template/package: PASS
- Bash syntax, ShellCheck error severity, `git diff --check`: PASS
- Independent focused source review: PASS / no blocker

Runtime-only residuals are the controller-created Job's source Pod reachability, `getent ahostsv4` availability/IP shape in the worker image, and the end-to-end handoff from postProvision to the ManagedJob operation.
