### PR TITLE
test(mongodb): validate README relative links

### DIFF
--- a/addons/mongodb/README.md
+++ b/addons/mongodb/README.md
@@ -33,8 +33,8 @@ MongoDB is a document database designed for ease of application development and 
 - Kubernetes cluster >= v1.21
 - `kubectl` installed, refer to [K8s Install Tools](https://kubernetes.io/docs/tasks/tools/)
 - Helm, refer to [Installing Helm](https://helm.sh/docs/intro/install/)
-- KubeBlocks installed and running, refer to [Install Kubeblocks](../docs/prerequisites.md)
-- MongoDB Addon Enabled, refer to [Install Addons](../docs/install-addon.md)
+- KubeBlocks installed and running, refer to [Install Kubeblocks](../../examples/docs/prerequisites.md)
+- MongoDB Addon Enabled, refer to [Install Addons](../../examples/docs/install-addon.md)
 - Create K8s Namespace `demo`, to keep resources created in this tutorial isolated:
 
   ```bash
@@ -618,7 +618,7 @@ print("systemLog.verbosity:", config.parsed.systemLog.verbosity);
 ### Backup
 
 > [!IMPORTANT]
-> Before you start, please create a `BackupRepo` to store the backup data. Refer to [BackupRepo](../docs/create-backuprepo.md) for more details.
+> Before you start, please create a `BackupRepo` to store the backup data. Refer to [BackupRepo](../../examples/docs/create-backuprepo.md) for more details.
 
 You may find the supported backup methods in the `BackupPolicy` of the cluster, and find how these methods will be scheduled in the `BackupSchedule` of the cluster.
 

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -47,9 +47,9 @@ Describe "MongoDB README relative-link closure"
           return [raw_target, destination, closer + 2, false]
         end
 
-        raw_end = link_end || line.length
+        raw_end = link_end || segment_end
         raw_target = line[target_start...raw_end].sub(/\r?\n\z/, "")
-        next_cursor = link_end ? link_end + 1 : line.length
+        next_cursor = link_end ? link_end + 1 : segment_end
         [raw_target, nil, next_cursor, true]
       end
 

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -139,18 +139,22 @@ run_mongodb_readme_link_oracle() {
       opener = /\[[^\]\n]+\]\(/
 
       text.each_line do |line|
+        source_encoding = line.encoding
+        line = line.b
         cursor = 0
         while (match = opener.match(line, cursor))
           target_start = match.end(0)
           if line.getbyte(target_start) == 60
-            segment_end = line.length
+            segment_end = line.bytesize
             raw_target, destination, cursor, malformed =
               pointy_destination(line, target_start, segment_end)
+            raw_target.force_encoding(source_encoding)
+            destination.force_encoding(source_encoding) if destination
             targets << [raw_target, destination, malformed]
             next
           end
 
-          segment_end = line.length
+          segment_end = line.bytesize
           result = bare_destination(line, target_start, segment_end)
           next_cursor = result.fetch(:next_cursor)
           unless target_start < next_cursor && next_cursor <= segment_end
@@ -161,9 +165,12 @@ run_mongodb_readme_link_oracle() {
               "segment_end=#{segment_end}"
             )
           end
+          result.fetch(:raw_target).force_encoding(source_encoding)
+          destination = result.fetch(:destination)
+          destination.force_encoding(source_encoding) if destination
           targets << [
             result.fetch(:raw_target),
-            result.fetch(:destination),
+            destination,
             result.fetch(:kind) == :malformed
           ]
           cursor = next_cursor

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -429,6 +429,16 @@ Describe "MongoDB README relative-link closure"
     The stderr should include 'link="bad%2G.md" malformed_percent_encoding'
   End
 
+  It "rejects percent-decoded invalid UTF-8 before filesystem resolution"
+    prepare_link_fixture
+    printf '%s\n' '[InvalidUTF8](%FF.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="%FF.md" malformed_percent_encoding'
+    The stderr should not include 'missing='
+  End
+
   It "keeps percent-encoded scheme text in the local-link contract"
     prepare_link_fixture
     printf '%s\n' \

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -1,177 +1,326 @@
 # shellcheck shell=bash
 
-Describe "MongoDB README relative-link closure"
+run_mongodb_readme_link_oracle() {
+  local mode
+  local ruby_bin
 
-  validate_mongodb_readme_links() {
-    local repo_root
-    local ruby_bin
+  mode=$1
+  shift
+  ruby_bin=${MONGODB_RUBY_BIN:-ruby}
 
-    repo_root=${MONGODB_REPO_ROOT:-$(git rev-parse --show-toplevel)} || return 2
-    ruby_bin=${MONGODB_RUBY_BIN:-ruby}
+  "$ruby_bin" -ruri -e '
+    def inside_root?(root, path)
+      path == root || path.start_with?("#{root}#{File::SEPARATOR}")
+    end
 
-    "$ruby_bin" -ruri -e '
-      def inside_root?(root, path)
-        path == root || path.start_with?("#{root}#{File::SEPARATOR}")
-      end
+    def pointy_destination(line, target_start, segment_end)
+      index = target_start + 1
+      backslash_run = 0
+      malformed = false
 
-      def pointy_destination(line, target_start, segment_end)
-        index = target_start + 1
-        backslash_run = 0
-        closer = nil
-        nested = false
-
-        while index < segment_end
-          byte = line.getbyte(index)
-          if byte == 92
-            backslash_run += 1
-            index += 1
-            next
-          end
-
-          escaped = backslash_run.odd?
-          nested = true if byte == 60 && !escaped
-          if byte == 62 && !escaped
-            closer = index
-            break
-          end
-
-          backslash_run = 0
+      while index < segment_end
+        byte = line.getbyte(index)
+        if byte == 92
+          backslash_run += 1
           index += 1
+          next
         end
 
-        link_end = line.rindex(")", segment_end - 1)
-        link_end = nil if link_end && link_end < target_start
-        if closer && line.getbyte(closer + 1) == 41 && !nested
-          raw_target = line[target_start..closer]
-          destination = raw_target.byteslice(1, raw_target.bytesize - 2)
-          return [raw_target, destination, closer + 2, false]
+        escaped = backslash_run.odd?
+        if byte == 60 && !escaped
+          malformed = true
+          break
+        end
+        if byte == 62 && !escaped
+          if line.getbyte(index + 1) == 41
+            raw_target = line[target_start..index]
+            destination = raw_target.byteslice(
+              1,
+              raw_target.bytesize - 2
+            )
+            return [raw_target, destination, index + 2, false]
+          end
+          malformed = true
+          break
         end
 
-        raw_end = link_end || segment_end
-        raw_target = line[target_start...raw_end].sub(/\r?\n\z/, "")
-        next_cursor = link_end ? link_end + 1 : segment_end
-        [raw_target, nil, next_cursor, true]
+        backslash_run = 0
+        index += 1
       end
 
-      def markdown_link_targets(text)
-        targets = []
-        opener = /\[[^\]\n]+\]\(/
+      next_match = /\[[^\]\n]+\]\(/.match(line, target_start + 1)
+      link_end = line.rindex(")", segment_end - 1) unless next_match
+      raw_end = next_match ? next_match.begin(0) : (link_end || segment_end)
+      raw_target = line[target_start...raw_end].sub(/\r?\n\z/, "")
+      next_cursor = next_match ? next_match.begin(0) : (link_end ? link_end + 1 : segment_end)
+      [raw_target, nil, next_cursor, true]
+    end
 
-        text.each_line do |line|
-          cursor = 0
-          while (match = opener.match(line, cursor))
-            target_start = match.end(0)
-            if line.getbyte(target_start) == 60
-              next_match = opener.match(line, target_start)
-              segment_end = next_match ? next_match.begin(0) : line.length
-              raw_target, destination, cursor, malformed =
-                pointy_destination(line, target_start, segment_end)
-              targets << [raw_target, destination, malformed]
-              next
-            end
+    def malformed_bare_result(
+      raw_target,
+      next_cursor,
+      reason,
+      code = nil,
+      offending_offset = nil
+    )
+      {
+        kind: :malformed,
+        raw_target: raw_target,
+        destination: nil,
+        next_cursor: next_cursor,
+        reason: reason,
+        code: code,
+        offending_offset: offending_offset
+      }
+    end
 
-            link_end = line.index(")", target_start)
-            break unless link_end
+    def bare_destination(line, target_start, segment_end)
+      index = target_start
+      depth = 0
+      backslash_run = 0
 
-            raw_target = line[target_start...link_end]
-            targets << [raw_target, raw_target, false]
-            cursor = link_end + 1
-          end
+      while index < segment_end
+        byte = line.getbyte(index)
+        if byte <= 32 || byte == 127
+          return malformed_bare_result(
+            line.byteslice(target_start, index - target_start + 1),
+            index + 1,
+            :forbidden_byte,
+            byte,
+            index - target_start
+          )
         end
 
-        targets
+        if byte == 92
+          backslash_run += 1
+          index += 1
+          next
+        end
+
+        escaped = backslash_run.odd?
+        if byte == 40 && !escaped
+          depth += 1
+        elsif byte == 41 && !escaped
+          if depth.zero?
+            raw_target = line.byteslice(
+              target_start,
+              index - target_start
+            )
+            return {
+              kind: :valid,
+              raw_target: raw_target,
+              destination: raw_target,
+              next_cursor: index + 1,
+              reason: nil,
+              code: nil,
+              offending_offset: nil
+            }
+          end
+          depth -= 1
+        end
+
+        backslash_run = 0
+        index += 1
       end
 
-      def normalize_markdown_destination(destination)
-        destination.gsub(/\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/) do
-          Regexp.last_match(1)
+      raw_target = line.byteslice(
+        target_start,
+        segment_end - target_start
+      ).sub(/\r?\n\z/, "")
+      malformed_bare_result(
+        raw_target,
+        segment_end,
+        :line_end_before_terminator
+      )
+    end
+
+    def markdown_link_targets(text)
+      targets = []
+      opener = /\[[^\]\n]+\]\(/
+
+      text.each_line do |line|
+        cursor = 0
+        while (match = opener.match(line, cursor))
+          target_start = match.end(0)
+          if line.getbyte(target_start) == 60
+            segment_end = line.length
+            raw_target, destination, cursor, malformed =
+              pointy_destination(line, target_start, segment_end)
+            targets << [raw_target, destination, malformed]
+            next
+          end
+
+          segment_end = line.length
+          result = bare_destination(line, target_start, segment_end)
+          next_cursor = result.fetch(:next_cursor)
+          unless target_start < next_cursor && next_cursor <= segment_end
+            abort(
+              "bare_destination cursor invariant failed: " \
+              "target_start=#{target_start} " \
+              "next_cursor=#{next_cursor} " \
+              "segment_end=#{segment_end}"
+            )
+          end
+          targets << [
+            result.fetch(:raw_target),
+            result.fetch(:destination),
+            result.fetch(:kind) == :malformed
+          ]
+          cursor = next_cursor
         end
       end
 
-      root = File.realpath(ARGV.fetch(0))
-      readmes = %w[
-        addons/mongodb/README.md
-        examples/mongodb/README.md
-      ]
-      shared_docs = %w[
-        prerequisites.md
-        install-addon.md
-        create-backuprepo.md
-      ]
-      failures = []
-      seen = Hash.new { |hash, key| hash[key] = [] }
+      targets
+    end
 
-      readmes.each do |relative_readme|
-        readme = File.join(root, relative_readme)
-        markdown_link_targets(File.read(readme)).each do |raw_target, destination, malformed|
-          if malformed
-            failures << "#{relative_readme} link=#{raw_target.inspect} malformed_markdown_destination"
-            next
-          end
+    def normalize_markdown_destination(destination)
+      destination.gsub(/\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/) do
+        Regexp.last_match(1)
+      end
+    end
 
-          raw_path = normalize_markdown_destination(destination).split(/[?#]/, 2).first.to_s
-          next if raw_path.empty?
-          next if raw_path.match?(/\A[a-z][a-z0-9+.-]*:/i)
+    mode = ARGV.shift
+    if mode != "validate"
+      code = Integer(ARGV.shift, 10) unless mode == "inspect-line-end"
+      case mode
+      when "inspect-code"
+        line = "ab".b + [code].pack("C") + "cd)"
+        result = bare_destination(line, 0, line.bytesize)
+        puts "#{result.fetch(:reason)}:#{result.fetch(:code)}"
+      when "inspect-escaped-code"
+        line = "ab\\".b + [code].pack("C") + "cd)"
+        result = bare_destination(line, 0, line.bytesize)
+        puts "#{result.fetch(:reason)}:#{result.fetch(:code)}"
+      when "inspect-result"
+        line = "zzab".b + [code].pack("C") + "cd)"
+        result = bare_destination(line, 2, 8)
+        puts [
+          "kind=#{result.fetch(:kind)}",
+          "reason=#{result.fetch(:reason)}",
+          "code=#{result.fetch(:code)}",
+          "raw_hex=#{result.fetch(:raw_target).unpack1("H*")}",
+          "offending_offset=#{result.fetch(:offending_offset)}",
+          "next_cursor=#{result.fetch(:next_cursor)}"
+        ].join(";")
+      when "inspect-line-end"
+        line = "unterminated".b
+        result = bare_destination(line, 0, line.bytesize)
+        puts result.fetch(:reason)
+      else
+        abort "unknown mode: #{mode.inspect}"
+      end
+      exit
+    end
 
-          if raw_path.match?(/%(?![0-9a-f]{2})/i)
-            failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
-            next
-          end
-          target = URI::DEFAULT_PARSER.unescape(raw_path)
-          unless target.valid_encoding? && !target.include?("\0")
-            failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
-            next
-          end
-          if target.match?(/%[0-9a-f]{2}/i)
-            failures << "#{relative_readme} link=#{raw_target.inspect} ambiguous_percent_encoding"
-            next
-          end
+    root = File.realpath(ARGV.fetch(0))
+    readmes = %w[
+      addons/mongodb/README.md
+      examples/mongodb/README.md
+    ]
+    shared_docs = %w[
+      prerequisites.md
+      install-addon.md
+      create-backuprepo.md
+    ]
+    failures = []
+    seen = Hash.new { |hash, key| hash[key] = [] }
 
-          basename = File.basename(target)
-          seen[[relative_readme, basename]] << target if shared_docs.include?(basename)
-          expanded = File.expand_path(target, File.dirname(readme))
-          unless inside_root?(root, expanded)
-            failures << "#{relative_readme} link=#{raw_target.inspect} escapes_repository"
-            next
-          end
-          unless File.file?(expanded)
-            failures << "#{relative_readme} link=#{raw_target.inspect} missing=#{expanded.delete_prefix("#{root}/")}"
-            next
-          end
+    readmes.each do |relative_readme|
+      readme = File.join(root, relative_readme)
+      markdown_link_targets(File.read(readme)).each do |raw_target, destination, malformed|
+        if malformed
+          failures << "#{relative_readme} link=#{raw_target.inspect} malformed_markdown_destination"
+          next
+        end
 
-          begin
-            actual = File.realpath(expanded)
-          rescue SystemCallError => error
-            failures << "#{relative_readme} link=#{raw_target.inspect} realpath_error=#{error.class}"
-            next
-          end
-          unless inside_root?(root, actual)
-            failures << "#{relative_readme} link=#{raw_target.inspect} real_target_escapes_repository"
-            next
-          end
+        raw_path = normalize_markdown_destination(destination).split(/[?#]/, 2).first.to_s
+        next if raw_path.empty?
+        next if raw_path.match?(/\A[a-z][a-z0-9+.-]*:/i)
 
-          next unless shared_docs.include?(basename)
+        if raw_path.match?(/%(?![0-9a-f]{2})/i)
+          failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
+          next
+        end
+        target = URI::DEFAULT_PARSER.unescape(raw_path)
+        unless target.valid_encoding? && !target.include?("\0")
+          failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
+          next
+        end
+        if target.match?(/%[0-9a-f]{2}/i)
+          failures << "#{relative_readme} link=#{raw_target.inspect} ambiguous_percent_encoding"
+          next
+        end
 
-          expected = File.realpath(File.join(root, "examples", "docs", basename))
-          unless actual == expected
-            failures << "#{relative_readme} link=#{raw_target.inspect} actual=#{actual.delete_prefix("#{root}/")} expected=#{expected.delete_prefix("#{root}/")}"
-          end
+        basename = File.basename(target)
+        seen[[relative_readme, basename]] << target if shared_docs.include?(basename)
+        expanded = File.expand_path(target, File.dirname(readme))
+        unless inside_root?(root, expanded)
+          failures << "#{relative_readme} link=#{raw_target.inspect} escapes_repository"
+          next
+        end
+        unless File.file?(expanded)
+          failures << "#{relative_readme} link=#{raw_target.inspect} missing=#{expanded.delete_prefix("#{root}/")}"
+          next
+        end
+
+        begin
+          actual = File.realpath(expanded)
+        rescue SystemCallError => error
+          failures << "#{relative_readme} link=#{raw_target.inspect} realpath_error=#{error.class}"
+          next
+        end
+        unless inside_root?(root, actual)
+          failures << "#{relative_readme} link=#{raw_target.inspect} real_target_escapes_repository"
+          next
+        end
+
+        next unless shared_docs.include?(basename)
+
+        expected = File.realpath(File.join(root, "examples", "docs", basename))
+        unless actual == expected
+          failures << "#{relative_readme} link=#{raw_target.inspect} actual=#{actual.delete_prefix("#{root}/")} expected=#{expected.delete_prefix("#{root}/")}"
         end
       end
+    end
 
-      readmes.product(shared_docs).each do |relative_readme, basename|
-        count = seen.fetch([relative_readme, basename], []).length
-        failures << "#{relative_readme} shared_doc=#{basename} count=#{count} expected=1" unless count == 1
-      end
+    readmes.product(shared_docs).each do |relative_readme, basename|
+      count = seen.fetch([relative_readme, basename], []).length
+      failures << "#{relative_readme} shared_doc=#{basename} count=#{count} expected=1" unless count == 1
+    end
 
-      unless failures.empty?
-        failures.each { |failure| warn failure }
-        abort "MongoDB README relative-link closure failed: #{failures.length} drift(s)"
-      end
+    unless failures.empty?
+      failures.each { |failure| warn failure }
+      abort "MongoDB README relative-link closure failed: #{failures.length} drift(s)"
+    end
 
-      puts "MongoDB README relative-link closure passed"
-    ' "$repo_root"
-  }
+    puts "MongoDB README relative-link closure passed"
+  ' "$mode" "$@"
+}
+
+validate_mongodb_readme_links() {
+  local repo_root
+
+  repo_root=${MONGODB_REPO_ROOT:-$(git rev-parse --show-toplevel)} || return 2
+  run_mongodb_readme_link_oracle validate "$repo_root"
+}
+
+inspect_mongodb_bare_destination_code() {
+  run_mongodb_readme_link_oracle inspect-code "$1"
+}
+
+inspect_mongodb_bare_destination_escaped_code() {
+  run_mongodb_readme_link_oracle inspect-escaped-code "$1"
+}
+
+inspect_mongodb_bare_destination_result() {
+  run_mongodb_readme_link_oracle inspect-result "$1"
+}
+
+inspect_mongodb_bare_destination_line_end() {
+  run_mongodb_readme_link_oracle inspect-line-end
+}
+
+Describe "MongoDB README relative-link closure"
 
   setup_readme_relative_link_test() {
     source_repo_root=$(git rev-parse --show-toplevel)

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -822,6 +822,32 @@ Describe "MongoDB README relative-link closure"
     The output should include "MongoDB README relative-link closure passed"
   End
 
+  It "accepts a UTF-8 bare destination"
+    prepare_link_fixture
+    unicode_name=$(printf '\344\275\240\345\245\275.md')
+    printf '# UTF-8 destination\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/$unicode_name"
+    printf '[Unicode](%s)\n' "$unicode_name" \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps byte offsets after a UTF-8 prefix"
+    prepare_link_fixture
+    unicode_prefix=$(printf '\350\257\264\346\230\216')
+    printf '# UTF-8 prefix target\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/local.md"
+    printf '%s [Unicode](local.md)\n' "$unicode_prefix" \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
   It "keeps opener-shaped bytes inside a complete bare destination"
     prepare_link_fixture
     printf '# bare opener-shaped destination\n' \

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -202,6 +202,28 @@ Describe "MongoDB README relative-link closure"
     The stderr should include 'link="bad%2G.md" malformed_percent_encoding'
   End
 
+  It "keeps percent-encoded scheme text in the local-link contract"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[EncodedScheme](%68ttps://example.invalid/resource.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="%68ttps://example.invalid/resource.md" missing=addons/mongodb/https:/example.invalid/resource.md'
+  End
+
+  It "skips a literal external scheme before local percent validation"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[External](https://example.invalid/bad%2G.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
   It "rejects an ambiguous target that remains percent-encoded after one decode"
     prepare_link_fixture
     printf '# ambiguous decoy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/literal%2520name.md"

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -20,7 +20,7 @@ Describe "MongoDB README relative-link closure"
         closer = nil
         nested = false
 
-        while index < line.length
+        while index < segment_end
           byte = line.getbyte(index)
           if byte == 92
             backslash_run += 1

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -558,4 +558,16 @@ Describe "MongoDB README relative-link closure"
     The status should eq 1
     The stderr should include 'link="<before)after" malformed_markdown_destination'
   End
+
+  It "recovers at the next opener after a pointy segment without a closing parenthesis"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[MalformedSegment](<before[Later](missing-later.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<before" malformed_markdown_destination'
+    The stderr should include 'link="missing-later.md" missing=addons/mongodb/missing-later.md'
+  End
 End

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -9,7 +9,7 @@ Describe "MongoDB README relative-link closure"
     repo_root=${MONGODB_REPO_ROOT:-$(git rev-parse --show-toplevel)} || return 2
     ruby_bin=${MONGODB_RUBY_BIN:-ruby}
 
-    "$ruby_bin" -e '
+    "$ruby_bin" -ruri -e '
       def inside_root?(root, path)
         path == root || path.start_with?("#{root}#{File::SEPARATOR}")
       end
@@ -30,8 +30,23 @@ Describe "MongoDB README relative-link closure"
       readmes.each do |relative_readme|
         readme = File.join(root, relative_readme)
         File.read(readme).scan(/\[([^\]]+)\]\(([^)]+)\)/).each do |_label, raw_target|
-          target = raw_target.split(/[?#]/, 2).first
-          next if target.empty? || target.start_with?("#")
+          raw_path = raw_target.split(/[?#]/, 2).first
+          next if raw_path.empty?
+
+          if raw_path.match?(/%(?![0-9a-f]{2})/i)
+            failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
+            next
+          end
+          target = URI::DEFAULT_PARSER.unescape(raw_path)
+          unless target.valid_encoding? && !target.include?("\0")
+            failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
+            next
+          end
+          if target.match?(/%[0-9a-f]{2}/i)
+            failures << "#{relative_readme} link=#{raw_target.inspect} ambiguous_percent_encoding"
+            next
+          end
+
           next if target.match?(/\A[a-z][a-z0-9+.-]*:/i)
 
           basename = File.basename(target)

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -10,6 +10,10 @@ Describe "MongoDB README relative-link closure"
     ruby_bin=${MONGODB_RUBY_BIN:-ruby}
 
     "$ruby_bin" -e '
+      def inside_root?(root, path)
+        path == root || path.start_with?("#{root}#{File::SEPARATOR}")
+      end
+
       root = File.realpath(ARGV.fetch(0))
       readmes = %w[
         addons/mongodb/README.md
@@ -33,7 +37,7 @@ Describe "MongoDB README relative-link closure"
           basename = File.basename(target)
           seen[[relative_readme, basename]] << target if shared_docs.include?(basename)
           expanded = File.expand_path(target, File.dirname(readme))
-          unless expanded.start_with?("#{root}/")
+          unless inside_root?(root, expanded)
             failures << "#{relative_readme} link=#{raw_target.inspect} escapes_repository"
             next
           end
@@ -42,10 +46,20 @@ Describe "MongoDB README relative-link closure"
             next
           end
 
+          begin
+            actual = File.realpath(expanded)
+          rescue SystemCallError => error
+            failures << "#{relative_readme} link=#{raw_target.inspect} realpath_error=#{error.class}"
+            next
+          end
+          unless inside_root?(root, actual)
+            failures << "#{relative_readme} link=#{raw_target.inspect} real_target_escapes_repository"
+            next
+          end
+
           next unless shared_docs.include?(basename)
 
           expected = File.realpath(File.join(root, "examples", "docs", basename))
-          actual = File.realpath(expanded)
           unless actual == expected
             failures << "#{relative_readme} link=#{raw_target.inspect} actual=#{actual.delete_prefix("#{root}/")} expected=#{expected.delete_prefix("#{root}/")}"
           end

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -14,6 +14,77 @@ Describe "MongoDB README relative-link closure"
         path == root || path.start_with?("#{root}#{File::SEPARATOR}")
       end
 
+      def pointy_destination(line, target_start)
+        index = target_start + 1
+        backslash_run = 0
+        closer = nil
+        nested = false
+
+        while index < line.length
+          byte = line.getbyte(index)
+          if byte == 92
+            backslash_run += 1
+            index += 1
+            next
+          end
+
+          escaped = backslash_run.odd?
+          nested = true if byte == 60 && !escaped
+          if byte == 62 && !escaped
+            closer = index
+            break
+          end
+
+          backslash_run = 0
+          index += 1
+        end
+
+        link_end = line.index(")", target_start)
+        if closer && line.getbyte(closer + 1) == 41 && !nested
+          raw_target = line[target_start..closer]
+          destination = raw_target.byteslice(1, raw_target.bytesize - 2)
+          return [raw_target, destination, closer + 2, false]
+        end
+
+        raw_end = link_end || line.length
+        raw_target = line[target_start...raw_end].sub(/\r?\n\z/, "")
+        next_cursor = link_end ? link_end + 1 : line.length
+        [raw_target, nil, next_cursor, true]
+      end
+
+      def markdown_link_targets(text)
+        targets = []
+        opener = /\[[^\]\n]+\]\(/
+
+        text.each_line do |line|
+          cursor = 0
+          while (match = opener.match(line, cursor))
+            target_start = match.end(0)
+            if line.getbyte(target_start) == 60
+              raw_target, destination, cursor, malformed =
+                pointy_destination(line, target_start)
+              targets << [raw_target, destination, malformed]
+              next
+            end
+
+            link_end = line.index(")", target_start)
+            break unless link_end
+
+            raw_target = line[target_start...link_end]
+            targets << [raw_target, raw_target, false]
+            cursor = link_end + 1
+          end
+        end
+
+        targets
+      end
+
+      def normalize_markdown_destination(destination)
+        destination.gsub(/\\([\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e])/) do
+          Regexp.last_match(1)
+        end
+      end
+
       root = File.realpath(ARGV.fetch(0))
       readmes = %w[
         addons/mongodb/README.md
@@ -29,8 +100,13 @@ Describe "MongoDB README relative-link closure"
 
       readmes.each do |relative_readme|
         readme = File.join(root, relative_readme)
-        File.read(readme).scan(/\[([^\]]+)\]\(([^)]+)\)/).each do |_label, raw_target|
-          raw_path = raw_target.split(/[?#]/, 2).first
+        markdown_link_targets(File.read(readme)).each do |raw_target, destination, malformed|
+          if malformed
+            failures << "#{relative_readme} link=#{raw_target.inspect} malformed_markdown_destination"
+            next
+          end
+
+          raw_path = normalize_markdown_destination(destination).split(/[?#]/, 2).first.to_s
           next if raw_path.empty?
           next if raw_path.match?(/\A[a-z][a-z0-9+.-]*:/i)
 

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -32,6 +32,7 @@ Describe "MongoDB README relative-link closure"
         File.read(readme).scan(/\[([^\]]+)\]\(([^)]+)\)/).each do |_label, raw_target|
           raw_path = raw_target.split(/[?#]/, 2).first
           next if raw_path.empty?
+          next if raw_path.match?(/\A[a-z][a-z0-9+.-]*:/i)
 
           if raw_path.match?(/%(?![0-9a-f]{2})/i)
             failures << "#{relative_readme} link=#{raw_target.inspect} malformed_percent_encoding"
@@ -46,8 +47,6 @@ Describe "MongoDB README relative-link closure"
             failures << "#{relative_readme} link=#{raw_target.inspect} ambiguous_percent_encoding"
             next
           end
-
-          next if target.match?(/\A[a-z][a-z0-9+.-]*:/i)
 
           basename = File.basename(target)
           seen[[relative_readme, basename]] << target if shared_docs.include?(basename)

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -14,7 +14,7 @@ Describe "MongoDB README relative-link closure"
         path == root || path.start_with?("#{root}#{File::SEPARATOR}")
       end
 
-      def pointy_destination(line, target_start)
+      def pointy_destination(line, target_start, segment_end)
         index = target_start + 1
         backslash_run = 0
         closer = nil
@@ -39,7 +39,8 @@ Describe "MongoDB README relative-link closure"
           index += 1
         end
 
-        link_end = line.index(")", target_start)
+        link_end = line.rindex(")", segment_end - 1)
+        link_end = nil if link_end && link_end < target_start
         if closer && line.getbyte(closer + 1) == 41 && !nested
           raw_target = line[target_start..closer]
           destination = raw_target.byteslice(1, raw_target.bytesize - 2)
@@ -61,8 +62,10 @@ Describe "MongoDB README relative-link closure"
           while (match = opener.match(line, cursor))
             target_start = match.end(0)
             if line.getbyte(target_start) == 60
+              next_match = opener.match(line, target_start)
+              segment_end = next_match ? next_match.begin(0) : line.length
               raw_target, destination, cursor, malformed =
-                pointy_destination(line, target_start)
+                pointy_destination(line, target_start, segment_end)
               targets << [raw_target, destination, malformed]
               next
             end

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -154,4 +154,48 @@ Describe "MongoDB README relative-link closure"
     The status should eq 1
     The stderr should include 'link="outside.md" real_target_escapes_repository'
   End
+
+  It "rejects percent-encoded dot segments that escape after URL path decoding"
+    prepare_link_fixture
+    mkdir -p "$MONGODB_REPO_ROOT/addons/mongodb/%2e%2e/%2e%2e/%2e%2e"
+    printf '# decoy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/%2e%2e/%2e%2e/%2e%2e/outside.md"
+    printf '%s\n' \
+      '[Escape](%2e%2e/%2e%2e/%2e%2e/outside.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="%2e%2e/%2e%2e/%2e%2e/outside.md" escapes_repository'
+  End
+
+  It "accepts a valid percent-encoded in-repository filename"
+    prepare_link_fixture
+    printf '# encoded filename\n' > "$MONGODB_REPO_ROOT/addons/mongodb/space name.md"
+    printf '%s\n' '[Space](space%20name.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "rejects malformed percent encoding before filesystem resolution"
+    prepare_link_fixture
+    printf '%s\n' '[Malformed](bad%2G.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="bad%2G.md" malformed_percent_encoding'
+  End
+
+  It "rejects an ambiguous target that remains percent-encoded after one decode"
+    prepare_link_fixture
+    printf '# ambiguous decoy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/literal%2520name.md"
+    printf '%s\n' \
+      '[Ambiguous](literal%2520name.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="literal%2520name.md" ambiguous_percent_encoding'
+  End
 End

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -570,4 +570,16 @@ Describe "MongoDB README relative-link closure"
     The stderr should include 'link="<before" malformed_markdown_destination'
     The stderr should include 'link="missing-later.md" missing=addons/mongodb/missing-later.md'
   End
+
+  It "does not borrow a pointy closer from a later bare destination"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[MalformedSegment](<before[Later](missing-later>)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<before" malformed_markdown_destination'
+    The stderr should include 'link="missing-later>" missing=addons/mongodb/missing-later>'
+  End
 End

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -1,0 +1,143 @@
+# shellcheck shell=bash
+
+Describe "MongoDB README relative-link closure"
+
+  validate_mongodb_readme_links() {
+    local repo_root
+    local ruby_bin
+
+    repo_root=${MONGODB_REPO_ROOT:-$(git rev-parse --show-toplevel)} || return 2
+    ruby_bin=${MONGODB_RUBY_BIN:-ruby}
+
+    "$ruby_bin" -e '
+      root = File.realpath(ARGV.fetch(0))
+      readmes = %w[
+        addons/mongodb/README.md
+        examples/mongodb/README.md
+      ]
+      shared_docs = %w[
+        prerequisites.md
+        install-addon.md
+        create-backuprepo.md
+      ]
+      failures = []
+      seen = Hash.new { |hash, key| hash[key] = [] }
+
+      readmes.each do |relative_readme|
+        readme = File.join(root, relative_readme)
+        File.read(readme).scan(/\[([^\]]+)\]\(([^)]+)\)/).each do |_label, raw_target|
+          target = raw_target.split(/[?#]/, 2).first
+          next if target.empty? || target.start_with?("#")
+          next if target.match?(/\A[a-z][a-z0-9+.-]*:/i)
+
+          basename = File.basename(target)
+          seen[[relative_readme, basename]] << target if shared_docs.include?(basename)
+          expanded = File.expand_path(target, File.dirname(readme))
+          unless expanded.start_with?("#{root}/")
+            failures << "#{relative_readme} link=#{raw_target.inspect} escapes_repository"
+            next
+          end
+          unless File.file?(expanded)
+            failures << "#{relative_readme} link=#{raw_target.inspect} missing=#{expanded.delete_prefix("#{root}/")}"
+            next
+          end
+
+          next unless shared_docs.include?(basename)
+
+          expected = File.realpath(File.join(root, "examples", "docs", basename))
+          actual = File.realpath(expanded)
+          unless actual == expected
+            failures << "#{relative_readme} link=#{raw_target.inspect} actual=#{actual.delete_prefix("#{root}/")} expected=#{expected.delete_prefix("#{root}/")}"
+          end
+        end
+      end
+
+      readmes.product(shared_docs).each do |relative_readme, basename|
+        count = seen.fetch([relative_readme, basename], []).length
+        failures << "#{relative_readme} shared_doc=#{basename} count=#{count} expected=1" unless count == 1
+      end
+
+      unless failures.empty?
+        failures.each { |failure| warn failure }
+        abort "MongoDB README relative-link closure failed: #{failures.length} drift(s)"
+      end
+
+      puts "MongoDB README relative-link closure passed"
+    ' "$repo_root"
+  }
+
+  setup_readme_relative_link_test() {
+    source_repo_root=$(git rev-parse --show-toplevel)
+    test_root=$(mktemp -d "${TMPDIR:-/tmp}/mongodb-readme-link-spec.XXXXXX")
+    export MONGODB_REPO_ROOT="$source_repo_root"
+  }
+  Before "setup_readme_relative_link_test"
+
+  cleanup_readme_relative_link_test() {
+    rm -rf "${test_root:?}"
+    unset MONGODB_REPO_ROOT
+  }
+  After "cleanup_readme_relative_link_test"
+
+  prepare_link_fixture() {
+    local basename
+    local repo_copy
+
+    repo_copy="$test_root/repo"
+    mkdir -p \
+      "$repo_copy/addons/mongodb" \
+      "$repo_copy/examples/docs" \
+      "$repo_copy/examples/mongodb"
+
+    for basename in prerequisites.md install-addon.md create-backuprepo.md; do
+      printf '# %s\n' "$basename" > "$repo_copy/examples/docs/$basename"
+    done
+    printf '# outside\n' > "$test_root/outside.md"
+
+    printf '%s\n' \
+      '[Prerequisites](../../examples/docs/prerequisites.md?source=fixture#install)' \
+      '[Install](../../examples/docs/install-addon.md)' \
+      '[BackupRepo](../../examples/docs/create-backuprepo.md)' \
+      > "$repo_copy/addons/mongodb/README.md"
+    printf '%s\n' \
+      '[Prerequisites](../docs/prerequisites.md)' \
+      '[Install](../docs/install-addon.md)' \
+      '[BackupRepo](../docs/create-backuprepo.md)' \
+      > "$repo_copy/examples/mongodb/README.md"
+
+    export MONGODB_REPO_ROOT="$repo_copy"
+  }
+
+  It "keeps every local link inside the repository and both READMEs on the canonical shared docs"
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps query and fragment suffixes on an in-repository local link"
+    prepare_link_fixture
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "rejects a lexical local-link escape"
+    prepare_link_fixture
+    printf '%s\n' '[Escape](../../../outside.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="../../../outside.md" escapes_repository'
+  End
+
+  It "rejects an in-repository symlink whose real target escapes the repository"
+    prepare_link_fixture
+    ln -s ../../../outside.md "$MONGODB_REPO_ROOT/addons/mongodb/outside.md"
+    printf '%s\n' '[Escape](outside.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="outside.md" real_target_escapes_repository'
+  End
+End

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -546,4 +546,13 @@ Describe "MongoDB README relative-link closure"
     The status should be success
     The output should include "MongoDB README relative-link closure passed"
   End
+
+  It "preserves closing-parenthesis data in a malformed pointy diagnostic"
+    prepare_link_fixture
+    printf '%s\n' '[MalformedRaw](<before)after)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<before)after" malformed_markdown_destination'
+  End
 End

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -571,7 +571,7 @@ Describe "MongoDB README relative-link closure"
     The stderr should include 'link="missing-later.md" missing=addons/mongodb/missing-later.md'
   End
 
-  It "does not borrow a pointy closer from a later bare destination"
+  It "keeps opener-shaped bytes inside a complete pointy destination"
     prepare_link_fixture
     printf '%s\n' \
       '[MalformedSegment](<before[Later](missing-later>)' \
@@ -579,7 +579,285 @@ Describe "MongoDB README relative-link closure"
 
     When call validate_mongodb_readme_links
     The status should eq 1
-    The stderr should include 'link="<before" malformed_markdown_destination'
-    The stderr should include 'link="missing-later>" missing=addons/mongodb/missing-later>'
+    The stderr should include \
+      'link="<before[Later](missing-later>" missing=addons/mongodb/before[Later](missing-later'
+    The stderr should not include 'malformed_markdown_destination'
+    The stderr should not include 'link="missing-later>"'
+  End
+
+  It "accepts opener-shaped bytes as pointy destination data"
+    prepare_link_fixture
+    printf '# opener-shaped data\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/before[Later](target.md"
+    printf '%s\n' \
+      '[OpenerData](<before[Later](target.md>)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "rejects an interior pointy opener without an early closer"
+    prepare_link_fixture
+    printf '# nested decoy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/nested<inside"
+    printf '%s\n' '[NestedOnly](<nested<inside>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "accepts balanced nested parentheses in a bare destination"
+    prepare_link_fixture
+    printf '# balanced bare destination\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/balanced(and(more(nested))).md"
+    printf '%s\n' \
+      '[BareBalanced](balanced(and(more(nested))).md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps an escaped closing parenthesis as bare destination data"
+    prepare_link_fixture
+    printf '# escaped bare parenthesis\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/escaped)name.md"
+    printf '%s\n' \
+      '[BareEscaped](escaped\)name.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps an escaped opening parenthesis as bare destination data"
+    prepare_link_fixture
+    printf '# escaped bare opening parenthesis\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/escaped(name.md"
+    printf '%s\n' \
+      '[BareEscapedOpen](escaped\(name.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "uses odd backslash parity beyond run three in a bare destination"
+    prepare_link_fixture
+    printf '# bare five parity\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/"'escaped\\)name.md'
+    printf '%s\n' \
+      '[BareFiveParity](escaped\\\\\)name.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "uses even backslash parity to terminate a bare destination"
+    prepare_link_fixture
+    printf '# bare even parity\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/"'even\'
+    printf '%s\n' \
+      '[BareEvenParity](even\\)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps opener-shaped bytes inside a complete bare destination"
+    prepare_link_fixture
+    printf '# bare opener-shaped destination\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/"'before[Later](target).md'
+    printf '%s\n' \
+      '[BareOpenerData](before[Later](target).md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "rejects an unescaped space inside a bare destination"
+    prepare_link_fixture
+    printf '# bare destination space decoy\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/space name.md"
+    printf '%s\n' \
+      '[BareSpace](space name.md)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "rejects an unescaped tab inside a bare destination"
+    prepare_link_fixture
+    tab_name=$(printf 'tab\tname.md')
+    printf '# bare destination tab decoy\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/$tab_name"
+    printf '[BareTab](tab\tname.md)\n' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "rejects an unescaped DEL byte inside a bare destination"
+    prepare_link_fixture
+    del_name=$(printf 'del\177name.md')
+    printf '# bare destination DEL decoy\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/$del_name"
+    printf '[BareDel](del\177name.md)\n' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "continues at a later opener after a forbidden bare byte"
+    prepare_link_fixture
+    tab_name=$(printf 'bad\tname.md')
+    printf '# forbidden-byte candidate decoy\n' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/$tab_name"
+    printf '[BadCursor](bad\tname.md)[LaterCursor](missing-after.md)\n' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+    The stderr should include \
+      'link="missing-after.md" missing=addons/mongodb/missing-after.md'
+  End
+
+  Parameters
+    "0"
+    "1"
+    "2"
+    "3"
+    "4"
+    "5"
+    "6"
+    "7"
+    "8"
+    "10"
+    "11"
+    "12"
+    "13"
+    "14"
+    "15"
+    "16"
+    "17"
+    "18"
+    "19"
+    "20"
+    "21"
+    "22"
+    "23"
+    "24"
+    "25"
+    "26"
+    "27"
+    "28"
+    "29"
+    "30"
+    "31"
+  End
+
+  It "rejects unescaped ASCII control byte $1 inside a bare destination"
+    prepare_link_fixture
+    control_code="$1"
+    control_octal=$(printf '%03o' "$control_code")
+    if [ "$control_code" -ne 0 ]; then
+      control_name=$(
+        printf 'control-%03d%b-name.md' \
+          "$control_code" "\\$control_octal"
+      )
+      printf '# bare destination control decoy\n' \
+        > "$MONGODB_REPO_ROOT/addons/mongodb/$control_name"
+    fi
+    printf '[BareControl%03d](control-%03d%b-name.md)\n' \
+      "$control_code" "$control_code" "\\$control_octal" \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+End
+
+Describe "MongoDB README bare parser reasons"
+  It "distinguishes line end before a bare terminator"
+    When call inspect_mongodb_bare_destination_line_end
+    The status should be success
+    The output should eq "line_end_before_terminator"
+  End
+
+  Parameters
+    "0"
+    "1"
+    "2"
+    "3"
+    "4"
+    "5"
+    "6"
+    "7"
+    "8"
+    "9"
+    "10"
+    "11"
+    "12"
+    "13"
+    "14"
+    "15"
+    "16"
+    "17"
+    "18"
+    "19"
+    "20"
+    "21"
+    "22"
+    "23"
+    "24"
+    "25"
+    "26"
+    "27"
+    "28"
+    "29"
+    "30"
+    "31"
+    "32"
+    "127"
+  End
+
+  It "reports exact forbidden bare byte $1 before line transport"
+    When call inspect_mongodb_bare_destination_code "$1"
+    The status should be success
+    The output should eq "forbidden_byte:$1"
+  End
+
+  It "reports exact forbidden bare byte $1 after a backslash"
+    When call inspect_mongodb_bare_destination_escaped_code "$1"
+    The status should be success
+    The output should eq "forbidden_byte:$1"
+  End
+
+  It "binds forbidden bare byte $1 result ownership and recovery cursor"
+    result_hex=$(printf '%02x' "$1")
+
+    When call inspect_mongodb_bare_destination_result "$1"
+    The status should be success
+    The output should eq \
+      "kind=malformed;reason=forbidden_byte;code=$1;raw_hex=6162$result_hex;offending_offset=2;next_cursor=5"
   End
 End

--- a/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/readme_relative_link_spec.sh
@@ -234,4 +234,240 @@ Describe "MongoDB README relative-link closure"
     The status should eq 1
     The stderr should include 'link="literal%2520name.md" ambiguous_percent_encoding'
   End
+
+  It "skips a pointy external scheme before local percent validation"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[ExternalPointy](<https://example.invalid/bad%2G.md>)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps query and fragment suffixes on a pointy canonical shared-doc link"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[PointyShared](<../../examples/docs/prerequisites.md?source=fixture#install>)' \
+      '[Install](../../examples/docs/install-addon.md)' \
+      '[BackupRepo](../../examples/docs/create-backuprepo.md)' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "accepts a pointy percent-encoded in-repository filename"
+    prepare_link_fixture
+    printf '# encoded filename\n' > "$MONGODB_REPO_ROOT/addons/mongodb/space name.md"
+    printf '%s\n' '[PointySpace](<space%20name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "rejects a pointy percent-encoded dot-segment escape"
+    prepare_link_fixture
+    mkdir -p "$MONGODB_REPO_ROOT/addons/mongodb/%2e%2e/%2e%2e/%2e%2e"
+    printf '# decoy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/%2e%2e/%2e%2e/%2e%2e/outside.md"
+    printf '%s\n' \
+      '[PointyEscape](<%2e%2e/%2e%2e/%2e%2e/outside.md>)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<%2e%2e/%2e%2e/%2e%2e/outside.md>" escapes_repository'
+  End
+
+  It "reports an unwrapped missing path for a pointy local link"
+    prepare_link_fixture
+    printf '%s\n' '[PointyMissing](<missing-pointy.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<missing-pointy.md>" missing=addons/mongodb/missing-pointy.md'
+  End
+
+  It "rejects a pointy symlink whose real target escapes the repository"
+    prepare_link_fixture
+    ln -s ../../../outside.md "$MONGODB_REPO_ROOT/addons/mongodb/pointy-outside.md"
+    printf '%s\n' '[PointySymlink](<pointy-outside.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<pointy-outside.md>" real_target_escapes_repository'
+  End
+
+  It "rejects a pointy shared-doc basename that resolves to the wrong real file"
+    prepare_link_fixture
+    printf '# wrong shared doc\n' > "$MONGODB_REPO_ROOT/addons/mongodb/install-addon.md"
+    printf '%s\n' \
+      '[Prerequisites](../../examples/docs/prerequisites.md)' \
+      '[WrongShared](<install-addon.md>)' \
+      '[BackupRepo](../../examples/docs/create-backuprepo.md)' \
+      > "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'actual=addons/mongodb/install-addon.md expected=examples/docs/install-addon.md'
+  End
+
+  It "rejects malformed percent encoding inside a pointy destination"
+    prepare_link_fixture
+    printf '%s\n' '[PointyMalformed](<bad%2G.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'link="<bad%2G.md>" malformed_percent_encoding'
+  End
+
+  It "rejects a leading pointy delimiter without a matching closer"
+    prepare_link_fixture
+    printf '%s\n' '[NoCloser](<missing.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "accepts a bare destination ending in a pointy delimiter"
+    prepare_link_fixture
+    printf '# bare closing pointy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/closing>"
+    printf '%s\n' '[BareClosing](closing>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "accepts a bare destination containing an interior pointy delimiter"
+    prepare_link_fixture
+    printf '# bare interior pointy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/middle>name.md"
+    printf '%s\n' '[BareInterior](middle>name.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "rejects nested unescaped pointy delimiters"
+    prepare_link_fixture
+    printf '%s\n' '[Nested](<<nested>.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "keeps an empty pointy destination as the empty destination"
+    prepare_link_fixture
+    printf '%s\n' '[Empty](<>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "accepts an escaped pointy delimiter as destination data"
+    prepare_link_fixture
+    printf '# escaped pointy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/escaped>name.md"
+    printf '%s\n' '[EscapedPointy](<escaped\>name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "captures an escaped closing parenthesis inside a pointy destination"
+    prepare_link_fixture
+    printf '# escaped parenthesis\n' > "$MONGODB_REPO_ROOT/addons/mongodb/escaped)name.md"
+    printf '%s\n' '[EscapedParen](<escaped\)name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "normalizes an escaped scheme colon before external ownership"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[EscapedScheme](<https\://example.invalid/bad%2G.md>)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "keeps an escaped percent encoded scheme locally owned"
+    prepare_link_fixture
+    printf '%s\n' \
+      '[EscapedPercent](<\%68ttps://example.invalid/resource.md>)' \
+      >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'missing=addons/mongodb/https:/example.invalid/resource.md'
+  End
+
+  It "rejects a pointy candidate whose only apparent closer is escaped"
+    prepare_link_fixture
+    printf '%s\n' '[OnlyEscaped](<escaped\>name.md)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "rejects a pointy candidate ending in a lone backslash"
+    prepare_link_fixture
+    printf '%s\n' '[LoneBackslash](<lone\)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "applies Markdown backslash normalization exactly once"
+    prepare_link_fixture
+    printf '# one-pass parenthesis\n' > "$MONGODB_REPO_ROOT/addons/mongodb/"'escaped\)name.md'
+    printf '%s\n' '[OnePass](<escaped\\)name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "uses even backslash parity to select the first unescaped pointy closer"
+    prepare_link_fixture
+    printf '# previous-byte decoy\n' > "$MONGODB_REPO_ROOT/addons/mongodb/"'escaped\>name.md'
+    printf '%s\n' '[EvenParity](<escaped\\>name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should eq 1
+    The stderr should include 'malformed_markdown_destination'
+  End
+
+  It "uses odd backslash parity beyond run one"
+    prepare_link_fixture
+    printf '# triple parity\n' > "$MONGODB_REPO_ROOT/addons/mongodb/"'escaped\>name.md'
+    printf '%s\n' '[TripleParity](<escaped\\\>name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
+
+  It "uses odd backslash parity beyond run three"
+    prepare_link_fixture
+    printf '# five parity\n' > "$MONGODB_REPO_ROOT/addons/mongodb/"'escaped\\>name.md'
+    printf '%s\n' '[FiveParity](<escaped\\\\\>name.md>)' >> "$MONGODB_REPO_ROOT/addons/mongodb/README.md"
+
+    When call validate_mongodb_readme_links
+    The status should be success
+    The output should include "MongoDB README relative-link closure passed"
+  End
 End


### PR DESCRIPTION
## Problem

The MongoDB addon README had three local links that resolve under `addons/docs/...`, where the referenced files do not exist:

- installation prerequisites;
- addon installation;
- BackupRepo setup.

The repository also had no MongoDB-native check for local Markdown link ownership, URL decoding, repository containment, symlink escapes, or malformed destinations. A naive checker introduced while closing that gap mixed Ruby character offsets with byte parsing: UTF-8 destinations were truncated, while converting all results to binary made `%FF.md` fall through to filesystem `missing=` instead of invalid-encoding rejection.

## Solution

- Correct the three README links to `../../examples/docs/...`.
- Add one MongoDB ShellSpec oracle covering both addon and example READMEs.
- Validate local link paths after one percent decode, reject malformed/ambiguous encodings, lexical and symlink escapes, missing files, and shared-document identity drift.
- Parse pointy and bare Markdown destinations with bounded byte coordinates, nested-parenthesis/backslash parity, malformed-segment recovery, and explicit cursor invariants.
- Preserve source encoding on parser results so UTF-8 semantics remain intact after binary scanning.

No addon runtime scripts, charts, or generated package content change.

## Evidence

Observed on the pre-change tree:

- the three original README targets resolve to missing `addons/docs/...` paths;
- UTF-8 destination `[Unicode](你好.md)` was truncated to malformed `"你好."`;
- a UTF-8 prefix shifted the target to malformed `"de](local."`;
- binary scanning without result-encoding restoration treated decoded `0xff` as a filesystem path instead of malformed encoding.

Final exact-head tests:

- focused relative-link spec: 185 examples, 0 failures on Bash 3.2.57 and Bash 5.3.9;
- full MongoDB ShellSpec directory: 263 examples, 0 failures on both shells;
- negative controls independently kill binary-without-encoding-restoration and bytesize-without-binary-scanning;
- retained parser mutants fail with exact ownership: previous-byte 1, next-opener 1, capped parity 1, escaped-close 2, inverted bare parity 35;
- Bash syntax, ShellSpec syntax, ShellCheck, diff-check, and strict Git fsck pass.

## Review focus

Please focus on:

1. whether the three corrected README targets are the canonical shared docs;
2. the local/external URL ownership and one-decode ordering;
3. pointy/bare malformed recovery and cursor bounds;
4. the binary-coordinate/source-encoding boundary in `markdown_link_targets`.

## Boundary

This is repository-native source/document validation only. Package, Kubernetes, backup/restore runtime, release, and accepted runtime counts are not claimed.
