### PR TITLE
fix(postgresql): use exec role probe

### DIFF
--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ description: A PostgreSQL (with Patroni HA) cluster definition Helm chart for Ku
 
 type: application
 
-version: 1.2.0-alpha.1
+version: 1.2.0-alpha.2
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # appVersion should be consistent with the highest PostgreSQL (with Patroni HA) kernel version.

--- a/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
@@ -40,6 +40,28 @@ Describe "PostgreSQL KubeBlocks API contract"
     '
   }
 
+  component_definitions_with_exec_role_probe() {
+    render_chart | ruby -ryaml -e '
+      definitions = YAML.load_stream(ARGF.read).compact.select do |document|
+        document["kind"] == "ComponentDefinition"
+      end
+      count = definitions.count do |definition|
+        role_probe = definition.dig("spec", "lifecycleActions", "roleProbe") || {}
+        command = role_probe.dig("exec", "command") || []
+        role_probe["http"].nil? &&
+          role_probe.dig("exec", "container") == "postgresql" &&
+          command == [
+            "curl",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "http://127.0.0.1:5001/v1.0/getrole"
+          ]
+      end
+      puts count
+    '
+  }
+
   It "declares the KB 1.2 floor required by the rendered API fields"
     When call kubeblocks_floor
     The status should eq 0
@@ -49,11 +71,11 @@ Describe "PostgreSQL KubeBlocks API contract"
   It "advances the chart identity when immutable ComponentDefinitions change"
     When call chart_version
     The status should eq 0
-    The output should eq "1.2.0-alpha.1"
+    The output should eq "1.2.0-alpha.2"
   End
 
   It "publishes every ComponentDefinition under the advanced immutable identity"
-    When call render_count '^  name: postgresql-\(12\|14\|15\|16\|17\|18\)-1.2.0-alpha.1$'
+    When call render_count '^  name: postgresql-\(12\|14\|15\|16\|17\|18\)-1.2.0-alpha.2$'
     The status should eq 0
     The output should eq "6"
   End
@@ -66,6 +88,12 @@ Describe "PostgreSQL KubeBlocks API contract"
 
   It "grants every ComponentDefinition the pod-list permission used by live arbitration"
     When call component_definitions_with_pod_list_rbac
+    The status should eq 0
+    The output should eq "6"
+  End
+
+  It "uses an exec role probe supported by KubeBlocks main"
+    When call component_definitions_with_exec_role_probe
     The status should eq 0
     The output should eq "6"
   End

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -229,9 +229,16 @@ spec:
     roleProbe:
       periodSeconds: 1
       timeoutSeconds: 1
-      http:
-        port: "5001"
-        path: "/v1.0/getrole"
+      # KubeBlocks schedules role probes through the exec action path. dbctl
+      # returns the plain role token; curl --fail preserves non-2xx as failure.
+      exec:
+        container: postgresql
+        command:
+          - curl
+          - --fail
+          - --silent
+          - --show-error
+          - http://127.0.0.1:5001/v1.0/getrole
     switchover:
       # script worst case ~45s (leader query 5s + switchover API 20s +
       # bounded verification ~20s); kbagent clamps every action call at 60s


### PR DESCRIPTION
## Problem

PostgreSQL R11 against KubeBlocks main froze with both database Pods `5/5 Running` while the Cluster and Component stayed `Creating`. Every Pod repeatedly reported:

```
roleProbe code=-1: only exec action is supported: notImplemented
RoleProbeNotDone / primary is not present
```

The tested addon exact was main `5fa53f531defe335cd044723ebb854e6f4de4dbe`; its ComponentDefinitions still declared `roleProbe.http` for dbctl. The frozen failure-events artifact is SHA256 `9755c786fb6cec11d6f25e407b95bcbf4736b00af8404901e7581599c4e05db7`.

## Fix

- Call the same localhost dbctl `/v1.0/getrole` endpoint through `roleProbe.exec`.
- Bind the action to the existing `postgresql` lifecycle container so all lifecycle exec actions keep one execution image/container contract.
- Use `curl --fail --silent --show-error`, preserving the plain role token on stdout and converting non-2xx responses into probe failures.
- Advance the chart to `1.2.0-alpha.2` because ComponentDefinition lifecycle actions are immutable.
- Add a structured rendered-manifest contract test for all six PostgreSQL ComponentDefinitions.

## Verification

- Focused KubeBlocks API contract: 12 examples, 0 failures
- All PostgreSQL ShellSpec under Bash 5.3.9: 148 examples, 0 failures
- ShellCheck `--severity=error`: PASS
- `helm lint addons/postgresql`: PASS
- `helm template`: PASS
- `git diff --check`: PASS

## Exact-head runtime evidence

Fixed Test independently ran exact addon `be6048824da17383ca47517508f47d3e7e8b43d9` with tests `956d3e7fad07f5c42d36cf9c080db83c098ee1d8` as run `tr-20260809130327141-9d4cae71`.

- Natural terminal: `SUCCEEDED / PRODUCT_PASS`, version-smoke `PASS=12 / FAIL=0 / SKIP=0`
- Job UID: `f94becca-fea6-48c1-a267-445fe9edd55b`
- Cleanup: PASS; product identity and namespace absent; reported VCluster UID `9c8c428a...1208` deleted; unsafe operations `0`
- Immutable evidence member: `evidence/runner-results.tar.xz::001-events-start-vs-17.5.0-role-service-write-read.txt`
- Evidence member SHA256: `1f508347a93a6fc8c0d853739e8c104dd513b8e98092b25396547f31baee574a`
- Line 52: pod-0 roleProbe `code:0`, output `cHJpbWFyeQ==` (`primary`)
- Line 82: pod-1 roleProbe `code:0`, output `c2Vjb25kYXJ5` (`secondary`)
- Lines 72-73: Component `Available` with `the role primary is present`; Cluster `Available` with `All components are available`
- Lines 83-87: Component `Healthy`/`Running`; Cluster `ClusterReady`/`Running`; component phase `Running`
- The same immutable archive records converged role labels, the primary Pod and Service endpoint, write/read PASS, and a runtime identity TSV binding both Pod UIDs and image IDs.

This exact run closes the roleProbe execution, role publication, and Component/Cluster convergence review gap. It is one version-smoke product pass, not repeated-full acceptance; the formal repeated-full ledger remains `N0`.

Fixed Test retains ownership of packaging, live execution, evidence, cleanup, and verdict. No old-run retry, resubmit, force operation, or manual cleanup was used.
