### PR TITLE
fix: brace config variable expansion

### DIFF
--- a/addons/clickhouse/dataprotection/common.sh
+++ b/addons/clickhouse/dataprotection/common.sh
@@ -237,7 +237,7 @@ EOF
 
 function getToolConfigValue() {
     local var=$1
-    cat $toolConfig | grep "$var[[:space:]]*=" | awk '{print $NF}'
+    cat $toolConfig | grep "${var}[[:space:]]*=" | awk '{print $NF}'
 }
 
 function configure_clickhouse_backup_custom_storage_if_encrypted() {

--- a/addons/nebula/dataprotection/br-backup.sh
+++ b/addons/nebula/dataprotection/br-backup.sh
@@ -16,7 +16,7 @@ trap handle_exit EXIT
 
 function getToolConfigValue() {
     local var=$1
-    cat $toolConfig | grep "$var[[:space:]]*=" | awk '{print $NF}'
+    cat $toolConfig | grep "${var}[[:space:]]*=" | awk '{print $NF}'
 }
 
 access_key_id=$(getToolConfigValue access_key_id)


### PR DESCRIPTION
## Summary
- brace `var` in ClickHouse and Nebula config lookup regexes
- prevent Shellcheck SC1087 from interpreting the character class as an array subscript

## Test plan
- [x] `docker run --rm -v \"$PWD:/mnt\" koalaman/shellcheck:stable --severity=error addons/clickhouse/dataprotection/common.sh addons/nebula/dataprotection/br-backup.sh`
- [x] `git diff --check`

Fixes the release-1.0 Shell Check failure: https://github.com/apecloud/kubeblocks-addons/actions/runs/29723103318

Made with [Cursor](https://cursor.com)