### PR TITLE
fix(postgresql): allow log_timezone to take effect without restart

### DIFF
--- a/addons/postgresql/config/pg12-config-effect-scope.yaml
+++ b/addons/postgresql/config/pg12-config-effect-scope.yaml
@@ -40,7 +40,6 @@ immutableParameters:
   - log_file_mode
   - logging_collector
   - log_line_prefix
-  - log_timezone
   - log_truncate_on_rotation
   - port
   - rds.max_tcp_buffers

--- a/addons/postgresql/config/pg14-config-effect-scope.yaml
+++ b/addons/postgresql/config/pg14-config-effect-scope.yaml
@@ -40,7 +40,6 @@ immutableParameters:
   - log_file_mode
   - logging_collector
   - log_line_prefix
-  - log_timezone
   - log_truncate_on_rotation
   - port
   - rds.max_tcp_buffers

--- a/addons/postgresql/config/pg15-config-effect-scope.yaml
+++ b/addons/postgresql/config/pg15-config-effect-scope.yaml
@@ -40,7 +40,6 @@ immutableParameters:
   - log_file_mode
   - logging_collector
   - log_line_prefix
-  - log_timezone
   - log_truncate_on_rotation
   - port
   - rds.max_tcp_buffers

--- a/addons/postgresql/config/pg16-config-effect-scope.yaml
+++ b/addons/postgresql/config/pg16-config-effect-scope.yaml
@@ -40,7 +40,6 @@ immutableParameters:
   - log_file_mode
   - logging_collector
   - log_line_prefix
-  - log_timezone
   - log_truncate_on_rotation
   - port
   - rds.max_tcp_buffers

--- a/addons/postgresql/config/pg17-config-effect-scope.yaml
+++ b/addons/postgresql/config/pg17-config-effect-scope.yaml
@@ -40,7 +40,6 @@ immutableParameters:
   - log_file_mode
   - logging_collector
   - log_line_prefix
-  - log_timezone
   - log_truncate_on_rotation
   - port
   - rds.max_tcp_buffers

--- a/addons/postgresql/config/pg18-config-effect-scope.yaml
+++ b/addons/postgresql/config/pg18-config-effect-scope.yaml
@@ -40,7 +40,6 @@ immutableParameters:
   - log_file_mode
   - logging_collector
   - log_line_prefix
-  - log_timezone
   - log_truncate_on_rotation
   - port
   - rds.max_tcp_buffers


### PR DESCRIPTION
## What's changed

Remove `log_timezone` from the `immutableParameters` list in the PostgreSQL config effect-scope files (pg12-pg18).

## Why

`log_timezone` does not require a restart to take effect — it is a reloadable (SIGHUP) parameter in PostgreSQL. Keeping it in `immutableParameters` forces an unnecessary pod restart when the value is changed. Removing it lets KubeBlocks apply the change dynamically with immediate effect.

## Files changed

- `addons/postgresql/config/pg12-config-effect-scope.yaml`
- `addons/postgresql/config/pg14-config-effect-scope.yaml`
- `addons/postgresql/config/pg15-config-effect-scope.yaml`
- `addons/postgresql/config/pg16-config-effect-scope.yaml`
- `addons/postgresql/config/pg17-config-effect-scope.yaml`
- `addons/postgresql/config/pg18-config-effect-scope.yaml`

## Verification

- [ ] Lint/CI passes