### PR TITLE
fix(mongodb): bound switchover completion

### DIFF
--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -1,0 +1,172 @@
+# shellcheck shell=bash
+
+Describe "MongoDB switchover lifecycle contract"
+
+  run_switchover() {
+    local role="$1"
+    local current_name="$2"
+    local candidate_name="$3"
+    local syncer_rc="${4:-0}"
+    local timeout_mode="${5:-run}"
+    local chart_dir
+    local script
+    local temp_dir
+    local original_path
+    local rc
+
+    chart_dir=$(cd .. && pwd)
+    script="$chart_dir/scripts/mongodb-switchover.sh"
+    temp_dir=$(mktemp -d)
+    original_path="$PATH"
+
+    mkdir -p "$temp_dir/bin"
+    cat > "$temp_dir/bin/syncerctl" <<'MOCK'
+#!/usr/bin/env bash
+printf 'SYNCERCTL' >> "$MOCK_CALL_LOG"
+printf ' <%s>' "$@" >> "$MOCK_CALL_LOG"
+printf '\n' >> "$MOCK_CALL_LOG"
+printf '%s\n' "${MOCK_SYNCER_STDOUT:-switchover success}"
+if [[ "${MOCK_SYNCER_RC:-0}" -ne 0 ]]; then
+  printf '%s' "${MOCK_SYNCER_STDERR:-}" >&2
+fi
+exit "${MOCK_SYNCER_RC:-0}"
+MOCK
+    cat > "$temp_dir/bin/timeout" <<'MOCK'
+#!/usr/bin/env bash
+printf 'TIMEOUT <%s>\n' "$1" >> "$MOCK_CALL_LOG"
+shift
+if [[ "${MOCK_TIMEOUT_MODE:-run}" == "expire" ]]; then
+  exit 124
+fi
+exec "$@"
+MOCK
+    chmod +x "$temp_dir/bin/syncerctl" "$temp_dir/bin/timeout"
+
+    export MOCK_CALL_LOG="$temp_dir/calls.log"
+    : > "$MOCK_CALL_LOG"
+    export MOCK_SYNCER_RC="$syncer_rc"
+    export MOCK_SYNCER_STDOUT="switchover success"
+    export MOCK_SYNCER_STDERR="syncer failure detail"
+    export MOCK_TIMEOUT_MODE="$timeout_mode"
+    export MONGODB_SYNCERCTL_BIN="$temp_dir/bin/syncerctl"
+    export PATH="$temp_dir/bin:$PATH"
+    export KB_SWITCHOVER_ROLE="$role"
+    export KB_SWITCHOVER_CURRENT_NAME="$current_name"
+    export KB_SWITCHOVER_CANDIDATE_NAME="$candidate_name"
+
+    bash "$script"
+    rc=$?
+    printf 'TEST:calls='
+    paste -sd, "$MOCK_CALL_LOG"
+
+    PATH="$original_path"
+    unset MONGODB_SYNCERCTL_BIN
+    rm -rf "$temp_dir"
+    return "$rc"
+  }
+
+  verify_rendered_switchover_actions() {
+    local chart_dir
+
+    chart_dir=$(cd .. && pwd)
+    # shellcheck disable=SC2016
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update | ruby -ryaml -e '
+      documents = YAML.load_stream($stdin.read).compact
+      actions = documents.each_with_object([]) do |document, matches|
+        next unless document["kind"] == "ComponentDefinition"
+        action = document.dig("spec", "lifecycleActions", "switchover")
+        matches << [document.dig("metadata", "name"), action] if action
+      end
+
+      abort "expected three switchover actions, got #{actions.length}" unless actions.length == 3
+      actions.each do |name, action|
+        timeout = action["timeoutSeconds"]
+        abort "#{name}: expected timeoutSeconds=30, got #{timeout.inspect}" unless timeout == 30
+
+        command = action.dig("exec", "command")
+        abort "#{name}: malformed command #{command.inspect}" unless command&.length == 3
+        abort "#{name}: expected /bin/sh -c" unless command[0, 2] == ["/bin/sh", "-c"]
+
+        body = command[2]
+        expected = "/scripts/mongodb-switchover.sh > /tmp/switchover.log"
+        abort "#{name}: unexpected command #{body.inspect}" unless body == expected
+        abort "#{name}: stderr must remain visible to kbagent" if body.include?("2>&1")
+      end
+    '
+  }
+
+  It "executes one bounded candidate switchover with exact argv"
+    When call run_switchover primary mongodb-0 mongodb-1
+    The status should be success
+    The output should include "switchover success"
+    The output should include "TEST:calls=TIMEOUT <20s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>"
+  End
+
+  It "executes one bounded candidate-free switchover with exact argv"
+    When call run_switchover primary mongodb-0 ""
+    The status should be success
+    The output should include "TEST:calls=TIMEOUT <20s>,SYNCERCTL <switchover> <--primary> <mongodb-0>"
+    The output should not include "<--candidate>"
+  End
+
+  It "returns a clean no-op for the declared secondary role"
+    When call run_switchover secondary mongodb-1 mongodb-0
+    The status should be success
+    The output should include "role=secondary does not require transfer"
+    The output should include "TEST:calls="
+    The output should not include "SYNCERCTL"
+  End
+
+  It "rejects an empty role before invoking syncerctl"
+    When call run_switchover "" mongodb-0 mongodb-1
+    The status should equal 2
+    The stderr should include "phase: invalid-role"
+    The stderr should include "next-retry-safe: no"
+    The output should include "TEST:calls="
+    The output should not include "SYNCERCTL"
+  End
+
+  It "rejects an unknown role before invoking syncerctl"
+    When call run_switchover arbiter mongodb-0 mongodb-1
+    The status should equal 2
+    The stderr should include "phase: invalid-role"
+    The stderr should include "observed-role: arbiter"
+    The stderr should include "next-retry-safe: no"
+    The output should include "TEST:calls="
+    The output should not include "SYNCERCTL"
+  End
+
+  It "rejects a missing current pod before invoking syncerctl"
+    When call run_switchover primary "" mongodb-1
+    The status should equal 2
+    The stderr should include "phase: missing-current-pod"
+    The stderr should include "next-retry-safe: no"
+    The output should include "TEST:calls="
+    The output should not include "SYNCERCTL"
+  End
+
+  It "preserves a syncerctl failure status and classifies it"
+    When call run_switchover primary mongodb-0 mongodb-1 23
+    The status should equal 23
+    The stderr should include "syncer failure detail"
+    The stderr should include "phase: syncerctl-failed"
+    The stderr should include "syncerctl-rc: 23"
+    The stderr should include "next-retry-safe: no"
+    The output should include "TEST:calls=TIMEOUT <20s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>"
+  End
+
+  It "preserves timeout status 124 and classifies uncertain completion"
+    When call run_switchover primary mongodb-0 mongodb-1 0 expire
+    The status should equal 124
+    The stderr should include "phase: syncerctl-timeout"
+    The stderr should include "syncerctl-rc: 124"
+    The stderr should include "next-retry-safe: no"
+    The output should include "TEST:calls=TIMEOUT <20s>"
+    The output should not include "SYNCERCTL"
+  End
+
+  It "renders all three actions with a 30 second ceiling and visible stderr"
+    When call verify_rendered_switchover_actions
+    The status should be success
+  End
+End

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -103,7 +103,12 @@ MOCK
     export PATH="$temp_dir/bin:$PATH"
     export KB_SWITCHOVER_ROLE="$role"
     export KB_SWITCHOVER_CURRENT_NAME="$current_name"
-    export KB_SWITCHOVER_CANDIDATE_NAME="$candidate_name"
+    if [ -n "$candidate_name" ]; then
+      export KB_SWITCHOVER_CANDIDATE_NAME="$candidate_name"
+      export KB_SWITCHOVER_CANDIDATE_FQDN="$candidate_name.test-ns.svc"
+    else
+      unset KB_SWITCHOVER_CANDIDATE_NAME KB_SWITCHOVER_CANDIDATE_FQDN
+    fi
     export CLUSTER_NAMESPACE="$namespace"
     export KB_CLUSTER_COMP_NAME="$cluster_component_name"
 
@@ -250,6 +255,9 @@ MOCK
 if [ "$ACTUAL_TIMEOUT_MODE" = "request" ]; then
   sleep 30
 fi
+printf 'ACTUAL_SYNCERCTL'
+printf ' <%s>' "$@"
+printf '\n'
 printf 'switchover accepted\n'
 MOCK
     cat > "$temp_dir/kubectl" <<'MOCK'
@@ -264,17 +272,26 @@ MOCK
       "$temp_dir/tools/syncerctl" \
       "$temp_dir/kubectl"
 
+    cat > "$temp_dir/action.env" <<ENV
+ACTUAL_TIMEOUT_MODE=$mode
+MONGODB_KUBECTL_BIN=/fixture/kubectl
+KB_SWITCHOVER_ROLE=primary
+KB_SWITCHOVER_CURRENT_NAME=mongodb-0
+CLUSTER_NAMESPACE=test-ns
+KB_CLUSTER_COMP_NAME=mongo-rs
+ENV
+    if [ "$mode" != "candidate-free" ]; then
+      printf '%s\n' \
+        "KB_SWITCHOVER_CANDIDATE_NAME=mongodb-1" \
+        "KB_SWITCHOVER_CANDIDATE_FQDN=mongodb-1.test-ns.svc" \
+        >> "$temp_dir/action.env"
+    fi
+
     "$host_timeout" 20s docker run --rm --platform linux/amd64 \
       --volume "$chart_dir/scripts:/scripts:ro" \
       --volume "$temp_dir/tools:/tools:ro" \
       --volume "$temp_dir/kubectl:/fixture/kubectl:ro" \
-      --env "ACTUAL_TIMEOUT_MODE=$mode" \
-      --env "MONGODB_KUBECTL_BIN=/fixture/kubectl" \
-      --env "KB_SWITCHOVER_ROLE=primary" \
-      --env "KB_SWITCHOVER_CURRENT_NAME=mongodb-0" \
-      --env "KB_SWITCHOVER_CANDIDATE_NAME=mongodb-1" \
-      --env "CLUSTER_NAMESPACE=test-ns" \
-      --env "KB_CLUSTER_COMP_NAME=mongo-rs" \
+      --env-file "$temp_dir/action.env" \
       local/kubeblocks-tools:a0f9a4405-linux-amd64 \
       sh /scripts/mongodb-switchover.sh
     rc=$?
@@ -443,6 +460,15 @@ MOCK
     The stderr should include "phase: completion-probe-timeout"
     The stderr should include "completion-probe-rc: 143"
     The stderr should include "next-retry-safe: no"
+  End
+
+  It "executes candidate-free switchover with candidate variables absent in the exact tools image"
+    When call run_actual_tools_image_timeout_control candidate-free
+    The status should be success
+    The output should include "ACTUAL_SYNCERCTL <switchover> <--primary> <mongodb-0>"
+    The output should not include "<--candidate>"
+    The output should include "phase: completed"
+    The output should include "completion-configmap: mongo-rs-switchover"
   End
 
   It "declares and passes the POSIX sh action-source gate"

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -173,8 +173,12 @@ MOCK
         end
 
         init = (component.dig("spec", "runtime", "initContainers") || [])
-          .find { |container| container["name"] == "init-kubectl" }
-        abort "#{name}: missing init-kubectl" unless init
+          .find do |container|
+            init_body = Array(container["command"]).join("\n")
+            init_body.include?("/opt/bitnami/kubectl/bin/kubectl") &&
+              init_body.include?("#{expected_data_path}/tmp/bin")
+          end
+        abort "#{name}: missing kubectl-producing init container" unless init
 
         mongodb = (component.dig("spec", "runtime", "containers") || [])
           .find { |container| container["name"] == "mongodb" }
@@ -196,7 +200,7 @@ MOCK
         init_body = Array(init["command"]).join("\n")
         unless init_body.include?("/opt/bitnami/kubectl/bin/kubectl") &&
                init_body.include?("#{expected_data_path}/tmp/bin")
-          abort "#{name}: init-kubectl does not project the expected binary"
+          abort "#{name}: kubectl init does not project the expected binary"
         end
 
         configmaps = (component.dig("spec", "policyRules") || []).find do |rule|
@@ -214,6 +218,70 @@ MOCK
     chart_dir=$(cd .. && pwd)
     verify_rendered_switchover_actions_for_path "$chart_dir" "/data/mongodb" || return
     verify_rendered_switchover_actions_for_path \
+      "$chart_dir" \
+      "/custom/mongodb-data" \
+      --set dataMountPath=/custom/mongodb-data
+  }
+
+  verify_rendered_completion_toolchain_for_path() {
+    local chart_dir="$1"
+    local expected_data_path="$2"
+    shift 2
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update "$@" |
+      EXPECTED_DATA_PATH="$expected_data_path" ruby -ryaml -e '
+      expected_data_path = ENV.fetch("EXPECTED_DATA_PATH")
+      documents = YAML.load_stream($stdin.read).compact
+      components = documents.select do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("spec", "lifecycleActions", "switchover")
+      end
+      abort "expected three switchover actions, got #{components.length}" unless components.length == 3
+
+      components.each do |component|
+        name = component.dig("metadata", "name")
+        mongodb = Array(component.dig("spec", "runtime", "containers"))
+          .find { |container| container["name"] == "mongodb" }
+        abort "#{name}: missing mongodb container" unless mongodb
+
+        mounts = Array(mongodb["volumeMounts"])
+        data_mount = mounts.find { |mount| mount["mountPath"] == expected_data_path }
+        tools_mount = mounts.find { |mount| mount["mountPath"] == "/tools" }
+        abort "#{name}: missing mongodb data mount" unless data_mount
+        abort "#{name}: missing mongodb tools mount" unless tools_mount
+
+        inits = Array(component.dig("spec", "runtime", "initContainers"))
+        kubectl_init = inits.find do |container|
+          body = Array(container["command"]).join("\n")
+          body.include?("/opt/bitnami/kubectl/bin/kubectl") &&
+            body.include?("#{expected_data_path}/tmp/bin")
+        end
+        abort "#{name}: missing kubectl-producing init container" unless kubectl_init
+        kubectl_mount = Array(kubectl_init["volumeMounts"]).find do |mount|
+          mount["name"] == data_mount["name"] &&
+            mount["mountPath"] == expected_data_path
+        end
+        abort "#{name}: kubectl producer does not share mongodb data volume" unless kubectl_mount
+
+        syncer_init = inits.find do |container|
+          body = Array(container["command"]).join("\n")
+          body.include?("/bin/syncerctl") && body.include?("/tools")
+        end
+        abort "#{name}: missing syncerctl-producing init container" unless syncer_init
+        syncer_mount = Array(syncer_init["volumeMounts"]).find do |mount|
+          mount["name"] == tools_mount["name"] &&
+            mount["mountPath"] == "/tools"
+        end
+        abort "#{name}: syncer producer does not share mongodb tools volume" unless syncer_mount
+      end
+    '
+  }
+
+  verify_rendered_completion_toolchain() {
+    local chart_dir
+
+    chart_dir=$(cd .. && pwd)
+    verify_rendered_completion_toolchain_for_path "$chart_dir" "/data/mongodb" || return
+    verify_rendered_completion_toolchain_for_path \
       "$chart_dir" \
       "/custom/mongodb-data" \
       --set dataMountPath=/custom/mongodb-data
@@ -469,6 +537,11 @@ ENV
     The output should not include "<--candidate>"
     The output should include "phase: completed"
     The output should include "completion-configmap: mongo-rs-switchover"
+  End
+
+  It "retains kubectl and syncer producers on the selected default and custom mounts"
+    When call verify_rendered_completion_toolchain
+    The status should be success
   End
 
   It "declares and passes the POSIX sh action-source gate"

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -118,12 +118,14 @@ MOCK
     return "$rc"
   }
 
-  verify_rendered_switchover_actions() {
-    local chart_dir
-
-    chart_dir=$(cd .. && pwd)
+  verify_rendered_switchover_actions_for_path() {
+    local chart_dir="$1"
+    local expected_data_path="$2"
+    shift 2
     # shellcheck disable=SC2016
-    helm template kb-addon-mongodb "$chart_dir" --dependency-update | ruby -ryaml -e '
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update "$@" |
+      EXPECTED_DATA_PATH="$expected_data_path" ruby -ryaml -e '
+      expected_data_path = ENV.fetch("EXPECTED_DATA_PATH")
       documents = YAML.load_stream($stdin.read).compact
       components = documents.select do |document|
         document["kind"] == "ComponentDefinition" &&
@@ -141,6 +143,9 @@ MOCK
         abort "#{name}: malformed command #{command.inspect}" unless command&.length == 3
         abort "#{name}: expected /bin/sh -c" unless command[0, 2] == ["/bin/sh", "-c"]
         abort "#{name}: unexpected action image" if action.dig("exec", "image")
+        unless action.dig("exec", "container") == "mongodb"
+          abort "#{name}: switchover must select the mongodb container"
+        end
 
         body = command[2]
         expected = "/scripts/mongodb-switchover.sh > /tmp/switchover.log"
@@ -151,7 +156,7 @@ MOCK
         end
         unless kubectl_env == {
           "name" => "MONGODB_KUBECTL_BIN",
-          "value" => "/data/mongodb/tmp/bin/kubectl"
+          "value" => "#{expected_data_path}/tmp/bin/kubectl"
         }
           abort "#{name}: missing exact MONGODB_KUBECTL_BIN env"
         end
@@ -165,9 +170,27 @@ MOCK
         init = (component.dig("spec", "runtime", "initContainers") || [])
           .find { |container| container["name"] == "init-kubectl" }
         abort "#{name}: missing init-kubectl" unless init
+
+        mongodb = (component.dig("spec", "runtime", "containers") || [])
+          .find { |container| container["name"] == "mongodb" }
+        abort "#{name}: missing selected mongodb runtime container" unless mongodb
+        mounts = Array(mongodb["volumeMounts"])
+        script_mount = mounts.find { |mount| mount["mountPath"] == "/scripts" }
+        abort "#{name}: selected container does not share /scripts" unless script_mount
+        tools_mount = mounts.find { |mount| mount["mountPath"] == "/tools" }
+        abort "#{name}: selected container does not share /tools" unless tools_mount
+        data_mount = mounts.find { |mount| mount["mountPath"] == expected_data_path }
+        abort "#{name}: selected container missing #{expected_data_path}" unless data_mount
+
+        init_data_mount = Array(init["volumeMounts"]).find do |mount|
+          mount["name"] == data_mount["name"] &&
+            mount["mountPath"] == expected_data_path
+        end
+        abort "#{name}: init and mongodb data mounts do not match" unless init_data_mount
+
         init_body = Array(init["command"]).join("\n")
         unless init_body.include?("/opt/bitnami/kubectl/bin/kubectl") &&
-               init_body.include?("/data/mongodb/tmp/bin")
+               init_body.include?("#{expected_data_path}/tmp/bin")
           abort "#{name}: init-kubectl does not project the expected binary"
         end
 
@@ -178,6 +201,17 @@ MOCK
         abort "#{name}: ConfigMap get permission missing" unless Array(configmaps["verbs"]).include?("get")
       end
     '
+  }
+
+  verify_rendered_switchover_actions() {
+    local chart_dir
+
+    chart_dir=$(cd .. && pwd)
+    verify_rendered_switchover_actions_for_path "$chart_dir" "/data/mongodb" || return
+    verify_rendered_switchover_actions_for_path \
+      "$chart_dir" \
+      "/custom/mongodb-data" \
+      --set dataMountPath=/custom/mongodb-data
   }
 
   verify_posix_action_source() {

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -73,7 +73,7 @@ MOCK
 printf 'TIMEOUT <%s>\n' "$1" >> "$MOCK_CALL_LOG"
 case "${MOCK_TIMEOUT_MODE:-run}:$1" in
   syncer-expire:10s|probe-expire:3s)
-    exit 124
+    exit 143
     ;;
 esac
 shift
@@ -225,6 +225,64 @@ MOCK
     shellcheck --shell=sh --severity=warning "$script"
   }
 
+  run_actual_tools_image_timeout_control() {
+    local mode="$1"
+    local chart_dir
+    local script
+    local temp_dir
+    local host_timeout
+    local rc
+
+    chart_dir=$(cd .. && pwd)
+    script="$chart_dir/scripts/mongodb-switchover.sh"
+
+    # Keep the exact-parent RED bounded; the actual-image command runs once
+    # the implementation contains both declared deadline surfaces.
+    grep -F "timeout 10s" "$script" >/dev/null || return 101
+    grep -F "timeout 3s" "$script" >/dev/null || return 101
+
+    host_timeout=$(command -v gtimeout || command -v timeout) || return 102
+    temp_dir=$(mktemp -d)
+    mkdir -p "$temp_dir/tools"
+
+    cat > "$temp_dir/tools/syncerctl" <<'MOCK'
+#!/bin/sh
+if [ "$ACTUAL_TIMEOUT_MODE" = "request" ]; then
+  sleep 30
+fi
+printf 'switchover accepted\n'
+MOCK
+    cat > "$temp_dir/kubectl" <<'MOCK'
+#!/bin/sh
+if [ "$ACTUAL_TIMEOUT_MODE" = "probe" ]; then
+  sleep 30
+fi
+MOCK
+    chmod 755 \
+      "$temp_dir" \
+      "$temp_dir/tools" \
+      "$temp_dir/tools/syncerctl" \
+      "$temp_dir/kubectl"
+
+    "$host_timeout" 20s docker run --rm --platform linux/amd64 \
+      --volume "$chart_dir/scripts:/scripts:ro" \
+      --volume "$temp_dir/tools:/tools:ro" \
+      --volume "$temp_dir/kubectl:/fixture/kubectl:ro" \
+      --env "ACTUAL_TIMEOUT_MODE=$mode" \
+      --env "MONGODB_KUBECTL_BIN=/fixture/kubectl" \
+      --env "KB_SWITCHOVER_ROLE=primary" \
+      --env "KB_SWITCHOVER_CURRENT_NAME=mongodb-0" \
+      --env "KB_SWITCHOVER_CANDIDATE_NAME=mongodb-1" \
+      --env "CLUSTER_NAMESPACE=test-ns" \
+      --env "KB_CLUSTER_COMP_NAME=mongo-rs" \
+      local/kubeblocks-tools:a0f9a4405-linux-amd64 \
+      sh /scripts/mongodb-switchover.sh
+    rc=$?
+
+    rm -rf "$temp_dir"
+    return "$rc"
+  }
+
   It "closes a candidate switchover only after the exact completion ConfigMap disappears"
     When call run_switchover primary mongodb-0 mongodb-1
     The status should be success
@@ -274,9 +332,9 @@ MOCK
 
   It "preserves a completion-probe timeout and classifies it"
     When call run_switchover primary mongodb-0 mongodb-1 0 probe-expire
-    The status should equal 124
+    The status should equal 143
     The stderr should include "phase: completion-probe-timeout"
-    The stderr should include "completion-probe-rc: 124"
+    The stderr should include "completion-probe-rc: 143"
     The stderr should include "next-retry-safe: no"
     The output should not include "KUBECTL"
     The output should not include "SLEEP"
@@ -362,13 +420,29 @@ MOCK
 
   It "preserves syncerctl timeout status and does not probe ambiguous absence"
     When call run_switchover primary mongodb-0 mongodb-1 0 syncer-expire
-    The status should equal 124
+    The status should equal 143
     The stderr should include "phase: syncerctl-timeout"
-    The stderr should include "syncerctl-rc: 124"
+    The stderr should include "syncerctl-rc: 143"
     The stderr should include "next-retry-safe: no"
     The output should include "TEST:calls=TIMEOUT <10s>"
     The output should not include "SYNCERCTL"
     The output should not include "KUBECTL"
+  End
+
+  It "classifies a hanging request under the exact BusyBox tools image"
+    When call run_actual_tools_image_timeout_control request
+    The status should equal 143
+    The stderr should include "phase: syncerctl-timeout"
+    The stderr should include "syncerctl-rc: 143"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "classifies a hanging completion probe under the exact BusyBox tools image"
+    When call run_actual_tools_image_timeout_control probe
+    The status should equal 143
+    The stderr should include "phase: completion-probe-timeout"
+    The stderr should include "completion-probe-rc: 143"
+    The stderr should include "next-retry-safe: no"
   End
 
   It "declares and passes the POSIX sh action-source gate"

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -8,6 +8,9 @@ Describe "MongoDB switchover lifecycle contract"
     local candidate_name="$3"
     local syncer_rc="${4:-0}"
     local timeout_mode="${5:-run}"
+    local kubectl_mode="${6:-pending-then-absent}"
+    local namespace="${7-test-ns}"
+    local cluster_component_name="${8-mongo-rs}"
     local chart_dir
     local script
     local temp_dir
@@ -25,34 +28,84 @@ Describe "MongoDB switchover lifecycle contract"
 printf 'SYNCERCTL' >> "$MOCK_CALL_LOG"
 printf ' <%s>' "$@" >> "$MOCK_CALL_LOG"
 printf '\n' >> "$MOCK_CALL_LOG"
-printf '%s\n' "${MOCK_SYNCER_STDOUT:-switchover success}"
+printf '%s\n' "${MOCK_SYNCER_STDOUT:-switchover accepted}"
 if [[ "${MOCK_SYNCER_RC:-0}" -ne 0 ]]; then
   printf '%s' "${MOCK_SYNCER_STDERR:-}" >&2
 fi
 exit "${MOCK_SYNCER_RC:-0}"
 MOCK
+    cat > "$temp_dir/bin/kubectl" <<'MOCK'
+#!/usr/bin/env bash
+printf 'KUBECTL' >> "$MOCK_CALL_LOG"
+printf ' <%s>' "$@" >> "$MOCK_CALL_LOG"
+printf '\n' >> "$MOCK_CALL_LOG"
+
+count=$(cat "$MOCK_KUBECTL_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$MOCK_KUBECTL_COUNT"
+
+case "${MOCK_KUBECTL_MODE:-pending-then-absent}" in
+  pending-then-absent)
+    if [[ "$count" -eq 1 ]]; then
+      printf 'configmap/%s-switchover\n' "$KB_CLUSTER_COMP_NAME"
+    fi
+    ;;
+  immediate-absent)
+    ;;
+  always-pending)
+    printf 'configmap/%s-switchover\n' "$KB_CLUSTER_COMP_NAME"
+    ;;
+  failure)
+    printf 'kubernetes api failure detail\n' >&2
+    exit 19
+    ;;
+  malformed)
+    printf 'configmap/unexpected-switchover\n'
+    ;;
+  *)
+    printf 'mock configuration error: %s\n' "$MOCK_KUBECTL_MODE" >&2
+    exit 98
+    ;;
+esac
+MOCK
     cat > "$temp_dir/bin/timeout" <<'MOCK'
 #!/usr/bin/env bash
 printf 'TIMEOUT <%s>\n' "$1" >> "$MOCK_CALL_LOG"
+case "${MOCK_TIMEOUT_MODE:-run}:$1" in
+  syncer-expire:10s|probe-expire:3s)
+    exit 124
+    ;;
+esac
 shift
-if [[ "${MOCK_TIMEOUT_MODE:-run}" == "expire" ]]; then
-  exit 124
-fi
 exec "$@"
 MOCK
-    chmod +x "$temp_dir/bin/syncerctl" "$temp_dir/bin/timeout"
+    cat > "$temp_dir/bin/sleep" <<'MOCK'
+#!/usr/bin/env bash
+printf 'SLEEP <%s>\n' "$1" >> "$MOCK_CALL_LOG"
+MOCK
+    chmod +x \
+      "$temp_dir/bin/syncerctl" \
+      "$temp_dir/bin/kubectl" \
+      "$temp_dir/bin/timeout" \
+      "$temp_dir/bin/sleep"
 
     export MOCK_CALL_LOG="$temp_dir/calls.log"
+    export MOCK_KUBECTL_COUNT="$temp_dir/kubectl-count"
     : > "$MOCK_CALL_LOG"
+    printf '0\n' > "$MOCK_KUBECTL_COUNT"
     export MOCK_SYNCER_RC="$syncer_rc"
-    export MOCK_SYNCER_STDOUT="switchover success"
+    export MOCK_SYNCER_STDOUT="switchover accepted"
     export MOCK_SYNCER_STDERR="syncer failure detail"
     export MOCK_TIMEOUT_MODE="$timeout_mode"
+    export MOCK_KUBECTL_MODE="$kubectl_mode"
     export MONGODB_SYNCERCTL_BIN="$temp_dir/bin/syncerctl"
+    export MONGODB_KUBECTL_BIN="$temp_dir/bin/kubectl"
     export PATH="$temp_dir/bin:$PATH"
     export KB_SWITCHOVER_ROLE="$role"
     export KB_SWITCHOVER_CURRENT_NAME="$current_name"
     export KB_SWITCHOVER_CANDIDATE_NAME="$candidate_name"
+    export CLUSTER_NAMESPACE="$namespace"
+    export KB_CLUSTER_COMP_NAME="$cluster_component_name"
 
     bash "$script"
     rc=$?
@@ -60,7 +113,7 @@ MOCK
     paste -sd, "$MOCK_CALL_LOG"
 
     PATH="$original_path"
-    unset MONGODB_SYNCERCTL_BIN
+    unset MONGODB_SYNCERCTL_BIN MONGODB_KUBECTL_BIN
     rm -rf "$temp_dir"
     return "$rc"
   }
@@ -72,16 +125,17 @@ MOCK
     # shellcheck disable=SC2016
     helm template kb-addon-mongodb "$chart_dir" --dependency-update | ruby -ryaml -e '
       documents = YAML.load_stream($stdin.read).compact
-      actions = documents.each_with_object([]) do |document, matches|
-        next unless document["kind"] == "ComponentDefinition"
-        action = document.dig("spec", "lifecycleActions", "switchover")
-        matches << [document.dig("metadata", "name"), action] if action
+      components = documents.select do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("spec", "lifecycleActions", "switchover")
       end
 
-      abort "expected three switchover actions, got #{actions.length}" unless actions.length == 3
-      actions.each do |name, action|
+      abort "expected three switchover actions, got #{components.length}" unless components.length == 3
+      components.each do |component|
+        name = component.dig("metadata", "name")
+        action = component.dig("spec", "lifecycleActions", "switchover")
         timeout = action["timeoutSeconds"]
-        abort "#{name}: expected timeoutSeconds=30, got #{timeout.inspect}" unless timeout == 30
+        abort "#{name}: expected timeoutSeconds=50, got #{timeout.inspect}" unless timeout == 50
 
         command = action.dig("exec", "command")
         abort "#{name}: malformed command #{command.inspect}" unless command&.length == 3
@@ -91,22 +145,104 @@ MOCK
         expected = "/scripts/mongodb-switchover.sh > /tmp/switchover.log"
         abort "#{name}: unexpected command #{body.inspect}" unless body == expected
         abort "#{name}: stderr must remain visible to kbagent" if body.include?("2>&1")
+        kubectl_env = Array(action.dig("exec", "env")).find do |item|
+          item["name"] == "MONGODB_KUBECTL_BIN"
+        end
+        unless kubectl_env == {
+          "name" => "MONGODB_KUBECTL_BIN",
+          "value" => "/data/mongodb/tmp/bin/kubectl"
+        }
+          abort "#{name}: missing exact MONGODB_KUBECTL_BIN env"
+        end
+
+        vars = component.dig("spec", "vars") || []
+        %w[CLUSTER_NAMESPACE KB_CLUSTER_COMP_NAME].each do |required|
+          variable = vars.find { |item| item["name"] == required }
+          abort "#{name}: missing required var #{required}" unless variable
+        end
+
+        init = (component.dig("spec", "runtime", "initContainers") || [])
+          .find { |container| container["name"] == "init-kubectl" }
+        abort "#{name}: missing init-kubectl" unless init
+        init_body = Array(init["command"]).join("\n")
+        unless init_body.include?("/opt/bitnami/kubectl/bin/kubectl") &&
+               init_body.include?("/data/mongodb/tmp/bin")
+          abort "#{name}: init-kubectl does not project the expected binary"
+        end
+
+        configmaps = (component.dig("spec", "policyRules") || []).find do |rule|
+          rule["apiGroups"] == [""] && Array(rule["resources"]).include?("configmaps")
+        end
+        abort "#{name}: missing ConfigMap policy rule" unless configmaps
+        abort "#{name}: ConfigMap get permission missing" unless Array(configmaps["verbs"]).include?("get")
       end
     '
   }
 
-  It "executes one bounded candidate switchover with exact argv"
+  It "closes a candidate switchover only after the exact completion ConfigMap disappears"
     When call run_switchover primary mongodb-0 mongodb-1
     The status should be success
-    The output should include "switchover success"
-    The output should include "TEST:calls=TIMEOUT <20s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>"
+    The output should include "switchover accepted"
+    The output should include "phase: completed"
+    The output should include "completion-configmap: mongo-rs-switchover"
+    The output should include "TEST:calls=TIMEOUT <10s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>,TIMEOUT <3s>,KUBECTL <--request-timeout=2s> <--namespace> <test-ns> <get> <configmap> <mongo-rs-switchover> <--ignore-not-found> <-o> <name>,SLEEP <2>,TIMEOUT <3s>,KUBECTL <--request-timeout=2s> <--namespace> <test-ns> <get> <configmap> <mongo-rs-switchover> <--ignore-not-found> <-o> <name>"
   End
 
-  It "executes one bounded candidate-free switchover with exact argv"
+  It "closes a candidate-free switchover only after the exact completion ConfigMap disappears"
     When call run_switchover primary mongodb-0 ""
     The status should be success
-    The output should include "TEST:calls=TIMEOUT <20s>,SYNCERCTL <switchover> <--primary> <mongodb-0>"
+    The output should include "phase: completed"
+    The output should include "completion-configmap: mongo-rs-switchover"
+    The output should include "TEST:calls=TIMEOUT <10s>,SYNCERCTL <switchover> <--primary> <mongodb-0>,TIMEOUT <3s>,KUBECTL"
     The output should not include "<--candidate>"
+  End
+
+  It "accepts immediate ConfigMap absence after a successful request as completed"
+    When call run_switchover primary mongodb-0 mongodb-1 0 run immediate-absent
+    The status should be success
+    The output should include "phase: completed"
+    The output should include "TEST:calls=TIMEOUT <10s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>,TIMEOUT <3s>,KUBECTL"
+    The output should not include "SLEEP"
+  End
+
+  It "fails closed after six bounded probes while the completion ConfigMap remains"
+    When call run_switchover primary mongodb-0 mongodb-1 0 run always-pending
+    The status should equal 1
+    The stderr should include "phase: completion-not-observed"
+    The stderr should include "completion-configmap: mongo-rs-switchover"
+    The stderr should include "completion-probes: 6"
+    The stderr should include "next-retry-safe: no"
+    The output should include "SLEEP <2>,TIMEOUT <3s>,KUBECTL"
+    The output should include "TEST:calls=TIMEOUT <10s>,SYNCERCTL"
+  End
+
+  It "preserves a completion-probe failure and classifies it"
+    When call run_switchover primary mongodb-0 mongodb-1 0 run failure
+    The status should equal 19
+    The stderr should include "kubernetes api failure detail"
+    The stderr should include "phase: completion-probe-failed"
+    The stderr should include "completion-probe-rc: 19"
+    The stderr should include "next-retry-safe: no"
+    The output should not include "SLEEP"
+  End
+
+  It "preserves a completion-probe timeout and classifies it"
+    When call run_switchover primary mongodb-0 mongodb-1 0 probe-expire
+    The status should equal 124
+    The stderr should include "phase: completion-probe-timeout"
+    The stderr should include "completion-probe-rc: 124"
+    The stderr should include "next-retry-safe: no"
+    The output should not include "KUBECTL"
+    The output should not include "SLEEP"
+  End
+
+  It "rejects malformed completion-probe output"
+    When call run_switchover primary mongodb-0 mongodb-1 0 run malformed
+    The status should equal 1
+    The stderr should include "phase: malformed-completion-probe"
+    The stderr should include "observed-output: configmap/unexpected-switchover"
+    The stderr should include "next-retry-safe: no"
+    The output should not include "SLEEP"
   End
 
   It "returns a clean no-op for the declared secondary role"
@@ -115,18 +251,20 @@ MOCK
     The output should include "role=secondary does not require transfer"
     The output should include "TEST:calls="
     The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
   End
 
-  It "rejects an empty role before invoking syncerctl"
+  It "rejects an empty role before invoking tools"
     When call run_switchover "" mongodb-0 mongodb-1
     The status should equal 2
     The stderr should include "phase: invalid-role"
     The stderr should include "next-retry-safe: no"
     The output should include "TEST:calls="
     The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
   End
 
-  It "rejects an unknown role before invoking syncerctl"
+  It "rejects an unknown role before invoking tools"
     When call run_switchover arbiter mongodb-0 mongodb-1
     The status should equal 2
     The stderr should include "phase: invalid-role"
@@ -134,38 +272,60 @@ MOCK
     The stderr should include "next-retry-safe: no"
     The output should include "TEST:calls="
     The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
   End
 
-  It "rejects a missing current pod before invoking syncerctl"
+  It "rejects a missing current pod before invoking tools"
     When call run_switchover primary "" mongodb-1
     The status should equal 2
     The stderr should include "phase: missing-current-pod"
     The stderr should include "next-retry-safe: no"
     The output should include "TEST:calls="
     The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
   End
 
-  It "preserves a syncerctl failure status and classifies it"
+  It "rejects a missing namespace before invoking tools"
+    When call run_switchover primary mongodb-0 mongodb-1 0 run pending-then-absent ""
+    The status should equal 2
+    The stderr should include "phase: missing-cluster-namespace"
+    The stderr should include "next-retry-safe: no"
+    The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
+  End
+
+  It "rejects a missing cluster-component identity before invoking tools"
+    When call run_switchover primary mongodb-0 mongodb-1 0 run pending-then-absent test-ns ""
+    The status should equal 2
+    The stderr should include "phase: missing-cluster-component-name"
+    The stderr should include "next-retry-safe: no"
+    The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
+  End
+
+  It "preserves a syncerctl failure and does not infer success from ConfigMap absence"
     When call run_switchover primary mongodb-0 mongodb-1 23
     The status should equal 23
     The stderr should include "syncer failure detail"
     The stderr should include "phase: syncerctl-failed"
     The stderr should include "syncerctl-rc: 23"
     The stderr should include "next-retry-safe: no"
-    The output should include "TEST:calls=TIMEOUT <20s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>"
+    The output should include "TEST:calls=TIMEOUT <10s>,SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>"
+    The output should not include "KUBECTL"
   End
 
-  It "preserves timeout status 124 and classifies uncertain completion"
-    When call run_switchover primary mongodb-0 mongodb-1 0 expire
+  It "preserves syncerctl timeout status and does not probe ambiguous absence"
+    When call run_switchover primary mongodb-0 mongodb-1 0 syncer-expire
     The status should equal 124
     The stderr should include "phase: syncerctl-timeout"
     The stderr should include "syncerctl-rc: 124"
     The stderr should include "next-retry-safe: no"
-    The output should include "TEST:calls=TIMEOUT <20s>"
+    The output should include "TEST:calls=TIMEOUT <10s>"
     The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
   End
 
-  It "renders all three actions with a 30 second ceiling and visible stderr"
+  It "renders all three actions with the completion-observation prerequisites"
     When call verify_rendered_switchover_actions
     The status should be success
   End

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -662,6 +662,7 @@ ENV
   It "classifies a hanging completion probe under the resolved MongoDB action image"
     When call run_actual_resolved_image_timeout_control probe
     The status should equal 124
+    The output should include "ACTUAL_SYNCERCTL <switchover> <--primary> <mongodb-0> <--candidate> <mongodb-1>"
     The stderr should include "phase: completion-probe-timeout"
     The stderr should include "completion-probe-rc: 124"
     The stderr should include "next-retry-safe: no"

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -73,6 +73,9 @@ MOCK
 printf 'TIMEOUT <%s>\n' "$1" >> "$MOCK_CALL_LOG"
 case "${MOCK_TIMEOUT_MODE:-run}:$1" in
   syncer-expire:10s|probe-expire:3s)
+    exit 124
+    ;;
+  syncer-expire-143:10s|probe-expire-143:3s)
     exit 143
     ;;
 esac
@@ -298,9 +301,119 @@ MOCK
     shellcheck --shell=sh --severity=warning "$script"
   }
 
-  run_actual_tools_image_timeout_control() {
+  verify_resolved_action_image_matrix() {
+    local chart_dir
+
+    chart_dir=$(cd .. && pwd)
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update |
+      ruby -ryaml -e '
+      expected = {
+        "8.0.17" => "docker.io/apecloud/percona-server-mongodb:8.0.17",
+        "7.0.28" => "docker.io/apecloud/percona-server-mongodb:7.0.28",
+        "6.0.27" => "docker.io/apecloud/percona-server-mongodb:6.0.27",
+        "5.0.29" => "docker.io/apecloud/percona-server-mongodb:5.0.29-multi",
+        "4.4.29" => "docker.io/apecloud/percona-server-mongodb:4.4.29-multi",
+        "4.0.28" => "docker.io/apecloud/percona-server-mongodb:4.0.28"
+      }
+      documents = YAML.load_stream($stdin.read).compact
+      components = documents.select do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("spec", "lifecycleActions", "switchover")
+      end
+      versions = documents.select { |document| document["kind"] == "ComponentVersion" }
+      abort "expected three switchover ComponentDefinitions, got #{components.length}" unless components.length == 3
+      abort "expected three ComponentVersions, got #{versions.length}" unless versions.length == 3
+
+      rows = []
+      components.each do |component|
+        component_name = component.dig("metadata", "name")
+        matches = versions.select do |version|
+          Array(version.dig("spec", "compatibilityRules")).any? do |rule|
+            Array(rule["compDefs"]).any? do |pattern|
+              Regexp.new(pattern).match?(component_name)
+            end
+          end
+        end
+        unless matches.length == 1
+          abort "#{component_name}: expected one compatible ComponentVersion, got #{matches.length}"
+        end
+
+        version = matches.first
+        releases = Array(version.dig("spec", "releases"))
+        unless releases.map { |release| release["serviceVersion"] }.sort == expected.keys.sort
+          abort "#{component_name}: supported serviceVersion matrix drift"
+        end
+
+        action_names = component.dig("spec", "lifecycleActions").keys.map(&:downcase)
+        releases.each do |release|
+          service_version = release.fetch("serviceVersion")
+          images = release.fetch("images").to_h do |name, image|
+            [name.downcase, image]
+          end
+          resolved_actions = action_names.map { |name| images[name] }.compact
+          switchover_image = images["switchover"]
+          abort "#{component_name}/#{service_version}: switchover image unresolved" unless switchover_image
+          unless resolved_actions.uniq == [switchover_image]
+            abort "#{component_name}/#{service_version}: multiple resolved action images #{resolved_actions.uniq.inspect}"
+          end
+          unless switchover_image == images["mongodb"]
+            abort "#{component_name}/#{service_version}: action image differs from mongodb image"
+          end
+          unless switchover_image == expected.fetch(service_version)
+            abort "#{component_name}/#{service_version}: unexpected image #{switchover_image}"
+          end
+          rows << [component_name, service_version, switchover_image]
+        end
+      end
+
+      abort "expected 18 resolved component/release rows, got #{rows.length}" unless rows.length == 18
+      abort "expected six unique action images" unless rows.map(&:last).uniq.sort == expected.values.sort
+      '
+  }
+
+  resolve_switchover_image() {
+    local service_version="$1"
+    local chart_dir
+
+    chart_dir=$(cd .. && pwd)
+    helm template kb-addon-mongodb "$chart_dir" --dependency-update |
+      SERVICE_VERSION="$service_version" \
+      ruby -ryaml -e '
+      service_version = ENV.fetch("SERVICE_VERSION")
+      documents = YAML.load_stream($stdin.read).compact
+      component = documents.find do |document|
+        document["kind"] == "ComponentDefinition" &&
+          document.dig("metadata", "name").start_with?("mongodb-") &&
+          document.dig("spec", "lifecycleActions", "switchover")
+      end
+      abort "default mongodb ComponentDefinition missing" unless component
+
+      component_name = component.dig("metadata", "name")
+      version = documents.find do |document|
+        document["kind"] == "ComponentVersion" &&
+          Array(document.dig("spec", "compatibilityRules")).any? do |rule|
+            Array(rule["compDefs"]).any? do |pattern|
+              Regexp.new(pattern).match?(component_name)
+            end
+          end
+      end
+      abort "compatible ComponentVersion missing" unless version
+
+      release = Array(version.dig("spec", "releases")).find do |item|
+        item["serviceVersion"] == service_version
+      end
+      abort "exact default serviceVersion release missing" unless release
+      images = release.fetch("images").to_h { |name, image| [name.downcase, image] }
+      image = images["switchover"]
+      abort "default switchover image unresolved" unless image
+      puts image
+      '
+  }
+
+  run_actual_resolved_image_timeout_control() {
     local mode="$1"
     local chart_dir
+    local image
     local script
     local temp_dir
     local host_timeout
@@ -308,6 +421,7 @@ MOCK
 
     chart_dir=$(cd .. && pwd)
     script="$chart_dir/scripts/mongodb-switchover.sh"
+    image=$(resolve_switchover_image "8.0.17") || return
 
     # Keep the exact-parent RED bounded; the actual-image command runs once
     # the implementation contains both declared deadline surfaces.
@@ -315,6 +429,8 @@ MOCK
     grep -F "timeout 3s" "$script" >/dev/null || return 101
 
     host_timeout=$(command -v gtimeout || command -v timeout) || return 102
+    "$host_timeout" 300s docker pull --platform linux/amd64 "$image" >/dev/null ||
+      return
     temp_dir=$(mktemp -d)
     mkdir -p "$temp_dir/tools"
 
@@ -360,8 +476,9 @@ ENV
       --volume "$temp_dir/tools:/tools:ro" \
       --volume "$temp_dir/kubectl:/fixture/kubectl:ro" \
       --env-file "$temp_dir/action.env" \
-      local/kubeblocks-tools:a0f9a4405-linux-amd64 \
-      sh /scripts/mongodb-switchover.sh
+      --entrypoint /bin/sh \
+      "$image" \
+      /scripts/mongodb-switchover.sh
     rc=$?
 
     rm -rf "$temp_dir"
@@ -415,11 +532,11 @@ ENV
     The output should not include "SLEEP"
   End
 
-  It "preserves a completion-probe timeout and classifies it"
+  It "preserves the resolved-image completion-probe timeout and classifies it"
     When call run_switchover primary mongodb-0 mongodb-1 0 probe-expire
-    The status should equal 143
+    The status should equal 124
     The stderr should include "phase: completion-probe-timeout"
-    The stderr should include "completion-probe-rc: 143"
+    The stderr should include "completion-probe-rc: 124"
     The stderr should include "next-retry-safe: no"
     The output should not include "KUBECTL"
     The output should not include "SLEEP"
@@ -503,35 +620,55 @@ ENV
     The output should not include "KUBECTL"
   End
 
-  It "preserves syncerctl timeout status and does not probe ambiguous absence"
+  It "preserves the resolved-image syncerctl timeout status and does not probe ambiguous absence"
     When call run_switchover primary mongodb-0 mongodb-1 0 syncer-expire
-    The status should equal 143
+    The status should equal 124
     The stderr should include "phase: syncerctl-timeout"
-    The stderr should include "syncerctl-rc: 143"
+    The stderr should include "syncerctl-rc: 124"
     The stderr should include "next-retry-safe: no"
     The output should include "TEST:calls=TIMEOUT <10s>"
     The output should not include "SYNCERCTL"
     The output should not include "KUBECTL"
   End
 
-  It "classifies a hanging request under the exact BusyBox tools image"
-    When call run_actual_tools_image_timeout_control request
+  It "also classifies BusyBox-style syncerctl timeout status without false success"
+    When call run_switchover primary mongodb-0 mongodb-1 0 syncer-expire-143
     The status should equal 143
     The stderr should include "phase: syncerctl-timeout"
     The stderr should include "syncerctl-rc: 143"
     The stderr should include "next-retry-safe: no"
+    The output should not include "SYNCERCTL"
+    The output should not include "KUBECTL"
   End
 
-  It "classifies a hanging completion probe under the exact BusyBox tools image"
-    When call run_actual_tools_image_timeout_control probe
+  It "also classifies BusyBox-style completion-probe timeout status without false success"
+    When call run_switchover primary mongodb-0 mongodb-1 0 probe-expire-143
     The status should equal 143
     The stderr should include "phase: completion-probe-timeout"
     The stderr should include "completion-probe-rc: 143"
     The stderr should include "next-retry-safe: no"
+    The output should not include "KUBECTL"
+    The output should not include "SLEEP"
   End
 
-  It "executes candidate-free switchover with candidate variables absent in the exact tools image"
-    When call run_actual_tools_image_timeout_control candidate-free
+  It "classifies a hanging request under the resolved MongoDB action image"
+    When call run_actual_resolved_image_timeout_control request
+    The status should equal 124
+    The stderr should include "phase: syncerctl-timeout"
+    The stderr should include "syncerctl-rc: 124"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "classifies a hanging completion probe under the resolved MongoDB action image"
+    When call run_actual_resolved_image_timeout_control probe
+    The status should equal 124
+    The stderr should include "phase: completion-probe-timeout"
+    The stderr should include "completion-probe-rc: 124"
+    The stderr should include "next-retry-safe: no"
+  End
+
+  It "executes candidate-free switchover with candidate variables absent in the resolved MongoDB action image"
+    When call run_actual_resolved_image_timeout_control candidate-free
     The status should be success
     The output should include "ACTUAL_SYNCERCTL <switchover> <--primary> <mongodb-0>"
     The output should not include "<--candidate>"
@@ -541,6 +678,11 @@ ENV
 
   It "retains kubectl and syncer producers on the selected default and custom mounts"
     When call verify_rendered_completion_toolchain
+    The status should be success
+  End
+
+  It "resolves one exact MongoDB action image for every supported component and service version"
+    When call verify_resolved_action_image_matrix
     The status should be success
   End
 

--- a/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/switchover_contract_spec.sh
@@ -24,18 +24,18 @@ Describe "MongoDB switchover lifecycle contract"
 
     mkdir -p "$temp_dir/bin"
     cat > "$temp_dir/bin/syncerctl" <<'MOCK'
-#!/usr/bin/env bash
+#!/bin/sh
 printf 'SYNCERCTL' >> "$MOCK_CALL_LOG"
 printf ' <%s>' "$@" >> "$MOCK_CALL_LOG"
 printf '\n' >> "$MOCK_CALL_LOG"
 printf '%s\n' "${MOCK_SYNCER_STDOUT:-switchover accepted}"
-if [[ "${MOCK_SYNCER_RC:-0}" -ne 0 ]]; then
+if [ "${MOCK_SYNCER_RC:-0}" -ne 0 ]; then
   printf '%s' "${MOCK_SYNCER_STDERR:-}" >&2
 fi
 exit "${MOCK_SYNCER_RC:-0}"
 MOCK
     cat > "$temp_dir/bin/kubectl" <<'MOCK'
-#!/usr/bin/env bash
+#!/bin/sh
 printf 'KUBECTL' >> "$MOCK_CALL_LOG"
 printf ' <%s>' "$@" >> "$MOCK_CALL_LOG"
 printf '\n' >> "$MOCK_CALL_LOG"
@@ -46,7 +46,7 @@ printf '%s\n' "$count" > "$MOCK_KUBECTL_COUNT"
 
 case "${MOCK_KUBECTL_MODE:-pending-then-absent}" in
   pending-then-absent)
-    if [[ "$count" -eq 1 ]]; then
+    if [ "$count" -eq 1 ]; then
       printf 'configmap/%s-switchover\n' "$KB_CLUSTER_COMP_NAME"
     fi
     ;;
@@ -69,7 +69,7 @@ case "${MOCK_KUBECTL_MODE:-pending-then-absent}" in
 esac
 MOCK
     cat > "$temp_dir/bin/timeout" <<'MOCK'
-#!/usr/bin/env bash
+#!/bin/sh
 printf 'TIMEOUT <%s>\n' "$1" >> "$MOCK_CALL_LOG"
 case "${MOCK_TIMEOUT_MODE:-run}:$1" in
   syncer-expire:10s|probe-expire:3s)
@@ -80,7 +80,7 @@ shift
 exec "$@"
 MOCK
     cat > "$temp_dir/bin/sleep" <<'MOCK'
-#!/usr/bin/env bash
+#!/bin/sh
 printf 'SLEEP <%s>\n' "$1" >> "$MOCK_CALL_LOG"
 MOCK
     chmod +x \
@@ -107,7 +107,7 @@ MOCK
     export CLUSTER_NAMESPACE="$namespace"
     export KB_CLUSTER_COMP_NAME="$cluster_component_name"
 
-    bash "$script"
+    sh "$script"
     rc=$?
     printf 'TEST:calls='
     paste -sd, "$MOCK_CALL_LOG"
@@ -140,6 +140,7 @@ MOCK
         command = action.dig("exec", "command")
         abort "#{name}: malformed command #{command.inspect}" unless command&.length == 3
         abort "#{name}: expected /bin/sh -c" unless command[0, 2] == ["/bin/sh", "-c"]
+        abort "#{name}: unexpected action image" if action.dig("exec", "image")
 
         body = command[2]
         expected = "/scripts/mongodb-switchover.sh > /tmp/switchover.log"
@@ -177,6 +178,17 @@ MOCK
         abort "#{name}: ConfigMap get permission missing" unless Array(configmaps["verbs"]).include?("get")
       end
     '
+  }
+
+  verify_posix_action_source() {
+    local chart_dir
+    local script
+
+    chart_dir=$(cd .. && pwd)
+    script="$chart_dir/scripts/mongodb-switchover.sh"
+    [ "$(sed -n '1p' "$script")" = "#!/bin/sh" ] || return 1
+    sh -n "$script" || return
+    shellcheck --shell=sh --severity=warning "$script"
   }
 
   It "closes a candidate switchover only after the exact completion ConfigMap disappears"
@@ -323,6 +335,11 @@ MOCK
     The output should include "TEST:calls=TIMEOUT <10s>"
     The output should not include "SYNCERCTL"
     The output should not include "KUBECTL"
+  End
+
+  It "declares and passes the POSIX sh action-source gate"
+    When call verify_posix_action_source
+    The status should be success
   End
 
   It "renders all three actions with the completion-observation prerequisites"

--- a/addons/mongodb/scripts/mongodb-switchover.sh
+++ b/addons/mongodb/scripts/mongodb-switchover.sh
@@ -1,8 +1,124 @@
-#!/bin/bash
+#!/bin/sh
 
-if [ "$KB_SWITCHOVER_ROLE" != "primary" ]; then
-    echo "switchover not triggered for primary, nothing to do, exit 0."
+role=${KB_SWITCHOVER_ROLE:-}
+current_name=${KB_SWITCHOVER_CURRENT_NAME:-}
+candidate_name=${KB_SWITCHOVER_CANDIDATE_NAME:-}
+namespace=${CLUSTER_NAMESPACE:-}
+component_name=${KB_CLUSTER_COMP_NAME:-}
+syncerctl_bin=${MONGODB_SYNCERCTL_BIN:-/tools/syncerctl}
+kubectl_bin=${MONGODB_KUBECTL_BIN:-/data/mongodb/tmp/bin/kubectl}
+
+case "$role" in
+  primary)
+    ;;
+  secondary)
+    printf 'role=secondary does not require transfer\n'
     exit 0
+    ;;
+  *)
+    printf 'phase: invalid-role\n' >&2
+    printf 'observed-role: %s\n' "$role" >&2
+    printf 'next-retry-safe: no\n' >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "$current_name" ]; then
+  printf 'phase: missing-current-pod\n' >&2
+  printf 'next-retry-safe: no\n' >&2
+  exit 2
 fi
 
-/tools/syncerctl switchover --primary "$KB_SWITCHOVER_CURRENT_NAME" ${KB_SWITCHOVER_CANDIDATE_NAME:+--candidate "$KB_SWITCHOVER_CANDIDATE_NAME"}
+if [ -z "$namespace" ]; then
+  printf 'phase: missing-cluster-namespace\n' >&2
+  printf 'next-retry-safe: no\n' >&2
+  exit 2
+fi
+
+if [ -z "$component_name" ]; then
+  printf 'phase: missing-cluster-component-name\n' >&2
+  printf 'next-retry-safe: no\n' >&2
+  exit 2
+fi
+
+if [ -n "$candidate_name" ]; then
+  timeout 10s "$syncerctl_bin" switchover \
+    --primary "$current_name" \
+    --candidate "$candidate_name"
+else
+  timeout 10s "$syncerctl_bin" switchover --primary "$current_name"
+fi
+rc=$?
+
+case "$rc" in
+  0)
+    ;;
+  124|143)
+    printf 'phase: syncerctl-timeout\n' >&2
+    printf 'syncerctl-rc: %s\n' "$rc" >&2
+    printf 'next-retry-safe: no\n' >&2
+    exit "$rc"
+    ;;
+  *)
+    printf 'phase: syncerctl-failed\n' >&2
+    printf 'syncerctl-rc: %s\n' "$rc" >&2
+    printf 'next-retry-safe: no\n' >&2
+    exit "$rc"
+    ;;
+esac
+
+completion_name="${component_name}-switchover"
+completion_object="configmap/${completion_name}"
+probe=1
+
+while [ "$probe" -le 6 ]; do
+  observed=$(
+    timeout 3s "$kubectl_bin" \
+      --request-timeout=2s \
+      --namespace "$namespace" \
+      get configmap "$completion_name" \
+      --ignore-not-found -o name
+  )
+  rc=$?
+
+  case "$rc" in
+    0)
+      ;;
+    124|143)
+      printf 'phase: completion-probe-timeout\n' >&2
+      printf 'completion-probe-rc: %s\n' "$rc" >&2
+      printf 'next-retry-safe: no\n' >&2
+      exit "$rc"
+      ;;
+    *)
+      printf 'phase: completion-probe-failed\n' >&2
+      printf 'completion-probe-rc: %s\n' "$rc" >&2
+      printf 'next-retry-safe: no\n' >&2
+      exit "$rc"
+      ;;
+  esac
+
+  if [ -z "$observed" ]; then
+    printf 'phase: completed\n'
+    printf 'completion-configmap: %s\n' "$completion_name"
+    exit 0
+  fi
+
+  if [ "$observed" != "$completion_object" ]; then
+    printf 'phase: malformed-completion-probe\n' >&2
+    printf 'observed-output: %s\n' "$observed" >&2
+    printf 'next-retry-safe: no\n' >&2
+    exit 1
+  fi
+
+  if [ "$probe" -eq 6 ]; then
+    printf 'phase: completion-not-observed\n' >&2
+    printf 'completion-configmap: %s\n' "$completion_name" >&2
+    printf 'completion-probes: 6\n' >&2
+    printf 'next-retry-safe: no\n' >&2
+    exit 1
+  fi
+
+  sleep 2
+  probe=$((probe + 1))
+done

--- a/addons/mongodb/templates/cmpd-config-server.yaml
+++ b/addons/mongodb/templates/cmpd-config-server.yaml
@@ -68,10 +68,14 @@ spec:
     switchover:
       exec:
         container: mongodb
+        env:
+          - name: MONGODB_KUBECTL_BIN
+            value: {{ .Values.dataMountPath }}/tmp/bin/kubectl
         command:
           - /bin/sh
           - -c
-          - /scripts/mongodb-switchover.sh > /tmp/switchover.log 2>&1
+          - /scripts/mongodb-switchover.sh > /tmp/switchover.log
+      timeoutSeconds: 50
   runtime:
     securityContext:
       # percona-server-mongodb needs run as root to have privilege to access to keyfile

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -92,10 +92,14 @@ spec:
     switchover:
       exec:
         container: mongodb
+        env:
+          - name: MONGODB_KUBECTL_BIN
+            value: {{ .Values.dataMountPath }}/tmp/bin/kubectl
         command:
           - /bin/sh
           - -c
-          - /scripts/mongodb-switchover.sh > /tmp/switchover.log 2>&1
+          - /scripts/mongodb-switchover.sh > /tmp/switchover.log
+      timeoutSeconds: 50
     postProvision:
       exec:
         container: mongodb

--- a/addons/mongodb/templates/cmpd.yaml
+++ b/addons/mongodb/templates/cmpd.yaml
@@ -94,10 +94,14 @@ spec:
     switchover:
       exec:
         container: mongodb
+        env:
+          - name: MONGODB_KUBECTL_BIN
+            value: {{ .Values.dataMountPath }}/tmp/bin/kubectl
         command:
           - /bin/sh
           - -c
-          - /scripts/mongodb-switchover.sh > /tmp/switchover.log 2>&1
+          - /scripts/mongodb-switchover.sh > /tmp/switchover.log
+      timeoutSeconds: 50
   runtime:
     securityContext:
       # percona-server-mongodb needs run as root to have privilege to access to keyfile


### PR DESCRIPTION
## Problem

MongoDB switchover currently treats any non-primary role as success, invokes
syncer without a response deadline, and returns immediately after the request.
The syncer request only creates a completion ConfigMap; actual promotion is
complete when MongoDB HA deletes that token. A connected syncer that withholds
its response can also block indefinitely.

## Change

- validate exact primary/secondary roles and required identities;
- submit exactly one syncer request under a 10-second bound;
- observe exact completion-token deletion through six bounded kubectl probes;
- preserve request/probe failures and timeout statuses without replay;
- keep the script POSIX for every resolved MongoDB action image;
- render all three switchover actions with the projected kubectl path,
  visible classified stderr, and a 50-second action ceiling; and
- add a contract suite covering roles, candidates, failures, completion,
  all supported ComponentVersion image mappings, and tool producers.

## Evidence

- focused ShellSpec: Bash 3.2 `24/0`, Bash 5.3 `24/0`;
- full MongoDB ShellSpec: Bash 3.2 `102/0`, Bash 5.3 `102/0`;
- actual resolved 8.0.17 image: hanging request, hanging probe, and absent
  candidate rows pass;
- Helm lint and default/custom-data-path renders pass;
- POSIX `sh -n`, ShellCheck warning, diff-check, strict fsck, and clean
  worktree pass;
- fresh independent design review: `DESIGN_CLEAR / BLOCKER_LIST0`;
- fresh independent implementation review: `APPROVE / BLOCKER_LIST0`.

## Boundaries

This PR contains static and container-local evidence only. It does not claim
Kubernetes runtime acceptance, package readiness, formal product N, merge,
deploy, or release readiness.

Open PR #3241 and PR #3110 remove the current kubectl producer from the same
ComponentDefinitions. Any future rebase must preserve both kubectl on the
selected data volume and syncerctl on `/tools`.
