### PR TITLE
fix(mongodb): validate PBM backup delete metadata

### DIFF
--- a/addons/mongodb/dataprotection/pbm-backup-delete.sh
+++ b/addons/mongodb/dataprotection/pbm-backup-delete.sh
@@ -14,23 +14,62 @@ if [ "$PBM_BACKUP_TYPE" = "continuous" ]; then
         backup_path=$(dirname "$DP_BACKUP_BASE_PATH")
         export DATASAFED_BACKEND_BASE_PATH="${backup_path#/}/$PBM_BACKUP_DIR_NAME"
         pbm_dir_name="pbmPitr"
-        if [ -n "$(datasafed list $pbm_dir_name)" ]; then
-            datasafed rm $pbm_dir_name -r
+        if [ -n "$(datasafed list "$pbm_dir_name")" ]; then
+            datasafed rm "$pbm_dir_name" -r
             echo "INFO: PBM pitr files deleted."
         fi
     fi
 else
-    if [ "$(datasafed list ${DP_BACKUP_JSON})" == "${DP_BACKUP_JSON}" ]; then
-        backup_status=$(datasafed pull "/${DP_BACKUP_JSON}" - | jq -r '.status')
+    metadata_listing=$(datasafed list "$DP_BACKUP_JSON")
+    if [ "$metadata_listing" = "$DP_BACKUP_JSON" ]; then
+        backup_json=$(datasafed pull "/${DP_BACKUP_JSON}" -)
     else
         echo "INFO: Backup has been deleted."
         exit 0
     fi
+
+    if metadata_validation=$(printf '%s\n' "$backup_json" | jq -e -s '
+        length == 1
+        and (.[0] | type == "object")
+        and (.[0].status | type == "string")
+        and (
+            (.[0].extras[0].backup_name? // null) as $backup_name
+            | $backup_name == null or ($backup_name | type == "string")
+        )
+    ' 2>&1); then
+        :
+    else
+        metadata_status=$?
+        echo "ERROR: Invalid backup metadata: $metadata_validation" >&2
+        exit "$metadata_status"
+    fi
+
+    backup_status=$(printf '%s\n' "$backup_json" | jq -r -s '.[0].status')
     echo "INFO: Backup status: $backup_status"
-    backup_name=$(echo "$backup_status" | jq -r '.extras[0].backup_name')
+
+    if backup_name=$(printf '%s\n' "$backup_json" | jq -e -r -s '
+        (.[0].extras[0].backup_name? // "") as $backup_name
+        | if $backup_name == ""
+          then $backup_name
+          elif (
+              ($backup_name | test("^[A-Za-z0-9._:+-]+$"))
+              and ($backup_name | startswith("-") | not)
+              and $backup_name != "."
+              and $backup_name != ".."
+          )
+          then $backup_name
+          else error("unsafe PBM backup name")
+          end
+    ' 2>&1); then
+        :
+    else
+        backup_name_status=$?
+        echo "ERROR: Invalid PBM backup name: $backup_name" >&2
+        exit "$backup_name_status"
+    fi
     echo "INFO: Backup name: $backup_name"
 
-    if [ -z "$backup_name" ] || [ "$backup_name" = "null" ]; then
+    if [ -z "$backup_name" ]; then
         echo "INFO: Backup name is empty, the backup  reis not completed and skip handling."
         exit 0
     fi
@@ -38,24 +77,24 @@ else
     backup_path=$(dirname "$DP_BACKUP_BASE_PATH")
     export DATASAFED_BACKEND_BASE_PATH="${backup_path#/}/$PBM_BACKUP_DIR_NAME"
     echo "INFO: Backup path: $DATASAFED_BACKEND_BASE_PATH"
-    if [ -n "$(datasafed list $backup_name)" ]; then
-        datasafed rm $backup_name -r
+    if [ -n "$(datasafed list "$backup_name")" ]; then
+        datasafed rm "$backup_name" -r
         echo "INFO: Backup directory $backup_name deleted."
     fi
 
     backup_pbm_json="${backup_name}.pbm.json"
-    if [ "$(datasafed list $backup_pbm_json)" == "$backup_pbm_json" ]; then
-        datasafed rm $backup_pbm_json
+    if [ "$(datasafed list "$backup_pbm_json")" = "$backup_pbm_json" ]; then
+        datasafed rm "$backup_pbm_json"
         echo "INFO: PBM config file $backup_pbm_json deleted."
     fi
 fi
 
 # delete pbm initial config file
 pbm_init=".pbm.init"
-if [ "$(datasafed list / | wc -l)" = "1" ] && [ "$(datasafed list $pbm_init)" = "$pbm_init" ]; then
-    datasafed rm $pbm_init
+if [ "$(datasafed list "/" | wc -l)" = "1" ] && [ "$(datasafed list "$pbm_init")" = "$pbm_init" ]; then
+    datasafed rm "$pbm_init"
     export DATASAFED_BACKEND_BASE_PATH="${backup_path#/}"
-    datasafed rmdir backups
+    datasafed rmdir "backups"
     echo "INFO: PBM initial config file $pbm_init deleted."
 fi
 echo "INFO: PBM backup delete script completed successfully."

--- a/addons/mongodb/dataprotection/pbm-backup-delete.sh
+++ b/addons/mongodb/dataprotection/pbm-backup-delete.sh
@@ -33,8 +33,16 @@ else
         and (.[0] | type == "object")
         and (.[0].status | type == "string")
         and (
-            (.[0].extras[0].backup_name? // null) as $backup_name
-            | $backup_name == null or ($backup_name | type == "string")
+            (.[0].extras[0]?) as $extra
+            | $extra == null
+              or (
+                  ($extra | type == "object")
+                  and (
+                      ($extra | has("backup_name") | not)
+                      or $extra.backup_name == null
+                      or ($extra.backup_name | type == "string")
+                  )
+              )
         )
     ' 2>&1); then
         :
@@ -48,11 +56,21 @@ else
     echo "INFO: Backup status: $backup_status"
 
     if backup_name=$(printf '%s\n' "$backup_json" | jq -e -r -s '
-        (.[0].extras[0].backup_name? // "") as $backup_name
+        (.[0].extras[0]?) as $extra
+        | (
+            if (
+                $extra == null
+                or ($extra | has("backup_name") | not)
+                or $extra.backup_name == null
+            )
+            then ""
+            else $extra.backup_name
+            end
+        ) as $backup_name
         | if $backup_name == ""
           then $backup_name
           elif (
-              ($backup_name | test("^[A-Za-z0-9._:+-]+$"))
+              ($backup_name | test("\\A[A-Za-z0-9._:+-]+\\z"))
               and ($backup_name | startswith("-") | not)
               and $backup_name != "."
               and $backup_name != ".."

--- a/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
@@ -177,4 +177,14 @@ SH
     The output should not include "|rm|"
     The stderr should not be blank
   End
+
+  It "rejects a backup name that could be parsed as a datasafed option"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":"--help"}]}'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should not be blank
+  End
 End

--- a/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
@@ -187,4 +187,24 @@ SH
     The output should not include "|rm|"
     The stderr should not be blank
   End
+
+  It "rejects a boolean false backup name before deleting artifacts"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":false}]}'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should not be blank
+  End
+
+  It "rejects a backup name with a trailing newline before deleting artifacts"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":"..\n"}]}'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should not be blank
+  End
 End

--- a/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
@@ -19,6 +19,9 @@ printf '\n' >>"$MONGODB_TEST_CALL_LOG"
 
 case "$command_name" in
   list)
+    if [ -n "${MONGODB_TEST_LIST_RC:-}" ]; then
+      exit "$MONGODB_TEST_LIST_RC"
+    fi
     target=${1:-}
     case "$target" in
       kubeblocks-backup.json)
@@ -59,7 +62,7 @@ SH
     export MONGODB_TEST_CALL_LOG="$test_root/calls.log"
     export MONGODB_TEST_METADATA_PRESENT=1
     export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":"backup-2026"}]}'
-    unset MONGODB_TEST_PULL_RC MONGODB_TEST_RM_RC
+    unset MONGODB_TEST_LIST_RC MONGODB_TEST_PULL_RC MONGODB_TEST_RM_RC
     : >"$MONGODB_TEST_CALL_LOG"
   }
   Before "setup_pbm_backup_delete"
@@ -72,7 +75,8 @@ SH
     unset DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH
     unset PBM_BACKUP_TYPE PBM_BACKUP_DIR_NAME RETAIN_PITR_FILES
     unset MONGODB_TEST_CALL_LOG MONGODB_TEST_METADATA_PRESENT
-    unset MONGODB_TEST_PULL_OUTPUT MONGODB_TEST_PULL_RC MONGODB_TEST_RM_RC
+    unset MONGODB_TEST_PULL_OUTPUT MONGODB_TEST_LIST_RC
+    unset MONGODB_TEST_PULL_RC MONGODB_TEST_RM_RC
   }
   After "cleanup_pbm_backup_delete"
 
@@ -130,5 +134,47 @@ SH
     The status should be failure
     The output should not include "|rm|"
     The stderr should include "parse error"
+  End
+
+  It "preserves metadata probe failure without reporting an idempotent delete"
+    export MONGODB_TEST_LIST_RC=17
+
+    When call run_delete_and_report
+
+    The status should equal 17
+    The output should not include "INFO: Backup has been deleted."
+    The output should not include "|rm|"
+    The stderr should be blank
+  End
+
+  It "rejects multiple backup metadata documents before deleting artifacts"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":"one"}]}
+{"status":"Completed","extras":[{"backup_name":"two"}]}'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should not be blank
+  End
+
+  It "rejects a non-string backup name before deleting artifacts"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":42}]}'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should not be blank
+  End
+
+  It "rejects an unsafe backup path before deleting artifacts"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":"../other-backup"}]}'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should not be blank
   End
 End

--- a/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/pbm_backup_delete_spec.sh
@@ -1,0 +1,134 @@
+# shellcheck shell=bash
+
+Describe "MongoDB PBM backup delete contract"
+  setup_pbm_backup_delete() {
+    test_root=$(mktemp -d "${TMPDIR:-/tmp}/mongodb-pbm-delete-spec.XXXXXX")
+    fake_bin="$test_root/bin"
+    original_path=$PATH
+    mkdir -p "$fake_bin"
+
+    cat >"$fake_bin/datasafed" <<'SH'
+#!/bin/sh
+command_name=${1:-}
+printf '%s|%s' "$DATASAFED_BACKEND_BASE_PATH" "${1:-}" >>"$MONGODB_TEST_CALL_LOG"
+shift
+for arg in "$@"; do
+  printf '|%s' "$arg" >>"$MONGODB_TEST_CALL_LOG"
+done
+printf '\n' >>"$MONGODB_TEST_CALL_LOG"
+
+case "$command_name" in
+  list)
+    target=${1:-}
+    case "$target" in
+      kubeblocks-backup.json)
+        if [ "${MONGODB_TEST_METADATA_PRESENT:-1}" = "1" ]; then
+          printf 'kubeblocks-backup.json\n'
+        fi
+        ;;
+      /)
+        printf 'artifact-one\nartifact-two\n'
+        ;;
+      *)
+        printf '%s\n' "$target"
+        ;;
+    esac
+    ;;
+  pull)
+    if [ -n "${MONGODB_TEST_PULL_OUTPUT:-}" ]; then
+      printf '%s\n' "$MONGODB_TEST_PULL_OUTPUT"
+    fi
+    exit "${MONGODB_TEST_PULL_RC:-0}"
+    ;;
+  rm)
+    exit "${MONGODB_TEST_RM_RC:-0}"
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+SH
+    chmod +x "$fake_bin/datasafed"
+
+    export PATH="$fake_bin:$original_path"
+    export DP_DATASAFED_BIN_PATH="$fake_bin"
+    export DP_BACKUP_BASE_PATH="/repo/backups/job-1"
+    export PBM_BACKUP_TYPE="physical"
+    export PBM_BACKUP_DIR_NAME="pbm"
+    export RETAIN_PITR_FILES="false"
+    export MONGODB_TEST_CALL_LOG="$test_root/calls.log"
+    export MONGODB_TEST_METADATA_PRESENT=1
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Completed","extras":[{"backup_name":"backup-2026"}]}'
+    unset MONGODB_TEST_PULL_RC MONGODB_TEST_RM_RC
+    : >"$MONGODB_TEST_CALL_LOG"
+  }
+  Before "setup_pbm_backup_delete"
+
+  cleanup_pbm_backup_delete() {
+    PATH=$original_path
+    export PATH
+    rm -rf "$test_root"
+    unset test_root fake_bin original_path
+    unset DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH
+    unset PBM_BACKUP_TYPE PBM_BACKUP_DIR_NAME RETAIN_PITR_FILES
+    unset MONGODB_TEST_CALL_LOG MONGODB_TEST_METADATA_PRESENT
+    unset MONGODB_TEST_PULL_OUTPUT MONGODB_TEST_PULL_RC MONGODB_TEST_RM_RC
+  }
+  After "cleanup_pbm_backup_delete"
+
+  run_delete_and_report() {
+    local status
+
+    "$SHELLSPEC_SHELL" ../dataprotection/pbm-backup-delete.sh
+    status=$?
+    printf '%s\n' "--- calls ---"
+    cat "$MONGODB_TEST_CALL_LOG"
+    return "$status"
+  }
+
+  It "deletes PBM artifacts named by valid completed backup metadata"
+    When call run_delete_and_report
+
+    The status should be success
+    The output should include "INFO: Backup status: Completed"
+    The output should include "INFO: Backup name: backup-2026"
+    The output should include "repo/backups/pbm|rm|backup-2026|-r"
+    The output should include "repo/backups/pbm|rm|backup-2026.pbm.json"
+    The output should include "INFO: PBM backup delete script completed successfully."
+    The stderr should be blank
+  End
+
+  It "keeps deletion idempotent when metadata is already absent"
+    export MONGODB_TEST_METADATA_PRESENT=0
+
+    When call run_delete_and_report
+
+    The status should be success
+    The output should include "INFO: Backup has been deleted."
+    The output should not include "|rm|"
+    The stderr should be blank
+  End
+
+  It "skips PBM artifact deletion when metadata has no backup name"
+    export MONGODB_TEST_PULL_OUTPUT='{"status":"Running","extras":[{}]}'
+
+    When call run_delete_and_report
+
+    The status should be success
+    The output should include "INFO: Backup status: Running"
+    The output should include "INFO: Backup name:"
+    The output should include "skip handling."
+    The output should not include "|rm|"
+    The stderr should be blank
+  End
+
+  It "fails closed on malformed backup metadata without deleting artifacts"
+    export MONGODB_TEST_PULL_OUTPUT='{invalid-json'
+
+    When call run_delete_and_report
+
+    The status should be failure
+    The output should not include "|rm|"
+    The stderr should include "parse error"
+  End
+End


### PR DESCRIPTION
## Problem

MongoDB PBM `preDelete` reads `kubeblocks-backup.json`, reduces the document
to `.status`, and then tries to read `.extras[0].backup_name` from that scalar.
Valid completed metadata therefore exits with jq rc5 before deleting either
the PBM backup directory or its companion metadata file.

The metadata existence probe also ran inside a shell condition, so a
`datasafed list` failure was interpreted as "already deleted" and returned
success.

## Solution

- preserve metadata probe and pull failures under the existing
  `set -e -o pipefail`;
- validate the complete metadata document before extracting fields;
- require exactly one object, a string status, and an absent/null/string PBM
  backup name;
- reject path-like, control-character, and option-like names before any PBM
  artifact probe or removal; and
- quote datasafed operands while preserving missing-metadata, missing-name,
  and continuous-backup behavior.

The stricter malformed/name checks are preventive contract hardening. No
runtime incident is claimed for those hostile inputs.

## Verification

- focused ShellSpec:
  - Bash 3.2.57: 11 examples, 0 failures
  - Bash 5.3.9: 11 examples, 0 failures
- full MongoDB ShellSpec, run serially:
  - Bash 3.2.57: 89 examples, 0 failures
  - Bash 5.3.9: 89 examples, 0 failures
- dual-shell syntax and ShellCheck warning severity pass
- Helm lint passes
- default and custom renders each contain exactly five byte-equal PBM
  `preDelete` consumers
- fresh independent implementation review: `APPROVE / BLOCKER_LIST0`

## Review Focus

- jq absent/null/type handling without boolean-false coalescing;
- absolute-end safe-name validation before datasafed calls; and
- preservation of existing idempotent and continuous control flow.

## Boundary

This PR has offline code, unit, lint, and render evidence. It does not claim a
packaged addon, Kubernetes/vcluster execution, tester P/F/N, deployment, or
release acceptance.
