### PR TITLE
fix(mongodb): make endpoint region parsing bash portable

### DIFF
--- a/addons/mongodb/dataprotection/common-scripts.sh
+++ b/addons/mongodb/dataprotection/common-scripts.sh
@@ -92,6 +92,9 @@ function set_backup_config_env() {
   local endpoint=""
   local bucket=""
   local force_path_style=""
+  local host=""
+  local regex=""
+  local region_label='[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?'
 
   IFS=$'\n'
   for line in $(cat ${toolConfig}); do
@@ -117,19 +120,50 @@ function set_backup_config_env() {
     endpoint="https://${endpoint}"
   fi
 
-  if [[ "$provider" == "Alibaba" ]]; then
-    regex='https?:\/\/oss-(.*?)\.aliyuncs\.com'
+  if [[ "$provider" == "Alibaba" || "$provider" == "TencentCOS" ]]; then
+    regex='^https?://([^/:?#]+)$'
     if [[ "$endpoint" =~ $regex ]]; then
-      region="${BASH_REMATCH[1]}"
-      DP_log "Extract region from $endpoint-> $region"
-    else
-      DP_log "Failed to extract region from endpoint: $endpoint"
-    fi
-  elif [[ "$provider" == "TencentCOS" ]]; then
-    regex='https?:\/\/cos\.(.*?)\.myqcloud\.com'
-    if [[ "$endpoint" =~ $regex ]]; then
-      region="${BASH_REMATCH[1]}"
-      DP_log "Extract region from $endpoint-> $region"
+      host="${BASH_REMATCH[1]}"
+      if [[ "$provider" == "Alibaba" ]]; then
+        if [[ "$host" == *finance* ||
+          "$host" == "oss-cn-hzjbp-a-internal.aliyuncs.com" ||
+          "$host" == "oss-cn-hzjbp-b-internal.aliyuncs.com" ||
+          "$host" == "oss-accelerate.aliyuncs.com" ||
+          "$host" == "oss-accelerate-overseas.aliyuncs.com" ]]; then
+          DP_log "Keep configured region for endpoint: $endpoint"
+        else
+          regex="^oss-(${region_label})-internal\\.aliyuncs\\.com$"
+          if [[ "$host" =~ $regex ]]; then
+            region="${BASH_REMATCH[1]}"
+            DP_log "Extract region from $endpoint-> $region"
+          else
+            regex="^oss-(${region_label})\\.aliyuncs\\.com$"
+            if [[ "$host" =~ $regex ]]; then
+              region="${BASH_REMATCH[1]}"
+              DP_log "Extract region from $endpoint-> $region"
+            else
+              regex="^(${region_label})\\.oss\\.aliyuncs\\.com$"
+              if [[ "$host" =~ $regex ]]; then
+                region="${BASH_REMATCH[1]}"
+                DP_log "Extract region from $endpoint-> $region"
+              else
+                DP_log "Failed to extract region from endpoint: $endpoint"
+              fi
+            fi
+          fi
+        fi
+      elif [[ "$host" == "cos.accelerate.myqcloud.com" ||
+        "$host" == "cos-internal.accelerate.tencentcos.cn" ]]; then
+        DP_log "Keep configured region for endpoint: $endpoint"
+      else
+        regex="^cos\\.(${region_label})\\.myqcloud\\.com$"
+        if [[ "$host" =~ $regex ]]; then
+          region="${BASH_REMATCH[1]}"
+          DP_log "Extract region from $endpoint-> $region"
+        else
+          DP_log "Failed to extract region from endpoint: $endpoint"
+        fi
+      fi
     else
       DP_log "Failed to extract region from endpoint: $endpoint"
     fi

--- a/addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh
@@ -32,6 +32,8 @@ Describe "MongoDB dataprotection common scripts"
     source ../dataprotection/common-scripts.sh
     set_backup_config_env >/dev/null
     echo "force_path_style=${S3_FORCE_PATH_STYLE:-}"
+    echo "region=${S3_REGION:-}"
+    echo "endpoint=${S3_ENDPOINT:-}"
   }
 
   write_datasafed_config() {
@@ -40,8 +42,8 @@ type = s3
 provider = $1
 access_key_id = access-key
 secret_access_key = secret-key
-region = us-east-1
-endpoint = http://minio.example.com
+region = ${4:-initial-region}
+endpoint = ${3:-http://minio.example.com}
 root = mongodb-bucket
 $2
 EOF
@@ -57,11 +59,468 @@ EOF
   End
 
   It "uses explicit force_path_style=true from datasafed config"
-    write_datasafed_config "Alibaba" "force_path_style = true"
+    write_datasafed_config "Alibaba" "force_path_style = true" \
+      "https://oss-cn-hangzhou.aliyuncs.com"
 
     When call run_set_backup_config_env
 
     The output should include "force_path_style=true"
+    The output should include "region=cn-hangzhou"
+    The output should include "endpoint=https://oss-cn-hangzhou.aliyuncs.com"
+    The status should be success
+  End
+
+  It "extracts the region from an Alibaba HTTP endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "http://oss-cn-hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou"
+    The output should include "endpoint=http://oss-cn-hangzhou.aliyuncs.com"
+    The status should be success
+  End
+
+  It "normalizes an Alibaba endpoint without a scheme to HTTPS"
+    write_datasafed_config "Alibaba" "" \
+      "oss-cn-hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou"
+    The output should include "endpoint=https://oss-cn-hangzhou.aliyuncs.com"
+    The status should be success
+  End
+
+  It "extracts an official digit-bearing Alibaba region"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-ap-southeast-1.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=ap-southeast-1"
+    The status should be success
+  End
+
+  It "accepts a one-character Alibaba region label"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-a.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=a"
+    The status should be success
+  End
+
+  It "accepts a 63-character Alibaba region label"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    The status should be success
+  End
+
+  It "extracts the region from an Alibaba internal endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hangzhou-internal.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou"
+    The status should be success
+  End
+
+  It "extracts the region from an Alibaba HTTP internal endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "http://oss-cn-hangzhou-internal.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou"
+    The status should be success
+  End
+
+  It "extracts the region from an Alibaba dual-stack endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "https://cn-hangzhou.oss.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou"
+    The status should be success
+  End
+
+  It "extracts the region from an Alibaba HTTP dual-stack endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "http://cn-hangzhou.oss.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba acceleration endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-accelerate.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba HTTP acceleration endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "http://oss-accelerate.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba overseas acceleration endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-accelerate-overseas.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba HTTP overseas acceleration endpoint"
+    write_datasafed_config "Alibaba" "" \
+      "http://oss-accelerate-overseas.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "preserves the canonical region for an Alibaba Finance Cloud public alias"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hzfinance.aliyuncs.com" \
+      "cn-hangzhou-finance"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou-finance"
+    The output should include "endpoint=https://oss-cn-hzfinance.aliyuncs.com"
+    The status should be success
+  End
+
+  It "preserves the canonical region for an Alibaba Finance Cloud internal alias"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-shanghai-finance-1-pub-internal.aliyuncs.com" \
+      "cn-shanghai-finance-1"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-shanghai-finance-1"
+    The output should include "endpoint=https://oss-cn-shanghai-finance-1-pub-internal.aliyuncs.com"
+    The status should be success
+  End
+
+  It "preserves the canonical region for an Alibaba Finance Cloud dual-stack alias"
+    write_datasafed_config "Alibaba" "" \
+      "https://cn-shanghai-finance.oss.aliyuncs.com" \
+      "cn-shanghai-finance-1"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-shanghai-finance-1"
+    The output should include "endpoint=https://cn-shanghai-finance.oss.aliyuncs.com"
+    The status should be success
+  End
+
+  It "preserves the canonical region for an Alibaba Finance Cloud hzjbp internal alias"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hzjbp-a-internal.aliyuncs.com" \
+      "cn-hangzhou-finance"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou-finance"
+    The output should include "endpoint=https://oss-cn-hzjbp-a-internal.aliyuncs.com"
+    The status should be success
+  End
+
+  It "preserves the canonical region for the second Alibaba Finance Cloud hzjbp internal alias"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hzjbp-b-internal.aliyuncs.com" \
+      "cn-hangzhou-finance"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=cn-hangzhou-finance"
+    The output should include "endpoint=https://oss-cn-hzjbp-b-internal.aliyuncs.com"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with a path-like host"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn/hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with a path suffix"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hangzhou.aliyuncs.com/path"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with suffix pollution"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hangzhou.aliyuncs.com.evil"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region when a supported Alibaba URL is embedded in a prefix"
+    write_datasafed_config "Alibaba" "" \
+      "https://prefix.example/https://oss-cn-hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba public endpoint with host-prefix pollution"
+    write_datasafed_config "Alibaba" "" \
+      "https://evil.oss-cn-hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba internal endpoint with host-prefix pollution"
+    write_datasafed_config "Alibaba" "" \
+      "https://evil.oss-cn-hangzhou-internal.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba internal endpoint with suffix pollution"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hangzhou-internal.aliyuncs.com.evil"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba dual-stack endpoint with host-prefix pollution"
+    write_datasafed_config "Alibaba" "" \
+      "https://evil.cn-hangzhou.oss.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba dual-stack endpoint with suffix pollution"
+    write_datasafed_config "Alibaba" "" \
+      "https://cn-hangzhou.oss.aliyuncs.com.evil"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with an empty region"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with an invalid DNS label"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss--cn-hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with a trailing-hyphen label"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-cn-hangzhou-.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with an uppercase label"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-CN-hangzhou.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for an Alibaba endpoint with an overlong region label"
+    write_datasafed_config "Alibaba" "" \
+      "https://oss-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aliyuncs.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "extracts the region from a Tencent COS endpoint"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos.ap-shanghai.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=ap-shanghai"
+    The output should include "endpoint=https://cos.ap-shanghai.myqcloud.com"
+    The status should be success
+  End
+
+  It "extracts the region from a Tencent HTTP COS endpoint"
+    write_datasafed_config "TencentCOS" "" \
+      "http://cos.ap-shanghai.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=ap-shanghai"
+    The output should include "endpoint=http://cos.ap-shanghai.myqcloud.com"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent global acceleration endpoint"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos.accelerate.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent HTTP global acceleration endpoint"
+    write_datasafed_config "TencentCOS" "" \
+      "http://cos.accelerate.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent private acceleration endpoint"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos-internal.accelerate.tencentcos.cn"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent HTTP private acceleration endpoint"
+    write_datasafed_config "TencentCOS" "" \
+      "http://cos-internal.accelerate.tencentcos.cn"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent endpoint with a path-like host"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos.ap/shanghai.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent endpoint with suffix pollution"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos.ap-shanghai.myqcloud.com.evil"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent endpoint with host-prefix pollution"
+    write_datasafed_config "TencentCOS" "" \
+      "https://evil.cos.ap-shanghai.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent endpoint with an empty region"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos..myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent endpoint with an invalid DNS label"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos.-ap-shanghai.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
+    The status should be success
+  End
+
+  It "keeps the configured region for a Tencent endpoint with an overlong region label"
+    write_datasafed_config "TencentCOS" "" \
+      "https://cos.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.myqcloud.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "region=initial-region"
     The status should be success
   End
 
@@ -71,6 +530,17 @@ EOF
     When call run_set_backup_config_env
 
     The output should include "force_path_style=true"
+    The status should be success
+  End
+
+  It "normalizes a Minio endpoint without a scheme before provider handling"
+    write_datasafed_config "Minio" "" \
+      "minio.example.com"
+
+    When call run_set_backup_config_env
+
+    The output should include "force_path_style=true"
+    The output should include "endpoint=https://minio.example.com"
     The status should be success
   End
 


### PR DESCRIPTION

### Problem

MongoDB dataprotection used non-POSIX `.*?` inside Bash `[[ =~ ]]` expressions
for Alibaba and Tencent endpoint parsing. Bash 3.2 fails the intended region
extractions; Bash 5.3 also emits `invalid regular expression`.

On the parent commit, the focused 49-example contract reports 12 failures in
both shells, plus 33 Bash 5.3 warnings. The failures are exactly the positive
region-extraction rows.

### Solution

- Gate Alibaba and Tencent endpoints as a whole HTTP/HTTPS URL and classify the
  extracted host.
- Use Bash-portable anchored EREs for Alibaba public, internal, and dual-stack
  hosts and Tencent default-domain hosts.
- Preserve configured regions for Finance Cloud and acceleration aliases.
- Validate extracted regions as 1-63 character lowercase DNS labels.
- Preserve the configured region for unsupported or malformed endpoints.
- Keep explicit endpoint exports unchanged and normalize only missing schemes
  to HTTPS.

### Verification

- Focused ShellSpec: Bash 3.2 `49/0`; Bash 5.3 `49/0`.
- Full MongoDB ShellSpec: Bash 3.2 `63/0`; Bash 5.3 standard directory
  discovery `63/0`.
- Cleared classifier oracle: `42/0` in both shells; 20 independent mutants are
  RED in both shells.
- Helm lint: `1 chart(s) linted, 0 failed`.
- Changed-file ShellCheck at CI error severity: PASS.
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: PASS.

### Boundary

This proves source/static parsing behavior only. It does not claim Kubernetes
runtime, real cloud endpoint access, backup/restore, package, deployment,
cleanup, release, or release readiness.

### Reviewer focus

- Whole-value URL gate and anchored provider host classifiers.
- Finance Cloud and acceleration preservation before region derivation.
- Endpoint export behavior and malformed-input fallback.


Closes #3258
