### PR TITLE
feat(postgresql): make database required for pgdump action

### DIFF
--- a/addons/postgresql/templates/actionset-pgdump.yaml
+++ b/addons/postgresql/templates/actionset-pgdump.yaml
@@ -12,10 +12,13 @@ spec:
       value: {{ .Values.dataMountPath }}/kb-selective-backup
   parametersSchema:
     openAPIV3Schema:
+      type: object
+      required:
+        - database
       properties:
         database:
           type: string
-          description: "The database to backup. If not specified, all databases will be backed up."
+          description: "The database to backup. This parameter is required."
         schemas:
           type: string
           description: "The schemas to backup. If not specified, all schemas will be backed up. comma separated list of schemas can be provided."


### PR DESCRIPTION
## What's changed

Mark the `database` parameter as **required** in the pgdump ActionSet `parametersSchema`:

- Added `type: object` + `required: [database]` to the OpenAPI schema
- Updated the parameter description to reflect the required semantics

This makes selective backups fail validation when `database` is not specified, preventing ambiguous full-database backups when the caller intended a selective one.

## Verification

- `helm lint addons/postgresql` passes