### PR TITLE
chore(rustfs): keep docs aligned with rendered boundaries

### DIFF
--- a/addons/rustfs/README.md
+++ b/addons/rustfs/README.md
@@ -4,7 +4,7 @@ This chart defines RustFS `1.0.0-beta.10`. The runtime and role-probe images use
 `docker.io/rustfs/rustfs:1.0.0-beta.10`; the init image uses
 `docker.io/apecloud/kubeblocks-tools:1.0.0`.
 
-The companion `addons-cluster/rustfs` chart creates four replicas. Its Cluster
+The companion `addons-cluster/rustfs` chart creates 4 replicas. Its Cluster
 does not set `serviceVersion`, so KubeBlocks resolves the version from the
 matching ComponentDefinition and ComponentVersion. Verify the resolved
 serviceVersion and images in the installed Component and Pods.

--- a/addons/rustfs/scripts-ut-spec/version_pin_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/version_pin_spec.sh
@@ -97,6 +97,39 @@ Describe "RustFS beta.10 version pin"
     validate_rendered_release
   }
 
+  validate_readme_boundaries() {
+    addon_render=$(helm template test "$(repo_root)/addons/rustfs") || return $?
+    cluster_render=$(helm template test "$(repo_root)/addons-cluster/rustfs") || return $?
+    printf '%s\n---\n%s\n' "${addon_render}" "${cluster_render}" | ruby -ryaml -e '
+      readme = File.read(ARGV.fetch(0))
+      documents = YAML.load_stream($stdin.read).select { |item| item.is_a?(Hash) }
+      component_definition = documents.find { |item| item["kind"] == "ComponentDefinition" }
+      component_version = documents.find { |item| item["kind"] == "ComponentVersion" }
+      cluster = documents.find { |item| item["kind"] == "Cluster" }
+      abort "rendered source objects are missing" unless component_definition && component_version && cluster
+
+      release = component_version.dig("spec", "releases").fetch(0)
+      images = release.fetch("images")
+      component = cluster.dig("spec", "componentSpecs").fetch(0)
+      replica_limit = component_definition.dig("spec", "replicasLimit")
+      member_leave = component_definition.dig("spec", "lifecycleActions", "memberLeave", "exec", "command").join("\n")
+
+      required = [
+        release.fetch("serviceVersion"),
+        images.fetch("rustfs"),
+        images.fetch("init"),
+        "creates #{component.fetch("replicas")} replicas",
+        "does not set `serviceVersion`",
+        "Scale-in is rejected",
+        "`minReplicas: #{replica_limit.fetch("minReplicas")}`"
+      ]
+      missing = required.reject { |text| readme.include?(text) }
+      abort "README boundary facts are missing: #{missing.join(" | ")}" unless missing.empty?
+      abort "memberLeave no longer rejects scale-in" unless member_leave.include?("does not support scale-in") && member_leave.match?(/exit\s+1/)
+      puts "README matches rendered version, replica, and scale-in boundaries"
+    ' "$(repo_root)/addons/rustfs/README.md"
+  }
+
   validate_cleanup_rejects_false_success() {
     chart_dir=${tmp_dir:?}
     fake_rm="${chart_dir}/fake-rm"
@@ -143,6 +176,12 @@ Describe "RustFS beta.10 version pin"
     When call validate_with_beta9_role_probe_image
     The status should be failure
     The stderr should include "unexpected rendered release"
+  End
+
+  It "keeps the README aligned with rendered version and scaling boundaries"
+    When call validate_readme_boundaries
+    The status should be success
+    The output should eq "README matches rendered version, replica, and scale-in boundaries"
   End
 
   It "rejects cleanup success while the chart tree still exists"

--- a/addons/rustfs/scripts-ut-spec/version_pin_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/version_pin_spec.sh
@@ -29,10 +29,13 @@ Describe "RustFS beta.10 version pin"
 
   prepare_chart() {
     tmp_dir=$(mktemp -d -t rustfs-version-pin-XXXXXX) || return $?
-    mkdir -p "${tmp_dir}/addons" || return $?
+    mkdir -p "${tmp_dir}/addons" "${tmp_dir}/addons-cluster" || return $?
     cp -R "$(repo_root)/addons/rustfs" "${tmp_dir}/addons/rustfs" || return $?
     cp -R "$(repo_root)/addons/kblib" "${tmp_dir}/addons/kblib" || return $?
+    cp -R "$(repo_root)/addons-cluster/rustfs" "${tmp_dir}/addons-cluster/rustfs" || return $?
+    cp -R "$(repo_root)/addons-cluster/kblib" "${tmp_dir}/addons-cluster/kblib" || return $?
     helm dependency build "${tmp_dir}/addons/rustfs" >/dev/null || return $?
+    helm dependency build "${tmp_dir}/addons-cluster/rustfs" >/dev/null || return $?
   }
 
   cleanup_chart() {
@@ -98,8 +101,8 @@ Describe "RustFS beta.10 version pin"
   }
 
   validate_readme_boundaries() {
-    addon_render=$(helm template test "$(repo_root)/addons/rustfs") || return $?
-    cluster_render=$(helm template test "$(repo_root)/addons-cluster/rustfs") || return $?
+    addon_render=$(helm template test "${tmp_dir}/addons/rustfs") || return $?
+    cluster_render=$(helm template test "${tmp_dir}/addons-cluster/rustfs") || return $?
     printf '%s\n---\n%s\n' "${addon_render}" "${cluster_render}" | ruby -ryaml -e '
       readme = File.read(ARGV.fetch(0))
       documents = YAML.load_stream($stdin.read).select { |item| item.is_a?(Hash) }
@@ -113,6 +116,7 @@ Describe "RustFS beta.10 version pin"
       component = cluster.dig("spec", "componentSpecs").fetch(0)
       replica_limit = component_definition.dig("spec", "replicasLimit")
       member_leave = component_definition.dig("spec", "lifecycleActions", "memberLeave", "exec", "command").join("\n")
+      abort "rendered Cluster unexpectedly sets serviceVersion" if component.key?("serviceVersion")
 
       required = [
         release.fetch("serviceVersion"),
@@ -121,6 +125,7 @@ Describe "RustFS beta.10 version pin"
         "creates #{component.fetch("replicas")} replicas",
         "does not set `serviceVersion`",
         "Scale-in is rejected",
+        "#{replica_limit.fetch("minReplicas")} through #{replica_limit.fetch("maxReplicas")} replicas",
         "`minReplicas: #{replica_limit.fetch("minReplicas")}`"
       ]
       missing = required.reject { |text| readme.include?(text) }


### PR DESCRIPTION
## Summary

- keep README boundaries aligned with rendered RustFS objects
- serve as the RustFS development/main source PR for the exact target and child set below

## Exact source candidate

- target branch/head: `main@474b3d76af28d13737aa2fb51f28a6b19a116f22`
- development branch/head/tree: `jessica/rustfs-source-boundaries-20260813@7487efc3a8e61e745e1a41e36f095a515fabd54d` / `b091e5cdd5f2f7ad7f84474586e43d49a7c8515c`
- included merged RustFS PRs: #3247, #3300, #3310
- included open child PR: #3314 at `90644143ada02d10622e4c86356e62b9c40b5187`, tree `8ba7d44d88860aa2b05c7cc16ae5f11e75164899`
- excluded RustFS drafts: #3263 backup/restore scope; #3270 and #3271 older backup-capability chain; #3289 older versioned-definition chain
- open non-draft PRs targeting this development branch: #3314 only (last-known; refresh succeeded for #3314 exact identity)

## Version pins

- addon repository/path: `apecloud/kubeblocks-addons`, `addons/rustfs`
- addon chart: `0.1.2`
- cluster chart: `0.1.1`
- RustFS image/service version: `1.0.0-beta.10`
- kubeblocks-tools init image: `1.0.0`
- KubeBlocks controller: `UNKNOWN/null` (Test-owned)
- syncer: `UNKNOWN/null` (Test-owned)
- kubeblocks-tests: `UNKNOWN/null` (Test-owned)
- vcluster: `UNKNOWN/null` (Test-owned)
- package identity: `UNKNOWN/null` until Jean/Test publishes an exact receipt

Any included SHA change creates a new source candidate. CI, review, package, and acceptance results from an older SHA do not migrate.

## Validation

- PR #3311 exact development head: hosted 8/8 PASS and APPROVED at last exact read
- included child #3314 exact `90644143...`: focused Bash 3.2 and dash 18/0; full Bash 5.3 78/0; ShellCheck/lint/diff-check PASS
- child hosted checks: exact-head 7/7 PASS; ShellSpec run `31958490463`, job `95192738146`
- child independent exact-head review: pending; old `72448ff1` review/CI do not migrate

The child adds fail-closed API/local-write handling, concurrent compare-and-retry, exact payload/retry/manifest checks, malformed-history rejection, and large signed-integer fidelity without awk precision loss.

## Acceptance boundary

This PR records source/code-test state only. Source closure requires the included child set to stay pinned and pass exact-head review and checks. Release acceptance additionally requires Jean/Test to publish exact KubeBlocks/syncer/tests/vcluster/package identities and run the requested full RustFS suite against that frozen package. This PR does not claim Test package, Kubernetes runtime, P/F/S, cleanup, residue, or formal-N.

Successor to merged docs PR #3310.
