### PR TITLE
docs: add Weaviate config examples and fix paths

### DIFF
--- a/addons/pulsar/README.md
+++ b/addons/pulsar/README.md
@@ -821,7 +821,7 @@ spec:
 By default, Pulsar does not expose any service to the external network. If you want to expose the service to the external network, you can enable the NodePort service.
 
 ```yaml
-kubectl apply -f examples/pulsar/cluster-nodeport.yaml
+kubectl apply -f examples/pulsar/cluster-node-port.yaml
 ```
 
 The key difference are:

--- a/addons/starrocks-ce/README.md
+++ b/addons/starrocks-ce/README.md
@@ -405,7 +405,7 @@ It sets up the `PodMonitor` to monitor this StarRocks cluster and scrapes the me
 
 ##### Access the Grafana Dashboard
 
-Login to the Grafana dashboard and import the dashboard provided in this example `./examples/starrocks-ce/dashboard/starrocks.json`.
+Login to the Grafana dashboard and import the dashboard provided in this example `./examples/starrocks-ce/grafana/starrocks.json`.
 
 You may refer to following links for more information:
 - StarRocks Overview provided by StarRocks team: [StarRocks Overview](https://github.com/StarRocks/starrocks/blob/main/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json)

--- a/addons/weaviate/README.md
+++ b/addons/weaviate/README.md
@@ -10,7 +10,7 @@ In Weaviate, metadata replication and data replication are separate. For the met
 
 | Horizontal<br/>scaling | Vertical <br/>scaling | Expand<br/>volume | Restart   | Stop/Start | Configure | Expose | Switchover |
 |------------------------|-----------------------|-------------------|-----------|------------|-----------|--------|------------|
-| No                     | Yes                   | Yes              | Yes       | Yes        | No        | Yes    | N/A      |
+| No                     | Yes                   | Yes              | Yes       | Yes        | Yes       | Yes    | N/A      |
 
 ### Versions
 
@@ -87,6 +87,143 @@ spec:
 kubectl apply -f examples/weaviate/cluster.yaml
 ```
 
+### Create with a custom configuration file
+
+Starting with KubeBlocks 1.0, Weaviate configuration is managed through the
+`Cluster.spec.componentSpecs[].configs` Configuration API. The previous
+`ParametersDefinition` and `ParamConfigRenderer` resources are no longer used.
+
+The example supplies a complete `conf.yaml` template through a ConfigMap and
+sets `query_defaults.limit` to `100` when the cluster is created:
+
+Replace `<your-weaviate-component-definition>` in the example with the
+ComponentDefinition installed for the Weaviate version you want to run.
+
+```yaml
+# cat examples/weaviate/cluster-with-config-template.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-weaviate-config-template
+  namespace: demo
+data:
+  conf.yaml: |-
+    ---
+    authentication:
+      anonymous_access:
+        enabled: true
+    authorization:
+      admin_list:
+        enabled: false
+    query_defaults:
+      limit: {{ .query_defaults_limit }}
+    debug: false
+---
+apiVersion: apps.kubeblocks.io/v1
+kind: Cluster
+metadata:
+  name: weaviate-cluster-with-config
+  namespace: demo
+spec:
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: weaviate
+      componentDef: weaviate
+      serviceVersion: 1.19.6
+      replicas: 1
+      configs:
+        # The name must match ComponentDefinition.spec.configs[].name.
+        - name: weaviate-config-template
+          configMap:
+            name: custom-weaviate-config-template
+          variables:
+            query_defaults_limit: "100"
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+        requests:
+          cpu: "0.5"
+          memory: 512Mi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi
+
+```
+
+```bash
+kubectl apply -f examples/weaviate/cluster-with-config-template.yaml
+```
+
+The config name `weaviate-config-template` must match the corresponding entry
+in `ComponentDefinition.spec.configs`. The ConfigMap contains the file template,
+while `variables` contains the values rendered into that template.
+
+#### Discover available configurations
+
+Configuration does not provide the parameter schema or value discovery that
+was previously supplied by `ParametersDefinition` and `ParamConfigRenderer`.
+Use the following sources to determine what can be configured.
+
+List the configuration files exposed by the Weaviate ComponentDefinition:
+
+```bash
+WEAVIATE_COMPONENT_DEFINITION="<your-weaviate-component-definition>"
+kubectl get cmpd "${WEAVIATE_COMPONENT_DEFINITION}" \
+  -o jsonpath='{range .spec.configs[*]}{.name}{"\t"}{.template}{"\t"}{.namespace}{"\n"}{end}'
+```
+
+Inspect the default file templates:
+
+```bash
+kubectl get configmap weaviate-config-template -n kb-system \
+  -o go-template='{{ index .data "conf.yaml" }}'
+
+kubectl get configmap weaviate-env-config-template -n kb-system \
+  -o go-template='{{ index .data "envs" }}'
+```
+
+For a custom ConfigMap, the placeholders in the file template define the
+variable names accepted under `configs[].variables`. For example,
+`{{ .query_defaults_limit }}` in this example defines the
+`query_defaults_limit` variable. KubeBlocks renders the supplied string value
+but does not validate its type or allowed range.
+
+Refer to the [Weaviate environment variable reference][weaviate-env-vars] for
+the engine settings, value formats, and defaults. Check that each setting is
+supported by Weaviate 1.19.6 because the latest documentation also describes
+settings introduced by newer releases.
+
+Inspect the files actually consumed by a running Pod to confirm the effective
+rendered values:
+
+```bash
+kubectl exec -n demo weaviate-cluster-with-config-weaviate-0 \
+  -- cat /weaviate-config/conf.yaml
+
+kubectl exec -n demo weaviate-cluster-with-config-weaviate-0 \
+  -- cat /weaviate-env/envs
+```
+
+### Update the custom configuration
+
+Update the Configuration variable directly on the Cluster:
+
+```bash
+kubectl patch cluster weaviate-cluster-with-config -n demo \
+  --type=json \
+  --patch-file=examples/weaviate/configure.json
+```
+
+This changes `query_defaults.limit` from `100` to `150`. Weaviate 1.19.6 loads
+this file at startup, so KubeBlocks restarts the component Pods after rendering
+the changed file. This workflow does not create a Reconfiguring OpsRequest.
+
 ### Vertical scaling
 
 Vertical scaling up or down specified components requests and limits cpu or memory resource in the cluster
@@ -137,20 +274,20 @@ If the `ALLOWVOLUMEEXPANSION` column is `true`, the storage class supports volum
 To increase size of volume storage with the specified components in the cluster
 
 ```yaml
-# cat examples/postgresql/volumeexpand.yaml
+# cat examples/weaviate/volumeexpand.yaml
 apiVersion: operations.kubeblocks.io/v1alpha1
 kind: OpsRequest
 metadata:
-  name: pg-volumeexpansion
+  name: weaviate-volumeexpansion
   namespace: demo
 spec:
   # Specifies the name of the Cluster resource that this operation is targeting.
-  clusterName: pg-cluster
+  clusterName: weaviate-cluster
   type: VolumeExpansion
   # Lists VolumeExpansion objects, each specifying a component and its corresponding volumeClaimTemplates that requires storage expansion.
   volumeExpansion:
     # Specifies the name of the Component.
-  - componentName: postgresql
+  - componentName: weaviate
     # volumeClaimTemplates specifies the storage size and volumeClaimTemplate name.
     volumeClaimTemplates:
     - name: data
@@ -159,7 +296,7 @@ spec:
 ```
 
 ```bash
-kubectl apply -f examples/postgresql/volumeexpand.yaml
+kubectl apply -f examples/weaviate/volumeexpand.yaml
 ```
 
 ### Restart
@@ -245,3 +382,5 @@ kubectl delete cluster -n demo weaviate-cluster
 ## References
 
 [^1]: Weaviate Cluster Architecture, <https://weaviate.io/developers/weaviate/concepts/replication-architecture/cluster-architecture#metadata-replication-raft>
+
+[weaviate-env-vars]: https://docs.weaviate.io/deploy/configuration/env-vars

--- a/examples/apecloud-mysql/README.md
+++ b/examples/apecloud-mysql/README.md
@@ -118,7 +118,7 @@ kubectl apply -f examples/apecloud-mysql/scale-in.yaml
 > [!IMPORTANT]
 > On scaling in, the replica will be forgotten from the cluster's Raft group before it is deleted.
 
-#### [Set Specified Replicas Offline](scale-in-specified-instance.yaml)
+#### [Set Specified Replicas Offline](scale-in-specified-pod.yaml)
 
 There are cases where you want to set a specified replica offline, when it is problematic or you want to do some maintenance work on it. You can use the `onlineInstancesToOffline` field in the `spec.horizontalScaling.scaleIn` section to specify the instance names that need to be taken offline.
 

--- a/examples/orchestrator/README.md
+++ b/examples/orchestrator/README.md
@@ -31,7 +31,7 @@ Orchestrator is a MySQL high availability and replication management tool, runs 
 
 ## Examples
 
-### [Create](cluster.yaml)
+### Create
 
 Orchestrator cluster has two modes: *raft* and *share-backend*.
 

--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -333,7 +333,7 @@ This example will change the `max_connections` to `200`.
 kbcli cluster explain-config pg-cluster # kbcli is a command line tool to interact with KubeBlocks
 ```
 
-### [Backup](backup.yaml)
+### Backup
 
 > [!IMPORTANT]
 > Before you start, please create a `BackupRepo` to store the backup data. Refer to [BackupRepo](../docs/create-backuprepo.md) for more details.
@@ -417,7 +417,7 @@ kubectl get backup -n demo -l app.kubernetes.io/instance=pg-cluster -l dataprote
 
 WAL-G is an archival restoration tool for PostgreSQL, MySQL/MariaDB, and MS SQL Server (beta for MongoDB and Redis).[^2]
 
-##### [Full Backup](basebackup-wal-g.yaml)
+##### [Full Backup](backup-wal-g.yaml)
 
 To create wal-g backup for the cluster, it is a multi-step process.
 

--- a/examples/pulsar/README.md
+++ b/examples/pulsar/README.md
@@ -301,7 +301,7 @@ spec:
 By default, Pulsar does not expose any service to the external network. If you want to expose the service to the external network, you can enable the NodePort service.
 
 ```yaml
-kubectl apply -f examples/pulsar/cluster-nodeport.yaml
+kubectl apply -f examples/pulsar/cluster-node-port.yaml
 ```
 
 The key difference are:

--- a/examples/rocketmq/README.md
+++ b/examples/rocketmq/README.md
@@ -151,7 +151,7 @@ spec:
                 storage: 30Gi
 ```
 
-### [Restart](restart.yaml)
+### [Restart](restart-namesrv.yaml)
 
 Restart the specified components in the cluster:
 

--- a/examples/starrocks-ce/README.md
+++ b/examples/starrocks-ce/README.md
@@ -142,7 +142,7 @@ It sets up the `PodMonitor` to monitor this StarRocks cluster and scrapes the me
 
 ##### Access the Grafana Dashboard
 
-Login to the Grafana dashboard and import the dashboard provided in this example `./examples/starrocks-ce/dashboard/starrocks.json`.
+Login to the Grafana dashboard and import the dashboard provided in this example `./examples/starrocks-ce/grafana/starrocks.json`.
 
 You may refer to following links for more information:
 - StarRocks Overview provided by StarRocks team: [StarRocks Overview](https://github.com/StarRocks/starrocks/blob/main/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json)

--- a/examples/vanilla-postgresql/README.md
+++ b/examples/vanilla-postgresql/README.md
@@ -91,7 +91,7 @@ NAME                 VERSIONS                                      STATUS      A
 vanilla-postgresql   12.15.0,14.7.0,15.7.0,15.6.1-138               Available   Xd
 ```
 
-### [Horizontal scaling](horizontalscale.yaml)
+### Horizontal scaling
 
 #### [Scale-out](scale-out.yaml)
 

--- a/examples/weaviate/README.md
+++ b/examples/weaviate/README.md
@@ -10,7 +10,7 @@ In Weaviate, metadata replication and data replication are separate. For the met
 
 | Horizontal<br/>scaling | Vertical <br/>scaling | Expand<br/>volume | Restart   | Stop/Start | Configure | Expose | Switchover |
 |------------------------|-----------------------|-------------------|-----------|------------|-----------|--------|------------|
-| No                     | Yes                   | Yes              | Yes       | Yes        | No        | Yes    | N/A      |
+| No                     | Yes                   | Yes              | Yes       | Yes        | Yes       | Yes    | N/A      |
 
 ### Versions
 
@@ -41,6 +41,86 @@ Create a weaviate cluster with three replicas:
 kubectl apply -f examples/weaviate/cluster.yaml
 ```
 
+### [Create with a custom configuration file](cluster-with-config-template.yaml)
+
+Starting with KubeBlocks 1.0, Weaviate configuration is managed through the
+`Cluster.spec.componentSpecs[].configs` Configuration API. The previous
+`ParametersDefinition` and `ParamConfigRenderer` resources are no longer used.
+
+The example supplies a complete `conf.yaml` template through a ConfigMap and
+sets `query_defaults.limit` to `100` when the cluster is created:
+
+Replace `<your-weaviate-component-definition>` in the example with the
+ComponentDefinition installed for the Weaviate version you want to run.
+
+```bash
+kubectl apply -f examples/weaviate/cluster-with-config-template.yaml
+```
+
+The config name `weaviate-config-template` must match the corresponding entry
+in `ComponentDefinition.spec.configs`. The ConfigMap contains the file template,
+while `variables` contains the values rendered into that template.
+
+#### Discover available configurations
+
+Configuration does not provide the parameter schema or value discovery that
+was previously supplied by `ParametersDefinition` and `ParamConfigRenderer`.
+Use the following sources to determine what can be configured.
+
+List the configuration files exposed by the Weaviate ComponentDefinition:
+
+```bash
+WEAVIATE_COMPONENT_DEFINITION="<your-weaviate-component-definition>"
+kubectl get cmpd "${WEAVIATE_COMPONENT_DEFINITION}" \
+  -o jsonpath='{range .spec.configs[*]}{.name}{"\t"}{.template}{"\t"}{.namespace}{"\n"}{end}'
+```
+
+Inspect the default file templates:
+
+```bash
+kubectl get configmap weaviate-config-template -n kb-system \
+  -o go-template='{{ index .data "conf.yaml" }}'
+
+kubectl get configmap weaviate-env-config-template -n kb-system \
+  -o go-template='{{ index .data "envs" }}'
+```
+
+For a custom ConfigMap, the placeholders in the file template define the
+variable names accepted under `configs[].variables`. For example,
+`{{ .query_defaults_limit }}` in this example defines the
+`query_defaults_limit` variable. KubeBlocks renders the supplied string value
+but does not validate its type or allowed range.
+
+Refer to the [Weaviate environment variable reference][weaviate-env-vars] for
+the engine settings, value formats, and defaults. Check that each setting is
+supported by Weaviate 1.19.6 because the latest documentation also describes
+settings introduced by newer releases.
+
+Inspect the files actually consumed by a running Pod to confirm the effective
+rendered values:
+
+```bash
+kubectl exec -n demo weaviate-cluster-with-config-weaviate-0 \
+  -- cat /weaviate-config/conf.yaml
+
+kubectl exec -n demo weaviate-cluster-with-config-weaviate-0 \
+  -- cat /weaviate-env/envs
+```
+
+### [Update the custom configuration](configure.json)
+
+Update the Configuration variable directly on the Cluster:
+
+```bash
+kubectl patch cluster weaviate-cluster-with-config -n demo \
+  --type=json \
+  --patch-file=examples/weaviate/configure.json
+```
+
+This changes `query_defaults.limit` from `100` to `150`. Weaviate 1.19.6 loads
+this file at startup, so KubeBlocks restarts the component Pods after rendering
+the changed file. This workflow does not create a Reconfiguring OpsRequest.
+
 ### [Vertical scaling](verticalscale.yaml)
 
 Vertical scaling up or down specified components requests and limits cpu or memory resource in the cluster
@@ -67,7 +147,7 @@ If the `ALLOWVOLUMEEXPANSION` column is `true`, the storage class supports volum
 To increase size of volume storage with the specified components in the cluster
 
 ```bash
-kubectl apply -f examples/postgresql/volumeexpand.yaml
+kubectl apply -f examples/weaviate/volumeexpand.yaml
 ```
 
 ### [Restart](restart.yaml)
@@ -107,3 +187,5 @@ kubectl delete cluster -n demo weaviate-cluster
 ## References
 
 [^1]: Weaviate Cluster Architecture, <https://weaviate.io/developers/weaviate/concepts/replication-architecture/cluster-architecture#metadata-replication-raft>
+
+[weaviate-env-vars]: https://docs.weaviate.io/deploy/configuration/env-vars

--- a/examples/weaviate/cluster-with-config-template.yaml
+++ b/examples/weaviate/cluster-with-config-template.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-weaviate-config-template
+  namespace: demo
+data:
+  conf.yaml: |-
+    ---
+    authentication:
+      anonymous_access:
+        enabled: true
+    authorization:
+      admin_list:
+        enabled: false
+    query_defaults:
+      limit: {{ .query_defaults_limit }}
+    debug: false
+---
+apiVersion: apps.kubeblocks.io/v1
+kind: Cluster
+metadata:
+  name: weaviate-cluster-with-config
+  namespace: demo
+spec:
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: weaviate
+      componentDef: weaviate
+      serviceVersion: 1.19.6
+      replicas: 1
+      configs:
+        # The name must match ComponentDefinition.spec.configs[].name.
+        - name: weaviate-config-template
+          configMap:
+            name: custom-weaviate-config-template
+          variables:
+            query_defaults_limit: "100"
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+        requests:
+          cpu: "0.5"
+          memory: 512Mi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi

--- a/examples/weaviate/configure.json
+++ b/examples/weaviate/configure.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/spec/componentSpecs/0/configs/0/variables/query_defaults_limit",
+    "value": "150"
+  }
+]


### PR DESCRIPTION
- to to https://github.com/apecloud/kubeblocks/issues/10277

## What changed

- add a Weaviate Configuration example for supplying a custom `conf.yaml` at cluster creation
- add a JSON Patch example for updating Configuration variables after creation
- document configuration discovery, effective-value inspection, restart behavior, and the PD/PCR capability boundary
- correct stale example paths across Weaviate and other addon READMEs
- regenerate the affected addon READMEs from their example sources

## Why

Weaviate no longer uses `ParametersDefinition` or `ParamConfigRenderer` on the KubeBlocks 1.0+ path, but the release-1.1 documentation did not show the supported Configuration workflow. Several existing README links also pointed to renamed or nonexistent example files.

## Validation

- `helm lint addons/weaviate`
- `helm lint addons-cluster/weaviate`
- KubeBlocks server-side dry-run on `kind-kb-upgrade-103b9`
- runtime verification with Weaviate 1.19.6: rendered `query_defaults.limit` changed from 100 to 150, the Pod restarted, and sentinel data remained readable
- scanned all `examples/*/README.md` references with no missing YAML, JSON, script, or Markdown paths
- regenerated addon READMEs with `hack/extend-readme-with-yaml.sh`
- `git diff --check`
