### PR TITLE
fix(zookeeper): fail closed on uncertain role probe

### DIFF
--- a/addons/zookeeper/scripts-ut-spec/roleprobe_spec.sh
+++ b/addons/zookeeper/scripts-ut-spec/roleprobe_spec.sh
@@ -122,5 +122,117 @@ Describe "ZooKeeper Startup Bash Script Tests"
       When call get_zk_role
       The output should eq "follower"
     End
+
+    It "returns observer when mode is observer"
+      get_zookeeper_mode() {
+        echo "observer"
+      }
+
+      When call get_zk_role
+      The status should be success
+      The output should eq "observer"
+    End
+  End
+
+  Describe "roleprobe.sh behavior"
+    setup_mock_nc() {
+      roleprobe_mock_bin="$(mktemp -d)"
+      roleprobe_original_path="$PATH"
+      cat > "$roleprobe_mock_bin/nc" <<'EOF'
+#!/bin/sh
+case "${ROLEPROBE_NC_CASE:-}" in
+  standalone|leader|follower|observer|looking)
+    printf 'Mode: %s\n' "$ROLEPROBE_NC_CASE"
+    ;;
+  ambiguous)
+    printf 'Mode: leader\nMode: follower\n'
+    ;;
+  empty)
+    ;;
+  refused)
+    exit 1
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+      chmod +x "$roleprobe_mock_bin/nc"
+      export PATH="$roleprobe_mock_bin:$PATH"
+    }
+
+    cleanup_mock_nc() {
+      PATH="$roleprobe_original_path"
+      export PATH
+      rm -rf "$roleprobe_mock_bin"
+      unset roleprobe_mock_bin roleprobe_original_path ROLEPROBE_NC_CASE
+    }
+
+    BeforeEach "setup_mock_nc"
+    AfterEach "cleanup_mock_nc"
+
+    It "maps standalone to leader"
+      export ROLEPROBE_NC_CASE="standalone"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be success
+      The output should eq "leader"
+    End
+
+    It "publishes leader"
+      export ROLEPROBE_NC_CASE="leader"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be success
+      The output should eq "leader"
+    End
+
+    It "publishes follower"
+      export ROLEPROBE_NC_CASE="follower"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be success
+      The output should eq "follower"
+    End
+
+    It "publishes observer"
+      export ROLEPROBE_NC_CASE="observer"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be success
+      The output should eq "observer"
+    End
+
+    It "fails closed on empty output"
+      export ROLEPROBE_NC_CASE="empty"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed on an uncertain mode"
+      export ROLEPROBE_NC_CASE="looking"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when nc refuses the connection"
+      export ROLEPROBE_NC_CASE="refused"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed on ambiguous multi-line mode output"
+      export ROLEPROBE_NC_CASE="ambiguous"
+
+      When run command bash ../scripts/roleprobe.sh
+      The status should be failure
+      The output should eq ""
+    End
   End
 End

--- a/addons/zookeeper/scripts/roleprobe.sh
+++ b/addons/zookeeper/scripts/roleprobe.sh
@@ -1,29 +1,48 @@
 #!/bin/bash
 
+set -o pipefail
+
 get_zk_mode_from_script() {
   $ZOOBINDIR/zkServer.sh status
 }
 
 get_zookeeper_mode() {
+  local stat mode
   if command -v nc >/dev/null 2>&1; then
-    local stat
-    stat=$(echo srvr | nc 127.0.0.1 2181 | grep Mode)
-    echo "$stat" | awk '{print $2}'
+    if ! stat=$(echo srvr | nc 127.0.0.1 2181 | grep '^Mode:'); then
+      return 1
+    fi
   else
-    local stat
-    stat=$(get_zk_mode_from_script)
-    echo "$stat" | grep "Mode:" | awk '{print $2}'
+    if ! stat=$(get_zk_mode_from_script | grep '^Mode:'); then
+      return 1
+    fi
   fi
+
+  mode=$(echo "$stat" | awk '{print $2}')
+  case "$mode" in
+    standalone|leader|follower|observer)
+      printf "%s" "$mode"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 get_zk_role() {
   local mode
-  mode=$(get_zookeeper_mode)
-  if [[ "$mode" == "standalone" ]]; then
-    printf "leader"
-  else
-    printf "%s" "$mode"
-  fi
+  mode=$(get_zookeeper_mode) || return 1
+  case "$mode" in
+    standalone)
+      printf "leader"
+      ;;
+    leader|follower|observer)
+      printf "%s" "$mode"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 # This is magic for shellspec ut framework.


### PR DESCRIPTION
## Problem

ZooKeeper `roleProbe` currently exits successfully when it cannot obtain a trustworthy role. On the base commit, an empty `nc` response and a refused connection both returned `rc=0` with empty output, while `Mode: looking` returned `rc=0` and published `looking` as a role.

The probe output drives Pod role labels and routing. An unknown state must be rejected instead of being published as a role.

## Change

- propagate failures from the `nc`/`zkServer.sh` probe pipelines
- accept only the exact modes `standalone`, `leader`, `follower`, and `observer`
- keep the existing `standalone` to `leader` mapping
- return non-zero with empty stdout for empty, uncertain, refused, or ambiguous multi-line results
- add direct behavior tests for the actual script, including the valid and fail-closed matrices

## Evidence

The new tests against the old implementation produced 18 examples with 4 expected failures: empty output, `Mode: looking`, connection refusal, and ambiguous multi-line output. The same tests pass after this change.

Validation:

- focused roleprobe ShellSpec: 18 examples, 0 failures
- all ZooKeeper script ShellSpec: 34 examples, 0 failures
- Helm render: updated script is present in the ConfigMap and the lifecycle action still invokes `/bin/bash -c /kubeblocks/scripts/roleprobe.sh`
- ShellCheck: only pre-existing SC2086 and ShellSpec indirect-call SC2329 informational findings; no new blocker
- independent implementation conformity review: GREEN on exact commit `c0bfd8f285e69be4bf7025e5411c85aacbc1536e`

## Review focus

Please focus on the exact role whitelist and whether every uncertain probe path returns non-zero without publishing stdout.

## Boundary

This PR validates the role-probe script contract and chart rendering. It does not rerun or change the existing ZooKeeper runtime repetition ledger, and it does not claim coverage of all controller routing timings.
