### PR TITLE
fix(mongodb): correct snapshot ActionSet ownership label

### DIFF
--- a/addons/mongodb/scripts-ut-spec/actionset_ownership_label_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/actionset_ownership_label_spec.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+
+Describe "MongoDB ActionSet ownership labels"
+
+  render_and_validate_actionset_ownership_labels() {
+    local chart_dir rendered
+
+    chart_dir=${MONGODB_CHART_DIR:-$(cd .. && pwd)}
+    helm dependency build "$chart_dir" >/dev/null || return
+    rendered=$(helm template kb-addon-mongodb "$chart_dir") || return
+    # shellcheck disable=SC2016
+    printf '%s\n' "$rendered" | ruby -ryaml -e '
+      action_sets = YAML.load_stream($stdin.read).compact.select do |document|
+        document["kind"] == "ActionSet"
+      end
+
+      expected_names = %w[
+        mongodb-dump-br
+        mongodb-physical-br
+        mongodb-pitr
+        mongodb-rs-pbm-physical
+        mongodb-rs-pbm-pitr
+        mongodb-shard-pbm-logical
+        mongodb-shard-pbm-physical
+        mongodb-shard-pbm-pitr
+        mongodb-volume-snapshot
+      ]
+      actual_names = action_sets.map { |action_set| action_set.dig("metadata", "name") }.sort
+      abort "ActionSet inventory=#{actual_names.inspect}, expected #{expected_names.inspect}" unless actual_names == expected_names
+
+      action_sets.each do |action_set|
+        name = action_set.dig("metadata", "name")
+        owner = action_set.dig(
+          "metadata",
+          "labels",
+          "clusterdefinition.kubeblocks.io/name"
+        )
+        abort "#{name} ownership label=#{owner.inspect}, expected \"mongodb\"" unless owner == "mongodb"
+      end
+
+      puts "ActionSet ownership labels passed for #{action_sets.length} resources"
+    '
+  }
+
+  It "labels every rendered ActionSet as owned by MongoDB"
+    When call render_and_validate_actionset_ownership_labels
+    The status should be success
+    The output should include "ActionSet ownership labels passed for 9 resources"
+  End
+End

--- a/addons/mongodb/templates/actionset-datafile.yaml
+++ b/addons/mongodb/templates/actionset-datafile.yaml
@@ -41,7 +41,7 @@ kind: ActionSet
 metadata:
   name: mongodb-volume-snapshot
   labels:
-    clusterdefinition.kubeblocks.io/name: apecloud-mysql
+    clusterdefinition.kubeblocks.io/name: mongodb
 spec:
   backupType: Full
   env:


### PR DESCRIPTION
## What this PR does

- corrects `ActionSet/mongodb-volume-snapshot` ownership from `apecloud-mysql` to `mongodb`
- adds a render-level invariant for the literal nine MongoDB ActionSet names and their owner labels
- preserves Helm render failures before parsing, preventing a downstream false GREEN

Current BackupPolicyTemplates bind the ActionSet directly by name, so this PR is scoped to ownership/discovery metadata correctness and does not claim a historical runtime failure.

## Exact scope

- base/parent: `2b9256b411591f713b5f1937b76113cbb12ff7bb`
- head: `9f505fd27dc9567068f4ce2ade4e8a1c4f4f96fd`
- tree: `ae87b42b3952d180a82d0c53c5021f0cd77f607d`
- one commit, two files

## Verification

- parent/base RED: 1 example / 1 failure on `mongodb-volume-snapshot ownership label="apecloud-mysql"`
- focused GREEN Bash 3.2 and Bash 5.3: 1 example / 0 failures each
- all MongoDB ShellSpec Bash 3.2: 19 examples / 0 failures
- Helm valid-render + rc42 mutant: ordinary RED preserving status 42
- same-cardinality ActionSet rename mutant: ordinary inventory RED
- another ActionSet wrong-owner mutant: ordinary owner RED
- `helm lint addons/mongodb`: 1 chart / 0 failures
- ShellCheck and `git diff --check`: pass

Magnus fact-first design review: APPROVE / blocker list 0 on this exact head. The approval is source/TDD/static only; no runtime, merge, or release claim.

Closes #3253