### PR TITLE
fix: align addon KubeBlocks version constraints

### DIFF
--- a/addons/apecloud-mysql/Chart.yaml
+++ b/addons/apecloud-mysql/Chart.yaml
@@ -31,6 +31,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/clickhouse/Chart.yaml
+++ b/addons/clickhouse/Chart.yaml
@@ -27,6 +27,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/elasticsearch/Chart.yaml
+++ b/addons/elasticsearch/Chart.yaml
@@ -30,7 +30,7 @@ maintainers:
     url: https://github.com/vipshop
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.0.2"
   addon.kubeblocks.io/model: "search-engine"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/etcd/Chart.yaml
+++ b/addons/etcd/Chart.yaml
@@ -44,6 +44,6 @@ maintainers:
     url: https://github.com/loomts
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "key-value"
   addon.kubeblocks.io/provider: "community"

--- a/addons/falkordb/Chart.yaml
+++ b/addons/falkordb/Chart.yaml
@@ -34,6 +34,6 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "key-value"
   addon.kubeblocks.io/provider: "community"

--- a/addons/influxdb/Chart.yaml
+++ b/addons/influxdb/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 annotations:
   category: Database
   licenses: Apache-2.0
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "time-series"
 
 dependencies:

--- a/addons/kafka/Chart.yaml
+++ b/addons/kafka/Chart.yaml
@@ -33,6 +33,6 @@ maintainers:
     url: https://github.com/vipshop
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "streaming"
   addon.kubeblocks.io/provider: "community"

--- a/addons/mariadb/Chart.yaml
+++ b/addons/mariadb/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/milvus/Chart.yaml
+++ b/addons/milvus/Chart.yaml
@@ -18,7 +18,7 @@ sources:
   - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "vector"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/mogdb/Chart.yaml
+++ b/addons/mogdb/Chart.yaml
@@ -31,7 +31,7 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/mongodb/Chart.yaml
+++ b/addons/mongodb/Chart.yaml
@@ -31,6 +31,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "document"
   addon.kubeblocks.io/provider: "community"

--- a/addons/mysql/Chart.yaml
+++ b/addons/mysql/Chart.yaml
@@ -31,6 +31,6 @@ sources:
 - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/nebula/Chart.yaml
+++ b/addons/nebula/Chart.yaml
@@ -26,7 +26,7 @@ maintainers:
     email: xuntao.cheng@vesoft.com
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "graph"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/oceanbase-ce/Chart.yaml
+++ b/addons/oceanbase-ce/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     url: https://github.com/shanshanying
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/openviking/Chart.yaml
+++ b/addons/openviking/Chart.yaml
@@ -33,6 +33,6 @@ maintainers:
     url: https://github.com/volcengine/OpenViking
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "rag"
   addon.kubeblocks.io/provider: "community"

--- a/addons/orchestrator/Chart.yaml
+++ b/addons/orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "HA"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/orioledb/Chart.yaml
+++ b/addons/orioledb/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/polardbx/Chart.yaml
+++ b/addons/polardbx/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -30,6 +30,6 @@ sources:
 - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/pulsar/Chart.yaml
+++ b/addons/pulsar/Chart.yaml
@@ -39,6 +39,6 @@ maintainers:
     url: https://github.com/caiq1nyu
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "streaming"
   addon.kubeblocks.io/provider: "community"

--- a/addons/rabbitmq/Chart.yaml
+++ b/addons/rabbitmq/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
     url: https://github.com/xuriwuyun
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "message"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/redis/Chart.yaml
+++ b/addons/redis/Chart.yaml
@@ -30,6 +30,6 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "key-value"
   addon.kubeblocks.io/provider: "community"

--- a/addons/rocketmq/Chart.yaml
+++ b/addons/rocketmq/Chart.yaml
@@ -30,6 +30,6 @@ sources:
   - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "streaming"
   addon.kubeblocks.io/provider: "apecloud"

--- a/addons/tidb/Chart.yaml
+++ b/addons/tidb/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     url: https://github.com/csuzhangxc
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/valkey/Chart.yaml
+++ b/addons/valkey/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.1.1
 appVersion: "9.0.0"
 description: Valkey KubeBlocks addon
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: key-value
   addon.kubeblocks.io/provider: community
 dependencies:

--- a/addons/vanilla-postgresql/Chart.yaml
+++ b/addons/vanilla-postgresql/Chart.yaml
@@ -30,6 +30,6 @@ sources:
   - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "apecloud"

--- a/addons/zookeeper/Chart.yaml
+++ b/addons/zookeeper/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
     url: https://github.com/kissycn
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.2.0"
   addon.kubeblocks.io/model: "middleware"
   addon.kubeblocks.io/provider: "community"
 


### PR DESCRIPTION
## What changed

- Require KubeBlocks `>=1.2.0` for 23 addon charts that render APIs introduced after the `release-1.1` schema, including direct `ParametersDefinition` bindings and `ComponentDefinition.spec.configs[].reconfigure`.
- Require KubeBlocks `>1.0.2` for MogDB, Orchestrator, and PolarDB-X because they render exclusive replica roles.
- Require KubeBlocks `>=1.0.2` for Elasticsearch because it renders `podUpgradePolicy`.
- Include MariaDB and Valkey, as identified in review feedback.

## Why

Several addon charts declared a KubeBlocks version floor that could not accept their rendered custom resources. This allowed incompatible addons to be selected and then rejected by the target KubeBlocks API server.

The constraints are derived from full rendered-manifest comparison against structural CRD schemas, rather than from a checker hardcoded to individual API fields.

## Impact

Addon compatibility metadata now prevents installation on unsupported KubeBlocks versions:

- 23 addons using post-1.1 configuration APIs require the 1.2 line.
- Addons using only the exclusive-role API remain compatible with the post-1.0.2 line.
- Elasticsearch remains compatible with KubeBlocks 1.0.2 and later.

This `main` PR is intentionally labeled `nopick`; release-branch constraints are handled in a separate PR based on the resources actually rendered by `release-1.1`.

## Validation

- Refreshed and compared against KubeBlocks `v1.0.1`, `v1.0.2`, `v1.0.3-beta.0`, `release-1.1`, and `main` CRD schemas.
- Rendered and linted all 42 installable addon charts.
- Confirmed the 23 `>=1.2.0` addons fail `release-1.1` structural validation and pass `main`.
- Confirmed Elasticsearch first passes at `v1.0.2`.
- Confirmed MogDB, Orchestrator, and PolarDB-X fail `v1.0.2` and pass `v1.0.3-beta.0`.
- Ran `git diff --check`.
- Confirmed the final diff changes only one compatibility annotation in each of 27 `Chart.yaml` files.
