### PR TITLE
fix(mongodb): declare snapshot target volume

### DIFF
--- a/addons/mongodb/scripts-ut-spec/backup_snapshot_volume_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/backup_snapshot_volume_spec.sh
@@ -1,0 +1,106 @@
+# shellcheck shell=bash
+
+Describe "MongoDB backup snapshot volume contract"
+
+  render_and_validate_snapshot_volumes() {
+    local chart_dir render_dir status
+
+    chart_dir=${MONGODB_CHART_DIR:-$(cd .. && pwd)}
+    render_dir=$(mktemp -d)
+
+    helm dependency build "$chart_dir" >/dev/null || return
+    # shellcheck disable=SC2016
+    helm template kb-addon-mongodb "$chart_dir" \
+      --set cmpdVersionPrefix=static-cmpd > "$render_dir/cmpd-prefix.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" \
+        --set resourceNamePrefix=static-resource \
+        --set cmpdVersionPrefix=static-cmpd > "$render_dir/both-prefixes.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" > "$render_dir/default.yaml" &&
+      helm template kb-addon-mongodb "$chart_dir" \
+        --set resourceNamePrefix=static-resource > "$render_dir/resource-prefix.yaml" &&
+      ruby -ryaml -e '
+      def compdef_match?(name, pattern)
+        return true if name.start_with?(pattern)
+        return false unless pattern.match?(/[\\.+*?()|\[\]{}^$]/)
+
+        Regexp.new(pattern).match?(name)
+      rescue RegexpError
+        false
+      end
+
+      total_snapshot_methods = 0
+      total_snapshot_volumes = 0
+      expected_snapshot_targets = {
+        "cmpd-prefix.yaml" => "static-cmpd-1.2.0-alpha.0/data",
+        "both-prefixes.yaml" => "static-cmpd-1.2.0-alpha.0/data",
+        "default.yaml" => "mongodb-1.2.0-alpha.0/data",
+        "resource-prefix.yaml" => "mongodb-1.2.0-alpha.0/data"
+      }
+
+      ARGV.each do |path|
+        expected_snapshot_target = expected_snapshot_targets.fetch(File.basename(path))
+        documents = YAML.load_stream(File.read(path)).compact
+        definitions = documents.select { |doc| doc["kind"] == "ComponentDefinition" }
+        policies = documents.select { |doc| doc["kind"] == "BackupPolicyTemplate" }
+        snapshot_methods = 0
+        snapshot_volumes = 0
+        snapshot_targets = []
+
+        policies.each do |policy|
+          patterns = Array(policy.dig("spec", "compDefs"))
+          matches = definitions.select do |definition|
+            name = definition.dig("metadata", "name")
+            patterns.any? { |pattern| compdef_match?(name, pattern) }
+          end
+          abort "#{path}: #{policy.dig("metadata", "name")} must resolve exactly one ComponentDefinition, got #{matches.length}" unless matches.length == 1
+
+          declared = Array(matches.first.dig("spec", "volumes")).to_h do |volume|
+            [volume.fetch("name"), volume["needSnapshot"] == true]
+          end
+
+          Array(policy.dig("spec", "backupMethods")).each do |method|
+            next unless method["snapshotVolumes"] == true
+
+            snapshot_methods += 1
+            names = Array(method.dig("targetVolumes", "volumes"))
+            abort "#{path}: #{method["name"]} snapshot method has no target volume" if names.empty?
+            names.each do |name|
+              snapshot_volumes += 1
+              abort "#{path}: #{method["name"]} target volume #{name.inspect} is not declared needSnapshot=true in #{matches.first.dig("metadata", "name")}" unless declared[name]
+              snapshot_targets << "#{matches.first.dig("metadata", "name")}/#{name}"
+            end
+          end
+        end
+
+        snapshot_declarations = definitions.flat_map do |definition|
+          Array(definition.dig("spec", "volumes")).each_with_object([]) do |volume, declarations|
+            if volume["needSnapshot"] == true
+              declarations << "#{definition.dig("metadata", "name")}/#{volume.fetch("name")}"
+            end
+          end
+        end
+
+        abort "#{path}: expected one snapshot method, got #{snapshot_methods}" unless snapshot_methods == 1
+        abort "#{path}: expected one snapshot target volume, got #{snapshot_volumes}" unless snapshot_volumes == 1
+        abort "#{path}: snapshot target/declaration mismatch targets=#{snapshot_targets.sort.inspect} declarations=#{snapshot_declarations.sort.inspect}" unless snapshot_targets.sort == snapshot_declarations.sort
+        abort "#{path}: expected snapshot target/declaration #{expected_snapshot_target.inspect}, got targets=#{snapshot_targets.sort.inspect} declarations=#{snapshot_declarations.sort.inspect}" unless snapshot_targets.sort == [expected_snapshot_target] && snapshot_declarations.sort == [expected_snapshot_target]
+
+        total_snapshot_methods += snapshot_methods
+        total_snapshot_volumes += snapshot_volumes
+      end
+
+      puts "snapshot volume contract passed for #{ARGV.length} renders, #{total_snapshot_methods} methods and #{total_snapshot_volumes} target volumes"
+    ' "$render_dir/cmpd-prefix.yaml" "$render_dir/both-prefixes.yaml" \
+      "$render_dir/default.yaml" "$render_dir/resource-prefix.yaml"
+    status=$?
+
+    rm -rf "$render_dir"
+    return "$status"
+  }
+
+  It "declares every CSI snapshot target volume in the matching ComponentDefinition"
+    When call render_and_validate_snapshot_volumes
+    The status should be success
+    The output should include "snapshot volume contract passed for 4 renders, 4 methods and 4 target volumes"
+  End
+End

--- a/addons/mongodb/templates/_helpers.tpl
+++ b/addons/mongodb/templates/_helpers.tpl
@@ -120,7 +120,11 @@ kubeblocks.io/crd-api-version: apps.kubeblocks.io/v1
 Define mongodb component definition name prefix
 */}}
 {{- define "mongodb.componentDefNamePrefix" -}}
-{{- printf "mongodb-" -}}
+{{- if eq (len .Values.cmpdVersionPrefix) 0 -}}
+mongodb-
+{{- else -}}
+{{ .Values.cmpdVersionPrefix }}-
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/addons/mongodb/templates/backuppolicytemplate.yaml
+++ b/addons/mongodb/templates/backuppolicytemplate.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "mongodb.labels" . | nindent 4 }}
 spec:
   serviceKind: MongoDB
-  compDefs: [mongodb]
+  compDefs: [{{ include "mongodb.componentDefNamePrefix" . }}]
   target:
     role: secondary
     fallbackRole: primary

--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -10,6 +10,9 @@ spec:
   provider: kubeblocks.io
   description: MongoDB is a document database designed for ease of application development and scaling.
   serviceKind: mongodb
+  volumes:
+    - name: data
+      needSnapshot: true
   services:
     - name: default
       serviceName: mongodb


### PR DESCRIPTION
## What problem does this solve?

MongoDB's replica BackupPolicyTemplate has the chart's only CSI
`snapshotVolumes: true` method and targets volume `data`, but the matching
ComponentDefinition did not declare `data.needSnapshot: true`.

The supported `cmpdVersionPrefix` value also changed the replica
ComponentDefinition name without changing the BPT match pattern. That render
resolved zero ComponentDefinitions under KubeBlocks' prefix-or-regex matching
rules.

This is a source/render contract fix. It does not claim a captured runtime
failure.

## What is changed?

- Make the replica ComponentDefinition prefix helper follow the effective
  `cmpdVersionPrefix`, preserving `mongodb-` as the default.
- Render the replica BPT `compDefs` from that helper.
- Declare replica volume `data` with `needSnapshot: true`.
- Add a structural ShellSpec invariant across default, resource-prefix,
  cmpd-prefix, and combined-prefix renders.

For each render independently, the test requires exactly one snapshot method
and target, each BPT to resolve exactly one ComponentDefinition, and exact
equality between all resolved CSI snapshot targets and all rendered
`needSnapshot: true` declarations. This proves both that every target is
declared and that shard/config-server/mongos do not gain unrelated snapshot
declarations. It additionally requires both sets to equal an independent
per-render replica `/data` identity instead of deriving product scope from the
candidate BPT.

## Evidence

Current `main` with the final test:

```text
cmpd-prefix.yaml: mongodb-backup-policy-template must resolve exactly one ComponentDefinition, got 0
```

Prefix-only intermediate:

```text
volume-snapshot target volume "data" is not declared needSnapshot=true
```

Review-induced mutants:

- method distribution `0/2/1/1` across the four renders: RED per render in
  Bash 3.2 and Bash 5.3
- unrelated shard `data.needSnapshot: true`: RED exact
  target/declaration mismatch in both shells
- coordinated migration of the BPT selector and snapshot declaration from
  replica to shard: RED independent expected-identity check in both shells

Candidate:

- exact head: `051f229d7e639bf342b6b2604003aba46d88af9e`
- parent: `2b9256b411591f713b5f1937b76113cbb12ff7bb`
- focused ShellSpec: Bash 3.2 `1/0`, Bash 5.3 `1/0`
- all MongoDB ShellSpec on Bash 3.2: `19/0`
- relevant Bash 5.3 specs: `5/0`
- Helm lint: `1/0`
- ShellCheck and diff-check: clean

The all-MongoDB Bash 5.3 suite still reports a pre-existing endpoint-regex
warning with zero failed examples. It is tracked separately and is outside
this PR.

## Boundary

Runtime validation, packaging, release readiness, and merge are separate.

Closes #3256
