### PR TITLE
fix(mongodb): serialize sharding provisioning

### DIFF
--- a/addons/mongodb/scripts-ut-spec/clusterdefinition_provision_order_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/clusterdefinition_provision_order_spec.sh
@@ -23,8 +23,9 @@ Describe "MongoDB sharding topology provision order"
       abort "expected one MongoDB ClusterDefinition, got #{definitions.length}" unless definitions.length == 1
 
       topologies = definitions.first.dig("spec", "topologies") || []
-      sharding = topologies.find { |topology| topology["name"] == "sharding" }
-      abort "MongoDB sharding topology is missing" unless sharding
+      shardings = topologies.select { |topology| topology["name"] == "sharding" }
+      abort "expected one MongoDB sharding topology, got #{shardings.length}" unless shardings.length == 1
+      sharding = shardings.first
 
       component_names = (sharding["components"] || []).map { |component| component["name"] }
       sharding_names = (sharding["shardings"] || []).map { |entry| entry["name"] }
@@ -87,6 +88,52 @@ FAKE_HELM
     return "$test_status"
   }
 
+  verify_duplicate_sharding_topology_is_rejected() {
+    local fake_bin test_status
+
+    fake_bin=$(mktemp -d)
+    cat > "$fake_bin/helm" <<'FAKE_HELM'
+#!/bin/sh
+cat <<'YAML'
+apiVersion: apps.kubeblocks.io/v1
+kind: ClusterDefinition
+metadata:
+  name: mongodb
+spec:
+  topologies:
+    - name: sharding
+      components:
+        - name: mongos
+        - name: config-server
+      shardings:
+        - name: shard
+      orders:
+        provision:
+          - config-server
+          - mongos
+          - shard
+        terminate:
+          - shard
+          - mongos,config-server
+        update:
+          - mongos,config-server
+          - shard
+    - name: sharding
+      components:
+        - name: unexpected
+      orders:
+        provision:
+          - unexpected
+YAML
+FAKE_HELM
+    chmod +x "$fake_bin/helm"
+
+    PATH="$fake_bin:$PATH" verify_sharding_provision_order
+    test_status=$?
+    rm -rf "$fake_bin"
+    return "$test_status"
+  }
+
   It "provisions config server, mongos, then shards"
     When call verify_sharding_provision_order
     The status should be success
@@ -96,5 +143,11 @@ FAKE_HELM
     When call verify_renderer_failure_is_propagated
     The stderr should include "helm template failed with status 42"
     The status should equal 42
+  End
+
+  It "rejects duplicate sharding topologies"
+    When call verify_duplicate_sharding_topology_is_rejected
+    The stderr should include "expected one MongoDB sharding topology, got 2"
+    The status should be failure
   End
 End

--- a/addons/mongodb/scripts-ut-spec/clusterdefinition_provision_order_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/clusterdefinition_provision_order_spec.sh
@@ -1,0 +1,100 @@
+# shellcheck shell=bash
+
+Describe "MongoDB sharding topology provision order"
+
+  verify_sharding_provision_order() {
+    local chart_dir rendered render_rc
+
+    chart_dir=$(cd .. && pwd)
+    rendered=$(helm template kb-addon-mongodb "$chart_dir" --dependency-update)
+    render_rc=$?
+    if [ "$render_rc" -ne 0 ]; then
+      echo "helm template failed with status $render_rc" >&2
+      return "$render_rc"
+    fi
+
+    # shellcheck disable=SC2016
+    printf '%s\n' "$rendered" | ruby -ryaml -e '
+      documents = YAML.load_stream($stdin.read).compact
+      definitions = documents.select do |document|
+        document["kind"] == "ClusterDefinition" &&
+          document.dig("metadata", "name") == "mongodb"
+      end
+      abort "expected one MongoDB ClusterDefinition, got #{definitions.length}" unless definitions.length == 1
+
+      topologies = definitions.first.dig("spec", "topologies") || []
+      sharding = topologies.find { |topology| topology["name"] == "sharding" }
+      abort "MongoDB sharding topology is missing" unless sharding
+
+      component_names = (sharding["components"] || []).map { |component| component["name"] }
+      sharding_names = (sharding["shardings"] || []).map { |entry| entry["name"] }
+      expected_members = ["config-server", "mongos", "shard"]
+      actual_members = (component_names + sharding_names).sort
+      abort "unexpected sharding members: #{actual_members.inspect}" unless actual_members == expected_members.sort
+
+      expected_order = ["config-server", "mongos", "shard"]
+      actual_order = sharding.dig("orders", "provision")
+      abort "expected provision order #{expected_order.inspect}, got #{actual_order.inspect}" unless actual_order == expected_order
+
+      expected_terminate = ["shard", "mongos,config-server"]
+      actual_terminate = sharding.dig("orders", "terminate")
+      abort "expected terminate order #{expected_terminate.inspect}, got #{actual_terminate.inspect}" unless actual_terminate == expected_terminate
+
+      expected_update = ["mongos,config-server", "shard"]
+      actual_update = sharding.dig("orders", "update")
+      abort "expected update order #{expected_update.inspect}, got #{actual_update.inspect}" unless actual_update == expected_update
+    '
+  }
+
+  verify_renderer_failure_is_propagated() {
+    local fake_bin test_status
+
+    fake_bin=$(mktemp -d)
+    cat > "$fake_bin/helm" <<'FAKE_HELM'
+#!/bin/sh
+cat <<'YAML'
+apiVersion: apps.kubeblocks.io/v1
+kind: ClusterDefinition
+metadata:
+  name: mongodb
+spec:
+  topologies:
+    - name: sharding
+      components:
+        - name: mongos
+        - name: config-server
+      shardings:
+        - name: shard
+      orders:
+        provision:
+          - config-server
+          - mongos
+          - shard
+        terminate:
+          - shard
+          - mongos,config-server
+        update:
+          - mongos,config-server
+          - shard
+YAML
+exit 42
+FAKE_HELM
+    chmod +x "$fake_bin/helm"
+
+    PATH="$fake_bin:$PATH" verify_sharding_provision_order
+    test_status=$?
+    rm -rf "$fake_bin"
+    return "$test_status"
+  }
+
+  It "provisions config server, mongos, then shards"
+    When call verify_sharding_provision_order
+    The status should be success
+  End
+
+  It "propagates a renderer failure after valid output"
+    When call verify_renderer_failure_is_propagated
+    The stderr should include "helm template failed with status 42"
+    The status should equal 42
+  End
+End

--- a/addons/mongodb/templates/clusterdefinition.yaml
+++ b/addons/mongodb/templates/clusterdefinition.yaml
@@ -23,6 +23,10 @@ spec:
         - name: shard
           shardingDef: {{ include "mongodbShard.componentDefNamePrefix" . }}
       orders:
+        provision:
+          - config-server
+          - mongos
+          - shard
         terminate:
           - shard
           - mongos,config-server


### PR DESCRIPTION
## Problem

The MongoDB sharding topology declares `config-server`, `mongos`, and `shard`, but it does not declare a provision order. The source dependency is serial: mongos needs the config server, and shards are added through mongos.

This is a source-contract gap. No live runtime failure is claimed by this PR.

## Solution

Add the exact serial provision stages:

```yaml
provision:
  - config-server
  - mongos
  - shard
```

The existing terminate and update orders are unchanged.

## Tests

- focused ShellSpec: Bash 3.2 and Bash 5.3, 3/0 each
- base plus the new spec: 3/1 each, with only the missing provision order failing
- full MongoDB ShellSpec: Bash 3.2 21/0; Bash 5.3 21/0 plus one pre-existing dataprotection regex warning
- valid duplicate `sharding` topology rejected in both shells
- missing, wrong, parallel, incomplete, terminate-drift, and update-drift mutants rejected in both shells
- valid Helm output followed by exit 42 preserves status 42
- Helm lint, ShellCheck error level, dual-shell syntax, and diff check pass

## Review focus

Please verify that the serial order matches the declared source dependency and that the focused oracle fails closed for zero or duplicate `sharding` topologies.

## Boundary

Source/render/TDD only. This PR does not claim API admission, controller execution, live `sh.addShard`, backup/restore, package, deployment, release, or runtime acceptance.
