### PR TITLE
feat(mongodb): use non-blocking shard removal

### DIFF
--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -16,6 +16,7 @@ spec:
   updateStrategy: Parallel
   lifecycleActions:
     shardRemove:
+      nonBlocking: true
       exec:
         container: mongodb
         command:


### PR DESCRIPTION
## What changed

Enable `nonBlocking` for the MongoDB `shardRemove` lifecycle action.

## Why

MongoDB shard removal waits for chunk migration, moves database primaries when necessary, and waits for `removeShard` to complete. Its duration depends on data volume and cluster conditions and can exceed the synchronous Action limit. KubeBlocks can now persist the selected targets and poll this action until it reaches a terminal result.

## User impact

MongoDB sharded-cluster scale-in no longer depends on the shard-removal command finishing within one synchronous controller call. This requires apecloud/kubeblocks#10725.

## Validation

- `helm dependency build addons/mongodb`
- `helm lint addons/mongodb`
- `helm template mongodb addons/mongodb` and verified `spec.lifecycleActions.shardRemove.nonBlocking: true`
