### PR TITLE
fix(mongodb): bound shard post-provision action

### DIFF
--- a/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
@@ -106,6 +106,43 @@ MOCK
     return "$rc"
   }
 
+  render_post_provision_command() {
+    local chart_dir
+    local rendered
+    local render_rc
+
+    chart_dir=$(cd .. && pwd)
+    helm dependency build "$chart_dir" >/dev/null || return
+    rendered=$(helm template kb-addon-mongodb "$chart_dir" \
+      --show-only templates/cmpd-mongodb-shard.yaml)
+    render_rc=$?
+    if [ "$render_rc" -ne 0 ]; then
+      echo "helm template failed with status $render_rc" >&2
+      return "$render_rc"
+    fi
+
+    # shellcheck disable=SC2016
+    printf '%s\n' "$rendered" | ruby -ryaml -e '
+      definitions = YAML.load_stream($stdin.read).compact.select do |document|
+        document["kind"] == "ComponentDefinition"
+      end
+      abort "expected one ComponentDefinition, got #{definitions.length}" unless definitions.length == 1
+
+      command = definitions.first.dig(
+        "spec", "lifecycleActions", "postProvision", "exec", "command", 2
+      )
+      abort "postProvision command is missing" unless command
+      puts command
+    '
+  }
+
+  It "keeps postProvision diagnostics on action stderr while logging stdout"
+    When call render_post_provision_command
+    The status should be success
+    The output should include "/scripts/mongodb-shard-manage.sh --post-provision >> /tmp/post-provision.log"
+    The output should not include "2>&1"
+  End
+
   It "preserves a failed mongos probe status and ignores stale ready output"
     When call run_post_provision '{ "ok": 1 }' 17
     The status should equal 17

--- a/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
@@ -5,11 +5,12 @@ Describe "MongoDB shard postProvision readiness contract"
   run_post_provision() {
     local ping_stdout="$1"
     local ping_rc="$2"
-    local shard_stdout="${3-shard-present}"
+    local shard_stdout="${3-{ \"_id\": \"mongodb-shard-0\" }}"
     local shard_rc="${4:-0}"
-    local shard_after_add_stdout="${5-shard-present}"
+    local shard_after_add_stdout="${5-{ \"_id\": \"mongodb-shard-0\" }}"
     local add_rc="${6:-0}"
     local add_stdout="${7-}"
+    local client_name="${8:-mongosh}"
     local temp_dir
     local script_file
     local rc
@@ -25,7 +26,7 @@ Describe "MongoDB shard postProvision readiness contract"
 
     cat > "$temp_dir/mongodb-common.sh" <<'MOCK'
 get_mongodb_client_name() {
-  echo "$MOCK_BIN_DIR/mongosh"
+  echo "$MOCK_BIN_DIR/$MOCK_CLIENT_NAME"
 }
 
 generate_endpoints() {
@@ -40,6 +41,15 @@ query=""
 for argument in "$@"; do
   query="$argument"
 done
+
+case "$query" in
+  *EJSON.stringify*)
+    echo "EJSON" >> "$MOCK_CALL_LOG"
+    ;;
+  *JSON.stringify*)
+    echo "JSON" >> "$MOCK_CALL_LOG"
+    ;;
+esac
 
 case "$query" in
   *ping*)
@@ -67,6 +77,7 @@ case "$query" in
     ;;
 esac
 MOCK
+    cp "$temp_dir/bin/mongosh" "$temp_dir/bin/mongo"
     cat > "$temp_dir/bin/sleep" <<'MOCK'
 #!/usr/bin/env bash
 exit 0
@@ -76,7 +87,8 @@ MOCK
 shift
 "$@"
 MOCK
-    chmod +x "$temp_dir/bin/mongosh" "$temp_dir/bin/sleep" "$temp_dir/bin/timeout"
+    chmod +x "$temp_dir/bin/mongosh" "$temp_dir/bin/mongo" \
+      "$temp_dir/bin/sleep" "$temp_dir/bin/timeout"
 
     export MOCK_BIN_DIR="$temp_dir/bin"
     export MOCK_CALL_LOG="$temp_dir/calls.log"
@@ -87,6 +99,7 @@ MOCK
     export MOCK_SHARD_RC="$shard_rc"
     export MOCK_ADD_RC="$add_rc"
     export MOCK_ADD_STDOUT="$add_stdout"
+    export MOCK_CLIENT_NAME="$client_name"
     export PATH="$temp_dir/bin:$PATH"
     export CLUSTER_COMPONENT_NAME=mongodb-shard-0
     export MONGOS_INTERNAL_HOST=mongodb-mongos
@@ -97,11 +110,13 @@ MOCK
     export KB_SERVICE_PORT=27017
     : > "$MOCK_CALL_LOG"
 
-    bash "$script_file" --post-provision
+    bash "$script_file" --post-provision >/dev/null
     rc=$?
     echo "TEST:ping-count=$(grep -c '^PING$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
     echo "TEST:exists-count=$(grep -c '^EXISTS$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
     echo "TEST:add-count=$(grep -c '^ADD$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
+    echo "TEST:ejson-count=$(grep -c '^EJSON$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
+    echo "TEST:json-count=$(grep -c '^JSON$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
     rm -rf "$temp_dir"
     return "$rc"
   }
@@ -132,15 +147,20 @@ MOCK
         "spec", "lifecycleActions", "postProvision", "exec", "command", 2
       )
       abort "postProvision command is missing" unless command
-      puts command
+      timeout = definitions.first.dig(
+        "spec", "lifecycleActions", "postProvision", "timeoutSeconds"
+      )
+      puts "COMMAND=#{command}"
+      puts "TIMEOUT=#{timeout.inspect}"
     '
   }
 
   It "keeps postProvision diagnostics on action stderr while logging stdout"
     When call render_post_provision_command
     The status should be success
-    The output should include "/scripts/mongodb-shard-manage.sh --post-provision >> /tmp/post-provision.log"
+    The output should include "COMMAND=/scripts/mongodb-shard-manage.sh --post-provision >> /tmp/post-provision.log"
     The output should not include "2>&1"
+    The output should include "TIMEOUT=30"
   End
 
   It "preserves a failed mongos probe status and ignores stale ready output"
@@ -179,10 +199,12 @@ MOCK
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=1"
     The output should include "TEST:add-count=0"
+    The output should include "TEST:ejson-count=2"
+    The output should include "TEST:json-count=0"
   End
 
   It "propagates one shard-add failure without retrying inside the invocation"
-    When call run_post_provision '{ "ok": 1 }' 0 '' 0 '' 23
+    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 23
     The status should equal 23
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=1"
@@ -193,7 +215,7 @@ MOCK
   End
 
   It "defers after one add when the shard is not yet positively visible"
-    When call run_post_provision '{ "ok": 1 }' 0 '' 0 '' 0
+    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 0
     The status should be failure
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=2"
@@ -204,7 +226,7 @@ MOCK
   End
 
   It "fails closed when addShard returns ok zero with process status zero"
-    When call run_post_provision '{ "ok": 1 }' 0 '' 0 '' 0 '{ "ok": 0 }'
+    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 0 '{ "ok": 0 }'
     The status should be failure
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=1"
@@ -215,10 +237,47 @@ MOCK
   End
 
   It "closes after one add is positively visible"
-    When call run_post_provision '{ "ok": 1 }' 0 '' 0 shard-present 0
+    When call run_post_provision '{ "ok": 1 }' 0 null 0 '{ "_id": "mongodb-shard-0" }' 0
     The status should be success
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=2"
     The output should include "TEST:add-count=1"
+  End
+
+  It "rejects malformed ping JSON after one probe"
+    When call run_post_provision not-json 0
+    The status should be failure
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=0"
+    The output should include "TEST:add-count=0"
+    The stderr should include "phase: mongos-probe-malformed"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "rejects malformed shard-presence JSON without mutation"
+    When call run_post_provision '{ "ok": 1 }' 0 not-json 0
+    The status should be failure
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=1"
+    The output should include "TEST:add-count=0"
+    The stderr should include "phase: shard-presence-malformed"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "rejects malformed addShard JSON without a second mutation"
+    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 0 not-json
+    The status should be failure
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=1"
+    The output should include "TEST:add-count=1"
+    The stderr should include "phase: shard-add-rejected"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "uses JSON serialization for the legacy mongo client"
+    When call run_post_provision '{ "ok": 1 }' 0 '{ "_id": "mongodb-shard-0" }' 0 '{ "_id": "mongodb-shard-0" }' 0 '{ "ok": 1 }' mongo
+    The status should be success
+    The output should include "TEST:ejson-count=0"
+    The output should include "TEST:json-count=2"
   End
 End

--- a/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
@@ -5,9 +5,9 @@ Describe "MongoDB shard postProvision readiness contract"
   run_post_provision() {
     local ping_stdout="$1"
     local ping_rc="$2"
-    local shard_stdout="${3-{ \"_id\": \"mongodb-shard-0\" }}"
+    local shard_stdout
     local shard_rc="${4:-0}"
-    local shard_after_add_stdout="${5-{ \"_id\": \"mongodb-shard-0\" }}"
+    local shard_after_add_stdout
     local add_rc="${6:-0}"
     local add_stdout="${7-}"
     local client_name="${8:-mongosh}"
@@ -15,6 +15,16 @@ Describe "MongoDB shard postProvision readiness contract"
     local script_file
     local rc
 
+    if [ "$#" -lt 3 ]; then
+      shard_stdout='{ "_id": "mongodb-shard-0" }'
+    else
+      shard_stdout="$3"
+    fi
+    if [ "$#" -lt 5 ]; then
+      shard_after_add_stdout='{ "_id": "mongodb-shard-0" }'
+    else
+      shard_after_add_stdout="$5"
+    fi
     if [ "$#" -lt 7 ]; then
       add_stdout='{ "ok": 1 }'
     fi
@@ -191,6 +201,9 @@ MOCK
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=0"
     The output should include "TEST:add-count=0"
+    The stderr should include "postProvision diagnosis:"
+    The stderr should include "phase: mongos-probe-failed"
+    The stderr should include "next-retry-safe: no"
   End
 
   It "continues when one successful probe positively reports ready"
@@ -204,7 +217,7 @@ MOCK
   End
 
   It "propagates one shard-add failure without retrying inside the invocation"
-    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 23
+    When call run_post_provision '{ "ok": 1 }' 0 'null' 0 'null' 23
     The status should equal 23
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=1"
@@ -215,7 +228,7 @@ MOCK
   End
 
   It "defers after one add when the shard is not yet positively visible"
-    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 0
+    When call run_post_provision '{ "ok": 1 }' 0 'null' 0 'null' 0
     The status should be failure
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=2"
@@ -226,7 +239,7 @@ MOCK
   End
 
   It "fails closed when addShard returns ok zero with process status zero"
-    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 0 '{ "ok": 0 }'
+    When call run_post_provision '{ "ok": 1 }' 0 'null' 0 'null' 0 '{ "ok": 0 }'
     The status should be failure
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=1"
@@ -237,7 +250,7 @@ MOCK
   End
 
   It "closes after one add is positively visible"
-    When call run_post_provision '{ "ok": 1 }' 0 null 0 '{ "_id": "mongodb-shard-0" }' 0
+    When call run_post_provision '{ "ok": 1 }' 0 'null' 0 '{ "_id": "mongodb-shard-0" }' 0
     The status should be success
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=2"
@@ -265,7 +278,7 @@ MOCK
   End
 
   It "rejects malformed addShard JSON without a second mutation"
-    When call run_post_provision '{ "ok": 1 }' 0 null 0 null 0 not-json
+    When call run_post_provision '{ "ok": 1 }' 0 'null' 0 'null' 0 not-json
     The status should be failure
     The output should include "TEST:ping-count=1"
     The output should include "TEST:exists-count=1"

--- a/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/shard_post_provision_readiness_spec.sh
@@ -1,0 +1,187 @@
+# shellcheck shell=bash
+
+Describe "MongoDB shard postProvision readiness contract"
+
+  run_post_provision() {
+    local ping_stdout="$1"
+    local ping_rc="$2"
+    local shard_stdout="${3-shard-present}"
+    local shard_rc="${4:-0}"
+    local shard_after_add_stdout="${5-shard-present}"
+    local add_rc="${6:-0}"
+    local add_stdout="${7-}"
+    local temp_dir
+    local script_file
+    local rc
+
+    if [ "$#" -lt 7 ]; then
+      add_stdout='{ "ok": 1 }'
+    fi
+
+    temp_dir=$(mktemp -d)
+    script_file="$temp_dir/mongodb-shard-manage.sh"
+    sed "s|\\. \"/scripts/mongodb-common.sh\"|. \"$temp_dir/mongodb-common.sh\"|" \
+      ../scripts/mongodb-shard-manage.sh > "$script_file"
+
+    cat > "$temp_dir/mongodb-common.sh" <<'MOCK'
+get_mongodb_client_name() {
+  echo "$MOCK_BIN_DIR/mongosh"
+}
+
+generate_endpoints() {
+  echo "mongodb-0.mongodb-headless:27017"
+}
+MOCK
+
+    mkdir -p "$temp_dir/bin"
+    cat > "$temp_dir/bin/mongosh" <<'MOCK'
+#!/usr/bin/env bash
+query=""
+for argument in "$@"; do
+  query="$argument"
+done
+
+case "$query" in
+  *ping*)
+    echo "PING" >> "$MOCK_CALL_LOG"
+    printf '%s\n' "$MOCK_PING_STDOUT"
+    exit "$MOCK_PING_RC"
+    ;;
+  *config*shards.find*)
+    echo "EXISTS" >> "$MOCK_CALL_LOG"
+    if grep -q '^ADD$' "$MOCK_CALL_LOG"; then
+      printf '%s\n' "$MOCK_SHARD_AFTER_ADD_STDOUT"
+    else
+      printf '%s\n' "$MOCK_SHARD_STDOUT"
+    fi
+    exit "$MOCK_SHARD_RC"
+    ;;
+  *sh.addShard*)
+    echo "ADD" >> "$MOCK_CALL_LOG"
+    printf '%s\n' "$MOCK_ADD_STDOUT"
+    exit "$MOCK_ADD_RC"
+    ;;
+  *)
+    echo "unexpected query: $query" >&2
+    exit 64
+    ;;
+esac
+MOCK
+    cat > "$temp_dir/bin/sleep" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+    cat > "$temp_dir/bin/timeout" <<'MOCK'
+#!/usr/bin/env bash
+shift
+"$@"
+MOCK
+    chmod +x "$temp_dir/bin/mongosh" "$temp_dir/bin/sleep" "$temp_dir/bin/timeout"
+
+    export MOCK_BIN_DIR="$temp_dir/bin"
+    export MOCK_CALL_LOG="$temp_dir/calls.log"
+    export MOCK_PING_STDOUT="$ping_stdout"
+    export MOCK_PING_RC="$ping_rc"
+    export MOCK_SHARD_STDOUT="$shard_stdout"
+    export MOCK_SHARD_AFTER_ADD_STDOUT="$shard_after_add_stdout"
+    export MOCK_SHARD_RC="$shard_rc"
+    export MOCK_ADD_RC="$add_rc"
+    export MOCK_ADD_STDOUT="$add_stdout"
+    export PATH="$temp_dir/bin:$PATH"
+    export CLUSTER_COMPONENT_NAME=mongodb-shard-0
+    export MONGOS_INTERNAL_HOST=mongodb-mongos
+    export MONGOS_INTERNAL_PORT=27017
+    export MONGODB_ADMIN_USER=root
+    export MONGODB_ADMIN_PASSWORD=password
+    export MONGODB_POD_FQDN_LIST=mongodb-0.mongodb-headless
+    export KB_SERVICE_PORT=27017
+    : > "$MOCK_CALL_LOG"
+
+    bash "$script_file" --post-provision
+    rc=$?
+    echo "TEST:ping-count=$(grep -c '^PING$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
+    echo "TEST:exists-count=$(grep -c '^EXISTS$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
+    echo "TEST:add-count=$(grep -c '^ADD$' "$MOCK_CALL_LOG" 2>/dev/null || true)"
+    rm -rf "$temp_dir"
+    return "$rc"
+  }
+
+  It "preserves a failed mongos probe status and ignores stale ready output"
+    When call run_post_provision '{ "ok": 1 }' 17
+    The status should equal 17
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=0"
+    The output should include "TEST:add-count=0"
+    The stderr should include "postProvision diagnosis:"
+    The stderr should include "phase: mongos-probe-failed"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "defers after one successful probe that positively reports not ready"
+    When call run_post_provision '{ "ok": 0 }' 0
+    The status should be failure
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=0"
+    The output should include "TEST:add-count=0"
+    The stderr should include "postProvision diagnosis:"
+    The stderr should include "phase: mongos-not-ready"
+    The stderr should include "next-retry-safe: yes"
+  End
+
+  It "does not loop inside one invocation when the mongos probe has no output"
+    When call run_post_provision '' 19
+    The status should equal 19
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=0"
+    The output should include "TEST:add-count=0"
+  End
+
+  It "continues when one successful probe positively reports ready"
+    When call run_post_provision '{ "ok": 1 }' 0
+    The status should be success
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=1"
+    The output should include "TEST:add-count=0"
+  End
+
+  It "propagates one shard-add failure without retrying inside the invocation"
+    When call run_post_provision '{ "ok": 1 }' 0 '' 0 '' 23
+    The status should equal 23
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=1"
+    The output should include "TEST:add-count=1"
+    The stderr should include "postProvision diagnosis:"
+    The stderr should include "phase: shard-add-failed"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "defers after one add when the shard is not yet positively visible"
+    When call run_post_provision '{ "ok": 1 }' 0 '' 0 '' 0
+    The status should be failure
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=2"
+    The output should include "TEST:add-count=1"
+    The stderr should include "postProvision diagnosis:"
+    The stderr should include "phase: shard-not-visible-after-add"
+    The stderr should include "next-retry-safe: yes"
+  End
+
+  It "fails closed when addShard returns ok zero with process status zero"
+    When call run_post_provision '{ "ok": 1 }' 0 '' 0 '' 0 '{ "ok": 0 }'
+    The status should be failure
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=1"
+    The output should include "TEST:add-count=1"
+    The stderr should include "postProvision diagnosis:"
+    The stderr should include "phase: shard-add-rejected"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "closes after one add is positively visible"
+    When call run_post_provision '{ "ok": 1 }' 0 '' 0 shard-present 0
+    The status should be success
+    The output should include "TEST:ping-count=1"
+    The output should include "TEST:exists-count=2"
+    The output should include "TEST:add-count=1"
+  End
+End

--- a/addons/mongodb/scripts/mongodb-shard-manage.sh
+++ b/addons/mongodb/scripts/mongodb-shard-manage.sh
@@ -44,24 +44,147 @@ check_shard_exists() {
     fi
 }
 
-initialize_or_scale_out_mongodb_shard() {
-    wait_for_mongos
+post_provision_diagnose_not_ready() {
+    local phase=$1
+    local retry_safe=$2
 
-    # Check if the shard exists
-    MAX_RETRIES=300
-    retry_count=0
-    while ! check_shard_exists; do
-        echo "INFO: Shard $MONGODB_REPLICA_SET_NAME does not exist, initializing... (attempt $((retry_count+1))/$MAX_RETRIES)"
-        retry_count=$((retry_count+1))
-        if [ $retry_count -ge $MAX_RETRIES ]; then
-            echo "ERROR: Shard $MONGODB_REPLICA_SET_NAME failed to initialize after $MAX_RETRIES attempts." >&2
-            exit 1
-        fi
-        sleep 2
-        pod_endpoints=$(generate_endpoints "$MONGODB_POD_FQDN_LIST" "$KB_SERVICE_PORT")
-        echo "INFO: Adding shard $MONGODB_REPLICA_SET_NAME with endpoints: $pod_endpoints"
-        $CLUSTER_MONGO "sh.addShard(\"$MONGODB_REPLICA_SET_NAME/$pod_endpoints\")"
-    done
+    {
+        echo "postProvision diagnosis:"
+        echo "action: postProvision"
+        echo "phase: $phase"
+        echo "component: $MONGODB_REPLICA_SET_NAME"
+        echo "next-retry-safe: $retry_safe"
+    } >&2
+}
+
+post_provision_run_json() {
+    local expression=$1
+    local serialized_expression
+
+    case "$CLIENT" in
+    mongosh | */mongosh)
+        serialized_expression="EJSON.stringify(($expression))"
+        ;;
+    *)
+        serialized_expression="JSON.stringify(($expression))"
+        ;;
+    esac
+
+    POST_PROVISION_RESULT=$(timeout 5s $CLUSTER_MONGO "$serialized_expression" 2>/dev/null)
+}
+
+post_provision_json_has_numeric_ok() {
+    printf '%s\n' "$1" |
+        jq -e 'type == "object" and has("ok") and (.ok | type == "number")' \
+            >/dev/null 2>&1
+}
+
+post_provision_json_ok_is_one() {
+    printf '%s\n' "$1" |
+        jq -e 'type == "object" and has("ok") and (.ok | type == "number") and .ok == 1' \
+            >/dev/null 2>&1
+}
+
+post_provision_probe_mongos() {
+    local command_status
+
+    post_provision_run_json 'db.adminCommand({ ping: 1 })'
+    command_status=$?
+    if [ "$command_status" -ne 0 ]; then
+        post_provision_diagnose_not_ready "mongos-probe-failed" "no"
+        return "$command_status"
+    fi
+
+    if ! post_provision_json_has_numeric_ok "$POST_PROVISION_RESULT"; then
+        post_provision_diagnose_not_ready "mongos-probe-malformed" "no"
+        return 1
+    fi
+    if ! post_provision_json_ok_is_one "$POST_PROVISION_RESULT"; then
+        post_provision_diagnose_not_ready "mongos-not-ready" "yes"
+        return 1
+    fi
+}
+
+post_provision_classify_presence() {
+    local result=$1
+
+    if printf '%s\n' "$result" |
+        jq -e 'type == "null"' >/dev/null 2>&1; then
+        POST_PROVISION_PRESENCE=absent
+        return 0
+    fi
+
+    if printf '%s\n' "$result" |
+        jq -e --arg name "$MONGODB_REPLICA_SET_NAME" \
+            'type == "object" and has("_id") and (._id | type == "string") and ._id == $name' \
+            >/dev/null 2>&1; then
+        POST_PROVISION_PRESENCE=present
+        return 0
+    fi
+
+    return 1
+}
+
+post_provision_probe_shard_presence() {
+    local command_status
+
+    post_provision_run_json \
+        "db.getSiblingDB(\"config\").shards.findOne({ _id: \"$MONGODB_REPLICA_SET_NAME\" })"
+    command_status=$?
+    if [ "$command_status" -ne 0 ]; then
+        post_provision_diagnose_not_ready "shard-presence-probe-failed" "no"
+        return "$command_status"
+    fi
+
+    if ! post_provision_classify_presence "$POST_PROVISION_RESULT"; then
+        post_provision_diagnose_not_ready "shard-presence-malformed" "no"
+        return 1
+    fi
+}
+
+initialize_or_scale_out_mongodb_shard() {
+    local command_status
+    local pod_endpoints
+
+    post_provision_probe_mongos
+    command_status=$?
+    if [ "$command_status" -ne 0 ]; then
+        return "$command_status"
+    fi
+
+    post_provision_probe_shard_presence
+    command_status=$?
+    if [ "$command_status" -ne 0 ]; then
+        return "$command_status"
+    fi
+    if [ "$POST_PROVISION_PRESENCE" = "present" ]; then
+        echo "INFO: Shard $MONGODB_REPLICA_SET_NAME is already present."
+        return 0
+    fi
+
+    pod_endpoints=$(generate_endpoints "$MONGODB_POD_FQDN_LIST" "$KB_SERVICE_PORT")
+    post_provision_run_json \
+        "sh.addShard(\"$MONGODB_REPLICA_SET_NAME/$pod_endpoints\")"
+    command_status=$?
+    if [ "$command_status" -ne 0 ]; then
+        post_provision_diagnose_not_ready "shard-add-failed" "no"
+        return "$command_status"
+    fi
+    if ! post_provision_json_ok_is_one "$POST_PROVISION_RESULT"; then
+        post_provision_diagnose_not_ready "shard-add-rejected" "no"
+        return 1
+    fi
+
+    post_provision_probe_shard_presence
+    command_status=$?
+    if [ "$command_status" -ne 0 ]; then
+        return "$command_status"
+    fi
+    if [ "$POST_PROVISION_PRESENCE" != "present" ]; then
+        post_provision_diagnose_not_ready "shard-not-visible-after-add" "yes"
+        return 1
+    fi
+
     echo "INFO: Shard $MONGODB_REPLICA_SET_NAME added."
 }
 
@@ -198,7 +321,7 @@ if [ $# -eq 1 ]; then
     ;;
   --post-provision)
     initialize_or_scale_out_mongodb_shard
-    exit 0
+    exit $?
     ;;
   --pre-terminate)
     delete_or_scale_in_mongodb_shard

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -102,10 +102,11 @@ spec:
         command:
           - /bin/bash
           - -c
-          - /scripts/mongodb-shard-manage.sh --post-provision >> /tmp/post-provision.log 2>&1
+          - /scripts/mongodb-shard-manage.sh --post-provision >> /tmp/post-provision.log
         targetPodSelector: Role
         matchingKey: primary
       preCondition: RuntimeReady
+      timeoutSeconds: 30
       retryPolicy:
         maxRetries: 10
   runtime:


### PR DESCRIPTION
## Problem

The sharded MongoDB `postProvision` lifecycle action can keep polling inside one invocation and can treat stale or malformed client output as success. That conflicts with the lifecycle contract: one invocation must either close or return a retryable failure within the agent timeout.

This is a code-contract fix. No Kubernetes runtime failure is claimed here.

## Evidence

The focused test-first parent reproduces 13 failures on both Bash 3.2 and Bash 5. The failures cover stale success output with a nonzero command status, malformed or wrong-typed JSON, mutation failure/status loss, repeated mutation, and swallowed diagnostics.

The implementation now passes the same focused suite with 13/13 examples and the full MongoDB script suite with 91/91 examples on both shells.

## Solution

- make `postProvision` a bounded single-shot path;
- use typed JSON serialization for `mongosh` and legacy `mongo`;
- preserve command status before interpreting stdout;
- accept only strict ping, presence, and add response schemas;
- run at most one ping, one initial presence query, one add, and one post-add query, each capped at five seconds;
- emit bounded stderr diagnostics without raw client output or credentials;
- keep `preTerminate` behavior unchanged;
- expose stderr through the action wrapper and set `postProvision.timeoutSeconds: 30`.

## Reviewer focus

- status capture and strict JSON schema handling in `mongodb-shard-manage.sh`;
- bounded call graph and retry ownership between the script and lifecycle agent;
- wrapper stderr behavior and the 30-second action timeout.

## Boundary

- Local focused tests: 13 examples, 0 failures on Bash 3.2 and Bash 5.
- Local full MongoDB script tests: 91 examples, 0 failures on both shells.
- Static gates: Bash/ShellSpec syntax, ShellCheck error severity, diff check, strict fsck, ASCII, and credential-shape scan pass.
- Kubernetes/runtime validation, packaging, accepted run counts, deployment, and release are not claimed.
- Open PRs #3241 and #3110 touch the same `postProvision.timeoutSeconds` hunk with `-1`; this PR intentionally requires `30` and a rebase must preserve it.
