### PR TITLE
fix(mongodb): map 4.0 dump image tag

### DIFF
--- a/addons/mongodb/scripts-ut-spec/backup_version_mapping_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/backup_version_mapping_spec.sh
@@ -1,0 +1,83 @@
+# shellcheck shell=bash
+
+Describe "MongoDB backup version mapping contract"
+
+  render_and_validate_backup_version_mappings() {
+    local chart_dir
+
+    chart_dir=${MONGODB_CHART_DIR:-$(cd .. && pwd)}
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update | ruby -ryaml -e '
+      def mapping_for(method, env_name)
+        env = Array(method["env"]).find { |item| item["name"] == env_name }
+        env&.dig("valueFrom", "versionMapping") || []
+      end
+
+      def resolve(mapping, service_version)
+        exact = mapping.find do |entry|
+          Array(entry["serviceVersions"]).include?(service_version)
+        end
+        return exact["mappedValue"] if exact
+
+        prefix = mapping.find do |entry|
+          Array(entry["serviceVersions"]).any? do |version|
+            service_version.start_with?(version)
+          end
+        end
+        prefix&.fetch("mappedValue", nil)
+      end
+
+      values = YAML.load_file(ARGV.fetch(0))
+      active = values.fetch("versions").flat_map do |group|
+        group.fetch("minors").reject { |minor| minor[4] }.map do |minor|
+          {
+            "serviceVersion" => minor[1],
+            "mongodbTag" => minor[2],
+            "pbmTag" => minor[3]
+          }
+        end
+      end
+
+      documents = YAML.load_stream($stdin.read).compact
+      policies = documents.select { |doc| doc["kind"] == "BackupPolicyTemplate" }
+      replica = policies.find { |doc| doc.dig("metadata", "name") == "mongodb-backup-policy-template" }
+      shard = policies.find { |doc| doc.dig("metadata", "name") == "mongodb-shard-backup-policy-template" }
+      abort "replica BackupPolicyTemplate is missing" unless replica
+      abort "shard BackupPolicyTemplate is missing" unless shard
+
+      replica_methods = replica.dig("spec", "backupMethods").to_h { |method| [method["name"], method] }
+      shard_methods = shard.dig("spec", "backupMethods").to_h { |method| [method["name"], method] }
+
+      active.each do |release|
+        service_version = release.fetch("serviceVersion")
+        actual = resolve(mapping_for(replica_methods.fetch("dump"), "IMAGE_TAG"), service_version)
+        expected = release.fetch("mongodbTag")
+        abort "replica dump #{service_version} IMAGE_TAG=#{actual.inspect}, expected #{expected.inspect}" unless actual == expected
+
+        %w[pbm-physical pbm-pitr].each do |method_name|
+          actual = resolve(mapping_for(replica_methods.fetch(method_name), "PBM_IMAGE_TAG"), service_version)
+          expected = release.fetch("pbmTag")
+          abort "replica #{method_name} #{service_version} PBM_IMAGE_TAG=#{actual.inspect}, expected #{expected.inspect}" unless actual == expected
+        end
+
+        %w[dump pbm-physical pbm-pitr].each do |method_name|
+          method = shard_methods.fetch(method_name)
+          actual_mongodb = resolve(mapping_for(method, "PSM_IMAGE_TAG"), service_version)
+          expected_mongodb = release.fetch("mongodbTag")
+          abort "shard #{method_name} #{service_version} PSM_IMAGE_TAG=#{actual_mongodb.inspect}, expected #{expected_mongodb.inspect}" unless actual_mongodb == expected_mongodb
+
+          actual_pbm = resolve(mapping_for(method, "PBM_IMAGE_TAG"), service_version)
+          expected_pbm = release.fetch("pbmTag")
+          abort "shard #{method_name} #{service_version} PBM_IMAGE_TAG=#{actual_pbm.inspect}, expected #{expected_pbm.inspect}" unless actual_pbm == expected_pbm
+        end
+      end
+
+      puts "backup version mapping contract passed for #{active.length} active releases"
+    ' "$chart_dir/values.yaml"
+  }
+
+  It "maps every active release to the declared MongoDB and PBM image tags"
+    When call render_and_validate_backup_version_mappings
+    The status should be success
+    The output should include "backup version mapping contract passed for 6 active releases"
+  End
+End

--- a/addons/mongodb/scripts-ut-spec/backup_version_mapping_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/backup_version_mapping_spec.sh
@@ -6,7 +6,8 @@ Describe "MongoDB backup version mapping contract"
     local chart_dir
 
     chart_dir=${MONGODB_CHART_DIR:-$(cd .. && pwd)}
-    helm template kb-addon-mongodb "$chart_dir" --dependency-update | ruby -ryaml -e '
+    helm dependency build "$chart_dir" >/dev/null || return
+    helm template kb-addon-mongodb "$chart_dir" | ruby -ryaml -e '
       def mapping_for(method, env_name)
         env = Array(method["env"]).find { |item| item["name"] == env_name }
         env&.dig("valueFrom", "versionMapping") || []

--- a/addons/mongodb/templates/backuppolicytemplate.yaml
+++ b/addons/mongodb/templates/backuppolicytemplate.yaml
@@ -34,6 +34,9 @@ spec:
             - serviceVersions:
               - "4.4"
               mappedValue: "4.4.29-multi"
+            - serviceVersions:
+              - "4.0"
+              mappedValue: "4.0.28"
     - name: datafile
       snapshotVolumes: false
       actionSetName: mongodb-physical-br


### PR DESCRIPTION
## What this PR does

- maps MongoDB replica dump serviceVersion `4.0` to the active `4.0.28` image tag
- adds a render-level contract test that derives non-deprecated releases from `values.yaml`
- verifies replica and sharded MongoDB/PBM backup image mappings for every active release
- keeps Helm dependency status output out of the YAML stream consumed by the contract test

Without the mapping, KubeBlocks omits the BackupMethod env override and silently retains the ActionSet default `IMAGE_TAG=8.0.17` for a 4.0.28 replica dump.

## Scope

- exact base: `62e3e560536092d7330a7b47159444123d952556`
- exact head: `3bf327a3220b5e940c170d5c3cba1f25b001dbf5`
- two commits, two files

## Verification

- mapping contract RED on parent: 1 example / 1 failure with `replica dump 4.0.28 IMAGE_TAG=nil`
- clean-worktree dependency-status regression RED on `d779420`: 1 example / 1 failure with `Psych::SyntaxError`
- clean-worktree dependency-status regression GREEN on exact head: 1 example / 0 failures
- focused mapping spec on Bash 3.2 and Bash 5.3: 1 example / 0 failures each
- all MongoDB ShellSpec on exact head: 17 examples / 0 failures
- `helm lint addons/mongodb`: 1 chart / 0 failures
- `git diff --check`: pass

The source/render correction changes no runtime product behavior beyond the missing 4.0 dump mapping. Runtime N remains 0 and is not claimed.

Closes #3250
