### PR TITLE
feat(sharding): use non-blocking shard removal

### DIFF
--- a/addons/falkordb/scripts-ut-spec/sharding_lifecycle_image_contract_spec.sh
+++ b/addons/falkordb/scripts-ut-spec/sharding_lifecycle_image_contract_spec.sh
@@ -41,6 +41,12 @@ Describe "FalkorDB sharding lifecycle image contract"
     The output should not include "image:"
   End
 
+  It "allows the same-name ShardingDefinition lifecycle spec to upgrade"
+    When call render_sharding_definition
+    The status should be success
+    The output should include 'apps.kubeblocks.io/skip-immutable-check: "true"'
+  End
+
   It "keeps lifecycle action images versioned by ComponentVersion"
     When call render_cluster_component_version
     The status should be success

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "falkordb.labels" . | nindent 4 }}
   annotations:
-    {{- include "falkordb.apiVersion" . | nindent 4 }}
+    {{- include "falkordb.annotations" . | nindent 4 }}
 spec:
   template:
     compDef: {{ include "falkordbCluster.cmpdRegexpPattern" . }}

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -20,7 +20,7 @@ spec:
   lifecycleActions:
     shardRemove:
       nonBlocking: true
-      timeoutSeconds: 600
+      timeoutSeconds: 3600
       exec:
         container: falkordb-cluster
         command:

--- a/addons/falkordb/templates/shardingdefinition.yaml
+++ b/addons/falkordb/templates/shardingdefinition.yaml
@@ -19,6 +19,7 @@ spec:
       shared: true
   lifecycleActions:
     shardRemove:
+      nonBlocking: true
       timeoutSeconds: 600
       exec:
         container: falkordb-cluster

--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -17,6 +17,7 @@ spec:
   lifecycleActions:
     shardRemove:
       nonBlocking: true
+      timeoutSeconds: 3600
       exec:
         container: mongodb
         command:
@@ -27,4 +28,3 @@ spec:
         matchingKey: primary
       retryPolicy:
         maxRetries: 10
-

--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -16,6 +16,7 @@ spec:
   updateStrategy: Parallel
   lifecycleActions:
     shardRemove:
+      nonBlocking: true
       exec:
         container: mongodb
         command:

--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -16,8 +16,8 @@ spec:
   updateStrategy: Parallel
   lifecycleActions:
     shardRemove:
-      # Each attempt is idempotent. Use the controller's default action timeout
-      # and rate limiter to retry removeShard without blocking reconciliation.
+      # Each attempt is idempotent; the controller tracks non-blocking completion.
+      nonBlocking: true
       exec:
         container: mongodb
         command:
@@ -28,4 +28,3 @@ spec:
         matchingKey: primary
       retryPolicy:
         maxRetries: 10
-

--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -18,6 +18,7 @@ spec:
     shardRemove:
       # Each attempt is idempotent; the controller tracks non-blocking completion.
       nonBlocking: true
+      timeoutSeconds: 3600
       exec:
         container: mongodb
         command:

--- a/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
@@ -93,14 +93,25 @@ EOF
     The result of function call_log should include "pg_restore"
   End
 
-  It "treats ignored per-object errors as success under the default CONTINUE policy"
+  It "fails when the ignored-errors warning has no error details"
     export DATASAFED_LIST_OUT="backup-test.tar"
     export PG_RESTORE_EXIT=1
     export PG_RESTORE_STDERR="pg_restore: warning: errors ignored on restore: 3"
     When run bash "$(script_path)"
+    The status should be failure
+    The output should include "parameters:"
+    The error should include "errors ignored on restore"
+  End
+
+  It "treats existing-object errors as success under the default CONTINUE policy"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export PG_RESTORE_EXIT=1
+    export PG_RESTORE_STDERR='pg_restore: error: could not execute query: ERROR: relation "items" already exists
+pg_restore: warning: errors ignored on restore: 1'
+    When run bash "$(script_path)"
     The status should eq 0
     The output should include "treating as success under conflict_policy=CONTINUE"
-    The error should include "errors ignored on restore"
+    The error should include "already exists"
   End
 
   It "propagates ignored-error failures when conflict_policy is FAIL"

--- a/addons/redis/scripts-ut-spec/sharding_lifecycle_contract_spec.sh
+++ b/addons/redis/scripts-ut-spec/sharding_lifecycle_contract_spec.sh
@@ -1,0 +1,25 @@
+# shellcheck shell=sh
+
+Describe "Redis sharding lifecycle contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/redis" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  render_sharding_definition() {
+    helm template test "$(chart_path)" \
+      --show-only templates/shardingdefinition.yaml
+  }
+
+  It "allows the same-name ShardingDefinition lifecycle spec to upgrade"
+    When call render_sharding_definition
+    The status should be success
+    The output should include 'apps.kubeblocks.io/skip-immutable-check: "true"'
+  End
+End

--- a/addons/redis/templates/shardingdefinition.yaml
+++ b/addons/redis/templates/shardingdefinition.yaml
@@ -19,6 +19,7 @@ spec:
       shared: true
   lifecycleActions:
     shardRemove:
+      nonBlocking: true
       timeoutSeconds: 600
       exec:
         container: redis-cluster

--- a/addons/redis/templates/shardingdefinition.yaml
+++ b/addons/redis/templates/shardingdefinition.yaml
@@ -20,7 +20,7 @@ spec:
   lifecycleActions:
     shardRemove:
       nonBlocking: true
-      timeoutSeconds: 600
+      timeoutSeconds: 3600
       exec:
         container: redis-cluster
         command:

--- a/addons/redis/templates/shardingdefinition.yaml
+++ b/addons/redis/templates/shardingdefinition.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "redis.labels" . | nindent 4 }}
   annotations:
-    {{- include "redis.apiVersion" . | nindent 4 }}
+    {{- include "redis.annotations" . | nindent 4 }}
 spec:
   template:
     compDef: {{ include "redisCluster.cmpdRegexpPattern" . }}


### PR DESCRIPTION
## What changed

Enable `nonBlocking` for the `shardRemove` lifecycle action in:

- Redis
- FalkorDB
- MongoDB

Set `timeoutSeconds: 3600` for all three actions. For non-blocking actions, this is the total execution budget across all argument invocations, retries, and retry intervals.

## Why

These shard-removal actions perform data-dependent work that can exceed the synchronous Action limit:

- Redis rebalances hash slots away from the shard and removes its cluster nodes.
- FalkorDB rebalances slots to zero and removes the shard nodes.
- MongoDB waits for chunk migration, moves database primaries when necessary, and waits for `removeShard` to complete.

Without an explicit timeout, MongoDB would use the 30-second default. The existing 600-second values for Redis and FalkorDB would become hard total limits after switching to non-blocking execution. A finite one-hour window matches the intended long-running shard-operation configuration while still bounding stuck actions.

KubeBlocks can persist the selected targets and poll these actions until they reach a terminal result.

## User impact

Scale-in for these sharded databases no longer depends on shard removal finishing within one synchronous controller call and has up to one hour to finish migration and retries. This requires apecloud/kubeblocks#10725.

## Validation

For each of `redis`, `falkordb`, and `mongodb`:

- `helm dependency build --skip-refresh addons/<addon>`
- `helm lint addons/<addon>`
- `helm template <addon> addons/<addon>` and verified `spec.lifecycleActions.shardRemove.nonBlocking: true` and `timeoutSeconds: 3600`
