### PR TITLE
fix(rustfs): bound role probe cadence

### DIFF
--- a/addons/rustfs/Chart.yaml
+++ b/addons/rustfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rustfs
 description: RustFS is an S3-compatible high-performance distributed object storage system written in Rust.
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0-beta.8"
 keywords:
   - storage

--- a/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
@@ -33,6 +33,81 @@ Describe "RustFS roleProbe render contract"
     '
   }
 
+  validate_roleprobe_command_hash() {
+    render_cmpd | ruby -ryaml -rdigest -e '
+      document = YAML.load_stream($stdin.read).compact.find do |item|
+        item.is_a?(Hash) && item["kind"] == "ComponentDefinition"
+      end
+      command = document.dig("spec", "lifecycleActions", "roleProbe", "exec", "command")
+      actual = Digest::SHA256.hexdigest(YAML.dump(command))
+      expected = "01fa10f938f541513fa73a58552b65e6a3ded71efc3b2cd6f40815781907e10e"
+      abort "roleProbe exec command changed: #{actual}" unless actual == expected
+      puts "RustFS roleProbe exec command hash is unchanged"
+    '
+  }
+
+  prepare_probe_stubs() {
+    stub_dir="${tmp_dir}/stubs"
+    call_log="${tmp_dir}/calls.log"
+    mkdir -p "$stub_dir" || return $?
+    : >"$call_log" || return $?
+
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'printf "wget\\n" >>"$CALL_LOG"' \
+      'case "$WGET_MODE" in' \
+      '  success) exit 0 ;;' \
+      '  fail) exit 1 ;;' \
+      '  hang) sleep 10; exit 1 ;;' \
+      '  *) exit 2 ;;' \
+      'esac' >"${stub_dir}/wget" || return $?
+    chmod +x "${stub_dir}/wget" || return $?
+
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'printf "curl\\n" >>"$CALL_LOG"' \
+      'case "$CURL_MODE" in' \
+      '  success) exit 0 ;;' \
+      '  fail) exit 1 ;;' \
+      '  *) exit 2 ;;' \
+      'esac' >"${stub_dir}/curl" || return $?
+    chmod +x "${stub_dir}/curl" || return $?
+  }
+
+  extract_probe_script() {
+    render_cmpd | ruby -ryaml -e '
+      document = YAML.load_stream($stdin.read).compact.find do |item|
+        item.is_a?(Hash) && item["kind"] == "ComponentDefinition"
+      end
+      puts document.dig("spec", "lifecycleActions", "roleProbe", "exec", "command").fetch(2)
+    '
+  }
+
+  run_probe_case() {
+    wget_mode="$1"
+    curl_mode="$2"
+    budget="${3:-0}"
+    prepare_chart || return $?
+    probe_script=$(extract_probe_script) || return $?
+    prepare_probe_stubs || return $?
+
+    if [ "$budget" -gt 0 ]; then
+      role=$(timeout "$budget" /usr/bin/env -i PATH="${stub_dir}:$PATH" CALL_LOG="$call_log" \
+        WGET_MODE="$wget_mode" CURL_MODE="$curl_mode" TLS_ENABLED=false "$SHELLSPEC_SHELL" -c "$probe_script")
+      rc=$?
+    else
+      role=$(/usr/bin/env -i PATH="${stub_dir}:$PATH" CALL_LOG="$call_log" \
+        WGET_MODE="$wget_mode" CURL_MODE="$curl_mode" TLS_ENABLED=false "$SHELLSPEC_SHELL" -c "$probe_script")
+      rc=$?
+    fi
+
+    printf 'ROLE=%s\n' "$role"
+    printf 'CALLS='
+    tr '\n' ',' <"$call_log"
+    printf '\n'
+    return "$rc"
+  }
+
   cleanup_chart() {
     [ -n "${tmp_dir:-}" ] && rm -rf "${tmp_dir}" 2>/dev/null || true
     tmp_dir=""
@@ -43,5 +118,43 @@ Describe "RustFS roleProbe render contract"
     When call validate_roleprobe_cadence
     The status should be success
     The output should include "RustFS roleProbe cadence is 1s/3s"
+  End
+
+  It "keeps the pre-change exec command structure byte-for-byte canonical"
+    When call validate_roleprobe_command_hash
+    The status should be success
+    The output should include "RustFS roleProbe exec command hash is unchanged"
+  End
+
+  It "reports readwrite when wget succeeds without calling curl"
+    When call run_probe_case success fail
+    The status should be success
+    The output should include "ROLE=readwrite"
+    The output should include "CALLS=wget,"
+    The output should not include "curl,"
+  End
+
+  It "falls back to curl after a fast wget failure"
+    When call run_probe_case fail success
+    The status should be success
+    The output should include "ROLE=readwrite"
+    The output should include "CALLS=wget,curl,"
+  End
+
+  It "reports notready when both clients fail"
+    When call run_probe_case fail fail
+    The status should be success
+    The output should include "ROLE=notready"
+    The output should include "CALLS=wget,curl,"
+  End
+
+  It "emits no role token when a hanging wget consumes the action budget"
+    When call run_probe_case hang success 3
+    The status should equal 124
+    The output should include "ROLE="
+    The output should not include "ROLE=readwrite"
+    The output should not include "ROLE=notready"
+    The output should include "CALLS=wget,"
+    The output should not include "curl,"
   End
 End

--- a/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=sh
+
+Describe "RustFS roleProbe render contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  prepare_chart() {
+    tmp_dir=$(mktemp -d -t rustfs-roleprobe-render-XXXXXX) || return $?
+    mkdir -p "${tmp_dir}/addons" || return $?
+    cp -R "$(repo_root)/addons/rustfs" "${tmp_dir}/addons/rustfs" || return $?
+    cp -R "$(repo_root)/addons/kblib" "${tmp_dir}/addons/kblib" || return $?
+  }
+
+  render_cmpd() {
+    prepare_chart || return $?
+    helm template test "${tmp_dir}/addons/rustfs" \
+      --dependency-update \
+      --show-only templates/cmpd.yaml
+  }
+
+  validate_roleprobe_cadence() {
+    render_cmpd | ruby -ryaml -e '
+      document = YAML.load_stream($stdin.read).compact.find do |item|
+        item.is_a?(Hash) && item["kind"] == "ComponentDefinition"
+      end
+      abort "ComponentDefinition is missing" unless document
+      probe = document.dig("spec", "lifecycleActions", "roleProbe")
+      abort "roleProbe is missing" unless probe.is_a?(Hash)
+      abort "periodSeconds must be 1, got #{probe["periodSeconds"].inspect}" unless probe["periodSeconds"] == 1
+      abort "timeoutSeconds must be 3, got #{probe["timeoutSeconds"].inspect}" unless probe["timeoutSeconds"] == 3
+      puts "RustFS roleProbe cadence is 1s/3s"
+    '
+  }
+
+  cleanup_chart() {
+    [ -n "${tmp_dir:-}" ] && rm -rf "${tmp_dir}" 2>/dev/null || true
+    tmp_dir=""
+  }
+  AfterEach 'cleanup_chart'
+
+  It "renders a one-second period and three-second timeout"
+    When call validate_roleprobe_cadence
+    The status should be success
+    The output should include "RustFS roleProbe cadence is 1s/3s"
+  End
+End

--- a/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
@@ -13,7 +13,6 @@ Describe "RustFS roleProbe render contract"
   }
 
   render_cmpd() {
-    prepare_chart || return $?
     helm template test "${tmp_dir}/addons/rustfs" \
       --dependency-update \
       --show-only templates/cmpd.yaml
@@ -87,7 +86,6 @@ Describe "RustFS roleProbe render contract"
     wget_mode="$1"
     curl_mode="$2"
     budget="${3:-0}"
-    prepare_chart || return $?
     probe_script=$(extract_probe_script) || return $?
     prepare_probe_stubs || return $?
 
@@ -109,9 +107,13 @@ Describe "RustFS roleProbe render contract"
   }
 
   cleanup_chart() {
-    [ -n "${tmp_dir:-}" ] && rm -rf "${tmp_dir}" 2>/dev/null || true
+    chart_dir="${tmp_dir:-}"
     tmp_dir=""
+    [ -z "$chart_dir" ] && return 0
+    rm -rf "$chart_dir" 2>/dev/null || return $?
+    [ ! -e "$chart_dir" ]
   }
+  BeforeEach 'prepare_chart'
   AfterEach 'cleanup_chart'
 
   It "renders a one-second period and three-second timeout"

--- a/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/roleprobe_cadence_spec.sh
@@ -9,13 +9,61 @@ Describe "RustFS roleProbe render contract"
     tmp_dir=$(mktemp -d -t rustfs-roleprobe-render-XXXXXX) || return $?
     mkdir -p "${tmp_dir}/addons" || return $?
     cp -R "$(repo_root)/addons/rustfs" "${tmp_dir}/addons/rustfs" || return $?
+    cp -R "$(repo_root)/addons/rustfs" "${tmp_dir}/addons/rustfs-base" || return $?
     cp -R "$(repo_root)/addons/kblib" "${tmp_dir}/addons/kblib" || return $?
+
+    ruby -e '
+      chart = ARGV.fetch(0)
+      cmpd = ARGV.fetch(1)
+      chart_text = File.read(chart).sub(/^version: .*$/, "version: 0.1.0")
+      cmpd_text = File.read(cmpd)
+        .sub(/^      periodSeconds: 1\n/, "")
+        .sub(/^      timeoutSeconds: 3\n/, "")
+      File.write(chart, chart_text)
+      File.write(cmpd, cmpd_text)
+    ' "${tmp_dir}/addons/rustfs-base/Chart.yaml" \
+      "${tmp_dir}/addons/rustfs-base/templates/cmpd.yaml" || return $?
   }
 
   render_cmpd() {
     helm template test "${tmp_dir}/addons/rustfs" \
       --dependency-update \
       --show-only templates/cmpd.yaml
+  }
+
+  render_base_cmpd() {
+    helm template test "${tmp_dir}/addons/rustfs-base" \
+      --dependency-update \
+      --show-only templates/cmpd.yaml
+  }
+
+  validate_immutable_upgrade_identity() {
+    base_file="${tmp_dir}/base-cmpd.yaml"
+    head_file="${tmp_dir}/head-cmpd.yaml"
+    render_base_cmpd >"$base_file" || return $?
+    render_cmpd >"$head_file" || return $?
+
+    ruby -ryaml -rdigest -e '
+      documents = ARGV.map do |path|
+        YAML.load_stream(File.read(path)).compact.find do |item|
+          item.is_a?(Hash) && item["kind"] == "ComponentDefinition"
+        end
+      end
+      base, head = documents
+      abort "ComponentDefinition is missing" unless base && head
+      base_probe = base.dig("spec", "lifecycleActions", "roleProbe")
+      head_probe = head.dig("spec", "lifecycleActions", "roleProbe")
+      base_command = base_probe.dig("exec", "command")
+      head_command = head_probe.dig("exec", "command")
+      abort "roleProbe command changed" unless base_command == head_command
+      puts [
+        base.dig("metadata", "name"),
+        head.dig("metadata", "name"),
+        "#{base_probe["periodSeconds"].inspect}/#{base_probe["timeoutSeconds"].inspect}",
+        "#{head_probe["periodSeconds"]}/#{head_probe["timeoutSeconds"]}",
+        Digest::SHA256.hexdigest(YAML.dump(head_command))
+      ].join("|")
+    ' "$base_file" "$head_file"
   }
 
   validate_roleprobe_cadence() {
@@ -120,6 +168,12 @@ Describe "RustFS roleProbe render contract"
     When call validate_roleprobe_cadence
     The status should be success
     The output should include "RustFS roleProbe cadence is 1s/3s"
+  End
+
+  It "publishes immutable roleProbe changes under a new chart-versioned identity"
+    When call validate_immutable_upgrade_identity
+    The status should be success
+    The output should eq "rustfs-0.1.0|rustfs-0.1.1|nil/nil|1/3|01fa10f938f541513fa73a58552b65e6a3ded71efc3b2cd6f40815781907e10e"
   End
 
   It "keeps the pre-change exec command structure byte-for-byte canonical"

--- a/addons/rustfs/templates/cmpd.yaml
+++ b/addons/rustfs/templates/cmpd.yaml
@@ -135,6 +135,8 @@ spec:
             echo "RustFS does not support scale-in: removing nodes from a distributed erasure-coding pool is not supported and would cause data loss." >&2
             exit 1
     roleProbe:
+      periodSeconds: 1
+      timeoutSeconds: 3
       exec:
         command:
           - /bin/sh


### PR DESCRIPTION
## Problem

In two independent RustFS beta.10 focused runs (r05 and r06), all four Pods were Ready, `/health/live` succeeded, roleProbe/Pod label was `readwrite`, and restart count stayed zero. Both runs stopped at the SB01 Cluster Running gate and did not enter S3 data-path validation.

The first role event arrived after the last InstanceSet status reconcile; `instanceStatus[].role` remained empty and Component/Cluster stayed Creating for 1500 seconds. This N=2 evidence proves that the role-publication control-plane chain did not converge in that exact scene. It does not yet prove cadence is the only cause, and it is not a RustFS data-path or release-wide claim.

## Falsifiable addon-side candidate

- add Helm render regression tests for the RustFS roleProbe cadence and unchanged exec command;
- set `periodSeconds: 1` and `timeoutSeconds: 3` on `lifecycleActions.roleProbe`;
- keep the existing loopback health check and `readwrite` / `notready` stdout semantics unchanged.

Contract anchors:

- `kubeblocks-addon-docs/docs/addon-api/05a-lifecycle-roles-and-probe.md`
- `kubeblocks-addon-docs/docs/addon-api/05c-lifecycle-action-contracts.md`

The fresh runtime gate must separately observe role event -> Pod role label -> InstanceSet role status -> Component Running -> Cluster Running. If event/label updates but InstanceSet role remains empty, the candidate is falsified and the first blocker moves to the control-plane branch.

## Current candidate identity

- target branch: `main`
- target commit: `dc0ab59ac1a48c98dfc7aeb9821346eb36e02786`
- development branch: `jessica/rustfs-roleprobe-cadence`
- candidate commit: `f170215ca27db0cf183f03db7fc9a2778068626b`
- candidate tree: `dfbc26a8f8ee297b8ffe3fe9ea9120faa1ded22d`
- addon path: `addons/rustfs`
- included addon PR: #3247
- inherited target update: merged PR #3200 is included through current `main`
- excluded addon PR: #3263; separate backup/restore scope with no changed-file overlap with this PR

The next Test package receipt must separately pin exact KubeBlocks, addon chart/package SHA, tests commit, vcluster identity/version, syncer identity/version, and any patch images. Those Test-owned runtime pins are intentionally not inferred from this Dev PR.

Any candidate SHA change restarts acceptance for the new package. The earlier focused r08 PASS belongs to the pre-rebase candidate `9d364681b8f5ff6bab65215768f8d30b95d915e4`; it is useful historical evidence but does not count for `f170215ca27db0cf183f03db7fc9a2778068626b`. The superseded rebased candidate `e8919bb396f097d2ab5c207e1a5e8a0835c83717` also has runtime N=0 and is not migrated.

## TDD and local verification

- before implementation: the new focused ShellSpec failed with `periodSeconds must be 1, got nil`;
- after rebase onto `main@dc0ab59ac1a48c98dfc7aeb9821346eb36e02786`: forced `--no-quick` Bash TAP run passes all six examples;
- rendered cadence is exactly 1/3;
- canonical SHA256 of the roleProbe exec command is unchanged;
- branch tests cover wget fast success, wget fast failure + curl success, both fail, and a hanging wget consuming the 3s action budget (no role token, curl not reached);
- chart preparation is owned by `BeforeEach`; `AfterEach` deletes the exact owned tree and fails if residue remains;
- isolated Bash run result is 6/0 with `rustfs-roleprobe-render-*` residue=0;
- Bash and `sh` ShellSpec syntax checks, ShellCheck excluding intentional SC2016 fixture literals, and `git diff --check` pass.

## Runtime boundary

Local checks prove chart/render, command-branch, and test cleanup contracts only. They do not prove event scheduling, reconcile timing, CPU/throttle behavior, runtime convergence, or S3 behavior. Test owns candidate packaging and real Kubernetes validation. r05/r06 remain diagnostic evidence only, and r08 belongs to the previous candidate SHA. Runtime acceptance for the current candidate starts at zero until Test publishes an exact package receipt and result.
