### PR TITLE
fix(etcd): make member join replay idempotent

### DIFF
--- a/addons/etcd/scripts-ut-spec/fixtures/member-join/etcd-3.5.15/after-add-unstarted.fields
+++ b/addons/etcd/scripts-ut-spec/fixtures/member-join/etcd-3.5.15/after-add-unstarted.fields
@@ -1,0 +1,27 @@
+"ClusterID" : 13973886929034234758
+"MemberID" : 7026481039975517645
+"Revision" : 0
+"RaftTerm" : 2
+"ID" : 1624589476481252013
+"Name" : "node3"
+"PeerURL" : "http://127.0.0.1:14400"
+"ClientURL" : "http://127.0.0.1:14399"
+"IsLearner" : false
+
+"ID" : 1994524592804184356
+"Name" : "node2"
+"PeerURL" : "http://127.0.0.1:14390"
+"ClientURL" : "http://127.0.0.1:14389"
+"IsLearner" : false
+
+"ID" : 4185663208878447165
+"Name" : ""
+"PeerURL" : "http://127.0.0.1:14410"
+"IsLearner" : false
+
+"ID" : 7026481039975517645
+"Name" : "node1"
+"PeerURL" : "http://127.0.0.1:14380"
+"ClientURL" : "http://127.0.0.1:14379"
+"IsLearner" : false
+

--- a/addons/etcd/scripts-ut-spec/fixtures/member-join/etcd-3.6.12/after-add-unstarted.fields
+++ b/addons/etcd/scripts-ut-spec/fixtures/member-join/etcd-3.6.12/after-add-unstarted.fields
@@ -1,0 +1,26 @@
+"ClusterID" : 3291992280926361974
+"MemberID" : 13049071153751544597
+"RaftTerm" : 2
+"ID" : 968486567321571443
+"Name" : "node2"
+"PeerURL" : "http://127.0.0.1:24390"
+"ClientURL" : "http://127.0.0.1:24389"
+"IsLearner" : false
+
+"ID" : 7058601719546094542
+"Name" : ""
+"PeerURL" : "http://127.0.0.1:24410"
+"IsLearner" : false
+
+"ID" : 12331849422721938888
+"Name" : "node3"
+"PeerURL" : "http://127.0.0.1:24400"
+"ClientURL" : "http://127.0.0.1:24399"
+"IsLearner" : false
+
+"ID" : 13049071153751544597
+"Name" : "node1"
+"PeerURL" : "http://127.0.0.1:24380"
+"ClientURL" : "http://127.0.0.1:24379"
+"IsLearner" : false
+

--- a/addons/etcd/scripts-ut-spec/member_join_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_join_spec.sh
@@ -1,108 +1,381 @@
 # shellcheck shell=bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2329
 
-# validate_shell_type_and_version defined in shellspec/spec_helper.sh used to validate the expected shell type and version this script needs to run.
 if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
-  echo "member_join_spec.sh skip cases because dependency bash version 4 or higher is not installed."
+  echo "member_join_spec.sh skip cases because bash 4 or higher is not installed."
   exit 0
 fi
 
-source ./utils.sh
-
-# The unit test needs to rely on the common library functions defined in kblib.
-# Therefore, we first dynamically generate the required common library files from the kblib library chart.
-common_library_file="./common.sh"
-generate_common_library $common_library_file
+member_join_script="./member-join-under-test.sh"
+sed -e '1,/^[[:space:]]*\. "\/scripts\/common\.sh"[[:space:]]*$/d' \
+  -e '/^# Shellspec magic/,$d' ../scripts/member-join.sh > "$member_join_script"
 
 Describe "Etcd Member Join Script Tests"
-  # load the scripts to be tested and dependencies
-  Include $common_library_file
+  Include ../scripts/common.sh
+  Include $member_join_script
 
-  init() {
-    # set ut_mode to true to hack control flow in the script
-    ut_mode="true"
+  setup() {
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+    export MEMBER_JOIN_CALL_LOG="$TEST_DIR/call.log"
+    export MEMBER_JOIN_READ_COUNT="$TEST_DIR/read-count"
+    export MEMBER_JOIN_STATES="$TEST_DIR/states"
+    : > "$MEMBER_JOIN_CALL_LOG"
+    printf '0' > "$MEMBER_JOIN_READ_COUNT"
+    : > "$MEMBER_JOIN_STATES"
 
-    # Setup test environment variables
     export LEADER_POD_FQDN="etcd-0.etcd-headless.default.svc.cluster.local"
     export KB_JOIN_MEMBER_POD_NAME="etcd-1"
     export KB_JOIN_MEMBER_POD_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
     export PEER_ENDPOINT=""
-    export CONFIG_FILE_PATH="/tmp/test_etcd.conf"
-    export config_file="$CONFIG_FILE_PATH"
+    export MEMBER_ADD_RC=0
 
-    # Create mock config file
-    mkdir -p /tmp
-    echo "initial-advertise-peer-urls: http://test:2380" > "$CONFIG_FILE_PATH"
-
-    # Mock functions
     get_endpoint_adapt_lb() {
-      local result_endpoint="$3"
-      echo "$result_endpoint"
+      printf '%s\n' "$3"
     }
 
     get_protocol() {
-      echo "http"
+      printf 'http\n'
     }
 
     log() {
-      echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
-    }
-
-    error_exit() {
-      echo "ERROR: $1" >&2
-      return 1
+      printf '%s\n' "$1" >&2
     }
 
     exec_etcdctl() {
       local endpoint="$1"
       shift
-      case "$1" in
-        "member")
-          case "$2" in
-            "add")
-              echo "Member $3 added to cluster $4"
-              return 0
-              ;;
-          esac
-          ;;
-      esac
-      echo "MOCK: exec_etcdctl $endpoint $*"
-      return 0
-    }
+      if [ "$1 $2" = "member list" ]; then
+        local index state
+        index=$(cat "$MEMBER_JOIN_READ_COUNT")
+        index=$((index + 1))
+        printf '%s' "$index" > "$MEMBER_JOIN_READ_COUNT"
+        state=$(sed -n "${index}p" "$MEMBER_JOIN_STATES")
+        case "$state" in
+          exact)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-1"' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          unstarted-registered)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          name-conflict)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-1"' \
+              '"PeerURL" : "http://wrong:2380"' ''
+            ;;
+          peer-conflict)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "other"' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          absent)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0:2380"' ''
+            ;;
+          query-failed)
+            return 1
+            ;;
+          *)
+            printf '%s\n' 'malformed output without member blocks'
+            ;;
+        esac
+        return 0
+      fi
 
-    # Define add_member function
-    add_member() {
-      local leader_endpoint join_member_endpoint peer_protocol
-
-      leader_pod_name="${LEADER_POD_FQDN%%.*}"
-      leader_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$leader_pod_name" "$LEADER_POD_FQDN")
-      join_member_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$KB_JOIN_MEMBER_POD_NAME" "$KB_JOIN_MEMBER_POD_FQDN")
-      peer_protocol=$(get_protocol "initial-advertise-peer-urls")
-
-      log "Adding member $KB_JOIN_MEMBER_POD_NAME to cluster via leader $leader_endpoint"
-      log "Join member peer URL: $peer_protocol://$join_member_endpoint:2380"
-      exec_etcdctl "$leader_endpoint:2379" member add "$KB_JOIN_MEMBER_POD_NAME" --peer-urls="$peer_protocol://$join_member_endpoint:2380" || error_exit "Failed to join member"
-      log "Member $KB_JOIN_MEMBER_POD_NAME joined cluster via leader $leader_endpoint"
+      printf '%s %s\n' "$endpoint" "$*" >> "$MEMBER_JOIN_CALL_LOG"
+      return "$MEMBER_ADD_RC"
     }
   }
-  BeforeAll "init"
+  BeforeEach "setup"
 
   cleanup() {
-    rm -f $common_library_file
-    rm -f "$CONFIG_FILE_PATH"
-    unset ut_mode LEADER_POD_FQDN KB_JOIN_MEMBER_POD_NAME KB_JOIN_MEMBER_POD_FQDN
-    unset PEER_ENDPOINT CONFIG_FILE_PATH config_file
-    unset -f get_endpoint_adapt_lb get_protocol log error_exit exec_etcdctl add_member
+    rm -rf "$TEST_DIR"
+    unset TEST_DIR MEMBER_JOIN_CALL_LOG MEMBER_JOIN_READ_COUNT MEMBER_JOIN_STATES
+    unset LEADER_POD_FQDN KB_JOIN_MEMBER_POD_NAME KB_JOIN_MEMBER_POD_FQDN
+    unset PEER_ENDPOINT MEMBER_ADD_RC
+    unset -f get_endpoint_adapt_lb get_protocol log exec_etcdctl
   }
-  AfterAll 'cleanup'
+  AfterEach "cleanup"
 
-  Describe "add_member() function"
-    It "joins a member to the cluster successfully"
+  cleanup_generated_script() {
+    rm -f "$member_join_script"
+  }
+  AfterAll "cleanup_generated_script"
+
+  set_member_states() {
+    printf '%s\n' "$@" > "$MEMBER_JOIN_STATES"
+  }
+
+  classify_fixture() {
+    local fixture="$1"
+    local target_name="$2"
+    local target_peer_url="$3"
+    classify_member_state "$target_name" "$target_peer_url" < "$fixture"
+  }
+
+  write_fields() {
+    printf '%s\n' "$@" > "$TEST_DIR/member-list.fields"
+  }
+
+  Describe "classify_member_state()"
+    It "classifies the byte-exact etcd 3.5.15 unstarted member fixture"
+      When call classify_fixture \
+        ./fixtures/member-join/etcd-3.5.15/after-add-unstarted.fields \
+        node4 http://127.0.0.1:14410
+      The status should be success
+      The output should eq "unstarted-registered"
+    End
+
+    It "classifies the byte-exact etcd 3.6.12 unstarted member fixture"
+      When call classify_fixture \
+        ./fixtures/member-join/etcd-3.6.12/after-add-unstarted.fields \
+        node4 http://127.0.0.1:24410
+      The status should be success
+      The output should eq "unstarted-registered"
+    End
+
+    It "classifies an exact member"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' \
+        '"IsLearner" : false' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
+        http://etcd-1.etcd-headless.default.svc.cluster.local:2380
+      The output should eq "exact"
+    End
+
+    It "classifies the same name with another URL as a name conflict"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://wrong:2380"' \
+        '"IsLearner" : false' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "name-conflict"
+    End
+
+    It "classifies the same URL with another nonempty name as a peer conflict"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "other"' \
+        '"PeerURL" : "http://target:2380"' \
+        '"IsLearner" : false' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "peer-conflict"
+    End
+
+    It "does not combine the target name and URL from different member blocks"
+      write_fields \
+        '"ID" : 1' '"Name" : "etcd-1"' '"PeerURL" : "http://wrong:2380"' '' \
+        '"ID" : 2' '"Name" : "other"' '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "name-conflict"
+    End
+
+    It "gives a name conflict priority over an unstarted target URL"
+      write_fields \
+        '"ID" : 1' '"Name" : ""' '"PeerURL" : "http://target:2380"' '' \
+        '"ID" : 2' '"Name" : "etcd-1"' '"PeerURL" : "http://wrong:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "name-conflict"
+    End
+
+    It "gives an exact member plus same-name ghost block a conflict verdict"
+      write_fields \
+        '"ID" : 1' '"Name" : "etcd-1"' '"PeerURL" : "http://target:2380"' '' \
+        '"ID" : 2' '"Name" : "etcd-1"' '"PeerURL" : "http://ghost:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "name-conflict"
+    End
+
+    It "gives an exact member plus same-URL foreign-name ghost a conflict verdict"
+      write_fields \
+        '"ID" : 1' '"Name" : "etcd-1"' '"PeerURL" : "http://target:2380"' '' \
+        '"ID" : 2' '"Name" : "other"' '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "peer-conflict"
+    End
+
+    It "accepts an exact member when one of multiple peer URLs matches"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://old:2380"' \
+        '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "exact"
+    End
+
+    It "classifies a missing name and URL as absent"
+      write_fields \
+        '"ClusterID" : 9' \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "http://etcd-0:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The output should eq "absent"
+    End
+
+
+    It "fails closed when output contains no member block"
+      write_fields '"ClusterID" : 9' '"MemberID" : 1'
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when a target peer block omits the Name field"
+      write_fields '"ID" : 1' '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+  End
+
+  Describe "add_member()"
+    It "fails closed before querying when required action-time inputs are empty"
+      unset LEADER_POD_FQDN KB_JOIN_MEMBER_POD_NAME KB_JOIN_MEMBER_POD_FQDN
+      When call add_member
+      The status should be failure
+      The error should include "phase: required-input-empty"
+      The error should include "LEADER_POD_FQDN"
+      The error should include "KB_JOIN_MEMBER_POD_NAME"
+      The error should include "KB_JOIN_MEMBER_POD_FQDN"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "0"
+    End
+
+    It "returns success without mutation when the exact member exists"
+      set_member_states exact
       When call add_member
       The status should be success
-      The stdout should include "Adding member etcd-1 to cluster via leader etcd-0"
-      The stdout should include "Member etcd-1 added to cluster"
-      The stdout should include "Member etcd-1 joined cluster via leader etcd-0"
+      The error should include "already joined"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "returns success without mutation for an unstarted registered member"
+      set_member_states unstarted-registered
+      When call add_member
+      The status should be success
+      The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "fails closed without mutation for a name conflict"
+      set_member_states name-conflict
+      When call add_member
+      The status should be failure
+      The error should include "action: memberJoin"
+      The error should include "phase: member-name-conflict"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+    End
+
+    It "fails closed without mutation for a peer URL conflict"
+      set_member_states peer-conflict
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-peer-url-conflict"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+    End
+
+    It "adds once and accepts an unstarted post-read state"
+      set_member_states absent unstarted-registered
+      When call add_member
+      The status should be success
+      The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq \
+        "etcd-0.etcd-headless.default.svc.cluster.local:2379 member add etcd-1 --peer-urls=http://etcd-1.etcd-headless.default.svc.cluster.local:2380"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "accepts an exact post-read even when the concurrent add returned nonzero"
+      set_member_states absent exact
+      MEMBER_ADD_RC=1
+      When call add_member
+      The status should be success
+      The error should include "already joined"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "accepts an unstarted post-read when the concurrent add returned nonzero"
+      set_member_states absent unstarted-registered
+      MEMBER_ADD_RC=1
+      When call add_member
+      The status should be success
+      The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "fails closed when a name conflict appears after add"
+      set_member_states absent name-conflict
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-name-conflict"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "fails closed when a peer URL conflict appears after add"
+      set_member_states absent peer-conflict
+      MEMBER_ADD_RC=1
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-peer-url-conflict"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "classifies add failure followed by absent as transient"
+      set_member_states absent absent
+      MEMBER_ADD_RC=1
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-add-failed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "classifies a successful add not observed by post-read as transient"
+      set_member_states absent absent
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-registration-not-observed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "classifies a pre-read query failure as transient without mutation"
+      set_member_states query-failed
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-list-query-failed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+    End
+
+    It "classifies a post-read query failure as transient after one add"
+      set_member_states absent query-failed
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-post-add-query-failed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
     End
   End
 End

--- a/addons/etcd/scripts-ut-spec/member_join_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_join_spec.sh
@@ -241,6 +241,43 @@ Describe "Etcd Member Join Script Tests"
       The status should be failure
       The output should eq ""
     End
+
+    It "fails closed when the Name value is missing"
+      write_fields '"ID" : 1' '"Name" :' '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when the Name value is unquoted"
+      write_fields '"ID" : 1' '"Name" : etcd-1' '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when the PeerURL value is unquoted"
+      write_fields '"ID" : 1' '"Name" : "etcd-1"' '"PeerURL" : http://target:2380' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when the member ID is not decimal"
+      write_fields '"ID" : not-decimal' '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when a member block has duplicate Name fields"
+      write_fields '"ID" : 1' '"Name" : "other"' '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://target:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
   End
 
   Describe "add_member()"

--- a/addons/etcd/scripts-ut-spec/member_join_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_join_spec.sh
@@ -82,6 +82,12 @@ Describe "Etcd Member Join Script Tests"
               '"Name" : "etcd-0"' \
               '"PeerURL" : "http://etcd-0:2380"' ''
             ;;
+          empty-peer-url)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "other"' \
+              '"PeerURL" : ""' ''
+            ;;
           query-failed)
             return 1
             ;;
@@ -263,6 +269,13 @@ Describe "Etcd Member Join Script Tests"
       The output should eq ""
     End
 
+    It "fails closed when the PeerURL value is quoted but empty"
+      write_fields '"ID" : 1' '"Name" : "other"' '"PeerURL" : ""' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
+      The status should be failure
+      The output should eq ""
+    End
+
     It "fails closed when the member ID is not decimal"
       write_fields '"ID" : not-decimal' '"Name" : "etcd-1"' \
         '"PeerURL" : "http://target:2380"' ''
@@ -329,6 +342,15 @@ Describe "Etcd Member Join Script Tests"
       The error should include "phase: member-peer-url-conflict"
       The error should include "next-retry-safe: no"
       The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+    End
+
+    It "fails closed without mutation for a quoted-empty peer URL"
+      set_member_states empty-peer-url
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-list-query-failed"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
     End
 
     It "adds once and accepts an unstarted post-read state"

--- a/addons/etcd/scripts/member-join.sh
+++ b/addons/etcd/scripts/member-join.sh
@@ -4,18 +4,229 @@ set -exo pipefail
 # shellcheck disable=SC1091
 . "/scripts/common.sh"
 
+member_join_diagnose_not_ready() {
+  local phase="$1"
+  local context="$2"
+  local retry_safe="$3"
+
+  {
+    echo "memberJoin diagnosis:"
+    echo "  action: memberJoin"
+    echo "  phase: ${phase}"
+    echo "${context}"
+    echo "  next-retry-safe: ${retry_safe}"
+  } >&2
+}
+
+classify_member_state() {
+  local target_name="$1"
+  local target_peer_url="$2"
+
+  awk -v target_name="$target_name" -v target_peer_url="$target_peer_url" '
+    function field_value(line, value) {
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/^"/, "", value)
+      sub(/"$/, "", value)
+      return value
+    }
+
+    function finish_member() {
+      if (!in_member) {
+        return
+      }
+
+      if (!name_seen || !peer_seen) {
+        malformed = 1
+      }
+
+      if (member_name == target_name && !peer_matches) {
+        name_conflict = 1
+      }
+
+      if (peer_matches) {
+        if (member_name == target_name) {
+          exact = 1
+        } else if (member_name == "") {
+          unstarted = 1
+        } else {
+          peer_conflict = 1
+        }
+      }
+
+      in_member = 0
+      member_name = ""
+      name_seen = 0
+      peer_seen = 0
+      peer_matches = 0
+    }
+
+    /^"ID"[[:space:]]*:/ {
+      finish_member()
+      in_member = 1
+      saw_member = 1
+      next
+    }
+
+    /^[[:space:]]*$/ {
+      finish_member()
+      next
+    }
+
+    in_member && /^"Name"[[:space:]]*:/ {
+      member_name = field_value($0)
+      name_seen = 1
+      next
+    }
+
+    in_member && /^"PeerURL"[[:space:]]*:/ {
+      peer_seen = 1
+      if (field_value($0) == target_peer_url) {
+        peer_matches = 1
+      }
+      next
+    }
+
+    END {
+      finish_member()
+      if (!saw_member || malformed) {
+        exit 2
+      } else if (name_conflict) {
+        print "name-conflict"
+      } else if (peer_conflict) {
+        print "peer-conflict"
+      } else if (exact) {
+        print "exact"
+      } else if (unstarted) {
+        print "unstarted-registered"
+      } else {
+        print "absent"
+      }
+    }
+  '
+}
+
+read_member_state() {
+  local endpoint="$1"
+  local target_name="$2"
+  local target_peer_url="$3"
+  local member_list
+
+  if ! member_list=$(exec_etcdctl "$endpoint" member list -w fields); then
+    return 1
+  fi
+
+  printf '%s\n' "$member_list" | classify_member_state "$target_name" "$target_peer_url"
+}
+
+validate_member_join_inputs() {
+  local missing=""
+  local context
+
+  [ -n "${LEADER_POD_FQDN:-}" ] || missing="${missing} LEADER_POD_FQDN"
+  [ -n "${KB_JOIN_MEMBER_POD_NAME:-}" ] || missing="${missing} KB_JOIN_MEMBER_POD_NAME"
+  [ -n "${KB_JOIN_MEMBER_POD_FQDN:-}" ] || missing="${missing} KB_JOIN_MEMBER_POD_FQDN"
+
+  if [ -n "$missing" ]; then
+    context=$(printf '  missing-inputs:%s' "$missing")
+    member_join_diagnose_not_ready "required-input-empty" "$context" "no"
+    return 1
+  fi
+}
+
 add_member() {
-  local leader_endpoint join_member_endpoint peer_protocol
+  local leader_pod_name leader_endpoint join_member_endpoint peer_protocol
+  local target_peer_url member_state context add_rc
+
+  validate_member_join_inputs || return 1
 
   leader_pod_name="${LEADER_POD_FQDN%%.*}"
   leader_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$leader_pod_name" "$LEADER_POD_FQDN")
   join_member_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$KB_JOIN_MEMBER_POD_NAME" "$KB_JOIN_MEMBER_POD_FQDN")
   peer_protocol=$(get_protocol "initial-advertise-peer-urls")
+  target_peer_url="$peer_protocol://$join_member_endpoint:2380"
+
+  context=$(printf '  member: %s\n  peer-url: %s' "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url")
+
+  if ! member_state=$(read_member_state "$leader_endpoint:2379" "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url"); then
+    member_join_diagnose_not_ready "member-list-query-failed" "$context" "yes"
+    return 1
+  fi
+
+  case "$member_state" in
+    exact)
+      log "Member $KB_JOIN_MEMBER_POD_NAME already joined via $target_peer_url"
+      return 0
+      ;;
+    unstarted-registered)
+      log "Member $KB_JOIN_MEMBER_POD_NAME registered but not started via $target_peer_url"
+      return 0
+      ;;
+    name-conflict)
+      member_join_diagnose_not_ready "member-name-conflict" "$context" "no"
+      return 1
+      ;;
+    peer-conflict)
+      member_join_diagnose_not_ready "member-peer-url-conflict" "$context" "no"
+      return 1
+      ;;
+    absent)
+      ;;
+    *)
+      context=$(printf '%s\n  observed-state: %s' "$context" "$member_state")
+      member_join_diagnose_not_ready "member-state-invalid" "$context" "no"
+      return 1
+      ;;
+  esac
 
   log "Adding member $KB_JOIN_MEMBER_POD_NAME to cluster via leader $leader_endpoint"
-  log "Join member peer URL: $peer_protocol://$join_member_endpoint:2380"
-  exec_etcdctl "$leader_endpoint:2379" member add "$KB_JOIN_MEMBER_POD_NAME" --peer-urls="$peer_protocol://$join_member_endpoint:2380" || error_exit "Failed to join member"
-  log "Member $KB_JOIN_MEMBER_POD_NAME joined cluster via leader $leader_endpoint"
+  log "Join member peer URL: $target_peer_url"
+
+  if exec_etcdctl "$leader_endpoint:2379" member add "$KB_JOIN_MEMBER_POD_NAME" --peer-urls="$target_peer_url"; then
+    add_rc=0
+  else
+    add_rc=$?
+  fi
+
+  context=$(printf '  member: %s\n  peer-url: %s\n  member-add-rc: %s' \
+    "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url" "$add_rc")
+
+  if ! member_state=$(read_member_state "$leader_endpoint:2379" "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url"); then
+    member_join_diagnose_not_ready "member-post-add-query-failed" "$context" "yes"
+    return 1
+  fi
+
+  case "$member_state" in
+    exact)
+      log "Member $KB_JOIN_MEMBER_POD_NAME already joined via $target_peer_url"
+      return 0
+      ;;
+    unstarted-registered)
+      log "Member $KB_JOIN_MEMBER_POD_NAME registered but not started via $target_peer_url"
+      return 0
+      ;;
+    name-conflict)
+      member_join_diagnose_not_ready "member-name-conflict" "$context" "no"
+      return 1
+      ;;
+    peer-conflict)
+      member_join_diagnose_not_ready "member-peer-url-conflict" "$context" "no"
+      return 1
+      ;;
+    absent)
+      if [ "$add_rc" -eq 0 ]; then
+        member_join_diagnose_not_ready "member-registration-not-observed" "$context" "yes"
+      else
+        member_join_diagnose_not_ready "member-add-failed" "$context" "yes"
+      fi
+      return 1
+      ;;
+    *)
+      context=$(printf '%s\n  observed-state: %s' "$context" "$member_state")
+      member_join_diagnose_not_ready "member-state-invalid" "$context" "no"
+      return 1
+      ;;
+  esac
 }
 
 # Shellspec magic

--- a/addons/etcd/scripts/member-join.sh
+++ b/addons/etcd/scripts/member-join.sh
@@ -90,7 +90,7 @@ classify_member_state() {
 
     /^"PeerURL"[[:space:]]*:/ {
       if (!in_member ||
-          $0 !~ /^"PeerURL"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*$/) {
+          $0 !~ /^"PeerURL"[[:space:]]*:[[:space:]]*"[^"]+"[[:space:]]*$/) {
         malformed = 1
         next
       }

--- a/addons/etcd/scripts/member-join.sh
+++ b/addons/etcd/scripts/member-join.sh
@@ -26,6 +26,7 @@ classify_member_state() {
     function field_value(line, value) {
       value = line
       sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
       sub(/^"/, "", value)
       sub(/"$/, "", value)
       return value
@@ -65,6 +66,9 @@ classify_member_state() {
       finish_member()
       in_member = 1
       saw_member = 1
+      if ($0 !~ /^"ID"[[:space:]]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+        malformed = 1
+      }
       next
     }
 
@@ -73,13 +77,23 @@ classify_member_state() {
       next
     }
 
-    in_member && /^"Name"[[:space:]]*:/ {
+    /^"Name"[[:space:]]*:/ {
+      if (!in_member || name_seen ||
+          $0 !~ /^"Name"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*$/) {
+        malformed = 1
+        next
+      }
       member_name = field_value($0)
       name_seen = 1
       next
     }
 
-    in_member && /^"PeerURL"[[:space:]]*:/ {
+    /^"PeerURL"[[:space:]]*:/ {
+      if (!in_member ||
+          $0 !~ /^"PeerURL"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*$/) {
+        malformed = 1
+        next
+      }
       peer_seen = 1
       if (field_value($0) == target_peer_url) {
         peer_matches = 1


### PR DESCRIPTION
## What this fixes

Closes #3234.

`memberJoin` no longer blindly adds a member on every lifecycle-action replay.
It now reads authoritative membership before mutation, adds an absent member at
most once, and verifies membership again after the add attempt.

## Behavior

- Exact existing member: success without mutation.
- Unstarted member with the expected peer URL: success without mutation.
- Same name with another peer URL: fail closed.
- Same peer URL with another nonempty name: fail closed.
- Absent member: one add attempt followed by an authoritative post-read.
- Query failure, malformed fields output, or unobserved registration: fail
  closed with retry classification.

The fields parser validates decimal member IDs, quoted Name values, nonempty
quoted PeerURL values, and duplicate Name fields. Multiple valid PeerURL fields
remain supported.

## Verification

- Genuine TDD reds: focused `31 examples / 4 failures` for malformed fields,
  then `34 examples / 2 failures` for the quoted-empty PeerURL boundary.
- Focused memberJoin ShellSpec: `34/0`.
- Full etcd script ShellSpec: `69/0`.
- Alice reviewer mutant harness: pass on Bash 5.3 and BusyBox 1.37, including
  production `add_member` returning rc=1 with zero add calls for malformed
  input.
- BusyBox 1.37: both byte-exact etcd fixtures classify as
  `unstarted-registered`; legal multiple-PeerURL input classifies as `exact`.
- Bash 3.2 and 5.3 parse, ShellCheck error severity, Helm lint, and Helm render:
  pass.

Fixture SHA-256 values remain unchanged:

- etcd 3.5.15: `25406312dafba48e31b88157df628f4c1f0691928f9a3b0e804f4930e24cc9d6`
- etcd 3.6.12: `c950babd452e3243e74a3d74c5584bd4fa26224077d13f62955e0ae04c245769`

The full base diff has two intentional `git diff --check` findings: the final
blank line in each real-output fixture is an exact captured block delimiter and
is protected by the fixture SHA.
