### PR TITLE
feat(mongodb): adapt shard lifecycle to syncer APIs

### DIFF
--- a/addons/mongodb/scripts-ut-spec/shard_manage_spec.sh
+++ b/addons/mongodb/scripts-ut-spec/shard_manage_spec.sh
@@ -1,0 +1,79 @@
+# shellcheck shell=bash
+
+Describe "MongoDB shard lifecycle polling"
+  setup() {
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+    export SYNCERCTL_BIN="$TEST_DIR/syncerctl"
+    export SYNCER_SHARD_POLL_INTERVAL_SECONDS=1
+    export SYNCER_ADD_SHARD_TIMEOUT_SECONDS=10
+    export SYNCER_REMOVE_SHARD_TIMEOUT_SECONDS=10
+  }
+  BeforeEach 'setup'
+
+  cleanup() {
+    rm -rf "$TEST_DIR"
+    unset TEST_DIR SYNCERCTL_BIN SYNCER_SHARD_POLL_INTERVAL_SECONDS
+    unset SYNCER_ADD_SHARD_TIMEOUT_SECONDS SYNCER_REMOVE_SHARD_TIMEOUT_SECONDS
+  }
+  AfterEach 'cleanup'
+
+  It "polls Running until add-shard succeeds"
+    cat > "$SYNCERCTL_BIN" <<'MOCK'
+#!/bin/bash
+count_file="$TEST_DIR/count"
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+count=$((count + 1))
+echo "$count" > "$count_file"
+if [ "$count" -lt 2 ]; then
+  echo "add shard is Running" >&2
+  exit 1
+fi
+echo "add shard success"
+MOCK
+    chmod +x "$SYNCERCTL_BIN"
+
+    When run bash ../scripts/mongodb-shard-manage.sh add-shard
+    The status should be success
+    The output should include "add shard is Running"
+    The output should include "add shard success"
+    The contents of file "$TEST_DIR/count" should equal 2
+  End
+
+  It "retries transient remove-shard errors"
+    cat > "$SYNCERCTL_BIN" <<'MOCK'
+#!/bin/bash
+count_file="$TEST_DIR/count"
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+count=$((count + 1))
+echo "$count" > "$count_file"
+if [ "$count" -lt 2 ]; then
+  echo "remove shard failed: temporary mongos connection error" >&2
+  exit 1
+fi
+echo "remove shard success"
+MOCK
+    chmod +x "$SYNCERCTL_BIN"
+
+    When run bash ../scripts/mongodb-shard-manage.sh remove-shard
+    The status should be success
+    The output should include "temporary mongos connection error"
+    The output should include "remove shard success"
+  End
+
+  It "fails immediately on a permanent remove-shard error"
+    cat > "$SYNCERCTL_BIN" <<'MOCK'
+#!/bin/bash
+echo "remove shard failed: shard demo has 1 jumbo chunks" >&2
+exit 1
+MOCK
+    chmod +x "$SYNCERCTL_BIN"
+
+    When run bash ../scripts/mongodb-shard-manage.sh remove-shard
+    The status should be failure
+    The output should include "jumbo chunks"
+    The error should include "failed permanently"
+  End
+End

--- a/addons/mongodb/scripts/mongodb-shard-manage.sh
+++ b/addons/mongodb/scripts/mongodb-shard-manage.sh
@@ -1,212 +1,77 @@
 #!/bin/bash
 
-# shellcheck disable=SC1091
-. "/scripts/mongodb-common.sh"
+set -o errexit
+set -o nounset
+set -o pipefail
 
-MONGODB_REPLICA_SET_NAME=$CLUSTER_COMPONENT_NAME
-CLIENT=$(get_mongodb_client_name)
-CLUSTER_MONGO="$CLIENT --host $MONGOS_INTERNAL_HOST --port $MONGOS_INTERNAL_PORT -u $MONGODB_ADMIN_USER -p $MONGODB_ADMIN_PASSWORD --quiet --eval"
+readonly POLL_INTERVAL_SECONDS="${SYNCER_SHARD_POLL_INTERVAL_SECONDS:-2}"
+readonly SYNCERCTL_BIN="${SYNCERCTL_BIN:-/tools/syncerctl}"
 
-wait_for_mongos() {
-    # Wait for the mongos service to be ready
-    MAX_RETRIES=300
-    retry_count=0
-    while [ $retry_count -lt $MAX_RETRIES ]; do
-        result=$($CLUSTER_MONGO "db.adminCommand({ ping: 1 })" 2>/dev/null)
-        if [[ "$result" == *"ok"* ]]; then
-            echo "INFO: Mongos is ready."
-            break
-        fi
-        echo "INFO: Waiting for mongos to be ready... (attempt $((retry_count+1))/$MAX_RETRIES)"
-        retry_count=$((retry_count+1))
-        sleep 2
-    done
-
-    if [ $retry_count -eq $MAX_RETRIES ]; then
-        echo "ERROR: Mongos failed to become ready after $MAX_RETRIES attempts." >&2
-        exit 1
-    fi
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
 }
 
-check_shard_exists() {
-    # check if the shard exists in the config database
-    local shard_exists
-    shard_exists=$($CLUSTER_MONGO "db.getSiblingDB(\"config\").shards.find({ _id: \"$MONGODB_REPLICA_SET_NAME\" })" 2>/dev/null)
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Failed to check if shard $MONGODB_REPLICA_SET_NAME exists." >&2
-        exit 1
-    fi
-    echo "INFO: Check if shard $MONGODB_REPLICA_SET_NAME exists: $shard_exists"
-    if [ -n "$shard_exists" ]; then
-        return 0 # true
-    else
-        return 1
-    fi
+is_permanent_error() {
+  local output=$1
+  case "$output" in
+    *"jumbo chunks"* | \
+    *"no active destination shard is available"* | \
+    *"already registered as shard"* | \
+    *"belongs to replica set"* | \
+    *"unknown state"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
-initialize_or_scale_out_mongodb_shard() {
-    wait_for_mongos
+poll_shard_operation() {
+  local command=$1
+  local timeout_seconds=$2
+  local started_at=$SECONDS
+  local output
+  local status
 
-    # Check if the shard exists
-    MAX_RETRIES=300
-    retry_count=0
-    while ! check_shard_exists; do
-        echo "INFO: Shard $MONGODB_REPLICA_SET_NAME does not exist, initializing... (attempt $((retry_count+1))/$MAX_RETRIES)"
-        retry_count=$((retry_count+1))
-        if [ $retry_count -ge $MAX_RETRIES ]; then
-            echo "ERROR: Shard $MONGODB_REPLICA_SET_NAME failed to initialize after $MAX_RETRIES attempts." >&2
-            exit 1
-        fi
-        sleep 2
-        pod_endpoints=$(generate_endpoints "$MONGODB_POD_FQDN_LIST" "$KB_SERVICE_PORT")
-        echo "INFO: Adding shard $MONGODB_REPLICA_SET_NAME with endpoints: $pod_endpoints"
-        $CLUSTER_MONGO "sh.addShard(\"$MONGODB_REPLICA_SET_NAME/$pod_endpoints\")"
-    done
-    echo "INFO: Shard $MONGODB_REPLICA_SET_NAME added."
+  if ! is_positive_integer "$POLL_INTERVAL_SECONDS" || ! is_positive_integer "$timeout_seconds"; then
+    echo "ERROR: shard operation poll interval and timeout must be positive integers" >&2
+    return 1
+  fi
+
+  while true; do
+    set +o errexit
+    output=$("$SYNCERCTL_BIN" "$command" 2>&1)
+    status=$?
+    set -o errexit
+
+    if [ -n "$output" ]; then
+      printf '%s\n' "$output"
+    fi
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+    if is_permanent_error "$output"; then
+      echo "ERROR: $command failed permanently" >&2
+      return "$status"
+    fi
+    if [ $((SECONDS - started_at)) -ge "$timeout_seconds" ]; then
+      echo "ERROR: $command did not succeed within ${timeout_seconds}s" >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
 }
 
-get_remove_shard_status() {
-    # Execute the removeShard command and capture its JSON output
-    local result
-    if [ "$CLIENT" = "mongosh" ]; then
-        result=$($CLUSTER_MONGO "EJSON.stringify(db.adminCommand( { removeShard: \"$MONGODB_REPLICA_SET_NAME\" } ))")
-    else
-        result=$($CLUSTER_MONGO "JSON.stringify(db.adminCommand( { removeShard: \"$MONGODB_REPLICA_SET_NAME\" } ))")
-    fi
-    echo "$result"
-}
-
-get_remove_shard_state() {
-    local result=$1
-    # Parse and log the state using jq
-    local state
-    state=$(echo "$result" | jq -r '.state')
-    # Return the state as the function output
-    echo "$state"
-}
-
-get_remaining_jumbo_chunks() {
-    local result=$1
-    # Parse and log the jumboChunks count using jq
-    local jumbo_chunks
-    if [ "$CLIENT" = "mongosh" ]; then
-        jumbo_chunks=$(echo "$result" | jq -r '.remaining.jumboChunks // 0')
-    else
-        jumbo_chunks=$(echo "$result" | jq -r '.remaining.jumboChunks.numberLong // 0')
-    fi
-    # Return the jumboChunks count as the function output
-    echo "$jumbo_chunks"
-}
-
-get_remaining_chunks() {
-    local result=$1
-    # Parse and log the chunks count using jq
-    local chunks
-    if [ "$CLIENT" = "mongosh" ]; then
-        chunks=$(echo "$result" | jq -r '.remaining.chunks // 0')
-    else
-        chunks=$(echo "$result" | jq -r '.remaining.chunks.numberLong // 0')
-    fi
-    # Return the chunks count as the function output
-    echo "$chunks"
-}
-
-delete_or_scale_in_mongodb_shard() {
-    wait_for_mongos
-
-    if ! check_shard_exists; then
-        echo "INFO: Shard $MONGODB_REPLICA_SET_NAME does not exist, skipping scale-in."
-        exit 0
-    fi
-
-    original_balance_status=$($CLUSTER_MONGO "sh.getBalancerState()")
-    if [ "$original_balance_status" = "false" ]; then
-        $CLUSTER_MONGO "sh.startBalancer()"
-    fi
-
-    echo "INFO: Shard $MONGODB_REPLICA_SET_NAME exists, scaling in..."
-    # Remove the shard and wait until the state is 'completed'
-    while true; do
-
-        if ! check_shard_exists; then
-            echo "INFO: Shard $MONGODB_REPLICA_SET_NAME does not exist, exiting."
-            exit 0
-        fi
-
-        status_json=$(get_remove_shard_status)
-        echo "INFO: Remove shard status: $status_json"
-        state=$(get_remove_shard_state "$status_json")
-        echo "INFO: Current state of shard $MONGODB_REPLICA_SET_NAME is $state"
-        if [ "$state" = "completed" ]; then
-            break
-        elif [ "$state" = "ongoing" ]; then
-            remaining_jumboChunks=$(get_remaining_jumbo_chunks "$status_json")
-            if [ "$remaining_jumboChunks" -gt 0 ]; then
-                echo "INFO: $remaining_jumboChunks jumbo chunks remaining, please clear jumbo chunks before removing the shard."
-                exit 1
-            fi
-
-            remaining_chunks=$(get_remaining_chunks "$status_json")
-            echo "INFO: $remaining_chunks chunks remaining."
-            if [ "$remaining_chunks" -eq 0 ]; then
-                dbs_to_move=$(echo "$status_json" | jq -r '.dbsToMove[]')
-                note=$(echo "$status_json" | jq -r '.note')
-                echo "INFO: $note"
-                echo "$dbs_to_move"
-                for db in $dbs_to_move; do
-                    echo "INFO: Database '$db' is scheduled for movePrimary..."
-                    if [ -z "$DESTINATION_SHARD" ]; then
-                        DESTINATION_SHARD=$($CLUSTER_MONGO "JSON.stringify(
-                            db.getSiblingDB('config').shards.find({
-                                _id: { \$ne: '$MONGODB_REPLICA_SET_NAME' }
-                            }).toArray()
-                        )" | jq -r '.[]._id' | shuf -n 1)
-                        if [ -z "$DESTINATION_SHARD" ]; then
-                            echo "ERROR: No available shard found for moving primary for database '$db'."
-                            exit 1
-                        fi
-                    fi
-                    echo "INFO: Moving primary for database '$db' to shard '$DESTINATION_SHARD'..."
-                    $CLUSTER_MONGO "db.adminCommand({ movePrimary: \"$db\", to: \"$DESTINATION_SHARD\" })"
-                done
-                continue
-            else
-                echo "INFO: $remaining_chunks chunks are still being migrated, waiting..."
-            fi
-        fi
-        sleep 2
-    done
-
-    # reset balancer state
-    if [ "$original_balance_status" = "false" ]; then
-        $CLUSTER_MONGO "sh.stopBalancer()"
-        echo "INFO: Balancer state has been reset to false."
-    fi
-    echo "INFO: Shard $MONGODB_REPLICA_SET_NAME has been successfully removed."
-}
-
-# main
-if [ $# -eq 1 ]; then
-  case $1 in
-  --help)
-    echo "Usage: $0 [options]"
-    echo "Options:"
-    echo "  --help                show help information"
-    echo "  --post-provision      initialize or scale out mongodb shard"
-    echo "  --pre-terminate       stop or scale in mongodb shard"
-    exit 0
+case "${1:-}" in
+  add-shard)
+    poll_shard_operation add-shard "${SYNCER_ADD_SHARD_TIMEOUT_SECONDS:-600}"
     ;;
-  --post-provision)
-    initialize_or_scale_out_mongodb_shard
-    exit 0
-    ;;
-  --pre-terminate)
-    delete_or_scale_in_mongodb_shard
-    exit 0
+  remove-shard)
+    poll_shard_operation remove-shard "${SYNCER_REMOVE_SHARD_TIMEOUT_SECONDS:-3600}"
     ;;
   *)
-    echo "Error: invalid option '$1'"
-    exit 1
+    echo "Usage: $0 {add-shard|remove-shard}" >&2
+    exit 2
     ;;
-  esac
-fi
+esac

--- a/addons/mongodb/templates/cmpd-mongodb-shard.yaml
+++ b/addons/mongodb/templates/cmpd-mongodb-shard.yaml
@@ -100,14 +100,15 @@ spec:
       exec:
         container: mongodb
         command:
-          - /bin/bash
-          - -c
-          - /scripts/mongodb-shard-manage.sh --post-provision >> /tmp/post-provision.log 2>&1
+          - /scripts/mongodb-shard-manage.sh
+          - add-shard
         targetPodSelector: Role
         matchingKey: primary
+        # Syncer's API is asynchronous. Keep polling in this action instead of
+        # relying on KubeBlocks action retries, whose backoff is too coarse for
+        # long-running shard operations.
+        timeoutSeconds: -1
       preCondition: RuntimeReady
-      retryPolicy:
-        maxRetries: 10
   runtime:
     securityContext:
       # percona-server-mongodb needs run as root to have privilege to access to keyfile

--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -19,11 +19,12 @@ spec:
       exec:
         container: mongodb
         command:
-          - /bin/bash
-          - -c
-          - /scripts/mongodb-shard-manage.sh --pre-terminate >> /tmp/pre-terminate.log 2>&1
+          - /scripts/mongodb-shard-manage.sh
+          - remove-shard
         targetPodSelector: Role
         matchingKey: primary
-      retryPolicy:
-        maxRetries: 10
+        # Draining chunks and database primaries can take much longer than the
+        # default action timeout. The script polls Syncer's async task and owns
+        # the explicit one-hour operation bound.
+        timeoutSeconds: -1
 


### PR DESCRIPTION
## Summary

- invoke Syncer's asynchronous `add-shard` API from the MongoDB shard `postProvision` lifecycle
- invoke Syncer's asynchronous `remove-shard` API from the sharding `shardRemove` lifecycle
- replace credential-bearing mongosh orchestration with a thin script that only polls `syncerctl`
- use explicit 10-minute add / 1-hour remove bounds and fail fast for permanent conditions such as jumbo chunks
- set lifecycle `timeoutSeconds: -1` because draining can exceed KubeBlocks' default action timeout

KubeBlocks 1.1.0-beta.8 action retries use coarse/exponential backoff and terminated a real remove operation before Syncer reached `Succeeded`; keeping the bounded polling loop inside the lifecycle action avoids that mismatch while preserving Syncer as the sole shard-operation owner.

## Dependency

Requires the Syncer shard operation implementation from `apecloud/syncer` branch `feature/mongodb-shard-operations` (commit `0d4de47` or a descendant) in the configured Syncer image.

## Validation

- `shellspec ... shard_manage_spec.sh`: 3 examples, 0 failures
- `helm lint addons/mongodb`
- `helm template mongodb addons/mongodb --namespace kb-system`
- `bash -n addons/mongodb/scripts/mongodb-shard-manage.sh`
- `git diff --check`
- live MongoDB 8.0.17 E2E: PASS in 466.37s with KubeBlocks/DataProtection 1.1.0-beta.8
  - sharding scale `1 -> 2 -> 1`
  - database primary and records placed on the actual scale-in victim
  - victim Component and Pod deleted; one shard Component remained
  - data and database primary migrated to the survivor
  - balancer disabled before removal and verified disabled afterward
  - Syncer `0d4de47`, companion Syncer-test `8f1a3e7`

Companion test: https://github.com/apecloud/syncer-test/pull/3