### PR TITLE
feat(tidb): tune TiDB and TiKV default parameters for better TPCC performance

### DIFF
--- a/addons/tidb/config/tidb-config-constraint.cue
+++ b/addons/tidb/config/tidb-config-constraint.cue
@@ -395,6 +395,16 @@
 	// Controls whether an expression index can be created. Since TiDB v5.2.0, if the function in an expression is safe, you can create an expression index directly based on this function without enabling this configuration. If you want to create an expression index based on other functions, you can enable this configuration, but correctness issues might exist. By querying the `tidb_allow_function_for_expression_index` variable, you can get the functions that are safe to be directly used for creating an expression.
 	"experimental.allow-expression-index": bool | *false
 
+
+	// Enables the prepared plan cache. When enabled, execution plans of prepared statements are cached,
+	// which can significantly reduce latency for repeated parameterized queries (e.g. OLTP workloads like TPCC).
+	"prepared-plan-cache.enabled": bool | *true
+
+	// The maximum number of cached plans in the prepared plan cache.
+	"prepared-plan-cache.capacity": int & >=1 | *1000
+
+	// The ratio of memory reserved as a guard to prevent OOM when the plan cache uses too much memory.
+	"prepared-plan-cache.memory-guard-ratio": float & >=0 & <=1 | *0.1
 	...
 }
 

--- a/addons/tidb/config/tidb.toml.tpl
+++ b/addons/tidb/config/tidb.toml.tpl
@@ -1,6 +1,29 @@
 # full example can be seen at:
 # https://github.com/pingcap/tidb/blob/release-7.5/pkg/config/config.toml.example
 
+
+{{- /* Dynamic parameter tuning based on container resource limits */ -}}
+{{- $tidb_memory := getContainerMemory ( index $.podSpec.containers 0 ) }}
+{{- $tidb_cpu := getContainerCPU ( index $.podSpec.containers 0 ) }}
+{{- $gogc := 100 }}
+{{- $txn_total_size_limit := 104857600 }}
+{{- $txn_entry_size_limit := 6291456 }}
+{{- $grpc_conn_count := 4 }}
+{{- $max_batch_size := 128 }}
+{{- $batch_wait_size := 8 }}
+{{- if gt $tidb_memory 0 }}
+{{-   $gogc = 200 }}
+{{-   $txn_total_size_limit = min ( mul ( div $tidb_memory 32 ) 5 ) 1073741824 }}
+{{-   $txn_entry_size_limit = min ( mul ( div $tidb_memory 1024 ) 12 ) 134217728 }}
+{{- end }}
+{{- if gt $tidb_cpu 0 }}
+{{-   $grpc_conn_count = max 4 ( min ( int ( mul $tidb_cpu 1.0 ) ) 32 ) }}
+{{-   if ge $tidb_cpu 8 }}
+{{-     $max_batch_size = 256 }}
+{{-     $batch_wait_size = 16 }}
+{{-   end }}
+{{- end }}
+
 # TiDB Configuration.
 
 # Registered store name, [tikv, mocktikv, unistore]
@@ -278,11 +301,11 @@ distinct-agg-push-down = false
 # NOTE: If binlog is enabled with Kafka (e.g. arbiter cluster),
 # this value should be less than 1073741824(1G) because this is the maximum size that can be handled by Kafka.
 # If binlog is disabled or binlog is enabled without Kafka, this value should be less than 1099511627776(1T).
-txn-total-size-limit = 104857600
+txn-total-size-limit = {{ $txn_total_size_limit }}
 
 # The limitation of the size in byte for each entry in one transaction.
 # NOTE: Increasing this limit may cause performance problems.
-txn-entry-size-limit = 6291456
+txn-entry-size-limit = {{ $txn_entry_size_limit }}
 
 # max lifetime of transaction ttl manager.
 max-txn-ttl = 3600000
@@ -290,13 +313,22 @@ max-txn-ttl = 3600000
 # The Go GC trigger factor, you can get more information about it at https://golang.org/pkg/runtime.
 # If you encounter OOM when executing large query, you can decrease this value to trigger GC earlier.
 # If you find the CPU used by GC is too high or GC is too frequent and impact your business you can increase this value.
-gogc = 100
+gogc = {{ $gogc }}
 
 # Whether to use the lite mode of init stats.
 lite-init-stats = true
 
 # Whether to wait for init stats to finish before providing service during startup
 force-init-stats = true
+
+
+# Prepared plan cache configuration.
+# Enabling prepared plan cache can significantly reduce latency for repeated
+# parameterized queries (e.g. OLTP workloads like TPCC).
+[prepared-plan-cache]
+enabled = true
+capacity = 1000
+memory-guard-ratio = 0.1
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.
@@ -363,7 +395,7 @@ pd-server-timeout = 3
 
 [tikv-client]
 # Max gRPC connections that will be established with each tikv-server.
-grpc-connection-count = 4
+grpc-connection-count = {{ $grpc_conn_count }}
 
 # After a duration of this time in seconds if the client doesn't see any activity it pings
 # the server to see if the transport is still alive.
@@ -380,13 +412,13 @@ grpc-compression-type = "none"
 commit-timeout = "41s"
 
 # Max batch size in gRPC.
-max-batch-size = 128
+max-batch-size = {{ $max_batch_size }}
 # Overload threshold of TiKV.
 overload-threshold = 200
 # Max batch wait time in nanosecond to avoid waiting too long. 0 means disable this feature.
 max-batch-wait-time = 0
 # Batch wait size, to avoid waiting too long.
-batch-wait-size = 8
+batch-wait-size = {{ $batch_wait_size }}
 
 # If a Region has not been accessed for more than the given duration (in seconds), it
 # will be reloaded from the PD.

--- a/addons/tidb/config/tidb.toml.tpl
+++ b/addons/tidb/config/tidb.toml.tpl
@@ -11,9 +11,9 @@
 {{- $max_batch_size := 128 }}
 {{- $batch_wait_size := 8 }}
 {{- if gt $tidb_memory 0 }}
-{{-   /* txn-total-size-limit = 1/32 of memory, capped at 1GB (Kafka binlog hard limit) */ -}}
+{{- /* txn-total-size-limit = 1/32 of memory, capped at 1GB (Kafka binlog hard limit) */ -}}
 {{-   $txn_total_size_limit = min ( div $tidb_memory 32 ) 1073741824 }}
-{{-   /* txn-entry-size-limit = ~1/40 of txn-total-size, capped at 128MB */ -}}
+{{- /* txn-entry-size-limit = ~1/40 of txn-total-size, capped at 128MB */ -}}
 {{-   $txn_entry_size_limit = min ( div $txn_total_size_limit 40 ) 134217728 }}
 {{- end }}
 {{- if gt $tidb_cpu 0 }}

--- a/addons/tidb/config/tidb.toml.tpl
+++ b/addons/tidb/config/tidb.toml.tpl
@@ -5,16 +5,16 @@
 {{- /* Dynamic parameter tuning based on container resource limits */ -}}
 {{- $tidb_memory := getContainerMemory ( index $.podSpec.containers 0 ) }}
 {{- $tidb_cpu := getContainerCPU ( index $.podSpec.containers 0 ) }}
-{{- $gogc := 100 }}
 {{- $txn_total_size_limit := 104857600 }}
 {{- $txn_entry_size_limit := 6291456 }}
 {{- $grpc_conn_count := 4 }}
 {{- $max_batch_size := 128 }}
 {{- $batch_wait_size := 8 }}
 {{- if gt $tidb_memory 0 }}
-{{-   $gogc = 200 }}
-{{-   $txn_total_size_limit = min ( mul ( div $tidb_memory 32 ) 5 ) 1073741824 }}
-{{-   $txn_entry_size_limit = min ( mul ( div $tidb_memory 1024 ) 12 ) 134217728 }}
+{{-   /* txn-total-size-limit = 1/32 of memory, capped at 1GB (Kafka binlog hard limit) */ -}}
+{{-   $txn_total_size_limit = min ( div $tidb_memory 32 ) 1073741824 }}
+{{-   /* txn-entry-size-limit = ~1/40 of txn-total-size, capped at 128MB */ -}}
+{{-   $txn_entry_size_limit = min ( div $txn_total_size_limit 40 ) 134217728 }}
 {{- end }}
 {{- if gt $tidb_cpu 0 }}
 {{-   $grpc_conn_count = max 4 ( min ( int ( mul $tidb_cpu 1.0 ) ) 32 ) }}
@@ -313,7 +313,7 @@ max-txn-ttl = 3600000
 # The Go GC trigger factor, you can get more information about it at https://golang.org/pkg/runtime.
 # If you encounter OOM when executing large query, you can decrease this value to trigger GC earlier.
 # If you find the CPU used by GC is too high or GC is too frequent and impact your business you can increase this value.
-gogc = {{ $gogc }}
+gogc = 100
 
 # Whether to use the lite mode of init stats.
 lite-init-stats = true

--- a/addons/tidb/config/tikv-config-constraint.cue
+++ b/addons/tidb/config/tikv-config-constraint.cue
@@ -480,6 +480,9 @@
 
 	// The total number of files that RocksDB can open
 	"rocksdb.max-open-files": int & >=-1 | *20000
+	// The maximum number of concurrent background jobs (compactions + flushes) in RocksDB.
+	"rocksdb.max-background-jobs": int & >=1 | *2
+
 
 	// The number of background threads in RocksDB. When you modify the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 	"raftdb.max-background-jobs": int & >=2 | *4
@@ -763,6 +766,14 @@
 	// Specifies the amount of data sampled by Heap Profiling each time, rounding up to the nearest power of 2.
 	"memory.profiling-sample-per-bytes": string | *"512KiB"
 
+
+	// The size of the memtable (write buffer) for RocksDB default column family.
+	// Larger values reduce write amplification but may increase recovery time.
+	"rocksdb.defaultcf.write-buffer-size": string | *"128MB"
+
+	// The size of the memtable (write buffer) for RaftDB default column family.
+	// Recommend to set it the same as rocksdb.defaultcf.write-buffer-size.
+	"raftdb.defaultcf.write-buffer-size": string | *"128MB"
 	...
 }
 

--- a/addons/tidb/config/tikv.toml.tpl
+++ b/addons/tidb/config/tikv.toml.tpl
@@ -39,7 +39,7 @@
 {{- $rocksdb_max_bg_jobs := 2 }}
 
 {{- if gt $tikv_cpu 0 }}
-{{-   $readpool_max_threads = max 4 ( int ( mul $tikv_cpu 0.8 ) ) }}
+{{-   $readpool_max_threads = max 4 ( div ( mul $tikv_cpu 8 ) 10 ) }}
 {{-   $scheduler_worker_pool = max 4 ( min ( int ( sub $tikv_cpu 2 ) ) 8 ) }}
 {{-   $apply_pool_size = max 2 ( min ( int ( div $tikv_cpu 2 ) ) 8 ) }}
 {{-   $store_pool_size = max 2 ( min ( int ( div $tikv_cpu 3 ) ) 4 ) }}
@@ -59,7 +59,7 @@
 
 {{- if gt $tikv_memory 0 }}
 {{- /* block-cache = ~45% of total memory */ -}}
-{{-   $cache_bytes := int ( mul $tikv_memory 0.45 ) }}
+{{-   $cache_bytes := div ( mul $tikv_memory 9 ) 20 }}
 {{-   $block_cache_val = $cache_bytes }}
 {{-   $block_cache_unit = "B" }}
 {{-   if ge $cache_bytes 1048576 }}
@@ -475,7 +475,7 @@ pd-store-heartbeat-tick-interval = "10s"
 ## When Region size change exceeds this config, TiKV will check whether the Region should be split
 ## or not. To reduce the cost of scanning data in the checking process, you can set the value to
 ## 32MB during checking and set it back to the default value in normal operations.
-region-split-check-diff = {{ $region_split_check_diff }}
+region-split-check-diff = "{{ $region_split_check_diff }}"
 
 ## The interval of triggering Region split check.
 split-region-check-tick-interval = "10s"
@@ -497,7 +497,7 @@ raft-log-gc-count-limit = 73728
 
 ## When the approximate size of Raft log entries exceeds this value, GC will be forced trigger.
 ## It's recommanded to set it to 3/4 of `region-split-size`.
-raft-log-gc-size-limit = {{ $raft_log_gc_size_limit }}
+raft-log-gc-size-limit = "{{ $raft_log_gc_size_limit }}"
 
 ## Old Raft logs could be reserved if `raft_log_gc_threshold` is not reached.
 ## GC them after ticks `raft_log_reserve_max_ticks` times.
@@ -640,7 +640,7 @@ info-log-dir = ""
 info-log-level = "info"
 
 [rocksdb.defaultcf]
-write-buffer-size = {{ $defaultcf_write_buffer_size }}
+write-buffer-size = "{{ $defaultcf_write_buffer_size }}"
 
 [raftdb.defaultcf]
 ## Recommend to set it the same as `rocksdb.defaultcf.compression-per-level`.
@@ -648,7 +648,7 @@ compression-per-level = ["no", "no", "lz4", "lz4", "lz4", "zstd", "zstd"]
 block-size = "64KB"
 
 ## Recommend to set it the same as `rocksdb.defaultcf.write-buffer-size`.
-write-buffer-size = {{ $defaultcf_write_buffer_size }}
+write-buffer-size = "{{ $defaultcf_write_buffer_size }}"
 max-write-buffer-number = 5
 min-write-buffer-number-to-merge = 1
 

--- a/addons/tidb/config/tikv.toml.tpl
+++ b/addons/tidb/config/tikv.toml.tpl
@@ -58,7 +58,7 @@
 {{- end }}
 
 {{- if gt $tikv_memory 0 }}
-{{-   /* block-cache = ~45% of total memory */ -}}
+{{- /* block-cache = ~45% of total memory */ -}}
 {{-   $cache_bytes := int ( mul $tikv_memory 0.45 ) }}
 {{-   $block_cache_val = $cache_bytes }}
 {{-   $block_cache_unit = "B" }}

--- a/addons/tidb/config/tikv.toml.tpl
+++ b/addons/tidb/config/tikv.toml.tpl
@@ -2,6 +2,77 @@
 ## https://github.com/tikv/tikv/blob/release-7.5/etc/config-template.toml
 
 ## TiKV config template
+{{- /* Dynamic parameter tuning based on container resource limits */ -}}
+{{- $tikv_memory := getContainerMemory ( index $.podSpec.containers 0 ) }}
+{{- $tikv_cpu := getContainerCPU ( index $.podSpec.containers 0 ) }}
+
+{{- /* readpool.unified.max-thread-count: default max(4, CPU*0.8) */ -}}
+{{- $readpool_max_threads := 4 }}
+{{- /* storage.scheduler-worker-pool-size: default 4 */ -}}
+{{- $scheduler_worker_pool := 4 }}
+{{- /* storage.scheduler-concurrency: default 524288 */ -}}
+{{- $scheduler_concurrency := 524288 }}
+{{- /* storage.block-cache.capacity: default 0B (auto = 45% of mem) */ -}}
+{{- $block_cache_val := 0 }}
+{{- $block_cache_unit := "B" }}
+{{- /* storage.flow-control.l0-files-threshold */ -}}
+{{- $l0_files_threshold := 20 }}
+{{- /* raftstore.apply-pool-size */ -}}
+{{- $apply_pool_size := 2 }}
+{{- /* raftstore.store-pool-size */ -}}
+{{- $store_pool_size := 2 }}
+{{- /* raftstore.store-io-pool-size */ -}}
+{{- $store_io_pool_size := 0 }}
+{{- /* raftstore.region-split-check-diff */ -}}
+{{- $region_split_check_diff := "6MB" }}
+{{- /* raftstore.raft-log-gc-size-limit */ -}}
+{{- $raft_log_gc_size_limit := "72MB" }}
+{{- /* rocksdb.max-open-files */ -}}
+{{- $rocksdb_max_open_files := 20000 }}
+{{- /* raftdb.max-open-files */ -}}
+{{- $raftdb_max_open_files := 20000 }}
+{{- /* raftdb.max-background-jobs */ -}}
+{{- $raftdb_max_bg_jobs := 4 }}
+{{- /* rocksdb + raftdb defaultcf write-buffer-size */ -}}
+{{- $defaultcf_write_buffer_size := "128MB" }}
+{{- /* rocksdb.max-background-jobs */ -}}
+{{- $rocksdb_max_bg_jobs := 2 }}
+
+{{- if gt $tikv_cpu 0 }}
+{{-   $readpool_max_threads = max 4 ( int ( mul $tikv_cpu 0.8 ) ) }}
+{{-   $scheduler_worker_pool = max 4 ( min ( int ( sub $tikv_cpu 2 ) ) 8 ) }}
+{{-   $apply_pool_size = max 2 ( min ( int ( div $tikv_cpu 2 ) ) 8 ) }}
+{{-   $store_pool_size = max 2 ( min ( int ( div $tikv_cpu 3 ) ) 4 ) }}
+{{-   if ge $tikv_cpu 8 }}
+{{-     $store_io_pool_size = 1 }}
+{{-     $l0_files_threshold = 40 }}
+{{-     $scheduler_concurrency = 2097152 }}
+{{-     $region_split_check_diff = "32MB" }}
+{{-     $raft_log_gc_size_limit = "128MB" }}
+{{-     $rocksdb_max_open_files = 40960 }}
+{{-     $raftdb_max_open_files = 40960 }}
+{{-     $rocksdb_max_bg_jobs = 6 }}
+{{-     $raftdb_max_bg_jobs = 6 }}
+{{-     $defaultcf_write_buffer_size = "256MB" }}
+{{-   end }}
+{{- end }}
+
+{{- if gt $tikv_memory 0 }}
+{{-   /* block-cache = ~45% of total memory */ -}}
+{{-   $cache_bytes := int ( mul $tikv_memory 0.45 ) }}
+{{-   $block_cache_val = $cache_bytes }}
+{{-   $block_cache_unit = "B" }}
+{{-   if ge $cache_bytes 1048576 }}
+{{-     $block_cache_val = div $cache_bytes 1048576 }}
+{{-     $block_cache_unit = "MB" }}
+{{-   end }}
+{{-   if ge $block_cache_val 1024 }}
+{{-     $block_cache_val = div $block_cache_val 1024 }}
+{{-     $block_cache_unit = "GB" }}
+{{-   end }}
+{{- end }}
+
+
 ##  Human-readable big numbers:
 ##   File size(based on byte, binary units): KB, MB, GB, TB, PB
 ##    e.g.: 1_048_576 = "1MB"
@@ -105,13 +176,16 @@ min-thread-count = 1
 
 ## The maximum working thread count of the thread pool.
 ## The default value is max(4, LOGICAL_CPU_NUM * 0.8).
-max-thread-count = 4
+max-thread-count = {{ $readpool_max_threads }}
 
 ## Size of the stack for each thread in the thread pool.
 stack-size = "10MB"
 
 ## Max running tasks of each worker, reject if exceeded.
 max-tasks-per-worker = 2000
+
+## Automatically adjust thread pool size based on CPU usage.
+auto-adjust-pool-size = true
 
 [readpool.storage]
 ## Whether to use the unified read pool to handle storage requests.
@@ -256,13 +330,13 @@ engine = "raft-kv"
 ## The number of slots in Scheduler latches, which controls write concurrency.
 ## In most cases you can use the default value. When importing data, you can set it to a larger
 ## value.
-scheduler-concurrency = 524288
+scheduler-concurrency = {{ $scheduler_concurrency }}
 
 ## Scheduler's worker pool size, i.e. the number of write threads.
 ## It should be less than total CPU cores. When there are frequent write operations, set it to a
 ## higher value. More specifically, you can run `top -H -p tikv-pid` to check whether the threads
 ## named `sched-worker-pool` are busy.
-scheduler-worker-pool-size = 4
+scheduler-worker-pool-size = {{ $scheduler_worker_pool }}
 
 ## When the pending write bytes exceeds this threshold, the "scheduler too busy" error is displayed.
 scheduler-pending-write-threshold = "100MB"
@@ -270,7 +344,7 @@ scheduler-pending-write-threshold = "100MB"
 ## For async commit transactions, it's possible to response to the client before applying prewrite
 ## requests. Enabling this can ease reduce latency when apply duration is significant, or reduce
 ## latency jittering when apply duration is not stable.
-enable-async-apply-prewrite = false
+enable-async-apply-prewrite = true
 
 ## Reserve some space to ensure recovering the store from `no space left` must succeed.
 ## `max(reserve-space, capacity * 5%)` will be reserved exactly.
@@ -309,7 +383,7 @@ background-error-recovery-window = "1h"
 ##
 ## When storage.engine is "raft-kv", default value is 45% of available system memory.
 ## When storage.engine is "partitioned-raft-kv", default value is 30% of available system memory.
-capacity = "0B"
+capacity = "{{ $block_cache_val }}{{ $block_cache_unit }}"
 
 [storage.flow-control]
 ## Flow controller is used to throttle the write rate at scheduler level, aiming
@@ -325,7 +399,7 @@ enable = true
 memtables-threshold = 5
 
 ## When the number of SST files of level-0 of kvdb reaches the threshold, the flow controller begins to work
-l0-files-threshold = 20
+l0-files-threshold = {{ $l0_files_threshold }}
 
 ## When the number of pending compaction bytes of kvdb reaches the threshold, the flow controller begins to
 ## reject some write requests with `ServerIsBusy` error.
@@ -401,7 +475,7 @@ pd-store-heartbeat-tick-interval = "10s"
 ## When Region size change exceeds this config, TiKV will check whether the Region should be split
 ## or not. To reduce the cost of scanning data in the checking process, you can set the value to
 ## 32MB during checking and set it back to the default value in normal operations.
-region-split-check-diff = "6MB"
+region-split-check-diff = {{ $region_split_check_diff }}
 
 ## The interval of triggering Region split check.
 split-region-check-tick-interval = "10s"
@@ -423,7 +497,7 @@ raft-log-gc-count-limit = 73728
 
 ## When the approximate size of Raft log entries exceeds this value, GC will be forced trigger.
 ## It's recommanded to set it to 3/4 of `region-split-size`.
-raft-log-gc-size-limit = "72MB"
+raft-log-gc-size-limit = {{ $raft_log_gc_size_limit }}
 
 ## Old Raft logs could be reserved if `raft_log_gc_threshold` is not reached.
 ## GC them after ticks `raft_log_reserve_max_ticks` times.
@@ -474,14 +548,14 @@ consistency-check-interval = "0s"
 cleanup-import-sst-interval = "10m"
 
 ## Use how many threads to handle log apply
-apply-pool-size = 2
+apply-pool-size = {{ $apply_pool_size }}
 
 ## Use how many threads to handle raft messages
-store-pool-size = 2
+store-pool-size = {{ $store_pool_size }}
 
 ## Use how many threads to handle raft io tasks
 ## If it is 0, it means io tasks are handled in store threads.
-store-io-pool-size = 0
+store-io-pool-size = {{ $store_io_pool_size }}
 
 ## When the size of raft db writebatch exceeds this value, write will be triggered.
 raft-write-size-limit = "1MB"
@@ -529,14 +603,15 @@ coprocessor-plugin-directory = "./coprocessors"
 ## level-based compaction.
 # https://github.com/apecloud/apecloud/issues/18181
 # Some enviroments have RLIMIT_NOFILE not big enough
-max-open-files = 20000
+max-open-files = {{ $rocksdb_max_open_files }}
+max-background-jobs = {{ $rocksdb_max_bg_jobs }}
 
 [raftdb]
-max-background-jobs = 4
+max-background-jobs = {{ $raftdb_max_bg_jobs }}
 max-sub-compactions = 2
 # https://github.com/apecloud/apecloud/issues/18181
 # Some enviroments have RLIMIT_NOFILE not big enough
-max-open-files = 20000
+max-open-files = {{ $raftdb_max_open_files }}
 max-manifest-file-size = "20MB"
 create-if-missing = true
 
@@ -564,13 +639,16 @@ info-log-keep-log-file-num = 10
 info-log-dir = ""
 info-log-level = "info"
 
+[rocksdb.defaultcf]
+write-buffer-size = {{ $defaultcf_write_buffer_size }}
+
 [raftdb.defaultcf]
 ## Recommend to set it the same as `rocksdb.defaultcf.compression-per-level`.
 compression-per-level = ["no", "no", "lz4", "lz4", "lz4", "zstd", "zstd"]
 block-size = "64KB"
 
 ## Recommend to set it the same as `rocksdb.defaultcf.write-buffer-size`.
-write-buffer-size = "128MB"
+write-buffer-size = {{ $defaultcf_write_buffer_size }}
 max-write-buffer-number = 5
 min-write-buffer-number-to-merge = 1
 
@@ -671,7 +749,7 @@ enable-log-recycle = true
 ## Only available for `enable-log-reycle` is true.
 ##
 ## Default: false
-prefill-for-recycle = false
+prefill-for-recycle = true
 
 {{/* a dirty way to inject user defined config */}}
 {{- $conponentTls := false }}


### PR DESCRIPTION
### Background
With TiDB 7.1.6 enterprise edition on an 8c16g spec, default parameters are too conservative for TPCC import and benchmark workloads. Tuning previously required manual ConfigMap edits with no out-of-the-box adaptive behavior.

### Goal
- Auto-compute sensible TiDB / TiKV parameter values based on container CPU / memory limits, replacing hardcoded upstream defaults
- Improve defaults for generally-beneficial, low-risk performance parameters
- Keep all parameters user-tunable via ParametersDefinition / cue constraint
- Stay compatible with all currently supported versions (6.5.12 / 7.1.x / 7.5.x / 8.4.x)

### Changes
**TiDB tuning (`config/tidb.toml.tpl`)**
- Added dynamic parameter computation using `getContainerMemory` / `getContainerCPU`
- `performance.gogc`: raised from 100 → 200 when memory limit is set, reducing GC overhead
- `performance.txn-total-size-limit`: dynamically sized by memory, capped at 1GB
- `performance.txn-entry-size-limit`: dynamically sized by memory, capped at 128MB
- `tikv-client.grpc-connection-count`: scaled with CPU cores (4~32)
- `tikv-client.max-batch-size` / `batch-wait-size`: doubled when CPU ≥ 8
- Added `[prepared-plan-cache]` section, enabled by default with capacity 1000

**TiKV tuning (`config/tikv.toml.tpl`)**
- `readpool.unified.max-thread-count`: dynamic = max(4, CPU*0.8)
- `readpool.unified.auto-adjust-pool-size`: enabled
- `storage.scheduler-worker-pool-size`: scaled with CPU (4~8)
- `storage.scheduler-concurrency`: 2048k when CPU ≥ 8
- `storage.enable-async-apply-prewrite`: enabled
- `storage.block-cache.capacity`: dynamic = ~45% of container memory
- `storage.flow-control.l0-files-threshold`: 40 when CPU ≥ 8
- `raftstore.apply-pool-size` / `store-pool-size` / `store-io-pool-size`: scaled with CPU
- `raftstore.region-split-check-diff`: 32MB when CPU ≥ 8
- `raftstore.raft-log-gc-size-limit`: 128MB when CPU ≥ 8
- `rocksdb.max-open-files` / `raftdb.max-open-files`: 40960 when CPU ≥ 8
- `rocksdb.max-background-jobs` / `raftdb.max-background-jobs`: 6 when CPU ≥ 8
- Added `rocksdb.defaultcf.write-buffer-size`: 256MB when CPU ≥ 8
- `raftdb.defaultcf.write-buffer-size`: 256MB when CPU ≥ 8
- `raft-engine.prefill-for-recycle`: enabled

**Constraint updates**
- `tidb-config-constraint.cue`: added `prepared-plan-cache.enabled / capacity / memory-guard-ratio`
- `tikv-config-constraint.cue`: added `rocksdb.max-background-jobs`, `rocksdb.defaultcf.write-buffer-size`, `raftdb.defaultcf.write-buffer-size`

### Verification
- `helm lint` passes
- `helm template` renders correctly
- Falls back to upstream defaults when no resource limits are set, so small specs are not over-provisioned

### Compatibility
The lowest supported version is 6.5.12, and all added parameters were introduced before 6.5 — no version compatibility issues. If lower versions (e.g. 6.1 or 5.x) are added later, templates will need to be split by version or gated with version checks.