### PR TITLE
fix(postgresql): use exec role probe on current main

### DIFF
--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ description: A PostgreSQL (with Patroni HA) cluster definition Helm chart for Ku
 
 type: application
 
-version: 1.2.0-alpha.2
+version: 1.2.0-alpha.3
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # appVersion should be consistent with the highest PostgreSQL (with Patroni HA) kernel version.

--- a/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
@@ -172,13 +172,31 @@ EOF
   It "advances the chart identity when immutable ComponentDefinitions change"
     When call chart_version
     The status should eq 0
-    The output should eq "1.2.0-alpha.2"
+    The output should eq "1.2.0-alpha.3"
   End
 
   It "publishes every ComponentDefinition under the advanced immutable identity"
-    When call render_count '^  name: postgresql-\(12\|13\|14\|15\|16\|17\|18\)-1.2.0-alpha.2$'
+    When call render_count '^  name: postgresql-\(12\|13\|14\|15\|16\|17\|18\)-1.2.0-alpha.3$'
     The status should eq 0
     The output should eq "7"
+  End
+
+  It "does not update the published alpha.2 ComponentDefinitions in place"
+    When call render_count '^  name: postgresql-\(12\|13\|14\|15\|16\|17\|18\)-1.2.0-alpha.2$'
+    The status should eq 0
+    The output should eq "0"
+  End
+
+  It "keeps the previous alpha.2 identities compatible through the major prefix"
+    When call render_count '^[[:space:]]*- postgresql-\(12\|13\|14\|15\|16\|17\|18\)-$'
+    The status should eq 0
+    The output should eq "7"
+  End
+
+  It "does not bypass ComponentDefinition immutability"
+    When call render_count 'apps.kubeblocks.io/skip-immutable-check:'
+    The status should eq 0
+    The output should eq "0"
   End
 
   It "does not project a create-time pod-name list into the runtime"

--- a/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
@@ -40,6 +40,28 @@ Describe "PostgreSQL KubeBlocks API contract"
     '
   }
 
+  component_definitions_with_exec_role_probe() {
+    render_chart | ruby -ryaml -e '
+      definitions = YAML.load_stream(ARGF.read).compact.select do |document|
+        document["kind"] == "ComponentDefinition"
+      end
+      count = definitions.count do |definition|
+        role_probe = definition.dig("spec", "lifecycleActions", "roleProbe") || {}
+        command = role_probe.dig("exec", "command") || []
+        role_probe["http"].nil? &&
+          role_probe.dig("exec", "container") == "postgresql" &&
+          command == [
+            "curl",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "http://127.0.0.1:5001/v1.0/getrole"
+          ]
+      end
+      puts count
+    '
+  }
+
   pg13_config_contract() {
     config="$(chart_dir)/config/pg13-config.tpl"
     schema="$(chart_dir)/config/pg13-config-constraint.cue"
@@ -167,6 +189,12 @@ EOF
 
   It "grants every ComponentDefinition the pod-list permission used by live arbitration"
     When call component_definitions_with_pod_list_rbac
+    The status should eq 0
+    The output should eq "7"
+  End
+
+  It "uses an exec role probe supported by KubeBlocks main"
+    When call component_definitions_with_exec_role_probe
     The status should eq 0
     The output should eq "7"
   End

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -229,9 +229,16 @@ spec:
     roleProbe:
       periodSeconds: 1
       timeoutSeconds: 1
-      http:
-        port: "5001"
-        path: "/v1.0/getrole"
+      # KubeBlocks schedules role probes through the exec action path. dbctl
+      # returns the plain role token; curl --fail preserves non-2xx as failure.
+      exec:
+        container: postgresql
+        command:
+          - curl
+          - --fail
+          - --silent
+          - --show-error
+          - http://127.0.0.1:5001/v1.0/getrole
     switchover:
       # script worst case ~45s (leader query 5s + switchover API 20s +
       # bounded verification ~20s); kbagent clamps every action call at 60s


### PR DESCRIPTION
Supersedes #3292, which conflicts with current `main` after PostgreSQL 13 support was added.

This successor preserves the current PG13 contracts, changes all seven PostgreSQL ComponentDefinitions from the legacy HTTP role probe to the KubeBlocks-supported exec action, and verifies the exact rendered command for 7/7 definitions.

Because `lifecycleActions.roleProbe` is immutable, the fix advances the chart and ComponentDefinition identities from `1.2.0-alpha.2` to `1.2.0-alpha.3`. ComponentVersion keeps the existing `postgresql-{major}-` compatibility prefixes, so published alpha.2 definitions are not updated in place and remain compatible. The chart does not bypass immutability with `apps.kubeblocks.io/skip-immutable-check`.

Source checks:
- `helm dependency build addons/postgresql`
- focused KubeBlocks API contract: 19 examples, 0 failures
- all PostgreSQL ShellSpec under Bash 5.3.9: 157 examples, 0 failures
- structured render: `CMPD=7 alpha3=7 compatibility-prefixes=7`
- Helm lint/render, ShellCheck error gate, Bash syntax, and `git diff --check`: PASS

No Test package, runner, or Kubernetes execution is included.
