### PR TITLE
fix(kafka): restore 40 percent automatic heap sizing

### DIFF
--- a/addons-cluster/kafka/values.schema.json
+++ b/addons-cluster/kafka/values.schema.json
@@ -178,13 +178,13 @@
       "title": "BrokerHeap",
       "description": "Kafka broker's jvm heap setting.",
       "type": "string",
-      "default": "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+      "default": "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
     },
     "controllerHeap": {
       "title": "ControllerHeap",
       "description": "Kafka controller's jvm heap setting for separated mode",
       "type": "string",
-      "default": "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+      "default": "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
     },
     "nodePortEnabled": {
       "type": "boolean",

--- a/addons-cluster/kafka/values.yaml
+++ b/addons-cluster/kafka/values.yaml
@@ -107,11 +107,11 @@ monitor:
     memory: 1
 
 ## kafka broker's jvm heap setting
-brokerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
+brokerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64
 
 ## kafka broker's jvm heap setting
 ## only effective when clusterMode='separated'
-controllerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
+controllerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64
 
 ## @param nodePortEnabled
 ## Whether to enable NodePort mode.

--- a/addons/kafka/README.md
+++ b/addons/kafka/README.md
@@ -48,7 +48,11 @@ Apache Kafka is a distributed streaming platform designed to build real-time pip
 
 ### Create
 
-Create a Kafka cluster with combined controller and broker components
+Create a Kafka cluster with combined controller and broker components.
+For `combined_monitor`, `2Gi` memory is the recommended minimum for the
+`kafka-combine` component when broker, controller, exporter validation, and
+in-pod workload tools share the same pod memory budget; smaller limits are not
+recommended for this topology.
 
 ```yaml
 # cat examples/kafka/cluster-combined.yaml
@@ -97,10 +101,10 @@ spec:
       resources:
         limits:
           cpu: "1"
-          memory: "1Gi"
+          memory: "2Gi"
         requests:
           cpu: "0.5"
-          memory: "0.5Gi"
+          memory: "2Gi"
       # Specifies a list of PersistentVolumeClaim templates that define the storage
       # requirements for the Component.
       volumeClaimTemplates:

--- a/addons/kafka/README.md
+++ b/addons/kafka/README.md
@@ -83,9 +83,9 @@ spec:
     - name: kafka-combine
       env:
         - name: KB_KAFKA_BROKER_HEAP # use this ENV to set BROKER HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP # use this ENV to set CONTOLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
           # Whether to enable direct Pod IP address access mode.
           # - If set to 'true', Kafka clients will connect to Brokers using the Pod IP address directly.
           # - If set to 'false', Kafka clients will connect to Brokers using the Headless Service's FQDN.
@@ -188,9 +188,9 @@ spec:
           memory: "0.5Gi"
       env:
         - name: KB_KAFKA_BROKER_HEAP # use this ENV to set BROKER HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP # use this ENV to set CONTOLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
           # Whether to enable direct Pod IP address access mode.
           # - If set to 'true', Kafka clients will connect to Brokers using the Pod IP address directly.
           # - If set to 'false', Kafka clients will connect to Brokers using the Headless Service's FQDN
@@ -653,9 +653,9 @@ spec:
           memory: "0.5Gi"
       env:
         - name: KB_KAFKA_BROKER_HEAP # use this ENV to set BROKER HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP # use this ENV to set CONTOLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
           # Whether to enable direct Pod IP address access mode.
           # - If set to 'true', Kafka clients will connect to Brokers using the Pod IP address directly.
           # - If set to 'false', Kafka clients will connect to Brokers using the Headless Service's FQDN
@@ -859,9 +859,9 @@ spec:
       replicas: 1
       env:
         - name: KB_KAFKA_BROKER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_BROKER_DIRECT_POD_ACCESS # set KB_BROKER_DIRECT_POD_ACCESS to FALSE to disable direct pod access
           value: "false"
 ```

--- a/addons/kafka/scripts/kafka-27-server-setup.sh
+++ b/addons/kafka/scripts/kafka-27-server-setup.sh
@@ -136,6 +136,10 @@ set_jvm_configuration() {
   if [[ -n "$KB_KAFKA_BROKER_HEAP" ]]; then
     export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}
     echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
+  elif [[ -n "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" =~ ^[0-9]+$ ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" -gt 0 ]]; then
+    local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 50 / 100))
+    export KAFKA_HEAP_OPTS="-XshowSettings:vm -Xmx${heap_mib}m -Xms${heap_mib}m -Ddepth=64"
+    echo "[jvm][KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB]export KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS}"
   fi
   export JMX_PORT=5555
   echo "[jvm][JMX_PORT]export JMX_PORT=5555"

--- a/addons/kafka/scripts/kafka-27-server-setup.sh
+++ b/addons/kafka/scripts/kafka-27-server-setup.sh
@@ -137,7 +137,7 @@ set_jvm_configuration() {
     export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}
     echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
   elif [[ -n "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" =~ ^[0-9]+$ ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" -gt 0 ]]; then
-    local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 50 / 100))
+    local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 40 / 100))
     export KAFKA_HEAP_OPTS="-XshowSettings:vm -Xmx${heap_mib}m -Xms${heap_mib}m -Ddepth=64"
     echo "[jvm][KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB]export KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS}"
   fi

--- a/addons/kafka/scripts/kafka-server-setup.sh
+++ b/addons/kafka/scripts/kafka-server-setup.sh
@@ -133,7 +133,7 @@ set_jvm_configuration() {
     export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}
     echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
   elif [[ -n "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" =~ ^[0-9]+$ ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" -gt 0 ]]; then
-    local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 50 / 100))
+    local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 40 / 100))
     export KAFKA_HEAP_OPTS="-XshowSettings:vm -Xmx${heap_mib}m -Xms${heap_mib}m -Ddepth=64"
     echo "[jvm][KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB]export KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS}"
   fi
@@ -255,7 +255,7 @@ set_cfg_metadata() {
       export KAFKA_HEAP_OPTS=${KB_KAFKA_CONTROLLER_HEAP}
       echo "[jvm][KB_KAFKA_CONTROLLER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_CONTROLLER_HEAP}"
     elif [[ "controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] && [[ -n "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" =~ ^[0-9]+$ ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" -gt 0 ]]; then
-      local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 50 / 100))
+      local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 40 / 100))
       export KAFKA_HEAP_OPTS="-XshowSettings:vm -Xmx${heap_mib}m -Xms${heap_mib}m -Ddepth=64"
       echo "[jvm][KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB]export KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS}"
     fi

--- a/addons/kafka/scripts/kafka-server-setup.sh
+++ b/addons/kafka/scripts/kafka-server-setup.sh
@@ -132,6 +132,10 @@ set_jvm_configuration() {
   if [[ -n "$KB_KAFKA_BROKER_HEAP" ]]; then
     export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}
     echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
+  elif [[ -n "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" =~ ^[0-9]+$ ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" -gt 0 ]]; then
+    local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 50 / 100))
+    export KAFKA_HEAP_OPTS="-XshowSettings:vm -Xmx${heap_mib}m -Xms${heap_mib}m -Ddepth=64"
+    echo "[jvm][KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB]export KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS}"
   fi
   export JMX_PORT=5555
   echo "[jvm][JMX_PORT]export JMX_PORT=5555"
@@ -250,6 +254,10 @@ set_cfg_metadata() {
     if [[ "controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] && [[ -n "$KB_KAFKA_CONTROLLER_HEAP" ]]; then
       export KAFKA_HEAP_OPTS=${KB_KAFKA_CONTROLLER_HEAP}
       echo "[jvm][KB_KAFKA_CONTROLLER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_CONTROLLER_HEAP}"
+    elif [[ "controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] && [[ -n "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" =~ ^[0-9]+$ ]] && [[ "$KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB" -gt 0 ]]; then
+      local heap_mib=$((KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB * 50 / 100))
+      export KAFKA_HEAP_OPTS="-XshowSettings:vm -Xmx${heap_mib}m -Xms${heap_mib}m -Ddepth=64"
+      echo "[jvm][KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB]export KAFKA_HEAP_OPTS=${KAFKA_HEAP_OPTS}"
     fi
     # generate node.id
     ID="${MY_POD_NAME#${COMPONENT_NAME}-}"

--- a/addons/kafka/templates/cmpd-broker-27.yaml
+++ b/addons/kafka/templates/cmpd-broker-27.yaml
@@ -227,7 +227,13 @@ spec:
             value: "/bitnami/kafka/data"
           - name: KAFKA_HEAP_OPTS
             #value: "-Xmx1024m -Xms1024m"
-            value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+            value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
+          - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: kafka
+                resource: limits.memory
+                divisor: 1Mi
           - name: SERVER_PROP_FILE
             value: /scripts/server.properties
           - name: KAFKA_KRAFT_CLUSTER_ID
@@ -292,7 +298,8 @@ spec:
         command:
           - java
         args:
-          - -XX:MaxRAMPercentage=100
+          - -Xmx128m
+          - -Xms64m
           - -XshowSettings:vm
           - -jar
           - jmx_prometheus_httpserver.jar

--- a/addons/kafka/templates/cmpd-broker.yaml
+++ b/addons/kafka/templates/cmpd-broker.yaml
@@ -199,7 +199,13 @@ spec:
             value: "/bitnami/kafka/data"
           - name: KAFKA_HEAP_OPTS
             #value: "-Xmx1024m -Xms1024m"
-            value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+            value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
+          - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: kafka
+                resource: limits.memory
+                divisor: 1Mi
           - name: SERVER_PROP_FILE
             value: /scripts/server.properties
           - name: KAFKA_KRAFT_CLUSTER_ID
@@ -264,7 +270,8 @@ spec:
         command:
           - java
         args:
-          - -XX:MaxRAMPercentage=100
+          - -Xmx128m
+          - -Xms64m
           - -XshowSettings:vm
           - -jar
           - jmx_prometheus_httpserver.jar

--- a/addons/kafka/templates/cmpd-combine.yaml
+++ b/addons/kafka/templates/cmpd-combine.yaml
@@ -196,7 +196,13 @@ spec:
             value: "/bitnami/kafka/data"
           - name: KAFKA_HEAP_OPTS
             #value: "-Xmx1024m -Xms1024m"
-            value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+            value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
+          - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: kafka
+                resource: limits.memory
+                divisor: 1Mi
           - name: SERVER_PROP_FILE
             value: /scripts/server.properties
           - name: KAFKA_KRAFT_CLUSTER_ID
@@ -264,7 +270,8 @@ spec:
         command:
           - java
         args:
-          - -XX:MaxRAMPercentage=100
+          - -Xmx128m
+          - -Xms64m
           - -XshowSettings:vm
           - -jar
           - jmx_prometheus_httpserver.jar

--- a/addons/kafka/templates/cmpd-controller.yaml
+++ b/addons/kafka/templates/cmpd-controller.yaml
@@ -118,7 +118,13 @@ spec:
             value: "/bitnami/kafka/data"
           - name: KAFKA_HEAP_OPTS
             #value: "-Xmx1024m -Xms1024m"
-            value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+            value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
+          - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
+            valueFrom:
+              resourceFieldRef:
+                containerName: kafka
+                resource: limits.memory
+                divisor: 1Mi
           - name: SERVER_PROP_FILE
             value: /scripts/server.properties
           - name: KAFKA_KRAFT_CLUSTER_ID
@@ -175,7 +181,8 @@ spec:
         command:
           - java
         args:
-          - -XX:MaxRAMPercentage=100
+          - -Xmx128m
+          - -Xms64m
           - -XshowSettings:vm
           - -jar
           - jmx_prometheus_httpserver.jar

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -48,7 +48,11 @@ Apache Kafka is a distributed streaming platform designed to build real-time pip
 
 ### Create
 
-Create a Kafka cluster with combined controller and broker components
+Create a Kafka cluster with combined controller and broker components.
+For `combined_monitor`, `2Gi` memory is the recommended minimum for the
+`kafka-combine` component when broker, controller, exporter validation, and
+in-pod workload tools share the same pod memory budget; smaller limits are not
+recommended for this topology.
 
 ```bash
 kubectl apply -f examples/kafka/cluster-combined.yaml

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -352,9 +352,9 @@ spec:
       replicas: 1
       env:
         - name: KB_KAFKA_BROKER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_BROKER_DIRECT_POD_ACCESS # set KB_BROKER_DIRECT_POD_ACCESS to FALSE to disable direct pod access
           value: "false"
 ```

--- a/examples/kafka/cluster-2x-ext-zk-svc-descriptor.yaml
+++ b/examples/kafka/cluster-2x-ext-zk-svc-descriptor.yaml
@@ -30,9 +30,9 @@ spec:
     - name: KB_KAFKA_ENABLE_SASL_SCRAM
       value: "false"
     - name: KB_KAFKA_BROKER_HEAP
-      value: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
+      value: -XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64
     - name: KB_KAFKA_CONTROLLER_HEAP
-      value: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
+      value: -XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64
     - name: KB_BROKER_DIRECT_POD_ACCESS
       value: "false"
     # By default, broker will store metadata in zookeeper's /$(CLUSTER_NAME) subpath.

--- a/examples/kafka/cluster-combined-nodeport.yaml
+++ b/examples/kafka/cluster-combined-nodeport.yaml
@@ -26,10 +26,10 @@ spec:
       resources:
         limits:
           cpu: "1"
-          memory: "1Gi"
+          memory: "2Gi"
         requests:
           cpu: "0.5"
-          memory: "0.5Gi"
+          memory: "2Gi"
       volumeClaimTemplates:
         - name: data
           spec:

--- a/examples/kafka/cluster-combined-nodeport.yaml
+++ b/examples/kafka/cluster-combined-nodeport.yaml
@@ -17,9 +17,9 @@ spec:
           podService: true
       env:
         - name: KB_KAFKA_BROKER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_BROKER_DIRECT_POD_ACCESS # set KB_BROKER_DIRECT_POD_ACCESS to FALSE to disable direct pod access
           value: "false"
       replicas: 1

--- a/examples/kafka/cluster-combined.yaml
+++ b/examples/kafka/cluster-combined.yaml
@@ -43,10 +43,10 @@ spec:
       resources:
         limits:
           cpu: "1"
-          memory: "1Gi"
+          memory: "2Gi"
         requests:
           cpu: "0.5"
-          memory: "0.5Gi"
+          memory: "2Gi"
       # Specifies a list of PersistentVolumeClaim templates that define the storage
       # requirements for the Component.
       volumeClaimTemplates:

--- a/examples/kafka/cluster-combined.yaml
+++ b/examples/kafka/cluster-combined.yaml
@@ -29,9 +29,9 @@ spec:
     - name: kafka-combine
       env:
         - name: KB_KAFKA_BROKER_HEAP # use this ENV to set BROKER HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP # use this ENV to set CONTOLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
           # Whether to enable direct Pod IP address access mode.
           # - If set to 'true', Kafka clients will connect to Brokers using the Pod IP address directly.
           # - If set to 'false', Kafka clients will connect to Brokers using the Headless Service's FQDN.

--- a/examples/kafka/cluster-separated.yaml
+++ b/examples/kafka/cluster-separated.yaml
@@ -42,9 +42,9 @@ spec:
           memory: "0.5Gi"
       env:
         - name: KB_KAFKA_BROKER_HEAP # use this ENV to set BROKER HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
         - name: KB_KAFKA_CONTROLLER_HEAP # use this ENV to set CONTOLLER_HEAP
-          value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+          value: "-XshowSettings:vm -XX:MaxRAMPercentage=75 -Ddepth=64"
           # Whether to enable direct Pod IP address access mode.
           # - If set to 'true', Kafka clients will connect to Brokers using the Pod IP address directly.
           # - If set to 'false', Kafka clients will connect to Brokers using the Headless Service's FQDN


### PR DESCRIPTION
## Problem

Task #54 formal runtime on addon candidate `67200df711766c01ec7a33829c1b0ee041b1f32a` reached the regression R2 check with the live Kafka process using `-XX:MaxRAMPercentage=100`. The candidate templates and README contain the same 100 percent value, while merged PR #2855 is not in the candidate ancestry.

## Change

- Integrate PR #2824's container-memory input and safer fallback heap defaults.
- Integrate PR #2855's 40 percent automatic heap calculation for Kafka 2.7 and current server setup paths.
- Keep this as a draft stacked on PR #3219's exact candidate branch until the stack is aggregated onto a valid release base.

## Verification

- `bash -n` passes for both server setup scripts.
- Kafka ShellSpec: 30 examples, 0 failures on Bash 5.3.
- Helm dependency build and `helm template` succeed.
- Rendered chart and Kafka source/examples contain no `MaxRAMPercentage=100`.
- Direct function check with a 1024 MiB limit produces `-Xmx409m -Xms409m` in both setup scripts.
- `git diff --check` passes.

Runtime retest, package, runner, sideload, evidence, and cleanup remain tester-owned.
