### PR TITLE
fix(tidb): preserve PITR log task on monitor failure

### DIFF
--- a/addons/tidb/dataprotection/backup-pitr.sh
+++ b/addons/tidb/dataprotection/backup-pitr.sh
@@ -1,44 +1,169 @@
 #!/bin/bash
 
-function save_backup_status() {
-    # shellcheck disable=SC2086
-    res=$(/br log status --task-name=pitr --pd "$PD_ADDRESS" $EXTRA_ARGS)
-    start_time_str=$(echo "$res" | awk -F': ' '/^\s*start:/ {print $2}')
-    checkpoint_time_str=$(echo "$res" | awk -F': ' '/^checkpoint\[global\]:/ {print $2}' | cut -d';' -f1)
-    start_time=$(date -d "$start_time_str" -u '+%Y-%m-%dT%H:%M:%SZ')
-    checkpoint_time=$(date -d "$checkpoint_time_str" -u '+%Y-%m-%dT%H:%M:%SZ')
+PITR_TERMINATION_REQUESTED=false
 
-    # use datasafed to get backup size
-    total_size=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+function run_br() {
+    /br "$@"
+}
+
+function get_log_backup_status() {
+    # shellcheck disable=SC2086
+    run_br log status --task-name=pitr --pd "$PD_ADDRESS" $EXTRA_ARGS
+}
+
+function normalize_utc_time() {
+    date -d "$1" -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+function get_backup_total_size() {
+    datasafed stat / | awk '/TotalSize/ {print $2; exit}'
+}
+
+function save_backup_status() {
+    local res start_time_str checkpoint_time_str start_time checkpoint_time total_size
+
+    if ! res=$(get_log_backup_status); then
+        echo "ERROR: failed to query TiDB log backup status" >&2
+        return 1
+    fi
+
+    start_time_str=$(printf '%s\n' "$res" | awk -F': ' '/^[[:space:]]*start:/ {print $2; exit}')
+    checkpoint_time_str=$(printf '%s\n' "$res" | awk -F': ' '/^[[:space:]]*checkpoint\[global\]:/ {print $2; exit}' | cut -d';' -f1)
+    if [ -z "$start_time_str" ] || [ -z "$checkpoint_time_str" ]; then
+        echo "ERROR: log backup status is missing start or global checkpoint" >&2
+        return 1
+    fi
+
+    if ! start_time=$(normalize_utc_time "$start_time_str"); then
+        echo "ERROR: invalid log backup start time: $start_time_str" >&2
+        return 1
+    fi
+    if ! checkpoint_time=$(normalize_utc_time "$checkpoint_time_str"); then
+        echo "ERROR: invalid log backup checkpoint time: $checkpoint_time_str" >&2
+        return 1
+    fi
+    if ! total_size=$(get_backup_total_size) || [ -z "$total_size" ]; then
+        echo "ERROR: failed to read log backup size" >&2
+        return 1
+    fi
+
     echo "start_time: $start_time, checkpoint_time: $checkpoint_time, total_size: $total_size"
     DP_save_backup_status_info "$total_size" "$start_time" "$checkpoint_time" "" ""
 }
 
-# if the script exits with a non-zero exit code, touch a file to indicate that the backup failed,
-# the sync progress container will check this file and exit if it exists
-function handle_exit() {
-  exit_code=$?
-  save_backup_status
-  # FIXME: an unexpected pod restart will remove previous log backup progress
-  # shellcheck disable=SC2086
-  /br log stop --task-name=pitr --pd "$PD_ADDRESS" --storage "s3://$BUCKET$DP_BACKUP_BASE_PATH?access-key=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY" --s3.endpoint "$ENDPOINT" $EXTRA_ARGS
-  if [ $exit_code -ne 0 ]; then
-    echo "failed with exit code $exit_code"
-    exit $exit_code
-  fi
+function save_backup_status_with_retry() {
+    local attempts="${PITR_STATUS_RETRY_ATTEMPTS:-3}"
+    local interval="${PITR_STATUS_RETRY_INTERVAL_SECONDS:-2}"
+    local attempt=1
+
+    case "$attempts" in
+        ''|*[!0-9]*|0)
+            echo "ERROR: PITR_STATUS_RETRY_ATTEMPTS must be a positive integer" >&2
+            return 2
+            ;;
+    esac
+    case "$interval" in
+        ''|*[!0-9]*)
+            echo "ERROR: PITR_STATUS_RETRY_INTERVAL_SECONDS must be a non-negative integer" >&2
+            return 2
+            ;;
+    esac
+
+    while [ "$attempt" -le "$attempts" ]; do
+        if save_backup_status; then
+            return 0
+        fi
+        echo "WARN: log backup status attempt $attempt/$attempts failed" >&2
+        if [ "$attempt" -lt "$attempts" ]; then
+            sleep "$interval"
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    echo "ERROR: log backup status failed after $attempts attempts" >&2
+    return 1
 }
 
+function start_log_backup() {
+    # shellcheck disable=SC2086
+    run_br log start --task-name=pitr --pd "$PD_ADDRESS" --storage "s3://$BUCKET$DP_BACKUP_BASE_PATH?access-key=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY" --s3.endpoint "$ENDPOINT" $BR_EXTRA_ARGS
+}
+
+function stop_log_backup() {
+    # shellcheck disable=SC2086
+    run_br log stop --task-name=pitr --pd "$PD_ADDRESS" --storage "s3://$BUCKET$DP_BACKUP_BASE_PATH?access-key=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY" --s3.endpoint "$ENDPOINT" $EXTRA_ARGS
+}
+
+function ensure_log_backup_started() {
+    local status_rc
+
+    if save_backup_status_with_retry; then
+        echo "INFO: attached to existing TiDB log backup task"
+        return 0
+    else
+        status_rc=$?
+    fi
+    if [ "$status_rc" -eq 2 ]; then
+        return "$status_rc"
+    fi
+
+    echo "INFO: no usable TiDB log backup task status; starting task"
+    if ! start_log_backup; then
+        echo "ERROR: failed to start TiDB log backup task" >&2
+        return 1
+    fi
+    return 0
+}
+
+function finish_log_backup() {
+    local exit_code="$1"
+    local termination_requested="${2:-false}"
+
+    if [ "$termination_requested" = "true" ]; then
+        save_backup_status_with_retry || echo "WARN: final log backup status could not be saved" >&2
+        if ! stop_log_backup; then
+            echo "ERROR: failed to stop TiDB log backup task during explicit termination" >&2
+            [ "$exit_code" -eq 0 ] && exit_code=1
+        fi
+    elif [ "$exit_code" -ne 0 ]; then
+        echo "ERROR: PITR monitor failed with exit code $exit_code; preserving the log backup task" >&2
+    else
+        echo "INFO: PITR monitor exited without an explicit termination request; preserving the log backup task" >&2
+    fi
+
+    return "$exit_code"
+}
+
+function handle_termination() {
+    PITR_TERMINATION_REQUESTED=true
+    exit 0
+}
+
+function handle_exit() {
+    local exit_code=$?
+    local final_exit_code
+
+    trap - EXIT TERM INT
+    set +e
+    finish_log_backup "$exit_code" "$PITR_TERMINATION_REQUESTED"
+    final_exit_code=$?
+    exit "$final_exit_code"
+}
+
+function main() {
+    setStorageVar
+    ensure_log_backup_started
+
+    set +x
+    while true; do
+        save_backup_status_with_retry || return $?
+        sleep "${PITR_STATUS_INTERVAL_SECONDS:-20}"
+    done
+}
+
+# This is magic for shellspec ut framework, do not modify!
+${__SOURCED__:+false} : || return 0
+
 trap handle_exit EXIT
-
-setStorageVar
-
-echo "start log backup"
-# shellcheck disable=SC2086
-/br log start --task-name=pitr --pd "$PD_ADDRESS" --storage "s3://$BUCKET$DP_BACKUP_BASE_PATH?access-key=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY" --s3.endpoint "$ENDPOINT" $BR_EXTRA_ARGS
-
-set +x
-while true; do
-  save_backup_status
-  # todo: prune outdated log
-  sleep 20
-done
+trap handle_termination TERM INT
+main "$@"

--- a/addons/tidb/dataprotection/backup-pitr.sh
+++ b/addons/tidb/dataprotection/backup-pitr.sh
@@ -19,6 +19,31 @@ function get_backup_total_size() {
     datasafed stat / | awk '/TotalSize/ {print $2; exit}'
 }
 
+function is_non_negative_int64() {
+    local value="$1"
+    local normalized
+    local max_int64="9223372036854775807"
+
+    case "$value" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+
+    normalized="$value"
+    while [ "${normalized#0}" != "$normalized" ]; do
+        normalized="${normalized#0}"
+    done
+    [ -n "$normalized" ] || normalized=0
+
+    if [ "${#normalized}" -gt 19 ]; then
+        return 1
+    fi
+    # Compare equal-width decimal strings without overflowing Bash 3.2 integers.
+    # shellcheck disable=SC2071
+    if [ "${#normalized}" -eq 19 ] && [[ "$normalized" > "$max_int64" ]]; then
+        return 1
+    fi
+}
+
 function save_backup_status() {
     local res start_time_str checkpoint_time_str start_time checkpoint_time total_size
 
@@ -42,8 +67,16 @@ function save_backup_status() {
         echo "ERROR: invalid log backup checkpoint time: $checkpoint_time_str" >&2
         return 1
     fi
+    if [ "$start_time" \> "$checkpoint_time" ]; then
+        echo "ERROR: log backup start time is later than checkpoint" >&2
+        return 1
+    fi
     if ! total_size=$(get_backup_total_size) || [ -z "$total_size" ]; then
         echo "ERROR: failed to read log backup size" >&2
+        return 1
+    fi
+    if ! is_non_negative_int64 "$total_size"; then
+        echo "ERROR: log backup size must be a non-negative decimal integer within int64 range" >&2
         return 1
     fi
 
@@ -52,8 +85,8 @@ function save_backup_status() {
 }
 
 function save_backup_status_with_retry() {
-    local attempts="${PITR_STATUS_RETRY_ATTEMPTS:-3}"
-    local interval="${PITR_STATUS_RETRY_INTERVAL_SECONDS:-2}"
+    local attempts="${PITR_STATUS_RETRY_ATTEMPTS-3}"
+    local interval="${PITR_STATUS_RETRY_INTERVAL_SECONDS-2}"
     local attempt=1
 
     case "$attempts" in

--- a/addons/tidb/scripts-ut-spec/backup_pitr_spec.sh
+++ b/addons/tidb/scripts-ut-spec/backup_pitr_spec.sh
@@ -20,6 +20,7 @@ Describe "TiDB continuous backup PITR monitor"
 
     STATUS_MODE="success"
     START_RC=0
+    TOTAL_SIZE="128"
     TEST_LEDGER="${SHELLSPEC_TMPBASE}/backup-pitr-ledger-${SHELLSPEC_SPECFILE_ID}"
     TEST_STATUS_COUNT="${TEST_LEDGER}.status-count"
     : > "${TEST_LEDGER}"
@@ -39,10 +40,40 @@ Describe "TiDB continuous backup PITR monitor"
             echo "[PD:client:ErrClientGetTSO] get TSO failed, tso client is nil" >&2
             return 1
           fi
-          if [ "${STATUS_MODE}" = "malformed" ]; then
-            echo "start: 2026-07-23 00:00:00 +0000"
-            return 0
-          fi
+          case "${STATUS_MODE}" in
+            malformed)
+              echo "start: 2026-07-23 00:00:00 +0000"
+              return 0
+              ;;
+            invalid-start)
+              cat <<'STATUS'
+    start: not-a-time
+    checkpoint[global]: 2026-07-23 00:05:00 +0000; gap=1m
+STATUS
+              return 0
+              ;;
+            invalid-checkpoint)
+              cat <<'STATUS'
+    start: 2026-07-23 00:00:00 +0000
+    checkpoint[global]: not-a-time; gap=1m
+STATUS
+              return 0
+              ;;
+            inverted-range)
+              cat <<'STATUS'
+    start: 2026-07-23 00:05:00 +0000
+    checkpoint[global]: 2026-07-23 00:00:00 +0000; gap=1m
+STATUS
+              return 0
+              ;;
+            fractional)
+              cat <<'STATUS'
+    start: 2026-07-23 00:00:00.123456789 +0000
+    checkpoint[global]: 2026-07-23 00:05:00.987654321 +0000; gap=1m
+STATUS
+              return 0
+              ;;
+          esac
           cat <<'STATUS'
               start: 2026-07-23 00:00:00 +0000
     checkpoint[global]: 2026-07-23 00:05:00 +0000; gap=1m
@@ -61,12 +92,14 @@ STATUS
       case "$1" in
         "2026-07-23 00:00:00 +0000") echo "2026-07-23T00:00:00Z" ;;
         "2026-07-23 00:05:00 +0000") echo "2026-07-23T00:05:00Z" ;;
+        "2026-07-23 00:00:00.123456789 +0000") echo "2026-07-23T00:00:00Z" ;;
+        "2026-07-23 00:05:00.987654321 +0000") echo "2026-07-23T00:05:00Z" ;;
         *) return 1 ;;
       esac
     }
 
     get_backup_total_size() {
-      echo "128"
+      echo "${TOTAL_SIZE}"
     }
 
     DP_save_backup_status_info() {
@@ -194,6 +227,52 @@ STATUS
     The stderr should include "must be a positive integer"
   End
 
+  run_empty_retry_config_case() {
+    local field="$1"
+    if [ "${field}" = "attempts" ]; then
+      PITR_STATUS_RETRY_ATTEMPTS=""
+    else
+      PITR_STATUS_RETRY_INTERVAL_SECONDS=""
+    fi
+    ensure_log_backup_started
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "start_calls=$(ledger_count '^br log start')"
+    return "${rc}"
+  }
+
+  It "rejects an explicitly empty retry-attempt count before probing or starting"
+    When call run_empty_retry_config_case attempts
+    The status should equal 2
+    The stdout should include "status_calls=0"
+    The stdout should include "start_calls=0"
+    The stderr should include "must be a positive integer"
+  End
+
+  It "rejects an explicitly empty retry interval before probing or starting"
+    When call run_empty_retry_config_case interval
+    The status should equal 2
+    The stdout should include "status_calls=0"
+    The stdout should include "start_calls=0"
+    The stderr should include "must be a non-negative integer"
+  End
+
+  run_unset_retry_config_case() {
+    unset PITR_STATUS_RETRY_ATTEMPTS PITR_STATUS_RETRY_INTERVAL_SECONDS
+    ensure_log_backup_started
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "start_calls=$(ledger_count '^br log start')"
+    return "${rc}"
+  }
+
+  It "uses bounded defaults only when retry configuration is absent"
+    When call run_unset_retry_config_case
+    The status should be success
+    The stdout should include "status_calls=1"
+    The stdout should include "start_calls=0"
+  End
+
   run_malformed_status_case() {
     STATUS_MODE="malformed"
     save_backup_status
@@ -207,6 +286,75 @@ STATUS
     The status should be failure
     The stdout should include "save_calls=0"
     The stderr should include "missing start or global checkpoint"
+  End
+
+  run_status_validation_case() {
+    STATUS_MODE="$1"
+    TOTAL_SIZE="${2:-128}"
+    save_backup_status
+    local rc=$?
+    echo "save_calls=$(ledger_count '^save ')"
+    return "${rc}"
+  }
+
+  It "rejects a non-empty invalid start time before writing status"
+    When call run_status_validation_case invalid-start
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "invalid log backup start time"
+  End
+
+  It "rejects a non-empty invalid checkpoint time before writing status"
+    When call run_status_validation_case invalid-checkpoint
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "invalid log backup checkpoint time"
+  End
+
+  It "rejects a start time later than the checkpoint before writing status"
+    When call run_status_validation_case inverted-range
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "later than checkpoint"
+  End
+
+  It "rejects a non-decimal backup size before writing status"
+    When call run_status_validation_case success NaN
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "non-negative decimal integer"
+  End
+
+  It "rejects a negative backup size before writing status"
+    When call run_status_validation_case success -1
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "non-negative decimal integer"
+  End
+
+  It "rejects a backup size above the non-negative int64 range before writing status"
+    When call run_status_validation_case success 9223372036854775808
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "within int64 range"
+  End
+
+  It "accepts a zero backup size"
+    When call run_status_validation_case success 0
+    The status should be success
+    The stdout should include "save_calls=1"
+  End
+
+  It "accepts the maximum non-negative int64 backup size"
+    When call run_status_validation_case success 9223372036854775807
+    The status should be success
+    The stdout should include "save_calls=1"
+  End
+
+  It "accepts the fractional timestamp shape emitted by BR v8.4"
+    When call run_status_validation_case fractional
+    The status should be success
+    The stdout should include "save_calls=1"
   End
 
   run_abnormal_exit_case() {

--- a/addons/tidb/scripts-ut-spec/backup_pitr_spec.sh
+++ b/addons/tidb/scripts-ut-spec/backup_pitr_spec.sh
@@ -1,0 +1,279 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317,SC2329
+
+Describe "TiDB continuous backup PITR monitor"
+  __SOURCED__=1
+  Include "${PITR_SCRIPT_PATH:-../dataprotection/backup-pitr.sh}"
+  unset __SOURCED__
+
+  setup() {
+    export PITR_STATUS_RETRY_ATTEMPTS=3
+    export PITR_STATUS_RETRY_INTERVAL_SECONDS=0
+    export PD_ADDRESS="tidb-pd.default.svc:2379"
+    export EXTRA_ARGS=""
+    export BR_EXTRA_ARGS=""
+    export BUCKET="bucket"
+    export DP_BACKUP_BASE_PATH="/continuous"
+    export ACCESS_KEY_ID="access"
+    export SECRET_ACCESS_KEY="secret"
+    export ENDPOINT="http://minio:9000"
+
+    STATUS_MODE="success"
+    START_RC=0
+    TEST_LEDGER="${SHELLSPEC_TMPBASE}/backup-pitr-ledger-${SHELLSPEC_SPECFILE_ID}"
+    TEST_STATUS_COUNT="${TEST_LEDGER}.status-count"
+    : > "${TEST_LEDGER}"
+    printf '0\n' > "${TEST_STATUS_COUNT}"
+
+    run_br() {
+      printf 'br %s\n' "$*" >> "${TEST_LEDGER}"
+      case "$1 $2" in
+        "log status")
+          local count
+          count=$(cat "${TEST_STATUS_COUNT}")
+          count=$((count + 1))
+          printf '%s\n' "${count}" > "${TEST_STATUS_COUNT}"
+          if [ "${STATUS_MODE}" = "always-fail" ] ||
+             { [ "${STATUS_MODE}" = "transient" ] && [ "${count}" -eq 1 ]; } ||
+             { [ "${STATUS_MODE}" = "attach-then-fail" ] && [ "${count}" -gt 1 ]; }; then
+            echo "[PD:client:ErrClientGetTSO] get TSO failed, tso client is nil" >&2
+            return 1
+          fi
+          if [ "${STATUS_MODE}" = "malformed" ]; then
+            echo "start: 2026-07-23 00:00:00 +0000"
+            return 0
+          fi
+          cat <<'STATUS'
+              start: 2026-07-23 00:00:00 +0000
+    checkpoint[global]: 2026-07-23 00:05:00 +0000; gap=1m
+STATUS
+          ;;
+        "log start")
+          return "${START_RC}"
+          ;;
+        "log stop")
+          return 0
+          ;;
+      esac
+    }
+
+    normalize_utc_time() {
+      case "$1" in
+        "2026-07-23 00:00:00 +0000") echo "2026-07-23T00:00:00Z" ;;
+        "2026-07-23 00:05:00 +0000") echo "2026-07-23T00:05:00Z" ;;
+        *) return 1 ;;
+      esac
+    }
+
+    get_backup_total_size() {
+      echo "128"
+    }
+
+    DP_save_backup_status_info() {
+      printf 'save %s\n' "$*" >> "${TEST_LEDGER}"
+    }
+
+    sleep() {
+      printf 'sleep %s\n' "$*" >> "${TEST_LEDGER}"
+    }
+
+    setStorageVar() {
+      :
+    }
+  }
+
+  BeforeEach 'setup'
+
+  ledger_count() {
+    local pattern="$1"
+    grep -c "${pattern}" "${TEST_LEDGER}" 2>/dev/null || true
+  }
+
+  run_transient_status_case() {
+    STATUS_MODE="transient"
+    save_backup_status_with_retry
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "save_calls=$(ledger_count '^save ')"
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "retries one transient status failure without stopping the log task"
+    When call run_transient_status_case
+    The status should be success
+    The stdout should include "status_calls=2"
+    The stdout should include "save_calls=1"
+    The stdout should include "stop_calls=0"
+    The stderr should include "status attempt 1/3 failed"
+  End
+
+  run_exhausted_status_case() {
+    STATUS_MODE="always-fail"
+    save_backup_status_with_retry
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "save_calls=$(ledger_count '^save ')"
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "fails after a bounded number of status attempts without stopping the log task"
+    When call run_exhausted_status_case
+    The status should be failure
+    The stdout should include "status_calls=3"
+    The stdout should include "save_calls=0"
+    The stdout should include "stop_calls=0"
+    The stderr should include "status failed after 3 attempts"
+  End
+
+  run_attach_case() {
+    ensure_log_backup_started
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "start_calls=$(ledger_count '^br log start')"
+    return "${rc}"
+  }
+
+  It "attaches to an existing log task without starting a replacement"
+    When call run_attach_case
+    The status should be success
+    The stdout should include "status_calls=1"
+    The stdout should include "start_calls=0"
+  End
+
+  run_start_case() {
+    STATUS_MODE="always-fail"
+    ensure_log_backup_started
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "start_calls=$(ledger_count '^br log start')"
+    return "${rc}"
+  }
+
+  It "starts a task only after bounded status checks find no usable task"
+    When call run_start_case
+    The status should be success
+    The stdout should include "status_calls=3"
+    The stdout should include "start_calls=1"
+    The stderr should include "status failed after 3 attempts"
+  End
+
+  run_start_failure_case() {
+    STATUS_MODE="always-fail"
+    START_RC=1
+    ensure_log_backup_started
+    local rc=$?
+    echo "start_calls=$(ledger_count '^br log start')"
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "fails closed when neither attach nor start succeeds"
+    When call run_start_failure_case
+    The status should be failure
+    The stdout should include "start_calls=1"
+    The stdout should include "stop_calls=0"
+    The stderr should include "failed to start TiDB log backup task"
+  End
+
+  run_invalid_retry_config_case() {
+    PITR_STATUS_RETRY_ATTEMPTS="invalid"
+    ensure_log_backup_started
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "start_calls=$(ledger_count '^br log start')"
+    return "${rc}"
+  }
+
+  It "does not start a task when retry configuration is invalid"
+    When call run_invalid_retry_config_case
+    The status should equal 2
+    The stdout should include "status_calls=0"
+    The stdout should include "start_calls=0"
+    The stderr should include "must be a positive integer"
+  End
+
+  run_malformed_status_case() {
+    STATUS_MODE="malformed"
+    save_backup_status
+    local rc=$?
+    echo "save_calls=$(ledger_count '^save ')"
+    return "${rc}"
+  }
+
+  It "rejects malformed status instead of overwriting the recoverable range"
+    When call run_malformed_status_case
+    The status should be failure
+    The stdout should include "save_calls=0"
+    The stderr should include "missing start or global checkpoint"
+  End
+
+  run_abnormal_exit_case() {
+    finish_log_backup 17 false
+    local rc=$?
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "preserves the log task on abnormal monitor exit"
+    When call run_abnormal_exit_case
+    The status should equal 17
+    The stdout should include "stop_calls=0"
+    The stderr should include "preserving the log backup task"
+  End
+
+  run_explicit_termination_case() {
+    finish_log_backup 0 true
+    local rc=$?
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "stops the log task on explicit monitor termination"
+    When call run_explicit_termination_case
+    The status should be success
+    The stdout should include "stop_calls=1"
+  End
+
+  run_main_failure_case() {
+    STATUS_MODE="attach-then-fail"
+    PITR_STATUS_RETRY_ATTEMPTS=2
+    (
+      PITR_TERMINATION_REQUESTED=false
+      trap handle_exit EXIT
+      main
+    )
+    local rc=$?
+    echo "status_calls=$(ledger_count '^br log status')"
+    echo "start_calls=$(ledger_count '^br log start')"
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "preserves the task when the real monitor loop exhausts status retries"
+    When call run_main_failure_case
+    The status should be failure
+    The stdout should include "status_calls=3"
+    The stdout should include "start_calls=0"
+    The stdout should include "stop_calls=0"
+    The stderr should include "preserving the log backup task"
+  End
+
+  run_termination_trap_case() {
+    (
+      PITR_TERMINATION_REQUESTED=false
+      trap handle_exit EXIT
+      handle_termination
+    )
+    local rc=$?
+    echo "stop_calls=$(ledger_count '^br log stop')"
+    return "${rc}"
+  }
+
+  It "routes explicit termination through the stop path"
+    When call run_termination_trap_case
+    The status should be success
+    The stdout should include "stop_calls=1"
+  End
+End


### PR DESCRIPTION
## Summary

- retry transient `br log status` failures and attach to an existing PITR task before attempting `br log start`
- preserve the BR log task on abnormal monitor exit while retaining the explicit TERM/INT stop path
- fail closed before publishing malformed, inverted, or invalid-size continuous-backup status

## Evidence

A live exact-stack run observed one TSO status failure terminate the monitor. The old EXIT trap then stopped the BR log task; restart created a new task whose time range began after the requested restore time, and restore failed out of range. This change is limited to the addon monitor lifecycle and status-writing contract.

## Verification

- TDD receipt: initial focused spec 7/7 RED on base plus source guard/main split
- Bash 3.2 focused: 23/0; all TiDB shell specs: 33/0
- Bash 5.3 focused: 23/0; all TiDB shell specs: 33/0
- mutation gates: empty-default 2F, normalize fail-open 2F, range-delete 1F, size-delete 3F on both Bash versions
- `bash -n`, ShellCheck error-level, `git diff --check`
- Helm lint/template and rendered ActionSet command `bash -n`
- independent exact-byte focused review: BLOCK0

## Boundary

This PR has local source/spec/static and target-image compatibility evidence. Fresh packaged runtime validation remains separate; this PR does not claim PITR runtime PASS or address the independent KubeBlocks restore-status invariant.
