### PR TITLE
fix(mariadb): make switchover completion non-preemptive

### DIFF
--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -203,6 +203,22 @@ EOF
     End
   End
 
+  Describe "resolve_candidate_mode()"
+    It "returns explicit before candidate-name resolution when the API supplied a candidate"
+      export KB_SWITCHOVER_CANDIDATE_NAME="mdb-mariadb-1"
+      When call resolve_candidate_mode
+      The status should be success
+      The output should eq "explicit"
+    End
+
+    It "returns auto before candidate-name resolution when the API candidate is empty"
+      export KB_SWITCHOVER_CANDIDATE_NAME=""
+      When call resolve_candidate_mode
+      The status should be success
+      The output should eq "auto"
+    End
+  End
+
   Describe "main() role guard"
     Context "when KB_SWITCHOVER_ROLE is not 'primary'"
       setup_secondary() {
@@ -216,6 +232,168 @@ EOF
         The output should include "Not the primary"
         The path "${SYNCERCTL_ARGS}" should not be exist
       End
+    End
+  End
+
+  Describe "main() candidate-source freeze"
+    It "captures candidate mode before resolving the candidate name and passes the frozen mode"
+      : > "${TEST_DIR}/calls"
+      export KB_SWITCHOVER_CANDIDATE_NAME="mdb-mariadb-1"
+      setup_mariadb_client_bin() { return 0; }
+      resolve_candidate_mode() {
+        record_call "1-mode"
+        printf '%s' "explicit"
+      }
+      resolve_candidate_name() {
+        record_call "2-name"
+        printf '%s' "mdb-mariadb-1"
+      }
+      resolve_candidate_fqdn() {
+        record_call "3-fqdn:$1"
+        printf '%s' "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+      }
+      run_switchover() {
+        record_call "4-run-mode:$3"
+        return 0
+      }
+
+      When call main
+      The status should be success
+      The contents of file "${TEST_DIR}/calls" should eq "1-mode
+2-name
+3-fqdn:mdb-mariadb-1
+4-run-mode:explicit"
+    End
+  End
+
+  Describe "run_switchover() r25 explicit/auto completion contract"
+    setup_completion_contract() {
+      : > "${TEST_DIR}/calls"
+      prepare_current_primary_for_switchover() { return 0; }
+      wait_candidate_sql_reachable_before_dcs() { return 0; }
+      syncerctl_switchover() { return 0; }
+      fence_current_primary_local_writes_after_dcs() { return 0; }
+    }
+    Before "setup_completion_contract"
+
+    It "fails closed before any stage when candidate mode is missing or unknown"
+      When call run_switchover \
+        "mdb-mariadb-1" \
+        "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+        "unknown"
+      The status should be failure
+      The stderr should include "reason=invalid_candidate_mode"
+      The stderr should include "candidate_mode=unknown"
+      The stderr should include "fail-closed"
+      The contents of file "${TEST_DIR}/calls" should eq ""
+    End
+
+    It "keeps exactly one production caller for each auto-only Stage5 and Stage6 helper"
+      source_file="${SHELLSPEC_CWD:?}/addons/mariadb/scripts/replication-switchover.sh"
+      When call awk '/^run_switchover\(\)/ { in_func=1; next } in_func && /^}/ { print promote_count + 0, ready_count + 0; exit } in_func && /^[[:space:]]*if ! wait_candidate_promoted_via_syncerctl/ { promote_count++ } in_func && /^[[:space:]]*if ! wait_candidate_remote_root_primary_ready/ { ready_count++ }' "${source_file}"
+      The status should be success
+      The output should eq "1 1"
+    End
+
+    It "delegates explicit-candidate convergence after DCS and old-primary fence without calling Stage5 or Stage6"
+      wait_candidate_promoted_via_syncerctl() {
+        record_call "BUG_explicit_stage5_called"
+        return 1
+      }
+      wait_candidate_remote_root_primary_ready() {
+        record_call "BUG_explicit_stage6_called"
+        return 1
+      }
+
+      When call run_switchover \
+        "mdb-mariadb-1" \
+        "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+        "explicit"
+      The status should be success
+      The output should include "candidate_mode=explicit"
+      The output should include "dcs_recorded=true"
+      The output should include "old_primary_fenced=true"
+      The output should include "convergence=delegated"
+      The contents of file "${TEST_DIR}/calls" should not include "BUG_explicit_stage5_called"
+      The contents of file "${TEST_DIR}/calls" should not include "BUG_explicit_stage6_called"
+    End
+
+    It "keeps empty-candidate auto mode fail-closed while the selected candidate remains secondary"
+      wait_candidate_promoted_via_syncerctl() {
+        record_call "auto_stage5_called"
+        return 1
+      }
+      wait_candidate_remote_root_primary_ready() {
+        record_call "BUG_auto_stage6_called_after_stage5_failure"
+        return 1
+      }
+
+      When call run_switchover \
+        "mdb-mariadb-1" \
+        "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+        "auto"
+      The status should be failure
+      The contents of file "${TEST_DIR}/calls" should include "auto_stage5_called"
+      The contents of file "${TEST_DIR}/calls" should not include "BUG_auto_stage6_called_after_stage5_failure"
+      The output should not include "convergence=delegated"
+      The output should not include "convergence=observed"
+    End
+
+    It "reports observed convergence for auto mode only after Stage5 and Stage6 both close"
+      wait_candidate_promoted_via_syncerctl() {
+        record_call "auto_stage5_called"
+        return 0
+      }
+      wait_candidate_remote_root_primary_ready() {
+        record_call "auto_stage6_called"
+        return 0
+      }
+
+      When call run_switchover \
+        "mdb-mariadb-1" \
+        "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+        "auto"
+      The status should be success
+      The output should include "candidate_mode=auto"
+      The output should include "dcs_recorded=true"
+      The output should include "old_primary_fenced=true"
+      The output should include "convergence=observed"
+      The contents of file "${TEST_DIR}/calls" should include "auto_stage5_called"
+      The contents of file "${TEST_DIR}/calls" should include "auto_stage6_called"
+    End
+  End
+
+  Describe "run_switchover() r25 real external timeout boundary"
+    It "reaps a slow DCS client at the remaining one-second budget, fences uncertain DCS, and never delegates"
+      export SWITCHOVER_DCS_STAGE_BUDGET_SECONDS=1
+      export SYNCERCTL_PER_CALL_TIMEOUT_SECONDS=5
+      : > "${TEST_DIR}/calls"
+      cat > "${SYNCERCTL_BIN}" <<'EOF'
+#!/bin/sh
+sleep 2
+printf '%s\n' "switchover success"
+EOF
+      chmod +x "${SYNCERCTL_BIN}"
+      prepare_current_primary_for_switchover() { return 0; }
+      wait_candidate_sql_reachable_before_dcs() { return 0; }
+      set_local_read_only() {
+        record_call "set_read_only=$1"
+        return 0
+      }
+      local_read_only_is() { [ "$1" = "1" ]; }
+
+      When call run_switchover \
+        "mdb-mariadb-1" \
+        "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+        "explicit"
+      The status should be failure
+      The stderr should include "reason=syncerctl_timeout"
+      The stderr should include "stage=dcs"
+      The stderr should include "stage_budget=1s"
+      The output should include "uncertain DCS switchover"
+      The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
+      The output should not include "convergence=delegated"
+      The output should not include "Switchover stage fence"
     End
   End
 
@@ -270,10 +448,10 @@ Last_SQL_Errno: 0
 Master_Host: mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local
 EOF
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be success
         The output should include "Switchover candidate remote root primary-readiness probe converged for mdb-mariadb-1"
-        The output should include "candidate root primary-readiness observed without mutating probe"
+        The output should include "convergence=observed"
       End
 
       It "passes pod names to syncerctl instead of candidate FQDN"
@@ -325,7 +503,7 @@ Last_SQL_Errno: 0
 Master_Host: mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local
 EOF
         }
-        run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         When run cat "${SYNCERCTL_ARGS}"
         The status should be success
         # alpha.79 v2: --force added to bypass syncer's "previous switchover
@@ -399,7 +577,7 @@ EOF
         When call main
         The status should be success
         The output should include "Switchover using mariadb client: ${MYSQL_CLIENT_DIR}/bin/mariadb"
-        The output should include "candidate root primary-readiness observed without mutating probe"
+        The output should include "convergence=observed"
       End
 
       It "alpha.59 contract: never invokes wait_switchover_done / wait_post_switchover_stabilization / wait_primary_service_routes_candidate / current_follows_candidate"
@@ -426,9 +604,9 @@ EOF
         wait_current_secondary_remote_root_fenced() { record_call "BUG_wait_current_secondary_remote_root_fenced_called"; return 0; }
         current_follows_candidate() { record_call "BUG_current_follows_candidate_called"; return 0; }
         primary_service_routes_candidate() { record_call "BUG_primary_service_routes_candidate_called"; return 0; }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be success
-        The output should include "candidate root primary-readiness observed without mutating probe"
+        The output should include "convergence=observed"
         The contents of file "${TEST_DIR}/calls" should not include "BUG_wait_switchover_done_called"
         The contents of file "${TEST_DIR}/calls" should not include "BUG_wait_post_switchover_stabilization_called"
         The contents of file "${TEST_DIR}/calls" should not include "BUG_wait_primary_service_routes_candidate_called"
@@ -453,7 +631,7 @@ EOF
             "127.0.0.1:SELECT @@global.read_only;"*) echo "1" ;;
           esac
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be failure
         The output should include "Switchover post-DCS guard passed"
         The stderr should include "reason=candidate_remote_root_primary_not_ready_in_budget"
@@ -485,7 +663,7 @@ esac
 exit 0
 EOF
         chmod +x "${MARIADB_CLIENT_BIN}"
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be failure
         The output should include "Switchover stage candidate_primary_ready budget=1s"
         The stderr should include "candidate_remote_root_explicit_primary_grant_verify"
@@ -516,7 +694,7 @@ EOF
         local_read_only_is() {
           [ "$1" = "1" ]
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be failure
         The output should include "Switchover: creating syncer DCS switchover"
         The output should include "fencing current primary read_only=1"
@@ -542,7 +720,7 @@ EOF
         local_read_only_is() {
           [ "$1" = "1" ]
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be failure
         The output should include "Switchover syncerctl output: switchover failed: operation precheck failed: mdb-mariadb-0 is not the primary"
         The stderr should include "Switchover failed: syncerctl did not report success"
@@ -561,13 +739,115 @@ EOF
           record_call "set_read_only=$1"
           return 1
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be failure
         The output should include "fencing current primary read_only=1"
         The stderr should include "could not set current primary read_only=1 after uncertain DCS switchover"
         The stderr should include "manual verification required to avoid split-brain"
         The contents of file "${TEST_DIR}/calls" should include "set_read_only=ON"
         The contents of file "${TEST_DIR}/calls" should not include "set_read_only=OFF"
+      End
+
+      It "fails closed when idempotent final-state is reached but the old-primary positive fence cannot close"
+        make_zero_status_failing_syncerctl
+        : > "${TEST_DIR}/calls"
+        prepare_current_primary_for_switchover() { return 0; }
+        wait_candidate_sql_reachable_before_dcs() { return 0; }
+        switchover_final_state_already_reached() { return 0; }
+        set_local_read_only() {
+          record_call "idempotent_set_read_only=$1"
+          return 0
+        }
+        local_read_only_is() { [ "$1" = "1" ]; }
+        revoke_user_facing_root_admin_privileges_for_secondary() {
+          record_call "idempotent_root_bypass_revoke_called"
+          return 0
+        }
+        verify_post_dcs_local_root_write_fenced() {
+          record_call "idempotent_root_bypass_verifier_called"
+          return 1
+        }
+
+        When call run_switchover \
+          "mdb-mariadb-1" \
+          "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+          "explicit"
+        The status should be failure
+        The stderr should include "syncerctl did not report success"
+        The stderr should include "current primary local write fence did not close"
+        The contents of file "${TEST_DIR}/calls" should include "idempotent_set_read_only=ON"
+        The contents of file "${TEST_DIR}/calls" should include "idempotent_root_bypass_revoke_called"
+        The contents of file "${TEST_DIR}/calls" should include "idempotent_root_bypass_verifier_called"
+        The output should not include "convergence=delegated"
+        The output should not include "convergence=observed"
+      End
+
+      It "returns structured delegated success for an explicit idempotent closeout only after the old-primary fence closes"
+        make_zero_status_failing_syncerctl
+        : > "${TEST_DIR}/calls"
+        prepare_current_primary_for_switchover() { return 0; }
+        wait_candidate_sql_reachable_before_dcs() { return 0; }
+        switchover_final_state_already_reached() { return 0; }
+        fence_current_primary_local_writes_after_dcs() {
+          record_call "idempotent_stage4_called"
+          return 0
+        }
+        wait_candidate_promoted_via_syncerctl() {
+          record_call "BUG_explicit_idempotent_stage5_called"
+          return 1
+        }
+        wait_candidate_remote_root_primary_ready() {
+          record_call "BUG_explicit_idempotent_stage6_called"
+          return 1
+        }
+
+        When call run_switchover \
+          "mdb-mariadb-1" \
+          "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+          "explicit"
+        The status should be success
+        The stderr should include "syncerctl did not report success"
+        The output should include "candidate_mode=explicit"
+        The output should include "dcs_recorded=true"
+        The output should include "old_primary_fenced=true"
+        The output should include "convergence=delegated"
+        The contents of file "${TEST_DIR}/calls" should include "idempotent_stage4_called"
+        The contents of file "${TEST_DIR}/calls" should not include "BUG_explicit_idempotent_stage5_called"
+        The contents of file "${TEST_DIR}/calls" should not include "BUG_explicit_idempotent_stage6_called"
+      End
+
+      It "returns structured observed success for an auto idempotent closeout after final-state proof and old-primary fence"
+        make_zero_status_failing_syncerctl
+        : > "${TEST_DIR}/calls"
+        prepare_current_primary_for_switchover() { return 0; }
+        wait_candidate_sql_reachable_before_dcs() { return 0; }
+        switchover_final_state_already_reached() { return 0; }
+        fence_current_primary_local_writes_after_dcs() {
+          record_call "idempotent_stage4_called"
+          return 0
+        }
+        wait_candidate_promoted_via_syncerctl() {
+          record_call "BUG_auto_idempotent_stage5_called"
+          return 1
+        }
+        wait_candidate_remote_root_primary_ready() {
+          record_call "BUG_auto_idempotent_stage6_called"
+          return 1
+        }
+
+        When call run_switchover \
+          "mdb-mariadb-1" \
+          "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+          "auto"
+        The status should be success
+        The stderr should include "syncerctl did not report success"
+        The output should include "candidate_mode=auto"
+        The output should include "dcs_recorded=true"
+        The output should include "old_primary_fenced=true"
+        The output should include "convergence=observed"
+        The contents of file "${TEST_DIR}/calls" should include "idempotent_stage4_called"
+        The contents of file "${TEST_DIR}/calls" should not include "BUG_auto_idempotent_stage5_called"
+        The contents of file "${TEST_DIR}/calls" should not include "BUG_auto_idempotent_stage6_called"
       End
 
       It "treats duplicate post-success invocation as idempotent success when final state is already reached"
@@ -608,10 +888,13 @@ EOF
           esac
           return 1
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be success
         The output should include "Switchover syncerctl output: switchover failed: operation precheck failed: mdb-mariadb-0 is not the primary"
         The output should include "Switchover idempotent success: desired final state already reached"
+        The output should include "candidate_mode=auto"
+        The output should include "old_primary_fenced=true"
+        The output should include "convergence=observed"
         The stderr should include "Switchover failed: syncerctl did not report success"
         The contents of file "${TEST_DIR}/calls" should not include "rollback"
       End
@@ -678,7 +961,7 @@ EOF_MOCK
           record_call "rollback"
           return 0
         }
-        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local"
+        When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         The status should be failure
         The output should include "Switchover post-DCS guard"
         The stderr should include "Switchover failed: current primary local write fence did not close after DCS switchover"
@@ -2054,7 +2337,7 @@ secondary-other"
         echo "1100" > "${TEST_DIR}/clock_now"
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "global deadline"
       The stderr should include "reason=action_deadline_exhausted_prepare"
@@ -2067,7 +2350,7 @@ secondary-other"
         advance_clock 100
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "Switchover stage prepare"
       The stderr should include "reason=action_deadline_exhausted_prepare_overrun"
@@ -2081,7 +2364,7 @@ secondary-other"
         advance_clock 100
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "Switchover stage dcs"
       The stderr should include "reason=action_deadline_exhausted_dcs_overrun"
@@ -2096,7 +2379,7 @@ secondary-other"
         advance_clock 100
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "Switchover stage fence"
       The stderr should include "reason=action_deadline_exhausted_fence_overrun"
@@ -2117,7 +2400,7 @@ secondary-other"
         advance_clock 100
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "Switchover stage candidate_promoted"
       The stderr should include "reason=action_deadline_exhausted_promote_overrun"
@@ -2139,7 +2422,7 @@ secondary-other"
         advance_clock 100
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "Switchover stage candidate_primary_ready"
       The stderr should include "reason=action_deadline_exhausted_ready_overrun"
@@ -2154,7 +2437,7 @@ secondary-other"
         echo "not-a-number" > "${TEST_DIR}/clock_now"
         return 0
       }
-      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local"
+      When call run_switchover "mdb-mariadb-1" "mdb-mariadb-1.headless.demo.svc.cluster.local" "auto"
       The status should be failure
       The output should include "Switchover stage prepare"
       The stderr should include "reason=action_deadline_exhausted_prepare_overrun"

--- a/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
+++ b/addons/mariadb/scripts-ut-spec/replication_switchover_spec.sh
@@ -318,6 +318,33 @@ EOF
       The contents of file "${TEST_DIR}/calls" should not include "BUG_explicit_stage6_called"
     End
 
+    It "returns an active-marker retryable conflict without final-state probing or local fencing"
+      syncerctl_switchover() {
+        SWITCHOVER_SYNCERCTL_OUTCOME="retryable_conflict"
+        log_switchover_error "Switchover failed: outcome=retryable_conflict mutation=0 reason=switchover_in_progress"
+        return 1
+      }
+      switchover_final_state_already_reached() {
+        record_call "BUG_active_conflict_final_state_probe"
+        return 1
+      }
+      fence_current_primary_after_uncertain_dcs() {
+        record_call "BUG_active_conflict_fence"
+        return 0
+      }
+
+      When call run_switchover \
+        "mdb-mariadb-1" \
+        "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
+        "explicit"
+      The status should be failure
+      The stderr should include "outcome=retryable_conflict"
+      The stderr should include "mutation=0"
+      The contents of file "${TEST_DIR}/calls" should not include "BUG_active_conflict_final_state_probe"
+      The contents of file "${TEST_DIR}/calls" should not include "BUG_active_conflict_fence"
+      The output should not include "Switchover stage fence"
+    End
+
     It "keeps empty-candidate auto mode fail-closed while the selected candidate remains secondary"
       wait_candidate_promoted_via_syncerctl() {
         record_call "auto_stage5_called"
@@ -333,6 +360,8 @@ EOF
         "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" \
         "auto"
       The status should be failure
+      The stderr should include "outcome=indeterminate_dcs_in_progress"
+      The stderr should include "mutation=remote-partial"
       The contents of file "${TEST_DIR}/calls" should include "auto_stage5_called"
       The contents of file "${TEST_DIR}/calls" should not include "BUG_auto_stage6_called_after_stage5_failure"
       The output should not include "convergence=delegated"
@@ -506,9 +535,10 @@ EOF
         run_switchover "mdb-mariadb-1" "mdb-mariadb-1.mdb-mariadb-headless.demo.svc.cluster.local" "auto"
         When run cat "${SYNCERCTL_ARGS}"
         The status should be success
-        # alpha.79 v2: --force added to bypass syncer's "previous switchover
-        # unfinished" DCS record so same-cluster repeat switchovers proceed.
-        The output should eq "--host 127.0.0.1 --port 3601 switchover --force --primary mdb-mariadb-0 --candidate mdb-mariadb-1"
+        # r25 completion contract: an active DCS operation is never preempted.
+        # The addon must not pass --force; syncer owns the stable retryable
+        # conflict and mutation=0 outcome for an existing marker.
+        The output should eq "--host 127.0.0.1 --port 3601 switchover --primary mdb-mariadb-0 --candidate mdb-mariadb-1"
       End
 
       It "fails before switchover when mariadb client is unavailable"
@@ -673,8 +703,8 @@ EOF
     End
 
     Context "when syncerctl cannot create DCS switchover"
-      # H2 split-brain fix: after syncerctl (invoked with --force under a
-      # timeout(1) wrapper) fails, the DCS record may already be persisted and
+      # H2 split-brain fix: after syncerctl (under a timeout(1) wrapper) fails,
+      # the DCS record may already be persisted and
       # syncer may be promoting the candidate. The current primary must be
       # fenced fail-closed (read_only=1), NOT rolled back to writable — the old
       # rollback path could leave two writable primaries.
@@ -2503,6 +2533,26 @@ EOF
       The output should include "syncerctl output"
       The stderr should include "syncerctl exited with rc=7"
       The stderr should not include "reason=syncerctl_timeout"
+    End
+
+    It "r25: maps an active DCS marker to a stable retryable conflict without claiming a mutation"
+      cat > "${SYNCERCTL_BIN}" <<'EOF'
+#!/bin/sh
+echo "SWITCHOVER_IN_PROGRESS leader=mdb-mariadb-1 candidate=mdb-mariadb-1" >&2
+exit 7
+EOF
+      chmod +x "${SYNCERCTL_BIN}"
+      timeout() {
+        shift
+        "$@"
+      }
+      When call syncerctl_switchover "mdb-mariadb-0" "mdb-mariadb-1" 3
+      The status should be failure
+      The output should include "Switchover syncerctl output: SWITCHOVER_IN_PROGRESS"
+      The stderr should include "outcome=retryable_conflict"
+      The stderr should include "mutation=0"
+      The stderr should include "reason=switchover_in_progress"
+      The stderr should include "SWITCHOVER_IN_PROGRESS leader=mdb-mariadb-1 candidate=mdb-mariadb-1"
     End
 
     It "alpha.61 v3: returns success when syncerctl reports 'switchover success' within budget"

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -18,8 +18,10 @@ SWITCHOVER_POLL_SECONDS="${SWITCHOVER_POLL_SECONDS:-1}"
 # bounded to a small budget; post-DCS convergence (Primary Service endpoint,
 # old-primary follow, secondary remote root fence, kb_health_check 1062 repair)
 # is delegated to roleProbe + KB endpoint controller. The candidate write probe
-# is still synchronous because it is part of the action's success contract:
-# action returns 0 only after we have proven the candidate is actually writable.
+# remains synchronous only for auto-selected candidates, because KubeBlocks
+# cannot observe the candidate name chosen inside the action. For an explicit
+# candidate, KubeBlocks keeps the OpsRequest Processing until that named
+# instance reports the expected primary role.
 #
 # alpha.61: action now uses a single global deadline rather than per-stage
 # fixed sleeps. This avoids the trap where the sum of per-stage sleep budgets
@@ -27,7 +29,7 @@ SWITCHOVER_POLL_SECONDS="${SWITCHOVER_POLL_SECONDS:-1}"
 # is the hard contract; per-stage maxima are clamped by the remaining global
 # deadline at runtime.
 #
-# alpha.61 v2 (Jack 02:00 review): POSIX-portable wall clock + 5-stage
+# alpha.61 v2 (Jack 02:00 review): POSIX-portable wall clock + six-stage
 # enforcement. The original v1 used bash-only $SECONDS / $'\n' case patterns
 # under #!/bin/sh shebang -- in dash $SECONDS is not auto-incrementing, so the
 # deadline expression evaluated to 0 forever and the stage loops would only be
@@ -39,7 +41,9 @@ SWITCHOVER_POLL_SECONDS="${SWITCHOVER_POLL_SECONDS:-1}"
 # (prepare/candidate_connect/dcs/fence/promote/ready) checks the remaining
 # global budget at entry and emits action_deadline_exhausted_<stage> if
 # exhausted.
-SWITCHOVER_ACTION_DEADLINE_SECONDS="${SWITCHOVER_ACTION_DEADLINE_SECONDS:-55}"
+# Keep a 10s buffer below the kbagent/CmpD 60s wrapper ceiling so shell
+# closeout and process teardown are not silently reaped after our own deadline.
+SWITCHOVER_ACTION_DEADLINE_SECONDS="${SWITCHOVER_ACTION_DEADLINE_SECONDS:-50}"
 SWITCHOVER_PREPARE_STAGE_BUDGET_SECONDS="${SWITCHOVER_PREPARE_STAGE_BUDGET_SECONDS:-10}"
 SWITCHOVER_CANDIDATE_CONNECT_READY_WAIT_SECONDS="${SWITCHOVER_CANDIDATE_CONNECT_READY_WAIT_SECONDS:-12}"
 SWITCHOVER_CANDIDATE_CONNECT_READY_POLL_SECONDS="${SWITCHOVER_CANDIDATE_CONNECT_READY_POLL_SECONDS:-1}"
@@ -257,9 +261,23 @@ resolve_candidate_name() {
   fi
 }
 
+resolve_candidate_mode() {
+  # Freeze the API source before resolve_candidate_name() turns an empty
+  # candidate into a concrete pod name. The two modes have different
+  # completion contracts in the exact KubeBlocks switchover state machine.
+  if [ -n "${KB_SWITCHOVER_CANDIDATE_NAME}" ]; then
+    printf '%s' "explicit"
+  else
+    printf '%s' "auto"
+  fi
+}
+
 resolve_candidate_fqdn() {
   local candidate
-  candidate=$(resolve_candidate_name)
+  candidate="${1:-}"
+  if [ -z "${candidate}" ]; then
+    candidate=$(resolve_candidate_name)
+  fi
   echo "${candidate}.${CLUSTER_NAME}-${COMPONENT_NAME}-headless.${CLUSTER_NAMESPACE}.svc.${CLUSTER_DOMAIN}"
 }
 
@@ -2212,8 +2230,8 @@ run_switchover() {
   #   3. dcs           - syncerctl_switchover (DCS record)
   #   4. fence         - fence_current_primary_local_writes_after_dcs
   #                      (revoke admin-bypass + verify_post_dcs_local_root_write_fenced)
-  #   5. promote       - wait_candidate_promoted_via_syncerctl
-  #   6. ready         - wait_candidate_remote_root_primary_ready
+  #   5. promote       - wait_candidate_promoted_via_syncerctl (auto only)
+  #   6. ready         - wait_candidate_remote_root_primary_ready (auto only)
   #
   # External tools that can block:
   #   - syncerctl getrole: wrapped with timeout(1) (initialize_action_clock
@@ -2228,6 +2246,8 @@ run_switchover() {
   # gate.
   local candidate_name="$1"
   local candidate_fqdn="$2"
+  local candidate_mode="$3"
+  local idempotent_final_state_reached="false"
   local current_name
   current_name=$(resolve_current_name)
 
@@ -2239,6 +2259,13 @@ run_switchover() {
     echo "Switchover failed: candidate name is empty" >&2
     return 1
   fi
+  case "${candidate_mode}" in
+    explicit|auto) ;;
+    *)
+      log_switchover_error "Switchover failed: reason=invalid_candidate_mode candidate_mode=${candidate_mode:-<empty>}; fail-closed"
+      return 1
+      ;;
+  esac
 
   if ! initialize_action_clock; then
     return 1
@@ -2281,17 +2308,23 @@ run_switchover() {
   log_switchover_info "Switchover: creating syncer DCS switchover primary=${current_name} candidate=${candidate_name}"
   if ! syncerctl_switchover "${current_name}" "${candidate_name}" "${dcs_budget}"; then
     if switchover_final_state_already_reached "${current_name}" "${candidate_name}" "${candidate_fqdn}"; then
-      return 0
+      # The duplicate call proves that DCS/candidate convergence already
+      # reached the requested topology, but read_only=1 alone does not prove
+      # user-facing root cannot bypass the old-primary fence. Continue through
+      # the same Stage4 revoke + SHOW GRANTS/write verifier before any rc=0.
+      idempotent_final_state_reached="true"
+    else
+      # H2: do NOT roll the current primary back to writable here. syncerctl runs
+      # with --force under a timeout(1) wrapper, so a non-zero/timeout return
+      # does not prove the DCS switchover record was not persisted — syncer may
+      # already be promoting the candidate. Unfencing the current primary would
+      # then make two writable primaries (split-brain). Fail closed by fencing
+      # instead; see fence_current_primary_after_uncertain_dcs for the full
+      # rationale.
+      fence_current_primary_after_uncertain_dcs || true
+      log_switchover_error "Switchover failed: syncerctl could not create DCS switchover; current primary fenced fail-closed (not rolled back to writable) to avoid split-brain if syncer completes the switchover"
+      return 1
     fi
-    # H2: do NOT roll the current primary back to writable here. syncerctl runs
-    # with --force under a timeout(1) wrapper, so a non-zero/timeout return does
-    # not prove the DCS switchover record was not persisted — syncer may already
-    # be promoting the candidate. Unfencing the current primary would then make
-    # two writable primaries (split-brain). Fail closed by fencing instead; see
-    # fence_current_primary_after_uncertain_dcs for the full rationale.
-    fence_current_primary_after_uncertain_dcs || true
-    log_switchover_error "Switchover failed: syncerctl could not create DCS switchover; current primary fenced fail-closed (not rolled back to writable) to avoid split-brain if syncer completes the switchover"
-    return 1
   fi
   # Defensive overrun guard mirrors prepare (DCS is bounded by the timeout(1)
   # wrapper but the rollback guard above is best-effort and could itself
@@ -2318,7 +2351,33 @@ run_switchover() {
     return 1
   fi
 
-  # Stage 5: candidate promoted via syncerctl
+  # A positive idempotent final-state probe already observed the candidate as
+  # primary/remote-root-ready and the old primary following it. After Stage4
+  # has now closed the bypass-capable old-primary fence, do not repeat the
+  # auto-only Stage5/6 waits; emit the same mode-specific success contract.
+  if [ "${idempotent_final_state_reached}" = "true" ]; then
+    if [ "${candidate_mode}" = "explicit" ]; then
+      log_switchover_info "Switchover action returned: candidate_mode=explicit dcs_recorded=true old_primary_fenced=true convergence=delegated idempotent_final_state=true elapsed=$(action_elapsed_seconds)s deadline=${SWITCHOVER_ACTION_DEADLINE_SECONDS}s"
+    else
+      log_switchover_info "Switchover action returned: candidate_mode=auto dcs_recorded=true old_primary_fenced=true convergence=observed candidate_promoted=true candidate_root_primary_ready=true idempotent_final_state=true elapsed=$(action_elapsed_seconds)s deadline=${SWITCHOVER_ACTION_DEADLINE_SECONDS}s"
+    fi
+    return 0
+  fi
+
+  # KubeBlocks retains an explicit-candidate OpsRequest in Processing after
+  # action rc=0 and independently waits for that named instance to report the
+  # expected primary role. The action therefore closes once the DCS request is
+  # accepted and the old primary is positively fenced; asynchronous candidate
+  # convergence is delegated to the controller role gate.
+  if [ "${candidate_mode}" = "explicit" ]; then
+    log_switchover_info "Switchover action returned: candidate_mode=explicit dcs_recorded=true old_primary_fenced=true convergence=delegated elapsed=$(action_elapsed_seconds)s deadline=${SWITCHOVER_ACTION_DEADLINE_SECONDS}s"
+    return 0
+  fi
+
+  # Auto mode has no candidate name in the controller request. KubeBlocks
+  # would mark action rc=0 immediately Succeeded, so the addon must retain the
+  # Stage5/6 compensation gate and prove the selected candidate converged.
+  # Stage 5: candidate promoted via syncerctl (auto only)
   local promoted_budget
   promoted_budget=$(stage_budget_or_exit "promote" "${CANDIDATE_PROMOTED_VIA_SYNCERCTL_WAIT_SECONDS}") || return 1
   log_switchover_info "Switchover stage candidate_promoted budget=${promoted_budget}s remaining_before=$(remaining_action_budget)s"
@@ -2337,7 +2396,7 @@ run_switchover() {
     return 1
   fi
 
-  # Stage 6: candidate remote root primary-readiness probe
+  # Stage 6: candidate remote root primary-readiness probe (auto only)
   local ready_budget
   ready_budget=$(stage_budget_or_exit "ready" "${CANDIDATE_REMOTE_ROOT_PRIMARY_READY_WAIT_SECONDS}") || return 1
   log_switchover_info "Switchover stage candidate_primary_ready budget=${ready_budget}s remaining_before=$(remaining_action_budget)s"
@@ -2358,7 +2417,7 @@ run_switchover() {
     return 1
   fi
 
-  log_switchover_info "Switchover action returned: DCS recorded, current primary fenced, candidate promoted via DCS, candidate root primary-readiness observed without mutating probe. Total elapsed=$(action_elapsed_seconds)s of ${SWITCHOVER_ACTION_DEADLINE_SECONDS}s deadline. Post-DCS convergence delegated to roleProbe + KB endpoint controller."
+  log_switchover_info "Switchover action returned: candidate_mode=auto dcs_recorded=true old_primary_fenced=true convergence=observed candidate_promoted=true candidate_root_primary_ready=true elapsed=$(action_elapsed_seconds)s deadline=${SWITCHOVER_ACTION_DEADLINE_SECONDS}s"
   return 0
 }
 
@@ -2369,15 +2428,17 @@ main() {
   fi
   setup_mariadb_client_bin || return 1
 
+  local candidate_mode
   local candidate_name
   local candidate_fqdn
+  candidate_mode=$(resolve_candidate_mode)
   candidate_name=$(resolve_candidate_name)
-  candidate_fqdn=$(resolve_candidate_fqdn)
+  candidate_fqdn=$(resolve_candidate_fqdn "${candidate_name}")
   # alpha.80 v1 (Helen): the alpha.76 unconditional clear_switchover_fence_
   # active_marker call has been removed. alpha.79 v1 minimalist deleted the
   # marker writer in prepare, so no marker exists to clear. Pure dead-code
   # cleanup, no runtime behavior change.
-  run_switchover "${candidate_name}" "${candidate_fqdn}"
+  run_switchover "${candidate_name}" "${candidate_fqdn}" "${candidate_mode}"
 }
 
 # This is magic for shellspec ut framework, do not modify!

--- a/addons/mariadb/scripts/replication-switchover.sh
+++ b/addons/mariadb/scripts/replication-switchover.sh
@@ -1247,7 +1247,7 @@ rollback_current_primary_switchover_guard() {
 fence_current_primary_after_uncertain_dcs() {
   # H2 split-brain guard for the Stage-3 (DCS switchover) failure path.
   #
-  # syncerctl_switchover is invoked with --force and wrapped by timeout(1). A
+  # syncerctl_switchover is wrapped by timeout(1). A
   # non-zero or timeout(1) (rc 124/125/137) return does NOT prove the DCS
   # switchover record was never persisted: syncer can accept and persist the
   # switchover request, begin asynchronously promoting the candidate, and then
@@ -1643,31 +1643,25 @@ syncerctl_switchover() {
   local output
   local rc
   local using_timeout=0
+  SWITCHOVER_SYNCERCTL_OUTCOME=""
 
-  # alpha.79 v2 (Helen TL autopilot 22:31 westonnnn `442a5d2e`): pass --force
-  # so syncer overrides any leftover "previous switchover unfinished" DCS
-  # record from a prior successful switchover. n1ad same-cluster repeat axis
-  # (2026-05-14 ~14:54 UTC) exposed this: after the first GREEN switchover
-  # cleared chart-side state and OpsRequest reached Succeed, syncer's DCS
-  # record stayed in "unfinished" state. Repeat switchovers got
-  # `Create switchover failed: there is another switchover
-  # maria-5d-n1ad-mariadb-switchover unfinished`. Using --force on every
-  # invocation is safe: first-time switchovers have no leftover record so
-  # --force is a no-op; repeated switchovers proceed cleanly. This is a
-  # syncer-layer cleanup gap (syncer should mark its own DCS record done
-  # when the switchover protocol completes); --force is a chart-side
-  # workaround until syncer side cleans up properly.
+  # r25 completion contract: the addon never preempts an existing DCS
+  # switchover. `--force` used to delete an unfinished marker without proving
+  # that the previous database/lease/grant side effects had rolled back. A
+  # second request must instead receive syncer's stable
+  # SWITCHOVER_IN_PROGRESS conflict and retry only after the first operation
+  # reaches terminal truth.
   if [ -n "${stage_budget}" ] && [ "${SWITCHOVER_HAS_TIMEOUT}" = "1" ]; then
     local wall="${SYNCERCTL_PER_CALL_TIMEOUT_SECONDS}"
     if [ "${stage_budget}" -lt "${wall}" ]; then wall="${stage_budget}"; fi
     if [ "${wall}" -lt 1 ]; then wall=1; fi
     using_timeout=1
     output=$(timeout "${wall}" "${SYNCERCTL_BIN}" --host "${SYNCERCTL_HOST}" --port "${SYNCERCTL_PORT}" \
-      switchover --force --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
+      switchover --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
     rc=$?
   else
     output=$("${SYNCERCTL_BIN}" --host "${SYNCERCTL_HOST}" --port "${SYNCERCTL_PORT}" \
-      switchover --force --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
+      switchover --primary "${current_name}" --candidate "${candidate_name}" 2>&1)
     rc=$?
   fi
 
@@ -1686,6 +1680,14 @@ syncerctl_switchover() {
         ;;
     esac
   fi
+
+  case "${output}" in
+    *"SWITCHOVER_IN_PROGRESS"*)
+      SWITCHOVER_SYNCERCTL_OUTCOME="retryable_conflict"
+      log_switchover_error "Switchover failed: outcome=retryable_conflict mutation=0 reason=switchover_in_progress detail=${output}; retry after the active DCS operation reaches terminal truth"
+      return 1
+      ;;
+  esac
 
   if [ "${rc}" -ne 0 ]; then
     log_switchover_error "Switchover failed: syncerctl exited with rc=${rc}"
@@ -2307,6 +2309,14 @@ run_switchover() {
   log_switchover_info "Switchover stage dcs budget=${dcs_budget}s remaining_before=$(remaining_action_budget)s primary=${current_name} candidate=${candidate_name}"
   log_switchover_info "Switchover: creating syncer DCS switchover primary=${current_name} candidate=${candidate_name}"
   if ! syncerctl_switchover "${current_name}" "${candidate_name}" "${dcs_budget}"; then
+    if [ "${SWITCHOVER_SYNCERCTL_OUTCOME:-}" = "retryable_conflict" ]; then
+      # The syncer active-marker precheck promises mutation=0. Do not run the
+      # uncertain-DCS final-state/fence path: that path is reserved for calls
+      # where the client cannot prove whether this request persisted remote
+      # side effects. A stable active-marker conflict proves this request did
+      # not mutate DCS and must leave the already-running operation untouched.
+      return 1
+    fi
     if switchover_final_state_already_reached "${current_name}" "${candidate_name}" "${candidate_fqdn}"; then
       # The duplicate call proves that DCS/candidate convergence already
       # reached the requested topology, but read_only=1 alone does not prove
@@ -2315,7 +2325,7 @@ run_switchover() {
       idempotent_final_state_reached="true"
     else
       # H2: do NOT roll the current primary back to writable here. syncerctl runs
-      # with --force under a timeout(1) wrapper, so a non-zero/timeout return
+      # under a timeout(1) wrapper, so a non-zero/timeout return
       # does not prove the DCS switchover record was not persisted — syncer may
       # already be promoting the candidate. Unfencing the current primary would
       # then make two writable primaries (split-brain). Fail closed by fencing
@@ -2382,6 +2392,7 @@ run_switchover() {
   promoted_budget=$(stage_budget_or_exit "promote" "${CANDIDATE_PROMOTED_VIA_SYNCERCTL_WAIT_SECONDS}") || return 1
   log_switchover_info "Switchover stage candidate_promoted budget=${promoted_budget}s remaining_before=$(remaining_action_budget)s"
   if ! wait_candidate_promoted_via_syncerctl "${candidate_name}" "${candidate_fqdn}" "${promoted_budget}"; then
+    log_switchover_error "Switchover failed: outcome=indeterminate_dcs_in_progress mutation=remote-partial stage=candidate_promoted reason=post_dcs_terminal_not_proven; old primary remains fenced and the DCS operation must not be preempted"
     return 1
   fi
   # Post-stage overrun check (mirrors prepare/dcs/fence). The promote loop is
@@ -2401,6 +2412,7 @@ run_switchover() {
   ready_budget=$(stage_budget_or_exit "ready" "${CANDIDATE_REMOTE_ROOT_PRIMARY_READY_WAIT_SECONDS}") || return 1
   log_switchover_info "Switchover stage candidate_primary_ready budget=${ready_budget}s remaining_before=$(remaining_action_budget)s"
   if ! wait_candidate_remote_root_primary_ready "${candidate_name}" "${candidate_fqdn}" "${ready_budget}"; then
+    log_switchover_error "Switchover failed: outcome=indeterminate_dcs_in_progress mutation=remote-partial stage=candidate_primary_ready reason=post_dcs_terminal_not_proven; old primary remains fenced and the DCS operation must not be preempted"
     return 1
   fi
   # Final-stage overrun check, BEFORE the success log/return. ready is the last

--- a/addons/mariadb/templates/cmpd-replication.yaml
+++ b/addons/mariadb/templates/cmpd-replication.yaml
@@ -109,8 +109,10 @@ spec:
       # KB kbagent enforces a hardcoded maxActionCallTimeout of 60s
       # (pkg/kbagent/service/action_utils.go), so any value above 60 is silently
       # truncated. We declare 60 here so the contract reflects what kbagent
-      # actually enforces. The switchover action is intentionally short and
-      # delegates post-DCS convergence to roleProbe + KB endpoint controller.
+      # actually enforces. The script uses a 50s internal deadline, leaving a
+      # 10s wrapper/teardown buffer. Explicit-candidate convergence is
+      # delegated to the controller's named-instance role gate; auto-candidate
+      # convergence remains action-observed because the controller has no name.
       timeoutSeconds: 60
       exec:
         container: mariadb


### PR DESCRIPTION
## Problem and observed evidence

This stacked PR now closes two addon-side parts of the MariaDB switchover contract.

### 1. Explicit candidates can converge after the action budget

Two independent runs showed the same shape:

- MariaDB 11.4.5: DCS request and old-primary fence closed, but the named candidate converged about 162 seconds later. The action exhausted its budget and returned `rc=1` first.
- MariaDB 11.4.8: the candidate converged about 141 seconds later, again after the action had returned `rc=1`.

Evidence strength is 11.4.5 N=1 plus 11.4.8 N=1. It is not a frequency claim.

### 2. A second request must not preempt an unfinished DCS switchover

In the fresh r7 failure, syncer prepared and promoted the candidate at 07:20:58, but the addon saw `secondary` for 28 polls and Stage 5 returned `rc=1`. The first authoritative lease refresh appeared at 07:25:45 and the database write commit at 07:25:48.

The old addon always passed `syncerctl switchover --force`. That allowed a later request to delete an unfinished marker without proving that the previous lease, database, or grant changes had rolled back.

This evidence proves the circular completion timing at the old exact. It does **not** prove the new addon exact or the companion syncer patch at runtime.

## Behavior changes

### Candidate-mode completion

- Explicit candidate: after DCS acceptance and a positive old-primary fence, return structured `convergence=delegated`. The exact KubeBlocks controller keeps the OpsRequest Processing until that named candidate reports the expected role.
- Auto-selected candidate: retain Stage 5/6 candidate-role and remote-root readiness proof, then return `convergence=observed`. An empty CandidateName has no controller-side named-candidate role gate.
- Unknown candidate mode fails closed.

The internal action deadline remains 50 seconds under the 60-second ComponentDefinition timeout.

### Non-preemptive in-flight handling

- Remove `--force` from both real `syncerctl switchover` invocations.
- Map syncer's stable `SWITCHOVER_IN_PROGRESS` response to `outcome=retryable_conflict mutation=0`.
- Return immediately on that proven conflict, before duplicate final-state probing or uncertain-DCS local fencing.
- If DCS was accepted but Stage 5/6 cannot prove terminal truth, report `outcome=indeterminate_dcs_in_progress mutation=remote-partial`; keep the old primary fenced.
- Keep the existing uncertain-DCS fence for all other non-zero/timeout responses, where persistence cannot be proven either way.

## TDD and independent review

- Candidate-mode OLD RED: 3 examples / 2 failures.
- Idempotent-fence OLD RED: 3 / 3 failures, then 7 / 0 GREEN.
- New in-flight contract: initial selected set 7 / 3 RED, then 7 / 0 GREEN.
- Action-level mutation0 test: old implementation 1 / 1 RED, then 1 / 0 GREEN.
- Final switchover ShellSpec: 215 / 0 / 6 historical pendings.
- Final full MariaDB ShellSpec: 803 / 0 / 9 historical pendings.
- Bash/dash syntax, ShellCheck error severity, `git diff --check`, Helm lint and default render: PASS.
- GitHub checks on current head: 7 success / 0 failure.

Magnus independently fetched exact `44e415d930484146f5e7a61cecfa12b48fc50b80`, reproduced focused 215/0/6, reproduced genuine base-script × new-spec RED 215/4, restored the head to 215/0/6, and reran the full 803/0/9 suite. Verdict: GREEN / CONFORMANT to design v3.

## Review focus

Please focus on:

1. The three-way outcome split: proven pre-DCS conflict (`mutation=0`), unknown persistence (uncertain-DCS fence), and accepted-DCS but unproven terminal truth (`remote-partial`).
2. Whether any active-marker path can reach local final-state probing/fencing.
3. Whether explicit delegation still preserves the positive old-primary fence and auto mode still proves Stage 5/6.

## Current boundary and merge order

- PR head: `44e415d930484146f5e7a61cecfa12b48fc50b80`.
- Stacked base: PR #3228 exact `8f1fcd78ffa564c8e356a8fc3b5f9c786a1bdeae`.
- Runtime validation of this head: N=0. Test owns package, approved environment, evidence, counting, and cleanup.
- Companion syncer PR #313 is still under independent review. Its current head is source/unit GREEN only; cross-layer review found two syncer-side candidates still being falsified (CAS-race stable token and legacy missing-holder commit evidence).
- Therefore this PR is ready for addon code review, but it must not be described as an end-to-end runtime fix or used for Test handoff until the companion syncer exact is terminal and the combined source identity is re-frozen.

Design v3 SHA256: `24a2130cab43c6d401f75be4a2939ed0d30956a117bfbcdbe7eaa08f7a96f1d6`.
