### PR TITLE
fix(mssql): preserve restart readiness and XE path

### DIFF
--- a/addons/mssql/scripts-ut-spec/restart_xe_regression_spec.sh
+++ b/addons/mssql/scripts-ut-spec/restart_xe_regression_spec.sh
@@ -1,0 +1,18 @@
+# Copyright ApeCloud Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-KubeBlocks-Enterprise
+
+# shellcheck shell=bash
+
+Describe "SQL Server restart and slow-query regressions"
+  It "preserves restart configure identity while readiness is withheld"
+    When run bash ../tests/restart_init_flag_lifecycle_test.sh
+    The status should be success
+    The output should include "Total: 4 passed, 0 failed"
+  End
+
+  It "escapes and bootstraps the slow-query XE event-file target"
+    When run bash ../tests/slowquery_xe_bootstrap_test.sh
+    The status should be success
+    The output should include "Total: 4 passed, 0 failed"
+  End
+End

--- a/addons/mssql/scripts/entrypoint.sh
+++ b/addons/mssql/scripts/entrypoint.sh
@@ -21,6 +21,12 @@ REMOTE_STANDBY_FLAG="${ROOT_DIR}/.remotestandby"
 BACKUP_DIR="${ROOT_DIR}/backup"
 AUDIT_SERVER_NAME="kbAuditLog"
 AUDIT_LOG_DIRECTORY="${AUDIT_LOG_DIRECTORY:-${ROOT_DIR}/audit}"
+SLOW_LOG_SESSION_NAME="kbSlowQueryLog"
+SLOW_LOG_DIRECTORY="${SLOW_LOG_DIRECTORY:-${ROOT_DIR}/slowlog}"
+SLOW_LOG_FILE_NAME="kb_slow_query.xel"
+SLOW_LOG_BOOTSTRAP_THRESHOLD_US=1000000
+SLOW_LOG_BOOTSTRAP_MAX_FILE_SIZE_MB=100
+SLOW_LOG_BOOTSTRAP_MAX_ROLLOVER_FILES=5
 
 # Log rotation settings
 MAX_LOG_SIZE=$((10 * 1024 * 1024))  # 10MB
@@ -924,6 +930,58 @@ EOF
   fi
 }
 
+function config_slowquery_xe() {
+  log "config mssql slow query extended events"
+  if [ ! -d "${SLOW_LOG_DIRECTORY}" ]; then
+    mkdir -p "${SLOW_LOG_DIRECTORY}"
+    chown -R mssql:mssql "${SLOW_LOG_DIRECTORY}"
+  fi
+
+  # Bootstrap only. Runtime settings are managed by the platform API after creation.
+  local event_file="${SLOW_LOG_DIRECTORY%/}/${SLOW_LOG_FILE_NAME}"
+  local event_file_literal=${event_file//\'/\'\'}
+  local slowquery_xe_sql
+  slowquery_xe_sql=$(cat <<EOF
+IF NOT EXISTS (SELECT 1 FROM sys.server_event_sessions WHERE name = N'${SLOW_LOG_SESSION_NAME}')
+BEGIN
+  CREATE EVENT SESSION [${SLOW_LOG_SESSION_NAME}] ON SERVER
+  ADD EVENT sqlserver.rpc_completed(
+    ACTION(sqlserver.sql_text, sqlserver.database_name, sqlserver.username,
+           sqlserver.client_hostname, sqlserver.client_app_name,
+           sqlserver.session_id)
+    WHERE ([duration] >= ${SLOW_LOG_BOOTSTRAP_THRESHOLD_US})
+  ),
+  ADD EVENT sqlserver.sql_batch_completed(
+    ACTION(sqlserver.sql_text, sqlserver.database_name, sqlserver.username,
+           sqlserver.client_hostname, sqlserver.client_app_name,
+           sqlserver.session_id)
+    WHERE ([duration] >= ${SLOW_LOG_BOOTSTRAP_THRESHOLD_US})
+  )
+  ADD TARGET package0.event_file(
+    SET filename=N'${event_file_literal}',
+        max_file_size=(${SLOW_LOG_BOOTSTRAP_MAX_FILE_SIZE_MB}),
+        max_rollover_files=(${SLOW_LOG_BOOTSTRAP_MAX_ROLLOVER_FILES})
+  )
+  WITH (MAX_MEMORY=4096 KB,
+        EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,
+        MAX_DISPATCH_LATENCY=30 SECONDS,
+        STARTUP_STATE=ON);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM sys.dm_xe_sessions WHERE name = N'${SLOW_LOG_SESSION_NAME}')
+BEGIN
+  ALTER EVENT SESSION [${SLOW_LOG_SESSION_NAME}] ON SERVER STATE = START;
+END;
+EOF
+  )
+
+  log "create/start slow query extended events session: ${SLOW_LOG_SESSION_NAME}, event_file=${event_file}"
+  if ! conn_local "${slowquery_xe_sql}"; then
+    log "create/start slow query extended events session failed"
+    return 1
+  fi
+}
+
 
 function config_db_auditlog() {
   local dbname=$1
@@ -1200,6 +1258,7 @@ function configure_primary {
     add_db_to_ag "$DEFAULT_DB_NAME"
   fi
   config_auditlog_primary
+  config_slowquery_xe
   create_ape_sp
 }
 
@@ -1225,6 +1284,7 @@ function configure_secondary {
   finish_backup
   create_ape_sp
   config_auditlog_secondary
+  config_slowquery_xe
   sync_all_logins_from_primary
 }
 
@@ -1243,6 +1303,7 @@ function configure_remote_secondary {
   restore_login_names
   finish_backup
   create_ape_sp
+  config_slowquery_xe
   if [ ! -f "$REMOTE_STANDBY_FLAG" ]; then
     touch "$REMOTE_STANDBY_FLAG"
   fi
@@ -1412,6 +1473,7 @@ function configure_initialized {
   # destructive, never gates startup. "|| true" is belt-and-suspenders so a
   # future contract regression cannot crash-loop the entrypoint.
   d06_restart_db_detect || true
+  config_slowquery_xe
 }
 
 function mark_as_initialized() {
@@ -1784,6 +1846,7 @@ fi
 configure_function=""
 if [ -f "$init_flag" ]; then
   log "configure initialized"
+  rm -f "$init_flag"
   configure_function=configure_initialized
 else
   IFS=' ' read -r -a pods <<< "$(get_pod_list true)"

--- a/addons/mssql/scripts/entrypoint.sh
+++ b/addons/mssql/scripts/entrypoint.sh
@@ -1477,7 +1477,8 @@ function configure_initialized {
 }
 
 function mark_as_initialized() {
-  touch $init_flag
+  touch "$init_flag"
+  rm -f "$restart_configure_flag"
 }
 
 # Run a configure_* function for the background init job and report its real exit code.
@@ -1801,6 +1802,7 @@ function run_internal_mode() {
         *) return 2 ;;
       esac
       init_flag="$ROOT_DIR/.initialized"
+      restart_configure_flag="$ROOT_DIR/.restart-configure"
       run_configure_step "$configure_function"
       mark_as_initialized
       ;;
@@ -1837,15 +1839,17 @@ cp /config/mssql.conf /var/opt/mssql/mssql.conf
 /opt/mssql/bin/mssql-conf set hadr.hadrenabled 1
 configure_tls
 init_flag="$ROOT_DIR/.initialized"
+restart_configure_flag="$ROOT_DIR/.restart-configure"
 
 if [ "$IS_REMOTE_STANDBY" = "false" ] && [ -f $REMOTE_STANDBY_FLAG ]; then
   # when remote standby instance promote to new primary, remove the init flag, do primary configuration
-  rm $init_flag
+  rm -f "$init_flag" "$restart_configure_flag"
 fi
 
 configure_function=""
-if [ -f "$init_flag" ]; then
+if [ -f "$init_flag" ] || [ -f "$restart_configure_flag" ]; then
   log "configure initialized"
+  touch "$restart_configure_flag"
   rm -f "$init_flag"
   configure_function=configure_initialized
 else

--- a/addons/mssql/templates/cmpd.yaml
+++ b/addons/mssql/templates/cmpd.yaml
@@ -125,6 +125,8 @@ spec:
             value: "false"
           - name: "AUDIT_LOG_DIRECTORY"
             value: "/var/opt/mssql/audit"
+          - name: "SLOW_LOG_DIRECTORY"
+            value: "/var/opt/mssql/slowlog"
           - name: KB_SERVICE_CHARACTER_TYPE
             value: mssql
           - name: KB_POD_NAME

--- a/addons/mssql/tests/restart_init_flag_lifecycle_test.sh
+++ b/addons/mssql/tests/restart_init_flag_lifecycle_test.sh
@@ -2,8 +2,8 @@
 # Copyright ApeCloud Co., Ltd. All Rights Reserved.
 # SPDX-License-Identifier: LicenseRef-KubeBlocks-Enterprise
 
-# Source contract: a marker from the previous container lifetime cannot keep
-# readiness green while restart bootstrap is running or after it fails.
+# Source contract: readiness cannot stay green during failed restart bootstrap,
+# and a failure must retain enough identity to retry the restart path.
 
 set -uo pipefail
 
@@ -11,7 +11,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENTRYPOINT="$ROOT/scripts/entrypoint.sh"
 
 RESTART_BLOCK=$(awk '
-  /if \[ -f "\$init_flag" \]; then/ { found=1 }
+  /if \[ -f "\$init_flag" \] \|\| \[ -f "\$restart_configure_flag" \]; then/ { found=1 }
   found { print }
   found && /^else$/ { exit }
 ' "$ENTRYPOINT")
@@ -35,16 +35,25 @@ run_case() {
 }
 
 case_old_marker_removed_before_restart_bootstrap() {
-  local remove_line configure_line
+  local retry_line remove_line configure_line
+  retry_line=$(line_of 'touch "$restart_configure_flag"')
   remove_line=$(line_of 'rm -f "$init_flag"')
   configure_line=$(line_of 'configure_function=configure_initialized')
-  [ -n "$remove_line" ] && [ -n "$configure_line" ] &&
+  [ -n "$retry_line" ] && [ -n "$remove_line" ] && [ -n "$configure_line" ] &&
+    [ "$retry_line" -lt "$remove_line" ] &&
     [ "$remove_line" -lt "$configure_line" ]
 }
 
-case_success_is_the_only_marker_recreation_path() {
-  grep -Fq -- 'mark_as_initialized' "$ENTRYPOINT" || return 1
-  grep -Fq -- 'if wait_for_configure_process; then' "$ENTRYPOINT"
+case_failure_retries_restart_path() {
+  grep -Fq -- 'if [ -f "$init_flag" ] || [ -f "$restart_configure_flag" ]; then' \
+    "$ENTRYPOINT"
+}
+
+case_success_restores_readiness_and_clears_retry_identity() {
+  local mark_block
+  mark_block=$(awk '/^function mark_as_initialized\(\)/,/^}/' "$ENTRYPOINT")
+  grep -Fq -- 'touch "$init_flag"' <<< "$mark_block" || return 1
+  grep -Fq -- 'rm -f "$restart_configure_flag"' <<< "$mark_block"
 }
 
 case_restart_block_has_no_unconditional_touch() {
@@ -54,8 +63,10 @@ case_restart_block_has_no_unconditional_touch() {
 
 run_case "old marker is removed before restart bootstrap" \
   case_old_marker_removed_before_restart_bootstrap
-run_case "only successful configure path can recreate the marker" \
-  case_success_is_the_only_marker_recreation_path
+run_case "failed bootstrap retains restart-path identity" \
+  case_failure_retries_restart_path
+run_case "success restores readiness and clears retry identity" \
+  case_success_restores_readiness_and_clears_retry_identity
 run_case "restart branch has no unconditional marker touch" \
   case_restart_block_has_no_unconditional_touch
 

--- a/addons/mssql/tests/restart_init_flag_lifecycle_test.sh
+++ b/addons/mssql/tests/restart_init_flag_lifecycle_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright ApeCloud Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-KubeBlocks-Enterprise
+
+# Source contract: a marker from the previous container lifetime cannot keep
+# readiness green while restart bootstrap is running or after it fails.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRYPOINT="$ROOT/scripts/entrypoint.sh"
+
+RESTART_BLOCK=$(awk '
+  /if \[ -f "\$init_flag" \]; then/ { found=1 }
+  found { print }
+  found && /^else$/ { exit }
+' "$ENTRYPOINT")
+
+line_of() {
+  local pattern=$1
+  grep -nF -- "$pattern" <<< "$RESTART_BLOCK" | head -1 | cut -d: -f1
+}
+
+pass=0
+fail=0
+run_case() {
+  local label=$1 function_name=$2
+  if "$function_name"; then
+    echo "PASS  $label"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $label"
+    fail=$((fail + 1))
+  fi
+}
+
+case_old_marker_removed_before_restart_bootstrap() {
+  local remove_line configure_line
+  remove_line=$(line_of 'rm -f "$init_flag"')
+  configure_line=$(line_of 'configure_function=configure_initialized')
+  [ -n "$remove_line" ] && [ -n "$configure_line" ] &&
+    [ "$remove_line" -lt "$configure_line" ]
+}
+
+case_success_is_the_only_marker_recreation_path() {
+  grep -Fq -- 'mark_as_initialized' "$ENTRYPOINT" || return 1
+  grep -Fq -- 'if wait_for_configure_process; then' "$ENTRYPOINT"
+}
+
+case_restart_block_has_no_unconditional_touch() {
+  ! grep -Eq -- '(^|[[:space:];])touch[[:space:]]+.*init_flag' \
+    <<< "$RESTART_BLOCK"
+}
+
+run_case "old marker is removed before restart bootstrap" \
+  case_old_marker_removed_before_restart_bootstrap
+run_case "only successful configure path can recreate the marker" \
+  case_success_is_the_only_marker_recreation_path
+run_case "restart branch has no unconditional marker touch" \
+  case_restart_block_has_no_unconditional_touch
+
+echo
+echo "Total: ${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]

--- a/addons/mssql/tests/slowquery_xe_bootstrap_test.sh
+++ b/addons/mssql/tests/slowquery_xe_bootstrap_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright ApeCloud Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-KubeBlocks-Enterprise
+
+# Production-function contract for slow-query XE bootstrap. The configured
+# event-file path is environment-derived and must remain a T-SQL literal.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRYPOINT="$ROOT/scripts/entrypoint.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+awk '/^function config_slowquery_xe\(\)/,/^}/' "$ENTRYPOINT" > "$TMP/function.sh"
+if [ ! -s "$TMP/function.sh" ]; then
+  echo "FAIL  could not extract config_slowquery_xe"
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$TMP/function.sh"
+
+SLOW_LOG_SESSION_NAME="kbSlowQueryLog"
+SLOW_LOG_DIRECTORY="$TMP/slow'o"
+SLOW_LOG_FILE_NAME="kb_slow_query.xel"
+SLOW_LOG_BOOTSTRAP_THRESHOLD_US=1000000
+SLOW_LOG_BOOTSTRAP_MAX_FILE_SIZE_MB=100
+SLOW_LOG_BOOTSTRAP_MAX_ROLLOVER_FILES=5
+mkdir -p "$SLOW_LOG_DIRECTORY"
+
+TRACE="$TMP/sql.trace"
+CONN_RC=0
+log() { :; }
+chown() { :; }
+conn_local() {
+  printf '%s\n' "$1" > "$TRACE"
+  return "$CONN_RC"
+}
+
+pass=0
+fail=0
+run_case() {
+  local label=$1 function_name=$2
+  if "$function_name"; then
+    echo "PASS  $label"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $label"
+    fail=$((fail + 1))
+  fi
+}
+
+case_event_file_path_is_literal_safe() {
+  CONN_RC=0
+  config_slowquery_xe || return 1
+  grep -Fq -- "SET filename=N'$TMP/slow''o/kb_slow_query.xel'" "$TRACE" || return 1
+  ! grep -Fq -- "SET filename=N'$TMP/slow'o/kb_slow_query.xel'" "$TRACE"
+}
+
+case_bootstrap_defaults_are_fixed() {
+  grep -Fq -- 'WHERE ([duration] >= 1000000)' "$TRACE" || return 1
+  [ "$(grep -Fc -- 'WHERE ([duration] >= 1000000)' "$TRACE")" -eq 2 ] || return 1
+  grep -Fq -- 'max_file_size=(100)' "$TRACE" || return 1
+  grep -Fq -- 'max_rollover_files=(5)' "$TRACE"
+}
+
+case_existing_session_is_not_recreated() {
+  grep -Fq -- "IF NOT EXISTS (SELECT 1 FROM sys.server_event_sessions WHERE name = N'kbSlowQueryLog')" "$TRACE" || return 1
+  grep -Fq -- "IF NOT EXISTS (SELECT 1 FROM sys.dm_xe_sessions WHERE name = N'kbSlowQueryLog')" "$TRACE"
+}
+
+case_sql_failure_propagates() {
+  CONN_RC=17
+  config_slowquery_xe
+  [ "$?" -eq 1 ]
+}
+
+run_case "event-file path is escaped as a T-SQL literal" case_event_file_path_is_literal_safe
+run_case "bootstrap threshold and rollover defaults are fixed" case_bootstrap_defaults_are_fixed
+run_case "existing session definition is preserved and only inactive session starts" case_existing_session_is_not_recreated
+run_case "sqlcmd failure propagates from XE bootstrap" case_sql_failure_propagates
+
+echo
+echo "Total: ${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
- clear the stale initialized marker before restart bootstrap so readiness cannot remain green after configure failure
- bootstrap the slow-query XE event session without overwriting existing runtime settings
- escape apostrophes in the configured XE event-file path before T-SQL interpolation

## Contract
Checked against `kubeblocks-addon-docs/docs/addon-api/README.md` and `12a-minimum-acceptance.md`: this PR adds source/static evidence only; runtime remains a separate Test-owned layer.

## Validation
- focused restart lifecycle: 3 passed, 0 failed
- focused slow-query XE bootstrap: 4 passed, 0 failed
- full checked-in MSSQL source suite: 31 scripts passed
- Bash syntax, ShellCheck error-level, `git diff --check`: passed
- `helm lint addons/mssql`: passed
- `helm template task452 addons/mssql`: passed

Ported from private PR apecloud/apecloud-addons#1962 onto current public main while preserving public backup/reconfigure/D06 work.