### PR TITLE
fix(tidb): make TiKV member leave state driven

### DIFF
--- a/addons/tidb/scripts-ut-spec/tikv_member_leave_spec.sh
+++ b/addons/tidb/scripts-ut-spec/tikv_member_leave_spec.sh
@@ -1,0 +1,116 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317,SC2329
+
+Describe "tikv member leave"
+    TIDB_SCRIPTS_DIR="../scripts"
+    __SOURCED__=true
+    Include ../scripts/tikv_member_leave.sh
+
+    setup() {
+        export KB_LEAVE_MEMBER_POD_FQDN="tidb-tikv-1.tidb-tikv-headless.default.svc"
+        export KB_ENABLE_TLS_BETWEEN_COMPONENTS="false"
+        export PD_ADDRESS="tidb-pd.default.svc:2379"
+        STATE_CALLS="${SHELLSPEC_TMPBASE}/state-calls"
+        : > "$STATE_CALLS"
+    }
+
+    BeforeEach 'setup'
+
+    It "closes idempotently when the store is already absent"
+        pd_ctl() {
+            [ "$*" = "store" ] || return 99
+            printf '{"stores":[]}\n'
+        }
+
+        When call run_tikv_member_leave
+        The status should be success
+        The output should include "already absent"
+    End
+
+    It "deletes an Up store and defers while it is Offline"
+        pd_ctl() {
+            case "$*" in
+                store)
+                    calls=$(wc -l < "$STATE_CALLS")
+                    printf 'x\n' >> "$STATE_CALLS"
+                    if [ "$calls" -eq 0 ]; then
+                        printf '{"stores":[{"store":{"address":"%s","state_name":"Up"}}]}\n' "$TIKV_ADDRESS"
+                    else
+                        printf '{"stores":[{"store":{"address":"%s","state_name":"Offline"}}]}\n' "$TIKV_ADDRESS"
+                    fi
+                    ;;
+                "store delete addr $TIKV_ADDRESS")
+                    printf 'Success!\n'
+                    ;;
+                *)
+                    return 99
+                    ;;
+            esac
+        }
+
+        When call run_tikv_member_leave
+        The status should be failure
+        The stderr should include "phase: store-offline"
+        The stderr should include "next-retry-safe: yes"
+    End
+
+    It "removes a Tombstone store and positively verifies absence"
+        pd_ctl() {
+            case "$*" in
+                store)
+                    calls=$(wc -l < "$STATE_CALLS")
+                    printf 'x\n' >> "$STATE_CALLS"
+                    if [ "$calls" -eq 0 ]; then
+                        printf '{"stores":[{"store":{"address":"%s","state_name":"Tombstone"}}]}\n' "$TIKV_ADDRESS"
+                    else
+                        printf '{"stores":[]}\n'
+                    fi
+                    ;;
+                "store remove-tombstone")
+                    printf 'Success!\n'
+                    ;;
+                *)
+                    return 99
+                    ;;
+            esac
+        }
+
+        When call run_tikv_member_leave
+        The status should be success
+        The output should include "member leave success"
+    End
+
+    It "fails closed when the store response is not valid JSON"
+        pd_ctl() {
+            [ "$*" = "store" ] || return 99
+            printf 'not-json\n'
+        }
+
+        When call run_tikv_member_leave
+        The status should be failure
+        The stderr should include "phase: store-probe-invalid"
+        The stderr should include "next-retry-safe: no"
+    End
+
+    It "fails closed when delete is rejected"
+        pd_ctl() {
+            case "$*" in
+                store)
+                    printf '{"stores":[{"store":{"address":"%s","state_name":"Up"}}]}\n' "$TIKV_ADDRESS"
+                    ;;
+                "store delete addr $TIKV_ADDRESS")
+                    printf 'permission denied\n'
+                    return 1
+                    ;;
+                *)
+                    return 99
+                    ;;
+            esac
+        }
+
+        When call run_tikv_member_leave
+        The status should be failure
+        The stderr should include "phase: delete-rejected"
+        The stderr should include "next-retry-safe: no"
+    End
+End

--- a/addons/tidb/scripts/tikv_member_leave.sh
+++ b/addons/tidb/scripts/tikv_member_leave.sh
@@ -1,30 +1,158 @@
 #!/bin/bash
 
-set -exo pipefail
+set -eo pipefail
 
 # shellcheck source=common.sh
-. /scripts/common.sh
+# shellcheck disable=SC1091
+. "${TIDB_SCRIPTS_DIR:-/scripts}/common.sh"
 
-set_component_tls_variables
+tikv_member_leave_diagnose_not_ready() {
+    local phase="$1"
+    local context="$2"
+    local retry_safe="$3"
+    {
+        echo "tikv memberLeave diagnosis:"
+        echo "  action: tikv-member-leave"
+        echo "  phase: $phase"
+        echo "  target: ${TIKV_ADDRESS:-<unset>}"
+        echo "  $context"
+        echo "  next-retry-safe: $retry_safe"
+    } >&2
+}
 
-TIKV_ADDRESS="${KB_LEAVE_MEMBER_POD_FQDN}:20160"
-echo "$TIKV_ADDRESS"
-# shellcheck disable=SC2086
-output=$(/pd-ctl -u "$scheme://$PD_ADDRESS" $extraArg store delete addr "$TIKV_ADDRESS")
-echo "$output"
-# ignore not found nodes to make the script idempotent
-if [[ $output != "Success!" && ! $output =~ not\ found ]]; then
-    echo "leave member $TIKV_ADDRESS failed"
-    exit 1
-fi
+pd_ctl() {
+    # shellcheck disable=SC2086,SC2154
+    /pd-ctl -u "$scheme://$PD_ADDRESS" $extraArg "$@"
+}
 
-# shellcheck disable=SC2086
-until [[ $(/pd-ctl -u "$scheme://$PD_ADDRESS" $extraArg store | jq "any(.stores[]; select(.store.address == \"$TIKV_ADDRESS\"))") == "false" ]]
-do
-    echo "waiting for tikv node to become tombstone"
-    sleep 10
-done
+read_store_state() {
+    local output
+    local state
 
-echo "removing tombstone"
-# shellcheck disable=SC2086
-/pd-ctl -u "$scheme://$PD_ADDRESS" $extraArg store remove-tombstone
+    if ! output=$(pd_ctl store); then
+        tikv_member_leave_diagnose_not_ready \
+            "store-probe-failed" "pd-ctl could not list stores" "no"
+        return 1
+    fi
+
+    if ! state=$(printf '%s\n' "$output" | jq -er --arg address "$TIKV_ADDRESS" \
+        '[.stores[]? | select(.store.address == $address) | .store.state_name][0] // "Absent"'); then
+        tikv_member_leave_diagnose_not_ready \
+            "store-probe-invalid" "pd-ctl returned an invalid store document" "no"
+        return 1
+    fi
+
+    printf '%s\n' "$state"
+}
+
+delete_store() {
+    local output
+
+    if ! output=$(pd_ctl store delete addr "$TIKV_ADDRESS" 2>&1); then
+        tikv_member_leave_diagnose_not_ready \
+            "delete-rejected" "pd-ctl rejected store deletion: $output" "no"
+        return 1
+    fi
+    if [ "$output" != "Success!" ]; then
+        tikv_member_leave_diagnose_not_ready \
+            "delete-rejected" "unexpected delete response: $output" "no"
+        return 1
+    fi
+}
+
+remove_tombstone() {
+    local output
+
+    if ! output=$(pd_ctl store remove-tombstone 2>&1); then
+        tikv_member_leave_diagnose_not_ready \
+            "remove-tombstone-rejected" "pd-ctl rejected tombstone removal: $output" "no"
+        return 1
+    fi
+    if [ "$output" != "Success!" ]; then
+        tikv_member_leave_diagnose_not_ready \
+            "remove-tombstone-rejected" "unexpected remove-tombstone response: $output" "no"
+        return 1
+    fi
+}
+
+run_tikv_member_leave() {
+    local state
+
+    if [ -z "${KB_LEAVE_MEMBER_POD_FQDN:-}" ]; then
+        tikv_member_leave_diagnose_not_ready \
+            "invalid-input" "KB_LEAVE_MEMBER_POD_FQDN is empty" "no"
+        return 1
+    fi
+    if [ -z "${PD_ADDRESS:-}" ]; then
+        tikv_member_leave_diagnose_not_ready \
+            "invalid-input" "PD_ADDRESS is empty" "no"
+        return 1
+    fi
+
+    set_component_tls_variables
+    TIKV_ADDRESS="${KB_LEAVE_MEMBER_POD_FQDN}:20160"
+
+    if ! state=$(read_store_state); then
+        return 1
+    fi
+
+    case "$state" in
+        Absent)
+            echo "tikv store $TIKV_ADDRESS is already absent"
+            return 0
+            ;;
+        Up)
+            if ! delete_store; then
+                return 1
+            fi
+            if ! state=$(read_store_state); then
+                return 1
+            fi
+            ;;
+        Offline|Tombstone)
+            ;;
+        *)
+            tikv_member_leave_diagnose_not_ready \
+                "store-state-invalid" "unexpected store state: $state" "no"
+            return 1
+            ;;
+    esac
+
+    case "$state" in
+        Absent)
+            echo "member leave success"
+            return 0
+            ;;
+        Offline)
+            tikv_member_leave_diagnose_not_ready \
+                "store-offline" "store is draining regions" "yes"
+            return 1
+            ;;
+        Tombstone)
+            if ! remove_tombstone; then
+                return 1
+            fi
+            if ! state=$(read_store_state); then
+                return 1
+            fi
+            if [ "$state" = "Absent" ]; then
+                echo "member leave success"
+                return 0
+            fi
+            tikv_member_leave_diagnose_not_ready \
+                "tombstone-still-present" "store state after removal: $state" "yes"
+            return 1
+            ;;
+        *)
+            tikv_member_leave_diagnose_not_ready \
+                "store-state-invalid" "unexpected store state after deletion: $state" "no"
+            return 1
+            ;;
+    esac
+}
+
+# This is magic for shellspec. The production action executes the function;
+# shellspec only sources the definitions.
+${__SOURCED__:+false} : || return 0
+
+run_tikv_member_leave


### PR DESCRIPTION
## Problem

`tikv_member_leave.sh` deletes the target store, then waits until the store address disappears before it invokes `store remove-tombstone`. PD retains the target address while the store is `Offline` or `Tombstone`, so that ordering can wait indefinitely and hit the lifecycle-action timeout.

Contract anchors:
- `docs/addon-api/05c-lifecycle-action-contracts.md`: memberLeave must distinguish convergence states, remain retry-safe, and avoid fixed/unbounded waiting.
- `docs/addon-api/05a-lifecycle-roles-and-probe.md`: memberLeave must be repeatable or fail safely.

## Change

- Probe the target store state before mutating.
- Treat `Absent` as an idempotent success.
- Delete only an `Up` store.
- Return a classified retry-safe failure while the store is `Offline`.
- Remove a `Tombstone` record, then positively verify the target is absent.
- Fail closed on invalid input, malformed probe output, unexpected state, and rejected PD mutations.
- Add five ShellSpec cases covering absent, Up-to-Offline defer, Tombstone removal, malformed probe output, and delete rejection.

## Verification

- ShellSpec, Bash 3.2: 38 examples, 0 failures
- ShellSpec, Bash 5.3: 38 examples, 0 failures
- ShellCheck: pass
- `helm lint addons/tidb`: pass
- `helm template tidb addons/tidb`: pass

## Boundary

This PR closes the product-code and code-level-test gap only. It does not claim a runtime TiKV scale-in PASS, formal addon acceptance, cleanup success, or release readiness.
