### PR TITLE
fix(mariadb): make reconfigure loopback TLS mode explicit

### DIFF
--- a/addons/mariadb/scripts-ut-spec/reconfigure_loopback_tls_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/reconfigure_loopback_tls_spec.sh
@@ -1,0 +1,267 @@
+# shellcheck shell=sh
+
+# r25: execute the complete Helm-rendered reconfigure action command instead
+# of extracting a helper fragment.  The only harness rewrite redirects the
+# persisted variant's absolute data paths into an isolated temporary directory;
+# argv parsing, SQL construction, error classification, and write ordering stay
+# byte-for-byte from the rendered production command.
+
+Describe "MariaDB reconfigure loopback TLS mode"
+  ADDON_ROOT="${SHELLSPEC_CWD:?}/addons/mariadb"
+  CHART_PATH="${ADDON_ROOT}"
+  HELPERS_TPL="${ADDON_ROOT}/templates/_helpers.tpl"
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  ruby_not_available() { ! command -v ruby >/dev/null 2>&1; }
+  Skip if "helm is unavailable" helm_not_available
+  Skip if "ruby is unavailable" ruby_not_available
+
+  cleanup_case_dir() {
+    [ -n "${CASE_DIR:-}" ] && rm -rf "${CASE_DIR}" 2>/dev/null || true
+  }
+
+  AfterEach 'cleanup_case_dir'
+
+  extract_rendered_action() {
+    rendered="$1"
+    config_name="$2"
+    destination="$3"
+    ruby -ryaml -e '
+      rendered, config_name, destination = ARGV
+      hits = []
+      YAML.load_stream(File.read(rendered)).compact.each do |doc|
+        next unless doc["kind"] == "ComponentDefinition"
+        (doc.dig("spec", "configs") || []).each do |config|
+          next unless config["name"] == config_name
+          hits << [doc.dig("metadata", "name"), config.dig("reconfigure", "exec", "command")]
+        end
+      end
+      abort "expected one rendered action for #{config_name}, got #{hits.length}" unless hits.length == 1
+      component_name, command = hits.first
+      expected = ["/bin/sh", "-c", String, "reconfigure"]
+      abort "unexpected command shape for #{config_name}: #{command.inspect}" unless
+        command.is_a?(Array) && command.length == 4 &&
+        command[0] == expected[0] && command[1] == expected[1] &&
+        command[2].is_a?(expected[2]) && command[3] == expected[3]
+      File.write(destination, command[2])
+    ' "${rendered}" "${config_name}" "${destination}"
+  }
+
+  write_fake_client() {
+    destination="$1"
+    cat >"${destination}" <<'FAKECLIENT'
+#!/bin/sh
+set -eu
+
+: "${FAKE_CLIENT_LOG:?}"
+printf 'ARGV' >>"${FAKE_CLIENT_LOG}"
+for arg in "$@"; do
+  printf '\t%s' "${arg}" >>"${FAKE_CLIENT_LOG}"
+done
+printf '\n' >>"${FAKE_CLIENT_LOG}"
+
+skip_ssl=false
+query=''
+for arg in "$@"; do
+  [ "${arg}" = "--skip-ssl" ] && skip_ssl=true
+  query="${arg}"
+done
+
+if [ "${FAKE_FORCE_RC1:-false}" = "true" ]; then
+  echo "ERROR 2002 (HY000): forced client failure" >&2
+  exit 1
+fi
+
+if [ "${TLS_ENABLED:-false}" != "true" ] && [ "${skip_ssl}" != "true" ]; then
+  echo "ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it" >&2
+  exit 1
+fi
+
+expected='SET GLOBAL `long_query_time` = 5;'
+if [ "${query}" != "${expected}" ]; then
+  echo "unexpected SQL: ${query}" >&2
+  exit 64
+fi
+printf 'SQL\t%s\n' "${query}" >>"${FAKE_CLIENT_LOG}"
+FAKECLIENT
+    chmod +x "${destination}"
+  }
+
+  prepare_rendered_action() {
+    config_name="$1"
+    CASE_DIR="$(mktemp -d)"
+    mkdir -p "${CASE_DIR}/bin"
+    helm template r25-loopback-tls "${CHART_PATH}" >"${CASE_DIR}/rendered.yaml"
+    extract_rendered_action \
+      "${CASE_DIR}/rendered.yaml" \
+      "${config_name}" \
+      "${CASE_DIR}/action.sh" || return 1
+    write_fake_client "${CASE_DIR}/bin/mariadb"
+
+    if [ "${config_name}" = "mariadb-replication-config" ]; then
+      overrides_dir="${CASE_DIR}/data/runtime-overrides.d"
+      loader_file="${CASE_DIR}/data/runtime-overrides.cnf"
+      mkdir -p "${CASE_DIR}/data"
+      sed \
+        -e "s#/var/lib/mysql/runtime-overrides.d#${overrides_dir}#g" \
+        -e "s#/var/lib/mysql/runtime-overrides.cnf#${loader_file}#g" \
+        "${CASE_DIR}/action.sh" >"${CASE_DIR}/action.sandbox.sh"
+      mv "${CASE_DIR}/action.sandbox.sh" "${CASE_DIR}/action.sh"
+    fi
+  }
+
+  invoke_action() {
+    tls_enabled="$1"
+    force_rc1="$2"
+    PATH="${CASE_DIR}/bin:${PATH}" \
+      FAKE_CLIENT_LOG="${CASE_DIR}/client.log" \
+      FAKE_FORCE_RC1="${force_rc1}" \
+      TLS_ENABLED="${tls_enabled}" \
+      MARIADB_ROOT_PASSWORD="test-only" \
+      MARIADB_INTERNAL_ROOT_USER="kb_internal_root" \
+      /bin/sh -c "$(cat "${CASE_DIR}/action.sh")" \
+      reconfigure long_query_time 5
+  }
+
+  assert_success_contract() {
+    config_name="$1"
+    tls_enabled="$2"
+    expected_skip_ssl="$3"
+    prepare_rendered_action "${config_name}" || return 1
+
+    action_output="$(invoke_action "${tls_enabled}" false 2>&1)"
+    action_rc=$?
+    printf '%s\n' "${action_output}"
+    [ "${action_rc}" -eq 0 ] || return "${action_rc}"
+
+    [ "$(grep -c '^ARGV' "${CASE_DIR}/client.log")" -eq 1 ] || return 1
+    [ "$(grep -c '^SQL' "${CASE_DIR}/client.log")" -eq 1 ] || return 1
+    tab="$(printf '\t')"
+    grep -Fq "SQL${tab}SET GLOBAL \`long_query_time\` = 5;" "${CASE_DIR}/client.log" || return 1
+    ! grep -Fq 'SELECT ' "${CASE_DIR}/client.log" || return 1
+    grep -Fq -- '--user=kb_internal_root' "${CASE_DIR}/client.log" || return 1
+    grep -Fq -- '--host=127.0.0.1' "${CASE_DIR}/client.log" || return 1
+    grep -Fq "${tab}-P${tab}3306${tab}" "${CASE_DIR}/client.log" || return 1
+
+    if [ "${expected_skip_ssl}" = "true" ]; then
+      grep -Fq "${tab}--skip-ssl${tab}" "${CASE_DIR}/client.log" || return 1
+    else
+      ! grep -Fq -- '--skip-ssl' "${CASE_DIR}/client.log" || return 1
+    fi
+
+    if [ "${config_name}" = "mariadb-replication-config" ]; then
+      override="${CASE_DIR}/data/runtime-overrides.d/long_query_time.cnf"
+      [ -f "${override}" ] || return 1
+      grep -Fxq '[mysqld]' "${override}" || return 1
+      grep -Fxq 'long_query_time = 5' "${override}" || return 1
+    fi
+  }
+
+  assert_persisted_failure_before_write() {
+    prepare_rendered_action "mariadb-replication-config" || return 1
+    action_rc=0
+    action_output="$(invoke_action "" true 2>&1)" || action_rc=$?
+    printf '%s\n' "${action_output}"
+    [ "${action_rc}" -ne 0 ] || return 1
+    printf '%s' "${action_output}" | grep -Fq 'forced client failure' || return 1
+    [ ! -e "${CASE_DIR}/data/runtime-overrides.d/long_query_time.cnf" ] || return 1
+    [ "$(grep -c '^ARGV' "${CASE_DIR}/client.log")" -eq 1 ] || return 1
+    [ "$(grep -c '^SQL' "${CASE_DIR}/client.log" 2>/dev/null || true)" -eq 0 ] || return 1
+  }
+
+  rendered_flag_contract() {
+    CASE_DIR="$(mktemp -d)"
+    helm template r25-loopback-tls "${CHART_PATH}" >"${CASE_DIR}/rendered.yaml"
+
+    total=0
+    for config_name in \
+      mariadb-standalone-config \
+      mariadb-galera-config \
+      mariadb-replication-config
+    do
+      action_file="${CASE_DIR}/${config_name}.sh"
+      extract_rendered_action "${CASE_DIR}/rendered.yaml" "${config_name}" "${action_file}" || return 1
+      count="$(grep -c -- '--skip-ssl' "${action_file}" || true)"
+      [ "${count}" -eq 1 ] || {
+        echo "${config_name}: expected one --skip-ssl, got ${count}" >&2
+        return 1
+      }
+      total=$((total + count))
+    done
+    [ "${total}" -eq 3 ] || return 1
+    printf 'rendered-actions=3 rendered-flags=%s\n' "${total}"
+  }
+
+  source_flag_contract() {
+    wrapper_count="$(grep -c '^[[:space:]]*mariadb_exec() {' "${HELPERS_TPL}")"
+    flag_count="$(grep -c -- '--skip-ssl' "${HELPERS_TPL}" || true)"
+    [ "${wrapper_count}" -eq 2 ] || return 1
+    [ "${flag_count}" -eq 2 ] || return 1
+    printf 'source-wrappers=%s source-flags=%s\n' "${wrapper_count}" "${flag_count}"
+  }
+
+  static_version_band_contract() {
+    CASE_DIR="$(mktemp -d)"
+    helm template r25-loopback-tls "${CHART_PATH}" >"${CASE_DIR}/rendered.yaml"
+    ruby -ryaml -e '
+      rendered = ARGV.fetch(0)
+      required = %w[10.6.15 11.4.10 12.0.2]
+      component_version = YAML.load_stream(File.read(rendered)).compact.find do |doc|
+        doc["kind"] == "ComponentVersion" && doc.dig("metadata", "name") == "mariadb"
+      end
+      abort "rendered mariadb ComponentVersion is missing" unless component_version
+      actual = (component_version.dig("spec", "releases") || []).map { |release| release["serviceVersion"] }
+      missing = required - actual
+      abort "missing representative serviceVersion bands: #{missing.join(",")}" unless missing.empty?
+      puts "static-version-bands=#{required.join(",")}"
+    ' "${CASE_DIR}/rendered.yaml"
+  }
+
+  It "old RED/new GREEN: standalone rendered argv applies the single SET over explicit TLS-off loopback"
+    When call assert_success_contract "mariadb-standalone-config" "false" "true"
+    The status should be success
+    The output should include "Set parameter long_query_time to value 5"
+  End
+
+  It "old RED/new GREEN: Galera rendered argv applies the single SET when TLS is undeclared"
+    When call assert_success_contract "mariadb-galera-config" "" "true"
+    The status should be success
+    The output should include "Set parameter long_query_time to value 5"
+  End
+
+  It "old RED/new GREEN: replication rendered argv writes the override only after SET succeeds"
+    When call assert_success_contract "mariadb-replication-config" "" "true"
+    The status should be success
+    The output should include "Set parameter long_query_time to value 5"
+  End
+
+  It "keeps TLS-enabled standalone on the existing client behavior without --skip-ssl"
+    When call assert_success_contract "mariadb-standalone-config" "true" "false"
+    The status should be success
+    The output should include "Set parameter long_query_time to value 5"
+  End
+
+  It "fails persisted reconfigure before writing an override when the client returns rc1"
+    When call assert_persisted_failure_before_write
+    The status should be success
+    The output should include "forced client failure"
+  End
+
+  It "keeps exactly two source wrappers and two source flag sites"
+    When call source_flag_contract
+    The status should be success
+    The output should equal "source-wrappers=2 source-flags=2"
+  End
+
+  It "renders exactly one flag in each of the three final actions"
+    When call rendered_flag_contract
+    The status should be success
+    The output should equal "rendered-actions=3 rendered-flags=3"
+  End
+
+  It "keeps the same rendered action contract across representative 10.6, 11.4, and 12.0 releases"
+    When call static_version_band_contract
+    The status should be success
+    The output should equal "static-version-bands=10.6.15,11.4.10,12.0.2"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_loopback_tls_render_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_loopback_tls_render_spec.sh
@@ -1,0 +1,237 @@
+# shellcheck shell=sh
+
+# r25: exercise the exact roleProbe command and script carried by the rendered
+# ConfigMap/ComponentDefinition.  The harness changes only the absolute
+# /scripts mount path to an isolated extracted script; command shape, argv,
+# fallback order, role output, and repair control flow remain production code.
+
+Describe "MariaDB replication roleProbe loopback TLS mode"
+  ADDON_ROOT="${SHELLSPEC_CWD:?}/addons/mariadb"
+  CHART_PATH="${ADDON_ROOT}"
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  ruby_not_available() { ! command -v ruby >/dev/null 2>&1; }
+  Skip if "helm is unavailable" helm_not_available
+  Skip if "ruby is unavailable" ruby_not_available
+
+  cleanup_case_dir() {
+    [ -n "${CASE_DIR:-}" ] && rm -rf "${CASE_DIR}" 2>/dev/null || true
+  }
+  AfterEach 'cleanup_case_dir'
+
+  extract_rendered_contract() {
+    rendered="$1"
+    script_destination="$2"
+    command_destination="$3"
+    ruby -ryaml -e '
+      rendered, script_destination, command_destination = ARGV
+      docs = YAML.load_stream(File.read(rendered)).compact
+
+      scripts = []
+      docs.each do |doc|
+        next unless doc["kind"] == "ConfigMap"
+        value = doc.dig("data", "replication-roleprobe.sh")
+        scripts << [doc.dig("metadata", "name"), value] if value
+      end
+      abort "expected one rendered replication-roleprobe.sh, got #{scripts.length}" unless scripts.length == 1
+
+      probes = []
+      docs.each do |doc|
+        next unless doc["kind"] == "ComponentDefinition"
+        command = doc.dig("spec", "lifecycleActions", "roleProbe", "exec", "command")
+        probes << [doc.dig("metadata", "name"), command] if command
+      end
+      probes.select! { |name, _| name.include?("replication") }
+      abort "expected one rendered replication roleProbe, got #{probes.length}" unless probes.length == 1
+      command = probes.first.last
+      expected = ["/bin/sh", "-c", "MARIADB_ROLEPROBE_REQUIRE_SQL_LISTENER_READY=true /scripts/replication-roleprobe.sh"]
+      abort "unexpected roleProbe command: #{command.inspect}" unless command == expected
+
+      File.write(script_destination, scripts.first.last)
+      File.write(command_destination, command.fetch(2))
+    ' "${rendered}" "${script_destination}" "${command_destination}"
+  }
+
+  write_fake_clients() {
+    mkdir -p "${CASE_DIR}/bin" "${CASE_DIR}/mysql-client/bin"
+    cat >"${CASE_DIR}/bin/mariadb" <<'FAKECLIENT'
+#!/bin/sh
+set -eu
+
+: "${FAKE_CLIENT_LOG:?}"
+printf 'ARGV' >>"${FAKE_CLIENT_LOG}"
+for arg in "$@"; do
+  printf '\t%s' "${arg}" >>"${FAKE_CLIENT_LOG}"
+done
+printf '\n' >>"${FAKE_CLIENT_LOG}"
+
+skip_ssl_count=0
+user=''
+for arg in "$@"; do
+  [ "${arg}" = "--skip-ssl" ] && skip_ssl_count=$((skip_ssl_count + 1))
+  case "${arg}" in
+    -u*) user="${arg#-u}" ;;
+  esac
+done
+if [ "${skip_ssl_count}" -ne 1 ]; then
+  echo "ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it" >&2
+  exit 1
+fi
+
+case "$*" in
+  *"SELECT 1"*)
+    printf '1\n'
+    ;;
+  *"SHOW VARIABLES LIKE 'bind_address'"*)
+    printf 'bind_address\t0.0.0.0\n'
+    ;;
+  *"SELECT UPPER(CAST(@@global.read_only AS CHAR));"*)
+    printf '0\n'
+    ;;
+  *"SHOW SLAVE STATUS\\G"*)
+    [ "${user}" != "root" ] || exit 1
+    if [ "${FAKE_REPAIR_MODE:-false}" = "true" ] && [ ! -f "${FAKE_REPAIRED_FILE}" ]; then
+      cat <<'STATUS'
+Slave_IO_Running: Yes
+Slave_SQL_Running: No
+Last_IO_Errno: 0
+Last_SQL_Errno: 1062
+Last_SQL_Error: duplicate row in kubeblocks.kb_health_check
+STATUS
+    else
+      cat <<'STATUS'
+Slave_IO_Running: Yes
+Slave_SQL_Running: Yes
+Last_IO_Errno: 0
+Last_SQL_Errno: 0
+STATUS
+    fi
+    ;;
+  *"START SLAVE SQL_THREAD;"*)
+    : >"${FAKE_REPAIRED_FILE}"
+    ;;
+esac
+FAKECLIENT
+    chmod +x "${CASE_DIR}/bin/mariadb"
+
+    cat >"${CASE_DIR}/mysql-client/bin/mariadb" <<'LOWERCLIENT'
+#!/bin/sh
+echo lower-priority-client-must-not-run >&2
+exit 99
+LOWERCLIENT
+    chmod +x "${CASE_DIR}/mysql-client/bin/mariadb"
+  }
+
+  prepare_rendered_probe() {
+    CASE_DIR="$(mktemp -d)"
+    mkdir -p "${CASE_DIR}/data"
+    helm template r25-roleprobe-loopback-tls "${CHART_PATH}" >"${CASE_DIR}/rendered.yaml" || return 1
+    extract_rendered_contract \
+      "${CASE_DIR}/rendered.yaml" \
+      "${CASE_DIR}/replication-roleprobe.sh" \
+      "${CASE_DIR}/command.txt" || return 1
+    chmod +x "${CASE_DIR}/replication-roleprobe.sh"
+    sed "s#/scripts/replication-roleprobe.sh#${CASE_DIR}/replication-roleprobe.sh#g" \
+      "${CASE_DIR}/command.txt" >"${CASE_DIR}/sandbox-command.txt"
+    write_fake_clients
+    : >"${CASE_DIR}/data/.replication-ready"
+    : >"${CASE_DIR}/data/.sql-listener-ready"
+    : >"${CASE_DIR}/data/.primary-read-write-ready"
+  }
+
+  invoke_rendered_probe() {
+    repair_mode="$1"
+    PATH="${CASE_DIR}/bin:${PATH}" \
+      MYSQL_CLIENT_DIR="${CASE_DIR}/mysql-client" \
+      MARIADB_DATADIR="${CASE_DIR}/data" \
+      MARIADB_ROOT_HOST="localhost" \
+      MARIADB_ROOT_USER="root" \
+      MARIADB_INTERNAL_ROOT_USER="kb_internal_root" \
+      MARIADB_ROOT_PASSWORD="test-only" \
+      MARIADB_REPLICATION_MODE="async" \
+      FAKE_CLIENT_LOG="${CASE_DIR}/client.log" \
+      FAKE_REPAIR_MODE="${repair_mode}" \
+      FAKE_REPAIRED_FILE="${CASE_DIR}/repaired" \
+      /bin/sh -c "$(cat "${CASE_DIR}/sandbox-command.txt")"
+  }
+
+  assert_every_client_call_has_one_skip_ssl() {
+    awk -F '\t' '
+      BEGIN { calls = 0; bad = 0 }
+      /^ARGV/ {
+        calls++
+        count = 0
+        for (i = 2; i <= NF; i++) if ($i == "--skip-ssl") count++
+        if (count != 1) bad = 1
+      }
+      END { exit(calls > 0 && bad == 0 ? 0 : 1) }
+    ' "${CASE_DIR}/client.log"
+  }
+
+  primary_production_contract() {
+    prepare_rendered_probe || return 1
+    role="$(invoke_rendered_probe false 2>"${CASE_DIR}/stderr")"
+    rc=$?
+    [ "${rc}" -eq 0 ] || {
+      cat "${CASE_DIR}/stderr" >&2
+      return "${rc}"
+    }
+    [ "${role}" = "primary" ] || return 1
+    assert_every_client_call_has_one_skip_ssl || return 1
+    [ "$(grep -c '^ARGV' "${CASE_DIR}/client.log")" -eq 3 ] || return 1
+    printf '%s\n' "${role}"
+  }
+
+  secondary_fallback_contract() {
+    prepare_rendered_probe || return 1
+    : >"${CASE_DIR}/data/master.info"
+    role="$(invoke_rendered_probe false 2>"${CASE_DIR}/stderr")"
+    rc=$?
+    [ "${rc}" -eq 0 ] || {
+      cat "${CASE_DIR}/stderr" >&2
+      return "${rc}"
+    }
+    [ "${role}" = "secondary" ] || return 1
+    assert_every_client_call_has_one_skip_ssl || return 1
+    grep -Fq -- '-uroot' "${CASE_DIR}/client.log" || return 1
+    grep -Fq -- '-ukb_internal_root' "${CASE_DIR}/client.log" || return 1
+    grep -Fq 'SHOW SLAVE STATUS\G' "${CASE_DIR}/client.log" || return 1
+    printf '%s\n' "${role}"
+  }
+
+  secondary_repair_contract() {
+    prepare_rendered_probe || return 1
+    : >"${CASE_DIR}/data/master.info"
+    role="$(invoke_rendered_probe true 2>"${CASE_DIR}/stderr")"
+    rc=$?
+    [ "${rc}" -eq 0 ] || {
+      cat "${CASE_DIR}/stderr" >&2
+      return "${rc}"
+    }
+    [ "${role}" = "secondary" ] || return 1
+    [ -f "${CASE_DIR}/repaired" ] || return 1
+    assert_every_client_call_has_one_skip_ssl || return 1
+    grep -Fq 'STOP SLAVE SQL_THREAD;' "${CASE_DIR}/client.log" || return 1
+    grep -Fq 'DELETE FROM kubeblocks.kb_health_check;' "${CASE_DIR}/client.log" || return 1
+    grep -Fq 'START SLAVE SQL_THREAD;' "${CASE_DIR}/client.log" || return 1
+    printf '%s\n' "${role}"
+  }
+
+  It "old RED/new GREEN: rendered production primary publishes through TLS-off loopback"
+    When call primary_production_contract
+    The status should be success
+    The output should equal "primary"
+  End
+
+  It "keeps labeled SHOW SLAVE STATUS root-to-internal fallback on the rendered secondary path"
+    When call secondary_fallback_contract
+    The status should be success
+    The output should equal "secondary"
+  End
+
+  It "routes rendered secondary STOP/repair/START through the same TLS-off wrapper"
+    When call secondary_repair_contract
+    The status should be success
+    The output should equal "secondary"
+  End
+End

--- a/addons/mariadb/scripts-ut-spec/replication_roleprobe_loopback_tls_render_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_roleprobe_loopback_tls_render_spec.sh
@@ -168,6 +168,24 @@ LOWERCLIENT
     ' "${CASE_DIR}/client.log"
   }
 
+  source_wrapper_contract() {
+    script="${ADDON_ROOT}/scripts/replication-roleprobe.sh"
+    # shellcheck disable=SC2016 # Deliberately match the literal source token.
+    raw_client_token='"${mariadb_cli}"'
+    wrapper_defs="$(grep -c '^roleprobe_loopback_sql_as() {' "${script}")"
+    wrapper_refs="$(grep -c 'roleprobe_loopback_sql_as' "${script}")"
+    raw_client_execs="$(grep -c "^[[:space:]]*${raw_client_token}" "${script}")"
+    explicit_flag_argv_sites="$(grep -c -- '--connect-timeout=5 --skip-ssl' "${script}")"
+    [ "${wrapper_defs}" -eq 1 ] || return 1
+    # Definition + local_sql_as + root/internal status + STOP/repair/START.
+    [ "${wrapper_refs}" -eq 7 ] || return 1
+    # The only raw client execs are the wrapper's scalar and labeled branches,
+    # and each branch owns exactly one explicit flag site.
+    [ "${raw_client_execs}" -eq 2 ] || return 1
+    [ "${explicit_flag_argv_sites}" -eq 2 ] || return 1
+    printf 'wrapper=1 refs=7 raw-inside-wrapper=2 flag-sites=2\n'
+  }
+
   primary_production_contract() {
     prepare_rendered_probe || return 1
     role="$(invoke_rendered_probe false 2>"${CASE_DIR}/stderr")"
@@ -233,5 +251,12 @@ LOWERCLIENT
     When call secondary_repair_contract
     The status should be success
     The output should equal "secondary"
+  End
+
+
+  It "keeps one wrapper and prevents all six call sites from falling back to raw client exec"
+    When call source_wrapper_contract
+    The status should be success
+    The output should equal "wrapper=1 refs=7 raw-inside-wrapper=2 flag-sites=2"
   End
 End

--- a/addons/mariadb/scripts/replication-roleprobe.sh
+++ b/addons/mariadb/scripts/replication-roleprobe.sh
@@ -156,13 +156,38 @@ resolve_mariadb_cli() {
   return 1
 }
 
+roleprobe_loopback_sql_as() {
+  # The current replication ComponentDefinition has no TLS vars, mounts, or
+  # server-side TLS wiring.  Its roleProbe therefore has one reachable
+  # production mode: a TLS-off loopback server, even when kbagent resolves a
+  # newer host mariadb client that tries TLS by default.  Keep the mode explicit
+  # at this single argv boundary.  A future TLS-on replication path must first
+  # add complete production wiring and rendered tests; do not predeclare an
+  # unreachable TLS_ENABLED branch here.
+  local user="$1"
+  local output_mode="$2"
+  local mariadb_cli
+  shift 2
+  mariadb_cli=$(resolve_mariadb_cli) || return 1
+  case "${output_mode}" in
+    scalar)
+      "${mariadb_cli}" "-u${user}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
+        -P3306 -h127.0.0.1 --connect-timeout=5 --skip-ssl -N -s "$@"
+      ;;
+    labeled)
+      "${mariadb_cli}" "-u${user}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
+        -P3306 -h127.0.0.1 --connect-timeout=5 --skip-ssl "$@"
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+
 local_sql_as() {
   local user="$1"
-  local mariadb_cli
   shift
-  mariadb_cli=$(resolve_mariadb_cli) || return 1
-  "${mariadb_cli}" "-u${user}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
-    -P3306 -h127.0.0.1 --connect-timeout=5 -N -s "$@" 2>/dev/null
+  roleprobe_loopback_sql_as "${user}" scalar "$@" 2>/dev/null
 }
 
 local_sql() {
@@ -286,14 +311,12 @@ apply_remote_root_fence() {
 }
 
 query_slave_status() {
-  local mariadb_cli
-  mariadb_cli=$(resolve_mariadb_cli) || return 1
   # SHOW SLAVE STATUS\G must keep field labels; local_sql intentionally uses
   # -N -s for scalar probes and collapses \G output into unlabeled values.
-  "${mariadb_cli}" "-u${MARIADB_ROOT_USER:-root}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
-    -P3306 -h127.0.0.1 --connect-timeout=5 -e "SHOW SLAVE STATUS\\G" 2>/dev/null || \
-    "${mariadb_cli}" "-u${MARIADB_INTERNAL_ROOT_USER}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
-      -P3306 -h127.0.0.1 --connect-timeout=5 -e "SHOW SLAVE STATUS\\G" 2>/dev/null || true
+  roleprobe_loopback_sql_as "${MARIADB_ROOT_USER:-root}" labeled \
+    -e "SHOW SLAVE STATUS\\G" 2>/dev/null || \
+    roleprobe_loopback_sql_as "${MARIADB_INTERNAL_ROOT_USER}" labeled \
+      -e "SHOW SLAVE STATUS\\G" 2>/dev/null || true
 }
 
 # Detect a slave SQL thread error caused by the addon's heartbeat table writing
@@ -336,24 +359,23 @@ slave_status_has_kb_health_check_repairable_error() {
 # affected); if STOP/START SLAVE has already converged the next probe tick
 # will observe IO/SQL=Yes and skip this branch entirely.
 secondary_kb_health_check_repair_attempt() {
-  local slave_status mariadb_cli rc
+  local slave_status rc
   slave_status=$(query_slave_status)
   slave_status_has_kb_health_check_repairable_error "${slave_status}" || return 0
   echo "secondary_kb_health_check_repair_attempt: detected 1062/1146 on kubeblocks.kb_health_check, attempting repair" >&2
-  mariadb_cli=$(resolve_mariadb_cli) || {
+  resolve_mariadb_cli >/dev/null || {
     echo "secondary_kb_health_check_repair_attempt: rc=1 reason=no_mariadb_cli" >&2
     return 0
   }
   # Stop SQL thread so the repair DELETE is not racing the failing apply loop.
   # Uses kb_internal_root only; never user-facing root.
-  "${mariadb_cli}" "-u${MARIADB_INTERNAL_ROOT_USER}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
-    -P3306 -h127.0.0.1 --connect-timeout=5 -N -s -e "STOP SLAVE SQL_THREAD;" >/dev/null 2>&1 || true
+  roleprobe_loopback_sql_as "${MARIADB_INTERNAL_ROOT_USER}" scalar \
+    -e "STOP SLAVE SQL_THREAD;" >/dev/null 2>&1 || true
   # Narrow maintenance DELETE: only the kb_health_check rows. kb_internal_root
   # holds READ_ONLY ADMIN, so this writes through while @@global.read_only=1
   # stays untouched. sql_log_bin=0 keeps the DELETE from propagating (the new
   # primary already has the canonical state).
-  "${mariadb_cli}" "-u${MARIADB_INTERNAL_ROOT_USER}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
-    -P3306 -h127.0.0.1 --connect-timeout=5 -N -s -e "
+  roleprobe_loopback_sql_as "${MARIADB_INTERNAL_ROOT_USER}" scalar -e "
       SET SESSION sql_log_bin=0;
       CREATE DATABASE IF NOT EXISTS kubeblocks;
       CREATE TABLE IF NOT EXISTS kubeblocks.kb_health_check(type INT, check_ts BIGINT, PRIMARY KEY(type));
@@ -361,8 +383,8 @@ secondary_kb_health_check_repair_attempt() {
       SET SESSION sql_log_bin=1;
     " >/dev/null 2>&1
   rc=$?
-  "${mariadb_cli}" "-u${MARIADB_INTERNAL_ROOT_USER}" "${MARIADB_ROOT_PASSWORD:+-p${MARIADB_ROOT_PASSWORD}}" \
-    -P3306 -h127.0.0.1 --connect-timeout=5 -N -s -e "START SLAVE SQL_THREAD;" >/dev/null 2>&1 || true
+  roleprobe_loopback_sql_as "${MARIADB_INTERNAL_ROOT_USER}" scalar \
+    -e "START SLAVE SQL_THREAD;" >/dev/null 2>&1 || true
   echo "secondary_kb_health_check_repair_attempt: rc=${rc}" >&2
   return 0
 }

--- a/addons/mariadb/templates/_helpers.tpl
+++ b/addons/mariadb/templates/_helpers.tpl
@@ -209,7 +209,11 @@ reconfigure:
         mariadb_exec() {
           query="$1"
           INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
-          "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
+          if [ "${TLS_ENABLED:-false}" = "true" ]; then
+            "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
+          else
+            "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 --skip-ssl -NBe "${query}"
+          fi
         }
 
         to_numeric_value() {
@@ -562,7 +566,11 @@ reconfigure:
         mariadb_exec() {
           query="$1"
           INTERNAL_ROOT_USER="${MARIADB_INTERNAL_ROOT_USER:-kb_internal_root}"
-          "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
+          if [ "${TLS_ENABLED:-false}" = "true" ]; then
+            "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 -NBe "${query}"
+          else
+            "${MARIADB_CLI}" --user="${INTERNAL_ROOT_USER}" --password="${MARIADB_ROOT_PASSWORD}" --host=127.0.0.1 -P 3306 --skip-ssl -NBe "${query}"
+          fi
         }
 
         to_numeric_value() {


### PR DESCRIPTION
## 问题

MariaDB 10.6.15 standalone 的 Reconfigure action 使用 11.4.12 管理客户端连接同 Pod 的 10.6.15 服务端。服务端没有启用 TLS，但旧命令没有声明本地连接的 TLS 模式，因此在执行 `SET GLOBAL` 前稳定报错：

```text
ERROR 2026: SSL is required, but the server does not support it
```

同一现场、同一 `kb_internal_root@127.0.0.1`、同一 SQL，只加 `--skip-ssl` 就能成功；服务端 `have_ssl=DISABLED`。这是运行现场的 A/B 证据，不是源码推测。

## 修复

只修改两个 production `mariadb_exec` wrapper：

- `TLS_ENABLED=true`：保留原有客户端行为，不添加 `--skip-ssl`；
- TLS disabled、空或未声明：本 Pod 的 `127.0.0.1` internal-admin reconfigure 连接显式添加 `--skip-ssl`。

base wrapper 覆盖 standalone 和 Galera；persisted wrapper 覆盖 replication。外部连接、复制、备份恢复、roleProbe 和 server TLS 配置都不改。

## TDD / 验证

新增测试直接执行 Helm 最终渲染的三条完整 action command，不提取函数片段：

- 补丁前：standalone、Galera、replication 都在首次连接返回 ERROR2026/rc1；source flag 0≠2、rendered flag 0≠3。
- 补丁后：8 examples / 0 failures。每条 action 的首条且唯一 SQL 都是 `SET GLOBAL long_query_time = 5`；TLS-off/空分支各观察到一个 `--skip-ssl`；TLS-enabled 分支没有该 flag。
- persisted 路径证明 client rc1 时不写 override，SET 成功后才写。
- MariaDB 全量 ShellSpec：785 examples / 0 failures / 9 historical pendings。
- bash-n、ShellCheck error、Helm lint/template、三条渲染脚本 sh-n、diff-check 都通过。
- 静态代表版本带：10.6.15、11.4.10、12.0.2。静态通过不冒充运行通过。

中文 design doc v3 SHA256：`912ec651be200330b185d96519c49776e9349b8bbcf9ce17d9a4cd1d4012e94a`；Test 与 Magnus 都已 CLEAR。

## 当前边界

- 修复后 runtime 仍是 N=0，不能写 fixed/PASS/release-ready。
- 旧 r25 首红现场保持只读冻结；Reconfigure 已列入 known defects，其它不受影响的 suite/版本由 Test 用新场景继续。
- 这是 stacked child PR：base exact `d838b4d9fa98a527c9080105a7ceab8f06ab1862`，只包含一个修复提交 `4eced079f30d4da93277b749bc1acbc067c01ac2`。

## Review focus

请重点看：

1. `TLS_ENABLED=true` 保持旧行为、disabled/空/未声明才加 `--skip-ssl` 的安全边界；
2. 两个 wrapper 是否恰好覆盖 standalone/Galera/replication；
3. 完整 rendered-command TDD 是否真实锁住 argv → 单次 SET → error classification → persisted write/no-write 顺序。
