### PR TITLE
feat(falkordb): use non-blocking shard removal

### DIFF
--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -19,6 +19,7 @@ spec:
       shared: true
   lifecycleActions:
     shardRemove:
+      nonBlocking: true
       timeoutSeconds: 600
       exec:
         container: falkordb-cluster


### PR DESCRIPTION
## What changed

Enable `nonBlocking` for the FalkorDB `shardRemove` lifecycle action.

## Why

FalkorDB shard removal rebalances slots to zero and removes the shard nodes. The duration depends on data volume and cluster conditions and can exceed the synchronous Action limit. KubeBlocks can now persist the selected targets and poll this action until it reaches a terminal result.

## User impact

FalkorDB scale-in no longer depends on the shard-removal command finishing within one synchronous controller call. This requires apecloud/kubeblocks#10725.

## Validation

- `helm dependency build addons/falkordb`
- `helm lint addons/falkordb`
- `helm template falkordb addons/falkordb` and verified `spec.lifecycleActions.shardRemove.nonBlocking: true`
