### PR TITLE
fix: align release-1.1 addon KubeBlocks version constraints

### DIFF
--- a/addons/apecloud-mysql/Chart.yaml
+++ b/addons/apecloud-mysql/Chart.yaml
@@ -31,6 +31,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/clickhouse/Chart.yaml
+++ b/addons/clickhouse/Chart.yaml
@@ -27,6 +27,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/elasticsearch/Chart.yaml
+++ b/addons/elasticsearch/Chart.yaml
@@ -30,7 +30,7 @@ maintainers:
     url: https://github.com/vipshop
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">=1.0.2"
   addon.kubeblocks.io/model: "search-engine"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/etcd/Chart.yaml
+++ b/addons/etcd/Chart.yaml
@@ -44,6 +44,6 @@ maintainers:
     url: https://github.com/loomts
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "key-value"
   addon.kubeblocks.io/provider: "community"

--- a/addons/falkordb/Chart.yaml
+++ b/addons/falkordb/Chart.yaml
@@ -34,6 +34,6 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "key-value"
   addon.kubeblocks.io/provider: "community"

--- a/addons/influxdb/Chart.yaml
+++ b/addons/influxdb/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 annotations:
   category: Database
   licenses: Apache-2.0
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "time-series"
 
 dependencies:

--- a/addons/mogdb/Chart.yaml
+++ b/addons/mogdb/Chart.yaml
@@ -31,7 +31,7 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/mongodb/Chart.yaml
+++ b/addons/mongodb/Chart.yaml
@@ -31,6 +31,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "document"
   addon.kubeblocks.io/provider: "community"

--- a/addons/orchestrator/Chart.yaml
+++ b/addons/orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "HA"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/orioledb/Chart.yaml
+++ b/addons/orioledb/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
     alias: extra
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/polardbx/Chart.yaml
+++ b/addons/polardbx/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -30,6 +30,6 @@ sources:
 - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"

--- a/addons/redis/Chart.yaml
+++ b/addons/redis/Chart.yaml
@@ -30,6 +30,6 @@ maintainers:
 
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "key-value"
   addon.kubeblocks.io/provider: "community"

--- a/addons/tidb/Chart.yaml
+++ b/addons/tidb/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     url: https://github.com/csuzhangxc
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "community"
 

--- a/addons/vanilla-postgresql/Chart.yaml
+++ b/addons/vanilla-postgresql/Chart.yaml
@@ -30,6 +30,6 @@ sources:
   - https://github.com/apecloud/kubeblocks/
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "RDBMS"
   addon.kubeblocks.io/provider: "apecloud"

--- a/addons/zookeeper/Chart.yaml
+++ b/addons/zookeeper/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
     url: https://github.com/kissycn
 
 annotations:
-  addon.kubeblocks.io/kubeblocks-version: ">=1.0.0"
+  addon.kubeblocks.io/kubeblocks-version: ">1.0.2"
   addon.kubeblocks.io/model: "middleware"
   addon.kubeblocks.io/provider: "community"
 


### PR DESCRIPTION
## What changed

- Require KubeBlocks `>1.0.2` for 15 release-1.1 addon charts that render exclusive replica roles.
- Require KubeBlocks `>=1.0.2` for Elasticsearch because it renders `podUpgradePolicy`.
- Keep MySQL unchanged because it already declares the correct `>1.0.2` floor.

## Why

These release-1.1 charts declared a KubeBlocks version floor that could not accept their rendered custom resources. This allowed incompatible addons to be selected on KubeBlocks 1.0.0 through 1.0.2.

The constraints are derived from full rendered-manifest comparison against structural CRD schemas, rather than from a checker hardcoded to individual API fields.

## Release-1.0 backport

The remote `release-1.0` snapshot renders the same incompatible fields for every chart common to this PR, so this PR is labeled `pick-1.0`.

FalkorDB exists on `release-1.1` but not on `release-1.0`. If the automatic cherry-pick reports a modify/delete conflict, omit `addons/falkordb/Chart.yaml`; the other 15 metadata changes apply to `release-1.0`.

## Validation

- Rendered and linted all 39 installable `release-1.1` addon charts.
- Compared the rendered resources against KubeBlocks `v1.0.1`, `v1.0.2`, `v1.0.3-beta.0`, and `release-1.1` structural CRD schemas.
- Confirmed Elasticsearch fails `v1.0.1` and passes `v1.0.2`.
- Confirmed the 16 exclusive-role addons fail `v1.0.2` and pass `v1.0.3-beta.0`; MySQL already had the correct floor.
- Rendered and linted all 39 installable addons from the remote `release-1.0` snapshot and confirmed the same schema requirements for its common charts.
- Ran `git diff --check`.
- Confirmed the final diff changes only one compatibility annotation in each of 16 `Chart.yaml` files.
