### PR TITLE
fix(mongodb): fail closed on uncertain member role

### DIFF
--- a/addons/mongodb/scripts-ut-spec/member_leave_role_probe_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/member_leave_role_probe_spec.sh
@@ -39,6 +39,14 @@ Describe "mongodb-member-leave.sh role safety"
     The output should include "SYNCER_CALL:leave --instance mongodb-1"
   End
 
+  It "propagates a leave command failure after a successful role probe"
+    ROLE_STDOUT="secondary"
+    LEAVE_RC=23
+    When call run_member_leave
+    The status should equal 23
+    The output should include "SYNCER_CALL:leave --instance mongodb-1"
+  End
+
   It "fails closed when the role probe times out"
     ROLE_RC=124
     When call run_member_leave

--- a/addons/mongodb/scripts-ut-spec/member_leave_role_probe_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/member_leave_role_probe_spec.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+
+Describe "mongodb-member-leave.sh role safety"
+
+  script_path() {
+    printf "%s/addons/mongodb/scripts/mongodb-member-leave.sh" "${SHELLSPEC_CWD:?}"
+  }
+
+  run_member_leave() (
+    timeout() {
+      printf '%s' "${ROLE_STDOUT-}"
+      return "${ROLE_RC:-0}"
+    }
+
+    function /tools/syncerctl {
+      printf 'SYNCER_CALL:%s\n' "$*"
+      return "${LEAVE_RC:-0}"
+    }
+
+    export KB_LEAVE_MEMBER_POD_NAME="mongodb-1"
+    # shellcheck disable=SC1090
+    . "$(script_path)"
+  )
+
+  BeforeEach 'ROLE_STDOUT=""; ROLE_RC=0; LEAVE_RC=0'
+
+  It "rejects leaving the current primary"
+    ROLE_STDOUT="primary"
+    When call run_member_leave
+    The status should equal 1
+    The output should include "current member role is primary."
+    The output should not include "SYNCER_CALL:leave"
+  End
+
+  It "leaves an observed non-primary member"
+    ROLE_STDOUT="secondary"
+    When call run_member_leave
+    The status should be success
+    The output should include "SYNCER_CALL:leave --instance mongodb-1"
+  End
+
+  It "fails closed when the role probe times out"
+    ROLE_RC=124
+    When call run_member_leave
+    The status should equal 124
+    The error should include "failed to determine current member role"
+    The output should not include "SYNCER_CALL:leave"
+  End
+
+  It "fails closed even if a failed role probe emitted stale output"
+    ROLE_STDOUT="secondary"
+    ROLE_RC=7
+    When call run_member_leave
+    The status should equal 7
+    The error should include "failed to determine current member role"
+    The output should not include "SYNCER_CALL:leave"
+  End
+
+End

--- a/addons/mongodb/scripts/mongodb-member-leave.sh
+++ b/addons/mongodb/scripts/mongodb-member-leave.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-if [[ "$(timeout 5s /tools/syncerctl getrole)" == "primary" ]]; then
+current_role=$(timeout 5s /tools/syncerctl getrole)
+role_rc=$?
+if [ "$role_rc" -ne 0 ]; then
+    echo "failed to determine current member role (rc=$role_rc)." >&2
+    exit "$role_rc"
+fi
+
+if [[ "$current_role" == "primary" ]]; then
     echo "current member role is primary."
     exit 1
 fi


### PR DESCRIPTION
## Problem

`mongodb-member-leave.sh` discarded the exit status from `syncerctl getrole`.
That made an uncertain role observation fail open: a timeout (`124`) or another
probe failure (`7`) with stale `secondary` output fell through to
`syncerctl leave` and returned success.

This conflicts with the addon lifecycle contract that member-leave actions
must repeat or fail safely and that diagnostic failures remain distinct from
successful convergence.

## Change

- Capture role stdout and the original probe exit status separately.
- On a nonzero probe result, emit a bounded diagnostic, return the same status,
  and do not invoke `leave`.
- Preserve the existing exact `primary` rejection.
- Preserve `KB_LEAVE_MEMBER_POD_NAME` as the leave identity.
- Keep `syncerctl leave` as the terminal command so its exit status propagates.

## Test-first evidence

Exact test-only parent `086e64d277761ee8d750e0d08e5775585d1ba91c`:

- Bash 3.2.57: `4 examples, 2 failures`
- Bash 5.3.9: `4 examples, 2 failures`
- Exact failures: timeout `124` and probe rc `7` with stale `secondary`; both
  incorrectly returned `0` and invoked leave.

Exact implementation head `8f4da6594ef752a183eeb5226777c40c02cf757c`:

- Focused spec, Bash 3.2.57 / 5.3.9: `5/0` each
- Full MongoDB specs, Bash 3.2.57 / 5.3.9: `83/0` each
- Dual Bash syntax, dual ShellSpec syntax, ShellCheck error-level, diff-check,
  strict fsck, ASCII, credential-shape, and clean-worktree gates pass.
- Fresh independent Dev review: `APPROVE/BLOCKER_LIST0`.

## Review focus

- Role-probe exit-status boundary and stale-output behavior
- Exact member identity passed to `leave`
- Preservation of primary rejection and terminal leave status

This PR proves the repository source/test contract only. It does not claim
package, Kubernetes, controller, syncer runtime, deployment, release, or
accepted test-run results.
