### PR TITLE
fix(kafka): resolve memory refs per action container

### DIFF
--- a/addons/kafka/scripts-ut-spec/container_memory_ref_render_check.rb
+++ b/addons/kafka/scripts-ut-spec/container_memory_ref_render_check.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
+definitions = documents.select { |doc| doc["kind"] == "ComponentDefinition" }
+
+expected = %w[
+  kafka27-broker-1.1.0-alpha.2
+  kafka-broker-1.1.0-alpha.2
+  kafka-combine-1.1.0-alpha.2
+  kafka-controller-1.1.0-alpha.2
+]
+
+actual = []
+definitions.each do |definition|
+  kafka = Array(definition.dig("spec", "runtime", "containers")).find do |container|
+    container["name"] == "kafka"
+  end
+  next unless kafka
+
+  memory_env = Array(kafka["env"]).select do |entry|
+    entry["name"] == "KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB"
+  end
+  next if memory_env.empty?
+
+  name = definition.dig("metadata", "name")
+  abort "#{name}: expected exactly one container memory env" unless memory_env.length == 1
+
+  resource_ref = memory_env.fetch(0).dig("valueFrom", "resourceFieldRef")
+  abort "#{name}: container memory ref must resolve against the executing container" unless resource_ref == {
+    "resource" => "limits.memory",
+    "divisor" => "1Mi"
+  }
+  actual << name
+end
+
+abort "unexpected ComponentDefinition container memory ref set" unless actual.sort == expected.sort

--- a/addons/kafka/scripts-ut-spec/container_memory_ref_spec.sh
+++ b/addons/kafka/scripts-ut-spec/container_memory_ref_spec.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=sh
+
+validate_rendered_container_memory_refs() {
+  chart_dir=$(cd .. && pwd)
+  addons_dir=$(cd ../.. && pwd)
+  render_root=$(mktemp -d)
+  render_chart="$render_root/kafka"
+  render_kblib="$render_root/kblib"
+  rendered="$render_root/rendered.yaml"
+  status=0
+
+  cp -R "$chart_dir" "$render_chart" || status=1
+  cp -R "$addons_dir/kblib" "$render_kblib" || status=1
+  if [ "$status" -eq 0 ]; then
+    rm -rf "$render_chart/charts"
+    helm dependency build "$render_chart" >/dev/null 2>&1 || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    helm template kafka "$render_chart" >"$rendered" || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    ruby ./container_memory_ref_render_check.rb "$rendered" || status=1
+  fi
+  rm -rf "$render_root"
+  return "$status"
+}
+
+Describe "Kafka container memory resource reference"
+  It "resolves against whichever container executes the action"
+    When call validate_rendered_container_memory_refs
+    The status should be success
+    The output should be blank
+  End
+End

--- a/addons/kafka/templates/cmpd-broker-27.yaml
+++ b/addons/kafka/templates/cmpd-broker-27.yaml
@@ -231,7 +231,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE

--- a/addons/kafka/templates/cmpd-broker.yaml
+++ b/addons/kafka/templates/cmpd-broker.yaml
@@ -203,7 +203,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE

--- a/addons/kafka/templates/cmpd-combine.yaml
+++ b/addons/kafka/templates/cmpd-combine.yaml
@@ -200,7 +200,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE

--- a/addons/kafka/templates/cmpd-controller.yaml
+++ b/addons/kafka/templates/cmpd-controller.yaml
@@ -122,7 +122,6 @@ spec:
           - name: KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB
             valueFrom:
               resourceFieldRef:
-                containerName: kafka
                 resource: limits.memory
                 divisor: 1Mi
           - name: SERVER_PROP_FILE


### PR DESCRIPTION
## Problem

Fresh task54 backup runtime on exact addon `2067c105` created an action Pod with only `backupdata` and `manager` containers. Both failed with `container kafka not found` because four Kafka ComponentDefinitions hard-coded `resourceFieldRef.containerName: kafka` for `KB_KAFKA_CONTAINER_MEMORY_LIMIT_MIB`.

## Change

- remove the hard-coded container name from the four Kafka ComponentDefinitions so Kubernetes resolves `limits.memory` against the container executing the action
- add a structured Helm-render regression test that requires exactly the four Kafka definitions to expose the memory env with `resource=limits.memory`, `divisor=1Mi`, and no container override

## Verification

- focused TDD: 1 failing example before the template change, then 1/0
- full Kafka ShellSpec with Bash 5.3: 31/0
- Bash 3.2 runnable subset: 9/0
- `sh -n`, Ruby syntax, ShellCheck, and `git diff --check`: pass

Stacked on #3248 exact addon head; kept Draft because the base is a custom branch.