### PR TITLE
fix(etcd): resolve member actions through the current leader

### DIFF
--- a/addons/etcd/scripts-ut-spec/member_join_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_join_spec.sh
@@ -117,6 +117,20 @@ Describe "Etcd Member Join Script Tests"
               '"Name" : ""' \
               '"PeerURL" : "http://ETCD-1.ETCD-HEADLESS.DEFAULT.SVC.CLUSTER.LOCAL.:2380"' ''
             ;;
+          duplicate-canonical-owners)
+            printf '%s\n' \
+              '"ID" : 0' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' '' \
+              '"ID" : 1' \
+              '"Name" : "etcd-1"' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2379"' '' \
+              '"ID" : 2' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://ETCD-1.ETCD-HEADLESS.DEFAULT.SVC.CLUSTER.LOCAL.:2380"' ''
+            ;;
           unstarted-target-only)
             printf '%s\n' \
               '"ID" : 1' \
@@ -315,6 +329,30 @@ Describe "Etcd Member Join Script Tests"
       The output should eq "name-conflict"
     End
 
+    It "fails closed when started and unstarted members share a canonical peer URL"
+      write_fields \
+        '"ID" : 1' '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://etcd-1.example:2380"' '' \
+        '"ID" : 2' '"Name" : ""' \
+        '"PeerURL" : "http://ETCD-1.EXAMPLE.:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
+        http://etcd-1.example:2380
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed when two unstarted members share a canonical peer URL"
+      write_fields \
+        '"ID" : 1' '"Name" : ""' \
+        '"PeerURL" : "http://etcd-1.example:2380"' '' \
+        '"ID" : 2' '"Name" : ""' \
+        '"PeerURL" : "http://ETCD-1.EXAMPLE.:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
+        http://etcd-1.example:2380
+      The status should be failure
+      The output should eq ""
+    End
+
     It "classifies the same name with another URL as a name conflict"
       write_fields \
         '"ID" : 1' \
@@ -359,12 +397,13 @@ Describe "Etcd Member Join Script Tests"
       The output should eq "name-conflict"
     End
 
-    It "gives an exact member plus same-URL foreign-name ghost a conflict verdict"
+    It "fails closed for exact and foreign-name owners of the same peer URL"
       write_fields \
         '"ID" : 1' '"Name" : "etcd-1"' '"PeerURL" : "http://target:2380"' '' \
         '"ID" : 2' '"Name" : "other"' '"PeerURL" : "http://target:2380"' ''
       When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 http://target:2380
-      The output should eq "peer-conflict"
+      The status should be failure
+      The output should eq ""
     End
 
     It "accepts an exact member when one of multiple peer URLs matches"
@@ -665,6 +704,16 @@ Describe "Etcd Member Join Script Tests"
       When call add_member
       The status should be success
       The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "fails closed before mutation when canonical target ownership is ambiguous"
+      set_member_states duplicate-canonical-owners
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-list-invalid"
+      The error should include "next-retry-safe: no"
       The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
       The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
     End

--- a/addons/etcd/scripts-ut-spec/member_join_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_join_spec.sh
@@ -18,9 +18,11 @@ Describe "Etcd Member Join Script Tests"
     TEST_DIR=$(mktemp -d)
     export TEST_DIR
     export MEMBER_JOIN_CALL_LOG="$TEST_DIR/call.log"
+    export MEMBER_JOIN_ENDPOINT_LOG="$TEST_DIR/endpoint.log"
     export MEMBER_JOIN_READ_COUNT="$TEST_DIR/read-count"
     export MEMBER_JOIN_STATES="$TEST_DIR/states"
     : > "$MEMBER_JOIN_CALL_LOG"
+    : > "$MEMBER_JOIN_ENDPOINT_LOG"
     printf '0' > "$MEMBER_JOIN_READ_COUNT"
     : > "$MEMBER_JOIN_STATES"
 
@@ -29,10 +31,7 @@ Describe "Etcd Member Join Script Tests"
     export KB_JOIN_MEMBER_POD_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
     export PEER_ENDPOINT=""
     export MEMBER_ADD_RC=0
-
-    get_endpoint_adapt_lb() {
-      printf '%s\n' "$3"
-    }
+    export LOCAL_LEADER_STATUS="leader"
 
     get_protocol() {
       printf 'http\n'
@@ -45,6 +44,34 @@ Describe "Etcd Member Join Script Tests"
     exec_etcdctl() {
       local endpoint="$1"
       shift
+      printf '%s %s\n' "$endpoint" "$*" >> "$MEMBER_JOIN_ENDPOINT_LOG"
+
+      if [ "$1 $2" = "endpoint status" ]; then
+        case "$LOCAL_LEADER_STATUS" in
+          leader)
+            printf '%s\n' '"MemberID" : 1' '"Leader" : 1'
+            ;;
+          follower)
+            printf '%s\n' '"MemberID" : 1' '"Leader" : 2'
+            ;;
+          zero)
+            printf '%s\n' '"MemberID" : 0' '"Leader" : 0'
+            ;;
+          adjacent-uint64-follower)
+            printf '%s\n' \
+              '"MemberID" : 18150782143940212502' \
+              '"Leader" : 18150782143940212503'
+            ;;
+          query-failed)
+            return 1
+            ;;
+          *)
+            printf '%s\n' 'malformed endpoint status'
+            ;;
+        esac
+        return 0
+      fi
+
       if [ "$1 $2" = "member list" ]; then
         local index state
         index=$(cat "$MEMBER_JOIN_READ_COUNT")
@@ -54,11 +81,33 @@ Describe "Etcd Member Join Script Tests"
         case "$state" in
           exact)
             printf '%s\n' \
+              '"ID" : 0' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' '' \
               '"ID" : 1' \
               '"Name" : "etcd-1"' \
-              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2379"' ''
+            ;;
+          exact-only)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-1"' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2379"' ''
             ;;
           unstarted-registered)
+            printf '%s\n' \
+              '"ID" : 0' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' '' \
+              '"ID" : 1' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          unstarted-target-only)
             printf '%s\n' \
               '"ID" : 1' \
               '"Name" : ""' \
@@ -66,21 +115,68 @@ Describe "Etcd Member Join Script Tests"
             ;;
           name-conflict)
             printf '%s\n' \
+              '"ID" : 0' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' '' \
               '"ID" : 1' \
               '"Name" : "etcd-1"' \
-              '"PeerURL" : "http://wrong:2380"' ''
+              '"PeerURL" : "http://wrong:2380"' \
+              '"ClientURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2379"' ''
             ;;
           peer-conflict)
             printf '%s\n' \
               '"ID" : 1' \
               '"Name" : "other"' \
-              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://other.etcd-headless.default.svc.cluster.local:2379"' ''
             ;;
           absent)
             printf '%s\n' \
               '"ID" : 1' \
               '"Name" : "etcd-0"' \
-              '"PeerURL" : "http://etcd-0:2380"' ''
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' ''
+            ;;
+          client-address-collision)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.internal:2380"' \
+              '"ClientURL" : "http://shared-lb.example:2379"' ''
+            ;;
+          unrelated-unstarted)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' '' \
+              '"ID" : 2' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://etcd-2.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          all-contacts-empty)
+            printf '%s\n' \
+              '"ID" : 2' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://etcd-2.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          malformed-client-url)
+            printf '%s\n' \
+              '"ID" : 1' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "not-a-url"' ''
+            ;;
+          over-limit)
+            local member
+            for member in 0 2 3 4 5 6 7 8 9; do
+              printf '%s\n' \
+                "\"ID\" : $member" \
+                "\"Name\" : \"etcd-$member\"" \
+                "\"PeerURL\" : \"http://etcd-$member.example:2380\"" \
+                "\"ClientURL\" : \"http://etcd-$member.example:2379\"" ''
+            done
             ;;
           empty-peer-url)
             printf '%s\n' \
@@ -106,10 +202,10 @@ Describe "Etcd Member Join Script Tests"
 
   cleanup() {
     rm -rf "$TEST_DIR"
-    unset TEST_DIR MEMBER_JOIN_CALL_LOG MEMBER_JOIN_READ_COUNT MEMBER_JOIN_STATES
+    unset TEST_DIR MEMBER_JOIN_CALL_LOG MEMBER_JOIN_ENDPOINT_LOG MEMBER_JOIN_READ_COUNT MEMBER_JOIN_STATES
     unset LEADER_POD_FQDN KB_JOIN_MEMBER_POD_NAME KB_JOIN_MEMBER_POD_FQDN
-    unset PEER_ENDPOINT MEMBER_ADD_RC
-    unset -f get_endpoint_adapt_lb get_protocol log exec_etcdctl
+    unset PEER_ENDPOINT MEMBER_ADD_RC LOCAL_LEADER_STATUS
+    unset -f get_protocol log exec_etcdctl
   }
   AfterEach "cleanup"
 
@@ -131,6 +227,21 @@ Describe "Etcd Member Join Script Tests"
 
   write_fields() {
     printf '%s\n' "$@" > "$TEST_DIR/member-list.fields"
+  }
+
+  build_contact_fixture() {
+    local fixture="$1"
+    local exclude_name="$2"
+    local client_protocol="$3"
+    local peer_protocol="${4:-$client_protocol}"
+    build_current_contact_candidates "$exclude_name" "$client_protocol" "" \
+      "contacts" "$peer_protocol" < "$fixture"
+  }
+
+  build_contact_fixture_excluding_id() {
+    local fixture="$1"
+    local exclude_id="$2"
+    build_current_contact_candidates "" http "$exclude_id" < "$fixture"
   }
 
   Describe "classify_member_state()"
@@ -293,16 +404,197 @@ Describe "Etcd Member Join Script Tests"
     End
   End
 
+  Describe "build_current_contact_candidates()"
+    It "canonicalizes and stably deduplicates hostnames before returning contacts"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "http://ETCD-0.EXAMPLE.:2380"' \
+        '"ClientURL" : "http://ETCD-0.EXAMPLE.:2379"' '' \
+        '"ID" : 2' \
+        '"Name" : "etcd-2"' \
+        '"PeerURL" : "http://etcd-2.example:2380"' \
+        '"ClientURL" : "http://etcd-0.example:2379"' ''
+      When call build_contact_fixture "$TEST_DIR/member-list.fields" "" http
+      The status should be success
+      The output should eq "http://etcd-0.example:2379"
+    End
+
+    It "canonicalizes IPv4 octets"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "http://010.000.000.001:2380"' \
+        '"ClientURL" : "http://010.000.000.001:2379"' ''
+      When call build_contact_fixture "$TEST_DIR/member-list.fields" "" http
+      The status should be success
+      The output should eq "http://10.0.0.1:2379"
+    End
+
+    It "accepts one consistent TLS protocol"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "https://etcd-0.example:2380"' \
+        '"ClientURL" : "https://etcd-0.example:2379"' ''
+      When call build_contact_fixture "$TEST_DIR/member-list.fields" "" https
+      The status should be success
+      The output should eq "https://etcd-0.example:2379"
+    End
+
+    It "accepts independently configured client TLS and peer plaintext"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "http://etcd-0.example:2380"' \
+        '"ClientURL" : "https://etcd-0.example:2379"' ''
+      When call build_contact_fixture "$TEST_DIR/member-list.fields" "" https http
+      The status should be success
+      The output should eq "https://etcd-0.example:2379"
+    End
+
+    It "fails closed when authoritative URLs mix protocols"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "https://etcd-0.example:2380"' \
+        '"ClientURL" : "https://etcd-0.example:2379"' '' \
+        '"ID" : 2' \
+        '"Name" : "etcd-2"' \
+        '"PeerURL" : "http://etcd-2.example:2380"' \
+        '"ClientURL" : "http://etcd-2.example:2379"' ''
+      When call build_contact_fixture "$TEST_DIR/member-list.fields" "" https
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "fails closed instead of numerically accepting a noncanonical client port"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "http://etcd-0.example:2380"' \
+        '"ClientURL" : "http://etcd-0.example:02379"' ''
+      When call build_contact_fixture "$TEST_DIR/member-list.fields" "" http
+      The status should be failure
+      The output should eq ""
+    End
+
+    It "excludes one raw uint64 ID without collapsing an adjacent ID"
+      write_fields \
+        '"ID" : 18150782143940212502' \
+        '"Name" : "etcd-0"' \
+        '"PeerURL" : "http://etcd-0.example:2380"' \
+        '"ClientURL" : "http://etcd-0.example:2379"' '' \
+        '"ID" : 18150782143940212503' \
+        '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://etcd-1.example:2380"' \
+        '"ClientURL" : "http://etcd-1.example:2379"' ''
+      When call build_contact_fixture_excluding_id \
+        "$TEST_DIR/member-list.fields" 18150782143940212502
+      The status should be success
+      The output should eq "http://etcd-1.example:2379"
+    End
+  End
+
+  Describe "get_endpoint_adapt_lb()"
+    It "matches the exact pod key when ordinals overlap"
+      When call get_endpoint_adapt_lb \
+        "etcd-10:10.0.0.10,etcd-1:10.0.0.1" etcd-1 etcd-1.internal
+      The status should be success
+      The output should eq "10.0.0.1"
+      The error should include "Using exact LoadBalancer endpoint"
+    End
+
+    It "fails closed for duplicate exact keys"
+      When call get_endpoint_adapt_lb \
+        "etcd-1:10.0.0.1,etcd-1:10.0.0.2" etcd-1 etcd-1.internal
+      The status should be failure
+    End
+
+    It "fails closed for malformed mapping tokens"
+      When call get_endpoint_adapt_lb \
+        "etcd-1:bad:host,etcd-2:10.0.0.2" etcd-1 etcd-1.internal
+      The status should be failure
+    End
+
+    It "fails closed when the target mapping collides with another pod"
+      When call get_endpoint_adapt_lb \
+        "etcd-1:10.0.0.1,etcd-2:10.0.0.1" etcd-1 etcd-1.internal
+      The status should be failure
+    End
+
+    It "canonicalizes a hostname mapping"
+      When call get_endpoint_adapt_lb \
+        "etcd-1:ETCD-1.EXAMPLE." etcd-1 etcd-1.internal
+      The status should be success
+      The output should eq "etcd-1.example"
+      The error should include "Using exact LoadBalancer endpoint"
+    End
+
+    It "falls back only to a nonempty action-time FQDN when mapping is missing"
+      When call get_endpoint_adapt_lb \
+        "etcd-2:10.0.0.2" etcd-1 etcd-1.internal
+      The status should be success
+      The output should eq "etcd-1.internal"
+      The error should include "mapping-missing-fallback-fqdn"
+    End
+  End
+
   Describe "add_member()"
+    It "uses the action-time local leader instead of stale topology snapshots"
+      export LEADER_POD_FQDN="deleted-0.old-headless.default.svc.cluster.local"
+      export PEER_FQDNS="deleted-0.old-headless.default.svc.cluster.local,etcd-2.old-headless.default.svc.cluster.local"
+      set_member_states exact
+      When call add_member
+      The status should be success
+      The error should include "already joined"
+      The contents of file "$MEMBER_JOIN_ENDPOINT_LOG" should include \
+        "127.0.0.1:2379 endpoint status -w fields"
+      The contents of file "$MEMBER_JOIN_ENDPOINT_LOG" should include \
+        "127.0.0.1:2379 member list -w fields"
+      The contents of file "$MEMBER_JOIN_ENDPOINT_LOG" should not include "deleted-0"
+    End
+
     It "fails closed before querying when required action-time inputs are empty"
       unset LEADER_POD_FQDN KB_JOIN_MEMBER_POD_NAME KB_JOIN_MEMBER_POD_FQDN
       When call add_member
       The status should be failure
       The error should include "phase: required-input-empty"
-      The error should include "LEADER_POD_FQDN"
+      The error should not include "LEADER_POD_FQDN"
       The error should include "KB_JOIN_MEMBER_POD_NAME"
       The error should include "KB_JOIN_MEMBER_POD_FQDN"
       The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "0"
+    End
+
+    It "defers before mutation when the selected action pod is not the current leader"
+      LOCAL_LEADER_STATUS=follower
+      set_member_states absent
+      When call add_member
+      The status should be failure
+      The error should include "phase: selected-contact-not-current-leader"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "0"
+    End
+
+    It "rejects a zero MemberID and Leader sentinel before mutation"
+      LOCAL_LEADER_STATUS=zero
+      set_member_states absent
+      When call add_member
+      The status should be failure
+      The error should include "phase: selected-contact-not-current-leader"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "0"
+    End
+
+    It "does not collapse adjacent uint64 MemberID and Leader values"
+      LOCAL_LEADER_STATUS=adjacent-uint64-follower
+      set_member_states absent
+      When call add_member
+      The status should be failure
+      The error should include "phase: selected-contact-not-current-leader"
       The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
       The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "0"
     End
@@ -321,6 +613,26 @@ Describe "Etcd Member Join Script Tests"
       When call add_member
       The status should be success
       The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "closes an exact replay even when the target is the only current contact"
+      set_member_states exact-only
+      When call add_member
+      The status should be success
+      The error should include "already joined"
+      The error should not include "contact-candidate-empty"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "closes an unstarted replay even when no member can contribute a contact"
+      set_member_states unstarted-target-only
+      When call add_member
+      The status should be success
+      The error should include "registered but not started"
+      The error should not include "contact-candidate-empty"
       The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
       The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
     End
@@ -348,7 +660,7 @@ Describe "Etcd Member Join Script Tests"
       set_member_states empty-peer-url
       When call add_member
       The status should be failure
-      The error should include "phase: member-list-query-failed"
+      The error should include "phase: member-list-invalid"
       The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
       The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
     End
@@ -358,9 +670,55 @@ Describe "Etcd Member Join Script Tests"
       When call add_member
       The status should be success
       The error should include "registered but not started"
-      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq \
-        "etcd-0.etcd-headless.default.svc.cluster.local:2379 member add etcd-1 --peer-urls=http://etcd-1.etcd-headless.default.svc.cluster.local:2380"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should include \
+        "member add etcd-1 --peer-urls=http://etcd-1.etcd-headless.default.svc.cluster.local:2380"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should include \
+        "--dial-timeout=2s --command-timeout=6s"
       The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "ignores an unrelated valid unstarted block when a started contact exists"
+      set_member_states unrelated-unstarted unstarted-registered
+      When call add_member
+      The status should be success
+      The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should include "member add etcd-1"
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "2"
+    End
+
+    It "fails distinctly when every non-target member has empty client URLs"
+      set_member_states all-contacts-empty
+      When call add_member
+      The status should be failure
+      The error should include "phase: contact-candidate-empty"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+    End
+
+    It "fails closed for a malformed nonempty client URL"
+      set_member_states malformed-client-url
+      When call add_member
+      The status should be failure
+      The error should include "phase: member-list-invalid"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+    End
+
+    It "fails closed when the target advertised host collides with a current member contact"
+      PEER_ENDPOINT="etcd-1:shared-lb.example"
+      set_member_states client-address-collision
+      When call add_member
+      The status should be failure
+      The error should include "phase: target-address-collision"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "fails closed instead of truncating more than eight contacts"
+      set_member_states over-limit
+      When call add_member
+      The status should be failure
+      The error should include "phase: contact-candidate-over-limit"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
     End
 
     It "accepts an exact post-read even when the concurrent add returned nonzero"

--- a/addons/etcd/scripts-ut-spec/member_join_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_join_spec.sh
@@ -107,6 +107,16 @@ Describe "Etcd Member Join Script Tests"
               '"Name" : ""' \
               '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' ''
             ;;
+          unstarted-canonical-equivalent)
+            printf '%s\n' \
+              '"ID" : 0' \
+              '"Name" : "etcd-0"' \
+              '"PeerURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "http://etcd-0.etcd-headless.default.svc.cluster.local:2379"' '' \
+              '"ID" : 1' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://ETCD-1.ETCD-HEADLESS.DEFAULT.SVC.CLUSTER.LOCAL.:2380"' ''
+            ;;
           unstarted-target-only)
             printf '%s\n' \
               '"ID" : 1' \
@@ -270,6 +280,39 @@ Describe "Etcd Member Join Script Tests"
       When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
         http://etcd-1.etcd-headless.default.svc.cluster.local:2380
       The output should eq "exact"
+    End
+
+    It "classifies a canonical-equivalent unstarted peer URL as registered"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : ""' \
+        '"PeerURL" : "http://ETCD-1.ETCD-HEADLESS.DEFAULT.SVC.CLUSTER.LOCAL.:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
+        http://etcd-1.etcd-headless.default.svc.cluster.local:2380
+      The status should be success
+      The output should eq "unstarted-registered"
+    End
+
+    It "classifies a canonical-equivalent started peer URL as exact"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://ETCD-1.ETCD-HEADLESS.DEFAULT.SVC.CLUSTER.LOCAL.:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
+        http://etcd-1.etcd-headless.default.svc.cluster.local:2380
+      The status should be success
+      The output should eq "exact"
+    End
+
+    It "keeps a genuinely different canonical peer URL as a name conflict"
+      write_fields \
+        '"ID" : 1' \
+        '"Name" : "etcd-1"' \
+        '"PeerURL" : "http://ETCD-OTHER.EXAMPLE.:2380"' ''
+      When call classify_fixture "$TEST_DIR/member-list.fields" etcd-1 \
+        http://etcd-1.etcd-headless.default.svc.cluster.local:2380
+      The status should be success
+      The output should eq "name-conflict"
     End
 
     It "classifies the same name with another URL as a name conflict"
@@ -610,6 +653,15 @@ Describe "Etcd Member Join Script Tests"
 
     It "returns success without mutation for an unstarted registered member"
       set_member_states unstarted-registered
+      When call add_member
+      The status should be success
+      The error should include "registered but not started"
+      The contents of file "$MEMBER_JOIN_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_JOIN_READ_COUNT" should eq "1"
+    End
+
+    It "closes canonical-equivalent unstarted replay without a second add"
+      set_member_states unstarted-canonical-equivalent
       When call add_member
       The status should be success
       The error should include "registered but not started"

--- a/addons/etcd/scripts-ut-spec/member_leave_spec.sh
+++ b/addons/etcd/scripts-ut-spec/member_leave_spec.sh
@@ -1,156 +1,338 @@
 # shellcheck shell=bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2329
 
-# validate_shell_type_and_version defined in shellspec/spec_helper.sh used to validate the expected shell type and version this script needs to run.
 if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
-  echo "member_leave_spec.sh skip cases because dependency bash version 4 or higher is not installed."
+  echo "member_leave_spec.sh skip cases because bash 4 or higher is not installed."
   exit 0
 fi
 
-source ./utils.sh
-
-# The unit test needs to rely on the common library functions defined in kblib.
-# Therefore, we first dynamically generate the required common library files from the kblib library chart.
-common_library_file="./common.sh"
-generate_common_library $common_library_file
+member_leave_script="./member-leave-under-test.sh"
+sed -e '1,/^[[:space:]]*\. "\/scripts\/common\.sh"[[:space:]]*$/d' \
+  -e '/^# Shellspec magic/,$d' ../scripts/member-leave.sh > "$member_leave_script"
 
 Describe "Etcd Member Leave Script Tests"
-  # load the scripts to be tested and dependencies
-  Include $common_library_file
+  Include ../scripts/common.sh
+  Include $member_leave_script
 
-  init() {
-    # set ut_mode to true to hack control flow in the script
-    ut_mode="true"
+  setup() {
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+    export MEMBER_LEAVE_CALL_LOG="$TEST_DIR/call.log"
+    export MEMBER_LEAVE_ENDPOINT_LOG="$TEST_DIR/endpoint.log"
+    export MEMBER_LEAVE_READ_COUNT="$TEST_DIR/read-count"
+    export MEMBER_LEAVE_STATES="$TEST_DIR/states"
+    : > "$MEMBER_LEAVE_CALL_LOG"
+    : > "$MEMBER_LEAVE_ENDPOINT_LOG"
+    printf '0' > "$MEMBER_LEAVE_READ_COUNT"
+    : > "$MEMBER_LEAVE_STATES"
 
-    # Setup test environment variables
+    export LEADER_POD_FQDN="deleted-0.old-headless.default.svc.cluster.local"
+    export PEER_FQDNS="deleted-0.old-headless.default.svc.cluster.local,etcd-2.old-headless.default.svc.cluster.local"
     export KB_LEAVE_MEMBER_POD_NAME="etcd-1"
     export KB_LEAVE_MEMBER_POD_FQDN="etcd-1.etcd-headless.default.svc.cluster.local"
-    export LEADER_POD_FQDN="etcd-0.etcd-headless.default.svc.cluster.local"
     export PEER_ENDPOINT=""
+    export MEMBER_REMOVE_RC=0
+    export LOCAL_LEADER_STATUS="leader"
 
-    # Mock functions
-    get_endpoint_adapt_lb() {
-      local result_endpoint="$3"
-      echo "$result_endpoint"
+    get_protocol() {
+      printf 'http\n'
     }
 
     log() {
-      echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
-    }
-
-    error_exit() {
-      echo "ERROR: $1" >&2
-      return 1
+      printf '%s\n' "$1" >&2
     }
 
     exec_etcdctl() {
       local endpoint="$1"
       shift
-      case "$1" in
-        "endpoint")
-          case "$2" in
-            "status")
-              echo '"MemberID" : 1002'
-              return 0
-              ;;
-          esac
-          ;;
-        "member")
-          case "$2" in
-            "remove")
-              echo "Member $3 removed successfully"
-              return 0
-              ;;
-          esac
-          ;;
-        *)
-          echo "MOCK: exec_etcdctl $endpoint $*"
-          return 0
-          ;;
-      esac
-    }
+      printf '%s %s\n' "$endpoint" "$*" >> "$MEMBER_LEAVE_ENDPOINT_LOG"
 
-    # Define functions
-    get_etcd_id() {
-      local endpoint="$1"
-      local decimal_id hex_id
-
-      if ! decimal_id=$(exec_etcdctl "$endpoint" endpoint status -w fields | grep -o '"MemberID" : [0-9]*' | awk '{print $3}'); then
-        return 1
-      fi
-
-      [ -z "$decimal_id" ] && return 1
-
-      hex_id=$(printf "%x" "$decimal_id")
-      echo "$hex_id"
-    }
-
-    remove_member() {
-      local etcd_id="$1"
-      local leader_pod_name leader_endpoint
-
-      leader_pod_name="${LEADER_POD_FQDN%%.*}"
-      leader_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$leader_pod_name" "$LEADER_POD_FQDN")
-
-      log "Removing member $etcd_id via leader $leader_endpoint"
-      exec_etcdctl "$leader_endpoint:2379" member remove "$etcd_id"
-    }
-
-    member_leave() {
-      local leaver_endpoint etcd_id
-
-      leaver_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$KB_LEAVE_MEMBER_POD_NAME" "$KB_LEAVE_MEMBER_POD_FQDN")
-      [ -z "$leaver_endpoint" ] && { error_exit "Leave member pod endpoint is empty"; return 1; }
-
-      log "Getting etcd ID for leaving member: $leaver_endpoint"
-      etcd_id=$(get_etcd_id "$leaver_endpoint:2379") || { error_exit "Failed to get etcd ID"; return 1; }
-      [ -z "$etcd_id" ] && { error_exit "Failed to get etcd ID"; return 1; }
-
-      remove_member "$etcd_id" || { error_exit "Failed to remove member"; return 1; }
-      log "Member $KB_LEAVE_MEMBER_POD_NAME left cluster"
-    }
-  }
-  BeforeAll "init"
-
-  cleanup() {
-    rm -f $common_library_file
-    unset ut_mode KB_LEAVE_MEMBER_POD_NAME KB_LEAVE_MEMBER_POD_FQDN LEADER_POD_FQDN PEER_ENDPOINT
-    unset -f get_endpoint_adapt_lb log error_exit exec_etcdctl get_etcd_id remove_member member_leave
-  }
-  AfterAll 'cleanup'
-
-  Describe "member_leave() function"
-    It "leaves the cluster successfully"
-      When call member_leave
-      The status should be success
-      The stdout should include "Getting etcd ID for leaving member"
-      The stdout should include "Member 3ea removed successfully"
-      The stdout should include "Member etcd-1 left cluster"
-    End
-
-    It "handles failed to get etcd ID"
-      # Override exec_etcdctl to fail getting status
-      exec_etcdctl() {
-        local endpoint="$1"
-        shift
-        case "$1" in
-          "endpoint")
-            case "$2" in
-              "status")
-                return 1
-                ;;
-            esac
+      if [ "$1 $2" = "endpoint status" ]; then
+        case "$LOCAL_LEADER_STATUS" in
+          leader)
+            printf '%s\n' '"MemberID" : 1' '"Leader" : 1'
+            ;;
+          follower)
+            printf '%s\n' '"MemberID" : 1' '"Leader" : 2'
+            ;;
+          query-failed)
+            return 1
             ;;
           *)
-            return 0
+            printf '%s\n' 'malformed endpoint status'
             ;;
         esac
-      }
+        return 0
+      fi
 
+      if [ "$1 $2" = "member list" ]; then
+        local index state member
+        index=$(cat "$MEMBER_LEAVE_READ_COUNT")
+        index=$((index + 1))
+        printf '%s' "$index" > "$MEMBER_LEAVE_READ_COUNT"
+        state=$(sed -n "${index}p" "$MEMBER_LEAVE_STATES")
+        case "$state" in
+          present)
+            print_started_member 1 etcd-0 etcd-0.etcd-headless.default.svc.cluster.local
+            print_started_member 1002 etcd-1 etcd-1.etcd-headless.default.svc.cluster.local
+            print_started_member 3 etcd-2 etcd-2.etcd-headless.default.svc.cluster.local
+            ;;
+          absent)
+            print_started_member 1 etcd-0 etcd-0.etcd-headless.default.svc.cluster.local
+            print_started_member 3 etcd-2 etcd-2.etcd-headless.default.svc.cluster.local
+            ;;
+          unrelated-unstarted)
+            print_started_member 1 etcd-0 etcd-0.etcd-headless.default.svc.cluster.local
+            print_started_member 1002 etcd-1 etcd-1.etcd-headless.default.svc.cluster.local
+            printf '%s\n' \
+              '"ID" : 3' \
+              '"Name" : ""' \
+              '"PeerURL" : "http://etcd-2.etcd-headless.default.svc.cluster.local:2380"' ''
+            ;;
+          target-only)
+            print_started_member 1002 etcd-1 etcd-1.etcd-headless.default.svc.cluster.local
+            ;;
+          malformed-client-url)
+            print_started_member 1 etcd-0 etcd-0.etcd-headless.default.svc.cluster.local
+            printf '%s\n' \
+              '"ID" : 1002' \
+              '"Name" : "etcd-1"' \
+              '"PeerURL" : "http://etcd-1.etcd-headless.default.svc.cluster.local:2380"' \
+              '"ClientURL" : "not-a-url"' ''
+            ;;
+          duplicate-target)
+            print_started_member 1 etcd-0 etcd-0.etcd-headless.default.svc.cluster.local
+            print_started_member 1002 etcd-1 etcd-1.etcd-headless.default.svc.cluster.local
+            print_started_member 1003 etcd-1 duplicate.etcd-headless.default.svc.cluster.local
+            ;;
+          over-limit)
+            print_started_member 1002 etcd-1 etcd-1.etcd-headless.default.svc.cluster.local
+            for member in 0 2 3 4 5 6 7 8 9; do
+              print_started_member "$member" "etcd-$member" "etcd-$member.example"
+            done
+            ;;
+          query-failed)
+            return 1
+            ;;
+          *)
+            printf '%s\n' 'malformed output without member blocks'
+            ;;
+        esac
+        return 0
+      fi
+
+      printf '%s %s\n' "$endpoint" "$*" >> "$MEMBER_LEAVE_CALL_LOG"
+      return "$MEMBER_REMOVE_RC"
+    }
+  }
+  BeforeEach "setup"
+
+  cleanup() {
+    rm -rf "$TEST_DIR"
+    unset TEST_DIR MEMBER_LEAVE_CALL_LOG MEMBER_LEAVE_ENDPOINT_LOG
+    unset MEMBER_LEAVE_READ_COUNT MEMBER_LEAVE_STATES
+    unset LEADER_POD_FQDN PEER_FQDNS KB_LEAVE_MEMBER_POD_NAME KB_LEAVE_MEMBER_POD_FQDN
+    unset PEER_ENDPOINT MEMBER_REMOVE_RC LOCAL_LEADER_STATUS
+    unset -f get_protocol log exec_etcdctl
+  }
+  AfterEach "cleanup"
+
+  cleanup_generated_script() {
+    rm -f "$member_leave_script"
+  }
+  AfterAll "cleanup_generated_script"
+
+  set_member_states() {
+    printf '%s\n' "$@" > "$MEMBER_LEAVE_STATES"
+  }
+
+  print_started_member() {
+    local id="$1"
+    local name="$2"
+    local host="$3"
+    printf '%s\n' \
+      "\"ID\" : $id" \
+      "\"Name\" : \"$name\"" \
+      "\"PeerURL\" : \"http://$host:2380\"" \
+      "\"ClientURL\" : \"http://$host:2379\"" ''
+  }
+
+  find_leave_fixture() {
+    local fixture="$1"
+    local target_name="$2"
+    find_leave_target_id "$target_name" < "$fixture"
+  }
+
+  Describe "find_leave_target_id()"
+    It "returns the target raw decimal member ID from one exact block"
+      print_started_member 1 etcd-0 etcd-0.example > "$TEST_DIR/member-list.fields"
+      print_started_member 1002 etcd-1 etcd-1.example >> "$TEST_DIR/member-list.fields"
+      When call find_leave_fixture "$TEST_DIR/member-list.fields" etcd-1
+      The status should be success
+      The output should eq "1002"
+    End
+
+    It "returns absent when the target name is not present"
+      print_started_member 1 etcd-0 etcd-0.example > "$TEST_DIR/member-list.fields"
+      When call find_leave_fixture "$TEST_DIR/member-list.fields" etcd-1
+      The status should be success
+      The output should eq "absent"
+    End
+
+    It "fails closed for duplicate target identities"
+      print_started_member 1002 etcd-1 etcd-1.example > "$TEST_DIR/member-list.fields"
+      print_started_member 1003 etcd-1 duplicate.example >> "$TEST_DIR/member-list.fields"
+      When call find_leave_fixture "$TEST_DIR/member-list.fields" etcd-1
+      The status should be failure
+      The output should eq ""
+    End
+  End
+
+  Describe "member_leave()"
+    It "uses the action-time local leader and current member list instead of static snapshots"
+      set_member_states absent
+      When call member_leave
+      The status should be success
+      The error should include "already absent"
+      The contents of file "$MEMBER_LEAVE_ENDPOINT_LOG" should include \
+        "127.0.0.1:2379 endpoint status -w fields"
+      The contents of file "$MEMBER_LEAVE_ENDPOINT_LOG" should include \
+        "127.0.0.1:2379 member list -w fields"
+      The contents of file "$MEMBER_LEAVE_ENDPOINT_LOG" should not include "deleted-0"
+    End
+
+    It "fails closed before querying when required action-time inputs are empty"
+      unset LEADER_POD_FQDN KB_LEAVE_MEMBER_POD_NAME KB_LEAVE_MEMBER_POD_FQDN
       When call member_leave
       The status should be failure
-      The stdout should include "Getting etcd ID for leaving member"
-      The stderr should include "ERROR: Failed to get etcd ID"
+      The error should include "phase: required-input-empty"
+      The error should not include "LEADER_POD_FQDN"
+      The error should include "KB_LEAVE_MEMBER_POD_NAME"
+      The error should include "KB_LEAVE_MEMBER_POD_FQDN"
+      The error should include "next-retry-safe: no"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "0"
+    End
+
+    It "defers before mutation when the selected action pod is not the current leader"
+      LOCAL_LEADER_STATUS=follower
+      set_member_states present
+      When call member_leave
+      The status should be failure
+      The error should include "phase: selected-contact-not-current-leader"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "0"
+    End
+
+    It "returns success without mutation when the target is already absent"
+      set_member_states absent
+      When call member_leave
+      The status should be success
+      The error should include "already absent"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "1"
+    End
+
+    It "removes once by raw target ID and closes only after an absent post-read"
+      set_member_states present absent
+      When call member_leave
+      The status should be success
+      The error should include "left cluster"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should include "member remove 3ea"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should include \
+        "--dial-timeout=2s --command-timeout=6s"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should not include \
+        "etcd-1.etcd-headless.default.svc.cluster.local:2379"
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "2"
+    End
+
+    It "accepts an absent post-read even when the concurrent remove returned nonzero"
+      set_member_states present absent
+      MEMBER_REMOVE_RC=1
+      When call member_leave
+      The status should be success
+      The error should include "left cluster"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should include "member remove 3ea"
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "2"
+    End
+
+    It "fails transiently when a successful remove is not observed"
+      set_member_states present present
+      When call member_leave
+      The status should be failure
+      The error should include "phase: member-removal-not-observed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should include "member remove 3ea"
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "2"
+    End
+
+    It "fails transiently when remove fails and the target remains present"
+      set_member_states present present
+      MEMBER_REMOVE_RC=1
+      When call member_leave
+      The status should be failure
+      The error should include "phase: member-remove-failed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "2"
+    End
+
+    It "accepts an unrelated valid unstarted block while using a started contact"
+      set_member_states unrelated-unstarted absent
+      When call member_leave
+      The status should be success
+      The error should include "left cluster"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should include "member remove 3ea"
+    End
+
+    It "fails distinctly when excluding the target leaves no current contact"
+      set_member_states target-only
+      When call member_leave
+      The status should be failure
+      The error should include "phase: contact-candidate-empty"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+    End
+
+    It "fails closed for a malformed nonempty client URL"
+      set_member_states malformed-client-url
+      When call member_leave
+      The status should be failure
+      The error should include "phase: member-list-invalid"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+    End
+
+    It "fails closed for a duplicate target identity"
+      set_member_states duplicate-target
+      When call member_leave
+      The status should be failure
+      The error should include "phase: member-list-invalid"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+    End
+
+    It "fails closed instead of truncating more than eight contacts"
+      set_member_states over-limit
+      When call member_leave
+      The status should be failure
+      The error should include "phase: contact-candidate-over-limit"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+    End
+
+    It "classifies a pre-read query failure as transient without mutation"
+      set_member_states query-failed
+      When call member_leave
+      The status should be failure
+      The error should include "phase: member-list-query-failed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_LEAVE_CALL_LOG" should eq ""
+    End
+
+    It "classifies a post-read query failure as transient after one remove"
+      set_member_states present query-failed
+      When call member_leave
+      The status should be failure
+      The error should include "phase: member-post-remove-query-failed"
+      The error should include "next-retry-safe: yes"
+      The contents of file "$MEMBER_LEAVE_READ_COUNT" should eq "2"
     End
   End
 End

--- a/addons/etcd/scripts/common.sh
+++ b/addons/etcd/scripts/common.sh
@@ -51,6 +51,49 @@ exec_etcdctl() {
   fi
 }
 
+exec_bounded_etcdctl() {
+  local endpoint="$1"
+  shift
+  exec_etcdctl "$endpoint" "$@" --dial-timeout=2s --command-timeout=6s
+}
+
+validate_local_leader() {
+  local endpoint="${1:-127.0.0.1:2379}"
+  local status
+
+  if ! status=$(exec_bounded_etcdctl "$endpoint" endpoint status -w fields); then
+    return 1
+  fi
+
+  printf '%s\n' "$status" | awk '
+    /^"MemberID"[[:space:]]*:/ {
+      if (++member_count != 1 || $0 !~ /^"MemberID"[[:space:]]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+        malformed = 1
+      }
+      member_id = $0
+      sub(/^[^:]*:[[:space:]]*/, "", member_id)
+      sub(/[[:space:]]*$/, "", member_id)
+      next
+    }
+    /^"Leader"[[:space:]]*:/ {
+      if (++leader_count != 1 || $0 !~ /^"Leader"[[:space:]]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+        malformed = 1
+      }
+      leader_id = $0
+      sub(/^[^:]*:[[:space:]]*/, "", leader_id)
+      sub(/[[:space:]]*$/, "", leader_id)
+      next
+    }
+    END {
+      if (malformed || member_count != 1 || leader_count != 1 ||
+          member_id == "0" || leader_id == "0" ||
+          ("id:" member_id) != ("id:" leader_id)) {
+        exit 2
+      }
+    }
+  '
+}
+
 get_protocol() {
   local url_type="$1"
 
@@ -73,27 +116,284 @@ check_backup_file() {
 get_endpoint_adapt_lb() {
   local lb_endpoints="$1"
   local pod_name="$2"
-  local result_endpoint="$3"
+  local fallback_endpoint="$3"
+  local result_endpoint rc
 
-  if [ -n "$lb_endpoints" ]; then
-    log "LoadBalancer mode detected. Adapting pod FQDN to balance IP."
-    local endpoints lb_endpoint
-    endpoints=$(echo "$lb_endpoints" | tr ',' '\n')
-    lb_endpoint=$(echo "$endpoints" | grep "$pod_name" | head -1)
-    if [ -n "$lb_endpoint" ]; then
-      # e.g.1 etcd-cluster-etcd-0
-      # e.g.2 etcd-cluster-etcd-0:127.0.0.1
-      if echo "$lb_endpoint" | grep -q ":"; then
-        result_endpoint=$(echo "$lb_endpoint" | cut -d: -f2)
-      else
-        result_endpoint="$lb_endpoint"
-      fi
-      log "Using LoadBalancer endpoint for $pod_name: $result_endpoint"
-    else
-      log "Failed to get LB endpoint for $pod_name, using default FQDN: $result_endpoint"
-    fi
+  if [ -z "$lb_endpoints" ]; then
+    canonicalize_endpoint_host "$fallback_endpoint"
+    return
   fi
-  echo "$result_endpoint"
+
+  if result_endpoint=$(printf '%s\n' "$lb_endpoints" | awk -v target="$pod_name" '
+    function canonical_host(host, parts, count, i, result) {
+      sub(/[.]$/, "", host)
+      host = tolower(host)
+      if (host == "" || length(host) > 253) {
+        return ""
+      }
+      if (host ~ /^[0-9.]+$/) {
+        count = split(host, parts, ".")
+        if (count != 4) {
+          return ""
+        }
+        result = ""
+        for (i = 1; i <= 4; i++) {
+          if (parts[i] !~ /^[0-9]+$/ || parts[i] + 0 > 255) {
+            return ""
+          }
+          result = result (i == 1 ? "" : ".") (parts[i] + 0)
+        }
+        return result
+      }
+      count = split(host, parts, ".")
+      for (i = 1; i <= count; i++) {
+        if (length(parts[i]) < 1 || length(parts[i]) > 63 ||
+            parts[i] !~ /^[a-z0-9][a-z0-9-]*$/ || parts[i] ~ /-$/) {
+          return ""
+        }
+      }
+      return host
+    }
+    {
+      if (NR != 1) malformed = 1
+      count = split($0, tokens, ",")
+      for (i = 1; i <= count; i++) {
+        token = tokens[i]
+        if (token == "" || token ~ /^[^:]*:[^:]*:[^:]*$/) {
+          malformed = 1
+          continue
+        }
+        colon = index(token, ":")
+        if (colon == 0) {
+          key = token
+          host = token
+        } else {
+          key = substr(token, 1, colon - 1)
+          host = substr(token, colon + 1)
+        }
+        if (key !~ /^[a-z0-9][a-z0-9.-]*$/) {
+          malformed = 1
+          continue
+        }
+        host = canonical_host(host)
+        if (host == "") {
+          malformed = 1
+          continue
+        }
+        keys[i] = key
+        hosts[i] = host
+        if (key == target) {
+          target_count++
+          target_host = host
+        }
+      }
+    }
+    END {
+      if (malformed) {
+        exit 2
+      }
+      if (target_count > 1) {
+        exit 3
+      }
+      if (target_count == 0) {
+        exit 10
+      }
+      for (i = 1; i <= count; i++) {
+        if (keys[i] != target && hosts[i] == target_host) {
+          exit 4
+        }
+      }
+      print target_host
+    }
+  '); then
+    log "Using exact LoadBalancer endpoint for $pod_name: $result_endpoint"
+    printf '%s\n' "$result_endpoint"
+    return 0
+  else
+    rc=$?
+  fi
+
+  if [ "$rc" -eq 10 ]; then
+    result_endpoint=$(canonicalize_endpoint_host "$fallback_endpoint") || return 1
+    log "mapping-missing-fallback-fqdn for $pod_name: $result_endpoint"
+    printf '%s\n' "$result_endpoint"
+    return 0
+  fi
+
+  return "$rc"
+}
+
+canonicalize_endpoint_host() {
+  local host="$1"
+  printf '%s\n' "$host" | awk '
+    function fail() { exit 1 }
+    {
+      sub(/[.]$/, "")
+      value = tolower($0)
+      if (value == "" || length(value) > 253) fail()
+      if (value ~ /^[0-9.]+$/) {
+        count = split(value, parts, ".")
+        if (count != 4) fail()
+        result = ""
+        for (i = 1; i <= 4; i++) {
+          if (parts[i] !~ /^[0-9]+$/ || parts[i] + 0 > 255) fail()
+          result = result (i == 1 ? "" : ".") (parts[i] + 0)
+        }
+        print result
+        next
+      }
+      count = split(value, parts, ".")
+      for (i = 1; i <= count; i++) {
+        if (length(parts[i]) < 1 || length(parts[i]) > 63 ||
+            parts[i] !~ /^[a-z0-9][a-z0-9-]*$/ || parts[i] ~ /-$/) fail()
+      }
+      print value
+    }
+  '
+}
+
+build_current_contact_candidates() {
+  local exclude_name="$1"
+  local expected_client_protocol="$2"
+  local exclude_id="${3:-}"
+  local output_mode="${4:-contacts}"
+  local expected_peer_protocol="${5:-$expected_client_protocol}"
+
+  awk -v exclude_name="$exclude_name" \
+    -v expected_client_protocol="$expected_client_protocol" \
+    -v expected_peer_protocol="$expected_peer_protocol" \
+    -v exclude_id="$exclude_id" -v output_mode="$output_mode" '
+    function field_value(line, value) {
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      sub(/^"/, "", value)
+      sub(/"$/, "", value)
+      return value
+    }
+    function canonical_host(host, parts, count, i, result) {
+      sub(/[.]$/, "", host)
+      host = tolower(host)
+      if (host == "" || length(host) > 253) return ""
+      if (host ~ /^[0-9.]+$/) {
+        count = split(host, parts, ".")
+        if (count != 4) return ""
+        result = ""
+        for (i = 1; i <= 4; i++) {
+          if (parts[i] !~ /^[0-9]+$/ || parts[i] + 0 > 255) return ""
+          result = result (i == 1 ? "" : ".") (parts[i] + 0)
+        }
+        return result
+      }
+      count = split(host, parts, ".")
+      for (i = 1; i <= count; i++) {
+        if (length(parts[i]) < 1 || length(parts[i]) > 63 ||
+            parts[i] !~ /^[a-z0-9][a-z0-9-]*$/ || parts[i] ~ /-$/) return ""
+      }
+      return host
+    }
+    function canonical_url(value, expected_port, required_protocol, marker, rest, host, port, protocol) {
+      marker = index(value, "://")
+      if (marker == 0) return ""
+      protocol = substr(value, 1, marker - 1)
+      rest = substr(value, marker + 3)
+      if (protocol != required_protocol || rest !~ /:[0-9]+$/) return ""
+      port = rest
+      sub(/^.*:/, "", port)
+      host = rest
+      sub(/:[0-9]+$/, "", host)
+      host = canonical_host(host)
+      if (host == "" || ("port:" port) != ("port:" expected_port)) return ""
+      return protocol "://" host ":" port
+    }
+    function clear_block(key) {
+      in_member = 0
+      member_id = ""
+      member_name = ""
+      id_seen = 0
+      name_seen = 0
+      peer_count = 0
+      client_count = 0
+      client_empty_count = 0
+      for (key in block_clients) delete block_clients[key]
+    }
+    function finish_member(i, url) {
+      if (!in_member) return
+      if (id_seen != 1 || name_seen != 1 || peer_count < 1) malformed = 1
+      if (member_name == "") {
+        if (client_count > 0) malformed = 1
+      } else if (client_count < 1 || client_empty_count > 0) {
+        malformed = 1
+      }
+      if (member_name != "" && member_name != exclude_name &&
+          ("id:" member_id) != ("id:" exclude_id)) {
+        for (i = 1; i <= client_count; i++) {
+          url = block_clients[i]
+          if (!candidate_seen[url]++) candidates[++candidate_count] = url
+        }
+      }
+      clear_block()
+    }
+    /^"ID"[[:space:]]*:/ {
+      finish_member()
+      in_member = 1
+      saw_member = 1
+      if ($0 !~ /^"ID"[[:space:]]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+        malformed = 1
+      } else {
+        member_id = field_value($0)
+        if (member_ids["id:" member_id]++) malformed = 1
+        id_seen = 1
+      }
+      next
+    }
+    /^[[:space:]]*$/ { finish_member(); next }
+    /^"Name"[[:space:]]*:/ {
+      if (!in_member || name_seen || $0 !~ /^"Name"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*$/) {
+        malformed = 1
+      } else {
+        member_name = field_value($0)
+        if (member_name != "" && member_names[member_name]++) malformed = 1
+        name_seen = 1
+      }
+      next
+    }
+    /^"PeerURL"[[:space:]]*:/ {
+      if (!in_member || $0 !~ /^"PeerURL"[[:space:]]*:[[:space:]]*"[^"]+"[[:space:]]*$/ ||
+          canonical_url(field_value($0), 2380, expected_peer_protocol) == "") {
+        malformed = 1
+      } else {
+        peer_count++
+      }
+      next
+    }
+    /^"ClientURL"[[:space:]]*:/ {
+      if (!in_member || $0 !~ /^"ClientURL"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*$/) {
+        malformed = 1
+      } else {
+        value = field_value($0)
+        if (value == "") {
+          client_empty_count++
+        } else {
+          value = canonical_url(value, 2379, expected_client_protocol)
+          if (value == "") malformed = 1
+          else block_clients[++client_count] = value
+        }
+      }
+      next
+    }
+    END {
+      finish_member()
+      if (!saw_member || malformed) exit 2
+      if (output_mode == "validate-only") exit 0
+      if (candidate_count > 8) exit 3
+      if (candidate_count == 0) exit 4
+      for (i = 1; i <= candidate_count; i++) {
+        printf "%s%s", (i == 1 ? "" : ","), candidates[i]
+      }
+      print ""
+    }
+  '
 }
 
 parse_endpoint_field() {

--- a/addons/etcd/scripts/member-join.sh
+++ b/addons/etcd/scripts/member-join.sh
@@ -92,6 +92,7 @@ classify_member_state() {
       }
 
       if (peer_matches) {
+        target_owner_count++
         if (member_name == target_name) {
           exact = 1
         } else if (member_name == "") {
@@ -155,7 +156,7 @@ classify_member_state() {
 
     END {
       finish_member()
-      if (!saw_member || malformed) {
+      if (!saw_member || malformed || target_owner_count > 1) {
         exit 2
       } else if (name_conflict) {
         print "name-conflict"

--- a/addons/etcd/scripts/member-join.sh
+++ b/addons/etcd/scripts/member-join.sh
@@ -120,24 +120,10 @@ classify_member_state() {
   '
 }
 
-read_member_state() {
-  local endpoint="$1"
-  local target_name="$2"
-  local target_peer_url="$3"
-  local member_list
-
-  if ! member_list=$(exec_etcdctl "$endpoint" member list -w fields); then
-    return 1
-  fi
-
-  printf '%s\n' "$member_list" | classify_member_state "$target_name" "$target_peer_url"
-}
-
 validate_member_join_inputs() {
   local missing=""
   local context
 
-  [ -n "${LEADER_POD_FQDN:-}" ] || missing="${missing} LEADER_POD_FQDN"
   [ -n "${KB_JOIN_MEMBER_POD_NAME:-}" ] || missing="${missing} KB_JOIN_MEMBER_POD_NAME"
   [ -n "${KB_JOIN_MEMBER_POD_FQDN:-}" ] || missing="${missing} KB_JOIN_MEMBER_POD_FQDN"
 
@@ -148,22 +134,112 @@ validate_member_join_inputs() {
   fi
 }
 
+build_join_contacts() {
+  local member_list="$1"
+  local target_name="$2"
+  local client_protocol="$3"
+  local peer_protocol="$4"
+  local context="$5"
+  local contacts rc
+
+  if contacts=$(printf '%s\n' "$member_list" | \
+    build_current_contact_candidates "$target_name" "$client_protocol" "" "contacts" "$peer_protocol"); then
+    printf '%s\n' "$contacts"
+    return 0
+  else
+    rc=$?
+  fi
+
+  case "$rc" in
+    2)
+      member_join_diagnose_not_ready "member-list-invalid" "$context" "no"
+      ;;
+    3)
+      member_join_diagnose_not_ready "contact-candidate-over-limit" "$context" "no"
+      ;;
+    4)
+      member_join_diagnose_not_ready "contact-candidate-empty" "$context" "yes"
+      ;;
+    *)
+      member_join_diagnose_not_ready "contact-candidate-build-failed" "$context" "no"
+      ;;
+  esac
+  return 1
+}
+
+classify_join_snapshot() {
+  local member_list="$1"
+  local target_name="$2"
+  local target_peer_url="$3"
+  printf '%s\n' "$member_list" | classify_member_state "$target_name" "$target_peer_url"
+}
+
+validate_join_snapshot() {
+  local member_list="$1"
+  local client_protocol="$2"
+  local peer_protocol="$3"
+  local context="$4"
+
+  if ! printf '%s\n' "$member_list" | \
+    build_current_contact_candidates "" "$client_protocol" "" \
+      "validate-only" "$peer_protocol" >/dev/null; then
+    member_join_diagnose_not_ready "member-list-invalid" "$context" "no"
+    return 1
+  fi
+}
+
+has_target_contact_collision() {
+  local target_host="$1"
+  local contacts="$2"
+
+  printf '%s\n' "$contacts" | awk -v target_host="$target_host" '
+    {
+      count = split($0, values, ",")
+      for (i = 1; i <= count; i++) {
+        host = values[i]
+        sub(/^[^:]+:\/\//, "", host)
+        sub(/:[0-9]+$/, "", host)
+        if (host == target_host) found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  '
+}
+
 add_member() {
-  local leader_pod_name leader_endpoint join_member_endpoint peer_protocol
-  local target_peer_url member_state context add_rc
+  local local_endpoint="127.0.0.1:2379"
+  local join_member_endpoint peer_protocol client_protocol target_peer_url
+  local member_list contacts member_state context add_rc
 
   validate_member_join_inputs || return 1
 
-  leader_pod_name="${LEADER_POD_FQDN%%.*}"
-  leader_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$leader_pod_name" "$LEADER_POD_FQDN")
-  join_member_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$KB_JOIN_MEMBER_POD_NAME" "$KB_JOIN_MEMBER_POD_FQDN")
+  context=$(printf '  member: %s\n  member-fqdn: %s' \
+    "$KB_JOIN_MEMBER_POD_NAME" "$KB_JOIN_MEMBER_POD_FQDN")
+  if ! validate_local_leader "$local_endpoint"; then
+    member_join_diagnose_not_ready "selected-contact-not-current-leader" "$context" "yes"
+    return 1
+  fi
+
+  if ! join_member_endpoint=$(get_endpoint_adapt_lb \
+    "${PEER_ENDPOINT:-}" "$KB_JOIN_MEMBER_POD_NAME" "$KB_JOIN_MEMBER_POD_FQDN"); then
+    member_join_diagnose_not_ready "target-endpoint-invalid" "$context" "no"
+    return 1
+  fi
   peer_protocol=$(get_protocol "initial-advertise-peer-urls")
+  client_protocol=$(get_protocol "advertise-client-urls")
   target_peer_url="$peer_protocol://$join_member_endpoint:2380"
 
   context=$(printf '  member: %s\n  peer-url: %s' "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url")
 
-  if ! member_state=$(read_member_state "$leader_endpoint:2379" "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url"); then
+  if ! member_list=$(exec_bounded_etcdctl "$local_endpoint" member list -w fields); then
     member_join_diagnose_not_ready "member-list-query-failed" "$context" "yes"
+    return 1
+  fi
+  validate_join_snapshot "$member_list" "$client_protocol" "$peer_protocol" \
+    "$context" || return 1
+  if ! member_state=$(classify_join_snapshot "$member_list" \
+    "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url"); then
+    member_join_diagnose_not_ready "member-list-invalid" "$context" "no"
     return 1
   fi
 
@@ -193,10 +269,17 @@ add_member() {
       ;;
   esac
 
-  log "Adding member $KB_JOIN_MEMBER_POD_NAME to cluster via leader $leader_endpoint"
+  contacts=$(build_join_contacts "$member_list" "$KB_JOIN_MEMBER_POD_NAME" \
+    "$client_protocol" "$peer_protocol" "$context") || return 1
+  if has_target_contact_collision "$join_member_endpoint" "$contacts"; then
+    member_join_diagnose_not_ready "target-address-collision" "$context" "no"
+    return 1
+  fi
+
+  log "Adding member $KB_JOIN_MEMBER_POD_NAME via current contacts $contacts"
   log "Join member peer URL: $target_peer_url"
 
-  if exec_etcdctl "$leader_endpoint:2379" member add "$KB_JOIN_MEMBER_POD_NAME" --peer-urls="$target_peer_url"; then
+  if exec_bounded_etcdctl "$contacts" member add "$KB_JOIN_MEMBER_POD_NAME" --peer-urls="$target_peer_url"; then
     add_rc=0
   else
     add_rc=$?
@@ -205,8 +288,15 @@ add_member() {
   context=$(printf '  member: %s\n  peer-url: %s\n  member-add-rc: %s' \
     "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url" "$add_rc")
 
-  if ! member_state=$(read_member_state "$leader_endpoint:2379" "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url"); then
+  if ! member_list=$(exec_bounded_etcdctl "$contacts" member list -w fields); then
     member_join_diagnose_not_ready "member-post-add-query-failed" "$context" "yes"
+    return 1
+  fi
+  validate_join_snapshot "$member_list" "$client_protocol" "$peer_protocol" \
+    "$context" || return 1
+  if ! member_state=$(classify_join_snapshot "$member_list" \
+    "$KB_JOIN_MEMBER_POD_NAME" "$target_peer_url"); then
+    member_join_diagnose_not_ready "member-list-invalid" "$context" "no"
     return 1
   fi
 

--- a/addons/etcd/scripts/member-join.sh
+++ b/addons/etcd/scripts/member-join.sh
@@ -32,6 +32,52 @@ classify_member_state() {
       return value
     }
 
+    function canonical_host(host, parts, count, i, result) {
+      sub(/[.]$/, "", host)
+      host = tolower(host)
+      if (host == "" || length(host) > 253) return ""
+      if (host ~ /^[0-9.]+$/) {
+        count = split(host, parts, ".")
+        if (count != 4) return ""
+        result = ""
+        for (i = 1; i <= 4; i++) {
+          if (parts[i] !~ /^[0-9]+$/ || parts[i] + 0 > 255) return ""
+          result = result (i == 1 ? "" : ".") (parts[i] + 0)
+        }
+        return result
+      }
+      count = split(host, parts, ".")
+      for (i = 1; i <= count; i++) {
+        if (length(parts[i]) < 1 || length(parts[i]) > 63 ||
+            parts[i] !~ /^[a-z0-9][a-z0-9-]*$/ || parts[i] ~ /-$/) return ""
+      }
+      return host
+    }
+
+    function canonical_peer_url(value, required_protocol, marker, rest, host, port, protocol) {
+      marker = index(value, "://")
+      if (marker == 0) return ""
+      protocol = substr(value, 1, marker - 1)
+      rest = substr(value, marker + 3)
+      if (protocol != required_protocol || rest !~ /:[0-9]+$/) return ""
+      port = rest
+      sub(/^.*:/, "", port)
+      if (port !~ /^[1-9][0-9]*$/ || port + 0 > 65535) return ""
+      host = rest
+      sub(/:[0-9]+$/, "", host)
+      host = canonical_host(host)
+      if (host == "") return ""
+      return protocol "://" host ":" port
+    }
+
+    BEGIN {
+      target_protocol = target_peer_url
+      sub(/:.*/, "", target_protocol)
+      if (target_protocol != "http" && target_protocol != "https") malformed = 1
+      canonical_target_peer_url = canonical_peer_url(target_peer_url, target_protocol)
+      if (canonical_target_peer_url == "") malformed = 1
+    }
+
     function finish_member() {
       if (!in_member) {
         return
@@ -89,13 +135,19 @@ classify_member_state() {
     }
 
     /^"PeerURL"[[:space:]]*:/ {
+      peer_url = ""
       if (!in_member ||
           $0 !~ /^"PeerURL"[[:space:]]*:[[:space:]]*"[^"]+"[[:space:]]*$/) {
         malformed = 1
         next
       }
+      peer_url = canonical_peer_url(field_value($0), target_protocol)
+      if (peer_url == "") {
+        malformed = 1
+        next
+      }
       peer_seen = 1
-      if (field_value($0) == target_peer_url) {
+      if (peer_url == canonical_target_peer_url) {
         peer_matches = 1
       }
       next

--- a/addons/etcd/scripts/member-leave.sh
+++ b/addons/etcd/scripts/member-leave.sh
@@ -4,33 +4,225 @@ set -exo pipefail
 # shellcheck disable=SC1091
 . "/scripts/common.sh"
 
-get_etcd_id() {
-  local endpoint="$1"
-  decimal_id=$(exec_etcdctl "$endpoint" endpoint status -w fields | grep -o '"MemberID" : [0-9]*' | awk '{print $3}')
-  hex_id=$(printf "%x" "$decimal_id")
-  echo "$hex_id"
+member_leave_diagnose_not_ready() {
+  local phase="$1"
+  local context="$2"
+  local retry_safe="$3"
+
+  {
+    echo "memberLeave diagnosis:"
+    echo "  action: memberLeave"
+    echo "  phase: ${phase}"
+    echo "${context}"
+    echo "  next-retry-safe: ${retry_safe}"
+  } >&2
 }
 
-remove_member() {
-  local etcd_id="$1"
+validate_member_leave_inputs() {
+  local missing=""
+  local context
 
-  leader_pod_name="${LEADER_POD_FQDN%%.*}"
-  leader_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$leader_pod_name" "$LEADER_POD_FQDN")
+  [ -n "${KB_LEAVE_MEMBER_POD_NAME:-}" ] || missing="${missing} KB_LEAVE_MEMBER_POD_NAME"
+  [ -n "${KB_LEAVE_MEMBER_POD_FQDN:-}" ] || missing="${missing} KB_LEAVE_MEMBER_POD_FQDN"
 
-  log "Removing member $etcd_id via leader $leader_endpoint"
-  exec_etcdctl "$leader_endpoint:2379" member remove "$etcd_id"
+  if [ -n "$missing" ]; then
+    context=$(printf '  missing-inputs:%s' "$missing")
+    member_leave_diagnose_not_ready "required-input-empty" "$context" "no"
+    return 1
+  fi
+}
+
+find_leave_target_id() {
+  local target_name="$1"
+
+  awk -v target_name="$target_name" '
+    function field_value(line, value) {
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      sub(/^"/, "", value)
+      sub(/"$/, "", value)
+      return value
+    }
+    function clear_block() {
+      in_member = 0
+      member_id = ""
+      member_name = ""
+      id_seen = 0
+      name_seen = 0
+      peer_count = 0
+    }
+    function finish_member() {
+      if (!in_member) return
+      if (id_seen != 1 || name_seen != 1 || peer_count < 1) malformed = 1
+      if (member_name == target_name) {
+        if (++target_count != 1) malformed = 1
+        target_id = member_id
+      }
+      clear_block()
+    }
+    /^"ID"[[:space:]]*:/ {
+      finish_member()
+      in_member = 1
+      saw_member = 1
+      if ($0 !~ /^"ID"[[:space:]]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+        malformed = 1
+      } else {
+        member_id = field_value($0)
+        if (member_ids["id:" member_id]++) malformed = 1
+        id_seen = 1
+      }
+      next
+    }
+    /^[[:space:]]*$/ { finish_member(); next }
+    /^"Name"[[:space:]]*:/ {
+      if (!in_member || name_seen ||
+          $0 !~ /^"Name"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*$/) {
+        malformed = 1
+      } else {
+        member_name = field_value($0)
+        if (member_name != "" && member_names[member_name]++) malformed = 1
+        name_seen = 1
+      }
+      next
+    }
+    /^"PeerURL"[[:space:]]*:/ {
+      if (!in_member ||
+          $0 !~ /^"PeerURL"[[:space:]]*:[[:space:]]*"[^"]+"[[:space:]]*$/) {
+        malformed = 1
+      } else {
+        peer_count++
+      }
+      next
+    }
+    END {
+      finish_member()
+      if (!saw_member || malformed) exit 2
+      if (target_count == 0) print "absent"
+      else print target_id
+    }
+  '
+}
+
+validate_leave_snapshot() {
+  local member_list="$1"
+  local target_name="$2"
+  local client_protocol="$3"
+  local peer_protocol="$4"
+  local context="$5"
+  local target_id
+
+  if ! printf '%s\n' "$member_list" | \
+    build_current_contact_candidates "" "$client_protocol" "" \
+      "validate-only" "$peer_protocol" >/dev/null; then
+    member_leave_diagnose_not_ready "member-list-invalid" "$context" "no"
+    return 1
+  fi
+
+  if ! target_id=$(printf '%s\n' "$member_list" | find_leave_target_id "$target_name"); then
+    member_leave_diagnose_not_ready "member-list-invalid" "$context" "no"
+    return 1
+  fi
+
+  printf '%s\n' "$target_id"
+}
+
+build_leave_contacts() {
+  local member_list="$1"
+  local target_id="$2"
+  local client_protocol="$3"
+  local peer_protocol="$4"
+  local context="$5"
+  local contacts rc
+
+  if contacts=$(printf '%s\n' "$member_list" | \
+    build_current_contact_candidates "" "$client_protocol" "$target_id" \
+      "contacts" "$peer_protocol"); then
+    printf '%s\n' "$contacts"
+    return 0
+  else
+    rc=$?
+  fi
+
+  case "$rc" in
+    2)
+      member_leave_diagnose_not_ready "member-list-invalid" "$context" "no"
+      ;;
+    3)
+      member_leave_diagnose_not_ready "contact-candidate-over-limit" "$context" "no"
+      ;;
+    4)
+      member_leave_diagnose_not_ready "contact-candidate-empty" "$context" "yes"
+      ;;
+    *)
+      member_leave_diagnose_not_ready "contact-candidate-build-failed" "$context" "no"
+      ;;
+  esac
+  return 1
 }
 
 member_leave() {
-  leaver_endpoint=$(get_endpoint_adapt_lb "$PEER_ENDPOINT" "$KB_LEAVE_MEMBER_POD_NAME" "$KB_LEAVE_MEMBER_POD_FQDN")
-  [ -z "$leaver_endpoint" ] && error_exit "Leave member pod endpoint is empty"
+  local local_endpoint="127.0.0.1:2379"
+  local client_protocol peer_protocol member_list target_id target_id_hex contacts context remove_rc
 
-  log "Getting etcd ID for leaving member: $leaver_endpoint"
-  etcd_id=$(get_etcd_id "$leaver_endpoint:2379")
-  [ -z "$etcd_id" ] && error_exit "Failed to get etcd ID"
+  validate_member_leave_inputs || return 1
 
-  remove_member "$etcd_id" || error_exit "Failed to remove member"
-  log "Member $KB_LEAVE_MEMBER_POD_NAME left cluster"
+  context=$(printf '  member: %s\n  member-fqdn: %s' \
+    "$KB_LEAVE_MEMBER_POD_NAME" "$KB_LEAVE_MEMBER_POD_FQDN")
+  if ! validate_local_leader "$local_endpoint"; then
+    member_leave_diagnose_not_ready "selected-contact-not-current-leader" "$context" "yes"
+    return 1
+  fi
+
+  client_protocol=$(get_protocol "advertise-client-urls")
+  peer_protocol=$(get_protocol "initial-advertise-peer-urls")
+  if ! member_list=$(exec_bounded_etcdctl "$local_endpoint" member list -w fields); then
+    member_leave_diagnose_not_ready "member-list-query-failed" "$context" "yes"
+    return 1
+  fi
+  target_id=$(validate_leave_snapshot "$member_list" "$KB_LEAVE_MEMBER_POD_NAME" \
+    "$client_protocol" "$peer_protocol" "$context") || return 1
+
+  if [ "$target_id" = "absent" ]; then
+    log "Member $KB_LEAVE_MEMBER_POD_NAME already absent from cluster"
+    return 0
+  fi
+
+  context=$(printf '  member: %s\n  member-id: %s' "$KB_LEAVE_MEMBER_POD_NAME" "$target_id")
+  contacts=$(build_leave_contacts "$member_list" "$target_id" \
+    "$client_protocol" "$peer_protocol" "$context") || return 1
+  if ! target_id_hex=$(printf '%x' "$target_id"); then
+    member_leave_diagnose_not_ready "member-id-invalid" "$context" "no"
+    return 1
+  fi
+
+  log "Removing member $target_id_hex via current contacts $contacts"
+  if exec_bounded_etcdctl "$contacts" member remove "$target_id_hex"; then
+    remove_rc=0
+  else
+    remove_rc=$?
+  fi
+
+  context=$(printf '  member: %s\n  member-id: %s\n  member-remove-rc: %s' \
+    "$KB_LEAVE_MEMBER_POD_NAME" "$target_id" "$remove_rc")
+  if ! member_list=$(exec_bounded_etcdctl "$contacts" member list -w fields); then
+    member_leave_diagnose_not_ready "member-post-remove-query-failed" "$context" "yes"
+    return 1
+  fi
+  target_id=$(validate_leave_snapshot "$member_list" "$KB_LEAVE_MEMBER_POD_NAME" \
+    "$client_protocol" "$peer_protocol" "$context") || return 1
+
+  if [ "$target_id" = "absent" ]; then
+    log "Member $KB_LEAVE_MEMBER_POD_NAME left cluster"
+    return 0
+  fi
+
+  if [ "$remove_rc" -eq 0 ]; then
+    member_leave_diagnose_not_ready "member-removal-not-observed" "$context" "yes"
+  else
+    member_leave_diagnose_not_ready "member-remove-failed" "$context" "yes"
+  fi
+  return 1
 }
 
 # Shellspec magic

--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -94,13 +94,6 @@ spec:
           optional: true
           host: Required
           loadBalancer: Required
-    - name: LEADER_POD_FQDN
-      valueFrom:
-        componentVarRef:
-          optional: false
-          podFQDNsForRole:
-            role: leader
-            option: Required
     - name: ETCD_COMPONENT_NAME
       valueFrom:
         componentVarRef:
@@ -167,13 +160,19 @@ spec:
       initialDelaySeconds: 10
       periodSeconds: 5
     memberJoin:
+      timeoutSeconds: 45
       exec:
+        targetPodSelector: Role
+        matchingKey: leader
         command:
           - /bin/bash
           - -c
           - /scripts/member-join.sh > /tmp/member-join.log 2>&1
     memberLeave:
+      timeoutSeconds: 45
       exec:
+        targetPodSelector: Role
+        matchingKey: leader
         command:
           - /bin/bash
           - -c


### PR DESCRIPTION
## What this changes

- execute etcd member join/leave on the Pod selected by the current `leader` role instead of relying on a Pod-creation-time `LEADER_POD_FQDN`
- verify the selected local endpoint is still the authoritative etcd leader before any membership mutation
- derive a bounded, canonical contact list from the action-time member list
- keep client TLS and peer TLS inputs separate
- preserve raw uint64 member-ID comparisons and reject malformed or ambiguous member ownership
- keep join/leave replay-safe with at most one membership mutation
- bound etcdctl calls to fit the lifecycle action deadline

Closes #3236.

## Stacked delivery boundary

This PR is intentionally based on `martin/etcd-memberjoin-idempotency`, the exact head of #3235 (`79c82e3ba6adb532625295a78046b82edd3a2d90`). It contains only the follow-up commits through `f130ae036bc999868a01d61a656c1c31c1682e3d`.

Do not retarget Test from #3235 to this PR implicitly. This stacked PR starts with runtime N=0 and needs its own exact-head Test contract after the code/CI gate closes.

## Verification

- genuine RED on the prior implementation for stale contact selection and canonical multi-owner ambiguity
- memberJoin focused: 65/0
- join + leave focused: 83/0
- full etcd ShellSpec: 116/0
- ambiguous pre-read: rc1, `member-list-invalid`, retry-safe no, mutation0, read1
- BusyBox production-function boundary: duplicate canonical owner rejected
- ShellCheck, Bash 3.2/5.3 syntax, diff-check, Helm lint/render: PASS
- independent B1 rereview: APPROVE/0 for exact `f130ae036bc999868a01d61a656c1c31c1682e3d`

The real-etcd matrix is N=1/version and supports only the bounded etcdctl timing claim; it does not execute the Kubernetes lifecycle action and is not a product Test or release verdict.
