### PR TITLE
fix(rustfs): fail closed on replicas history API errors

### DIFF
--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -5,8 +5,9 @@ Describe "RustFS replicas history ConfigMap contract"
     case_dir=$(mktemp -d -t rustfs-replicas-history-XXXXXX) || return $?
     mock_bin="${case_dir}/bin"
     call_log="${case_dir}/kubectl.calls"
-    history_file="${case_dir}/RUSTFS_REPLICAS_HISTORY"
-    mkdir -p "${mock_bin}" || return $?
+    history_dir="${case_dir}/history"
+    history_file="${history_dir}/RUSTFS_REPLICAS_HISTORY"
+    mkdir -p "${mock_bin}" "${history_dir}" || return $?
     : >"${call_log}" || return $?
 
     cat >"${mock_bin}/kubectl" <<'EOF'
@@ -101,6 +102,15 @@ EOF
     When call run_case fail success success success
     The status should be failure
     The stderr should include "Failed to check ConfigMap"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when confirmed ConfigMap history cannot be written locally"
+    rm -rf "${history_dir}"
+    When call run_case present success success success
+    The status should be failure
+    The stderr should include "Failed to write RUSTFS_REPLICAS_HISTORY"
+    The output should not include "written to the local file"
     The path "${history_file}" should not be exist
   End
 End

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -88,6 +88,14 @@ EOF
     The contents of file "${history_file}" should eq "[4,8]"
   End
 
+  It "replaces the local snapshot when an init container retries"
+    run_case present success success success >/dev/null || return $?
+    When call run_case present success success success
+    The status should be success
+    The output should include "updated successfully"
+    The contents of file "${history_file}" should eq "[4,8]"
+  End
+
   It "fails closed when ConfigMap data cannot be read"
     When call run_case present fail success success
     The status should be failure

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -157,7 +157,7 @@ EOF
   It "fails closed when the ConfigMap patch is rejected"
     When call run_case present success success fail
     The status should be failure
-    The stderr should include "Failed to update RUSTFS_REPLICAS_HISTORY"
+    The stderr should include "Failed to update RUSTFS_REPLICAS_HISTORY in ConfigMap test/rustfs-rustfs-configuration after 5 attempts."
     The path "${history_file}" should not be exist
   End
 

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -33,7 +33,7 @@ case "$*" in
     ;;
   "get configmaps rustfs-rustfs-configuration -n test -o jsonpath={.data.RUSTFS_REPLICAS_HISTORY}")
     [ "${KUBECTL_READ_MODE:-success}" = success ] || exit 42
-    printf '%s' '[4]'
+    printf '%s' "${KUBECTL_READ_VALUE-[4]}"
     ;;
   "create -f -")
     cat >/dev/null
@@ -75,6 +75,7 @@ EOF
       KUBECTL_CREATE_MODE="${3:-success}" \
       KUBECTL_PATCH_MODE="${4:-success}" \
       KUBECTL_RECHECK_MODE="${5:-}" \
+      KUBECTL_READ_VALUE="${6-[4]}" \
       "${SHELLSPEC_SHELL}" "${case_dir}/replicas-history-config.sh"
   }
 
@@ -86,6 +87,13 @@ EOF
     The status should be success
     The output should include "updated successfully"
     The contents of file "${history_file}" should eq "[4,8]"
+  End
+
+  It "creates a missing ConfigMap and writes the initial history snapshot"
+    When call run_case absent success success success '' ''
+    The status should be success
+    The output should include "updated successfully"
+    The contents of file "${history_file}" should eq "[8]"
   End
 
   It "replaces the local snapshot when an init container retries"

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -192,6 +192,15 @@ EOF
     The path "${history_file}" should not be exist
   End
 
+  It "preserves the largest valid history value when the current replica count is lower"
+    When call run_case present success success success '' '[9223372036854775807]'
+    The status should be success
+    The output should include "RUSTFS_REPLICAS_HISTORY=[9223372036854775807]"
+    The stderr should not include "integer expression expected"
+    The contents of file "${history_file}" should eq "[9223372036854775807]"
+    The contents of file "${call_log}" should include '"RUSTFS_REPLICAS_HISTORY":"[9223372036854775807]"'
+  End
+
   It "fails closed when a missing ConfigMap cannot be created"
     When call run_case absent success fail success
     The status should be failure

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -1,0 +1,106 @@
+# shellcheck shell=sh
+
+Describe "RustFS replicas history ConfigMap contract"
+  setup_case() {
+    case_dir=$(mktemp -d -t rustfs-replicas-history-XXXXXX) || return $?
+    mock_bin="${case_dir}/bin"
+    call_log="${case_dir}/kubectl.calls"
+    history_file="${case_dir}/RUSTFS_REPLICAS_HISTORY"
+    mkdir -p "${mock_bin}" || return $?
+    : >"${call_log}" || return $?
+
+    cat >"${mock_bin}/kubectl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"${KUBECTL_CALL_LOG}"
+
+case "$*" in
+  "get configmaps rustfs-rustfs-configuration -n test --ignore-not-found -o name")
+    case "${KUBECTL_GET_MODE:-present}" in
+      present) printf '%s\n' 'configmap/rustfs-rustfs-configuration' ;;
+      absent) : ;;
+      fail) exit 41 ;;
+      *) exit 46 ;;
+    esac
+    ;;
+  "get configmaps rustfs-rustfs-configuration -n test -o jsonpath={.data.RUSTFS_REPLICAS_HISTORY}")
+    [ "${KUBECTL_READ_MODE:-success}" = success ] || exit 42
+    printf '%s' '[4]'
+    ;;
+  "create -f -")
+    cat >/dev/null
+    [ "${KUBECTL_CREATE_MODE:-success}" = success ] || exit 43
+    ;;
+  "patch configmap rustfs-rustfs-configuration -n test --type strategic -p "*)
+    [ "${KUBECTL_PATCH_MODE:-success}" = success ] || exit 44
+    ;;
+  *)
+    printf 'unexpected kubectl call: %s\n' "$*" >&2
+    exit 45
+    ;;
+esac
+EOF
+    chmod +x "${mock_bin}/kubectl" || return $?
+
+    sed \
+      -e "s|replicas_history_file=\"/rustfs-config/RUSTFS_REPLICAS_HISTORY\"|replicas_history_file=\"${history_file}\"|" \
+      -e 's/namespace={{ .CLUSTER_NAMESPACE }}/namespace=test/' \
+      -e 's/name={{ .RUSTFS_COMPONENT_NAME }}-rustfs-configuration/name=rustfs-rustfs-configuration/' \
+      "${SHELLSPEC_CWD}/addons/rustfs/scripts/replicas-history-config.sh" \
+      >"${case_dir}/replicas-history-config.sh" || return $?
+    chmod +x "${case_dir}/replicas-history-config.sh" || return $?
+
+    export PATH="${mock_bin}:${PATH}"
+    export KUBECTL_CALL_LOG="${call_log}"
+    export RUSTFS_COMP_REPLICAS=8
+  }
+
+  cleanup_case() {
+    rm -rf "${case_dir}"
+  }
+
+  run_case() {
+    KUBECTL_GET_MODE="${1:-present}" \
+      KUBECTL_READ_MODE="${2:-success}" \
+      KUBECTL_CREATE_MODE="${3:-success}" \
+      KUBECTL_PATCH_MODE="${4:-success}" \
+      "${SHELLSPEC_SHELL}" "${case_dir}/replicas-history-config.sh"
+  }
+
+  BeforeEach 'setup_case'
+  AfterEach 'cleanup_case'
+
+  It "updates ConfigMap history and writes the confirmed value locally"
+    When call run_case present success success success
+    The status should be success
+    The output should include "updated successfully"
+    The contents of file "${history_file}" should eq "[4,8]"
+  End
+
+  It "fails closed when ConfigMap data cannot be read"
+    When call run_case present fail success success
+    The status should be failure
+    The stderr should include "Failed to read RUSTFS_REPLICAS_HISTORY"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when a missing ConfigMap cannot be created"
+    When call run_case absent success fail success
+    The status should be failure
+    The stderr should include "Failed to create ConfigMap"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when the ConfigMap patch is rejected"
+    When call run_case present success success fail
+    The status should be failure
+    The stderr should include "Failed to update RUSTFS_REPLICAS_HISTORY"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when ConfigMap existence cannot be checked"
+    When call run_case fail success success success
+    The status should be failure
+    The stderr should include "Failed to check ConfigMap"
+    The path "${history_file}" should not be exist
+  End
+End

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -35,12 +35,38 @@ case "$*" in
     [ "${KUBECTL_READ_MODE:-success}" = success ] || exit 42
     printf '%s' "${KUBECTL_READ_VALUE-[4]}"
     ;;
+  "get configmaps rustfs-rustfs-configuration -n test -o jsonpath={.metadata.resourceVersion}{'\\t'}{.data.RUSTFS_REPLICAS_HISTORY}")
+    case "${KUBECTL_READ_MODE:-success}" in
+      success)
+        if [ "${KUBECTL_PATCH_MODE:-success}" = race ] && [ "$(cat "${KUBECTL_RACE_PHASE_FILE}")" -gt 0 ]; then
+          printf '2\t[4,12]'
+        else
+          printf '1\t%s' "${KUBECTL_READ_VALUE-[4]}"
+        fi
+        ;;
+      malformed) printf '%s' "${KUBECTL_READ_VALUE-[4]}" ;;
+      *) exit 42 ;;
+    esac
+    ;;
   "create -f -")
     cat >/dev/null
     [ "${KUBECTL_CREATE_MODE:-success}" = success ] || exit 43
     ;;
   "patch configmap rustfs-rustfs-configuration -n test --type strategic -p "*)
-    [ "${KUBECTL_PATCH_MODE:-success}" = success ] || exit 44
+    case "${KUBECTL_PATCH_MODE:-success}" in
+      success) : ;;
+      race)
+        case "$*" in
+          *'"resourceVersion":"1"'*)
+            printf '1\n' >"${KUBECTL_RACE_PHASE_FILE}"
+            exit 44
+            ;;
+          *'"resourceVersion":"2"'*) : ;;
+          *) : ;;
+        esac
+        ;;
+      *) exit 44 ;;
+    esac
     ;;
   *)
     printf 'unexpected kubectl call: %s\n' "$*" >&2
@@ -62,6 +88,8 @@ EOF
     export KUBECTL_CALL_LOG="${call_log}"
     export KUBECTL_GET_COUNT_FILE="${case_dir}/kubectl.get-count"
     printf '0\n' >"${KUBECTL_GET_COUNT_FILE}" || return $?
+    export KUBECTL_RACE_PHASE_FILE="${case_dir}/kubectl.race-phase"
+    printf '0\n' >"${KUBECTL_RACE_PHASE_FILE}" || return $?
     export RUSTFS_COMP_REPLICAS=8
   }
 
@@ -111,6 +139,13 @@ EOF
     The path "${history_file}" should not be exist
   End
 
+  It "fails closed when the ConfigMap snapshot has no resource version"
+    When call run_case present malformed success success
+    The status should be failure
+    The stderr should include "Failed to parse RUSTFS_REPLICAS_HISTORY snapshot"
+    The path "${history_file}" should not be exist
+  End
+
   It "fails closed when a missing ConfigMap cannot be created"
     When call run_case absent success fail success
     The status should be failure
@@ -146,6 +181,13 @@ EOF
     The status should be success
     The output should include "updated successfully"
     The contents of file "${history_file}" should eq "[4,8]"
+  End
+
+  It "preserves a higher concurrent replicas history update"
+    When call run_case present success success race
+    The status should be success
+    The output should include "RUSTFS_REPLICAS_HISTORY=[4,12]"
+    The contents of file "${history_file}" should eq "[4,12]"
   End
 
   It "fails closed when create fails and the ConfigMap remains absent"

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -39,11 +39,26 @@ case "$*" in
   "get configmaps rustfs-rustfs-configuration -n test -o jsonpath={.metadata.resourceVersion}{'\\t'}{.data.RUSTFS_REPLICAS_HISTORY}")
     case "${KUBECTL_READ_MODE:-success}" in
       success)
-        if [ "${KUBECTL_PATCH_MODE:-success}" = race ] && [ "$(cat "${KUBECTL_RACE_PHASE_FILE}")" -gt 0 ]; then
-          printf '2\t[4,12]'
-        else
-          printf '1\t%s' "${KUBECTL_READ_VALUE-[4]}"
-        fi
+        case "${KUBECTL_PATCH_MODE:-success}:$(cat "${KUBECTL_RACE_PHASE_FILE}")" in
+          race:1) printf '2\t[4,12]' ;;
+          post_patch_race:1) printf '2\t[4,8,12]' ;;
+          *)
+            if [ -s "${KUBECTL_PATCHED_VALUE_FILE}" ]; then
+              case "${KUBECTL_CONFIRM_MODE:-success}" in
+                success)
+                  printf '2\t'
+                  cat "${KUBECTL_PATCHED_VALUE_FILE}"
+                  ;;
+                fail) exit 42 ;;
+                malformed) printf '2' ;;
+                stale) printf '2\t[4]' ;;
+                *) exit 47 ;;
+              esac
+            else
+              printf '1\t%s' "${KUBECTL_READ_VALUE-[4]}"
+            fi
+            ;;
+        esac
         ;;
       malformed) printf '%s' "${KUBECTL_READ_VALUE-[4]}" ;;
       *) exit 42 ;;
@@ -55,16 +70,24 @@ case "$*" in
     ;;
   "patch configmap rustfs-rustfs-configuration -n test --type strategic -p "*)
     case "${KUBECTL_PATCH_MODE:-success}" in
-      success) : ;;
+      success)
+        printf '%s' "$*" | sed -n 's/.*"RUSTFS_REPLICAS_HISTORY":"\([^"]*\)".*/\1/p' >"${KUBECTL_PATCHED_VALUE_FILE}"
+        ;;
       race)
         case "$*" in
           *'"resourceVersion":"1"'*)
             printf '1\n' >"${KUBECTL_RACE_PHASE_FILE}"
             exit 44
             ;;
-          *'"resourceVersion":"2"'*) : ;;
+          *'"resourceVersion":"2"'*)
+            printf '%s' "$*" | sed -n 's/.*"RUSTFS_REPLICAS_HISTORY":"\([^"]*\)".*/\1/p' >"${KUBECTL_PATCHED_VALUE_FILE}"
+            ;;
           *) : ;;
         esac
+        ;;
+      post_patch_race)
+        printf '%s' "$*" | sed -n 's/.*"RUSTFS_REPLICAS_HISTORY":"\([^"]*\)".*/\1/p' >"${KUBECTL_PATCHED_VALUE_FILE}"
+        printf '1\n' >"${KUBECTL_RACE_PHASE_FILE}"
         ;;
       *) exit 44 ;;
     esac
@@ -96,6 +119,8 @@ EOF
     printf '0\n' >"${KUBECTL_GET_COUNT_FILE}" || return $?
     export KUBECTL_RACE_PHASE_FILE="${case_dir}/kubectl.race-phase"
     printf '0\n' >"${KUBECTL_RACE_PHASE_FILE}" || return $?
+    export KUBECTL_PATCHED_VALUE_FILE="${case_dir}/kubectl.patched-value"
+    : >"${KUBECTL_PATCHED_VALUE_FILE}" || return $?
     export RUSTFS_COMP_REPLICAS=8
   }
 
@@ -110,6 +135,7 @@ EOF
       KUBECTL_PATCH_MODE="${4:-success}" \
       KUBECTL_RECHECK_MODE="${5:-}" \
       KUBECTL_READ_VALUE="${6-[4]}" \
+      KUBECTL_CONFIRM_MODE="${7:-success}" \
       "${SHELLSPEC_SHELL}" "${case_dir}/replicas-history-config.sh"
   }
 
@@ -244,6 +270,34 @@ EOF
     The output should include "RUSTFS_REPLICAS_HISTORY=[4,12]"
     The contents of file "${history_file}" should eq "[4,12]"
     The contents of file "${call_log}" should include 'patch configmap rustfs-rustfs-configuration -n test --type strategic -p {"metadata":{"resourceVersion":"2"},"data":{"RUSTFS_REPLICAS_HISTORY":"[4,12]"}}'
+  End
+
+  It "writes the confirmed history when another pod advances it after patch success"
+    When call run_case present success success post_patch_race
+    The status should be success
+    The output should include "RUSTFS_REPLICAS_HISTORY=[4,8,12]"
+    The contents of file "${history_file}" should eq "[4,8,12]"
+  End
+
+  It "fails closed when the patched ConfigMap cannot be confirmed"
+    When call run_case present success success success '' '[4]' fail
+    The status should be failure
+    The stderr should include "Failed to read RUSTFS_REPLICAS_HISTORY"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when the confirmed ConfigMap snapshot is malformed"
+    When call run_case present success success success '' '[4]' malformed
+    The status should be failure
+    The stderr should include "Failed to parse confirmed RUSTFS_REPLICAS_HISTORY snapshot"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when confirmed history does not include the current replicas"
+    When call run_case present success success success '' '[4]' stale
+    The status should be failure
+    The stderr should include "does not contain replicas 8"
+    The path "${history_file}" should not be exist
   End
 
   It "fails closed when create fails and the ConfigMap remains absent"

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -16,7 +16,15 @@ printf '%s\n' "$*" >>"${KUBECTL_CALL_LOG}"
 
 case "$*" in
   "get configmaps rustfs-rustfs-configuration -n test --ignore-not-found -o name")
-    case "${KUBECTL_GET_MODE:-present}" in
+    get_count_file="${KUBECTL_GET_COUNT_FILE}"
+    get_count=$(cat "${get_count_file}")
+    get_count=$((get_count + 1))
+    printf '%s\n' "${get_count}" >"${get_count_file}"
+    get_mode="${KUBECTL_GET_MODE:-present}"
+    if [ "${get_count}" -gt 1 ] && [ -n "${KUBECTL_RECHECK_MODE:-}" ]; then
+      get_mode="${KUBECTL_RECHECK_MODE}"
+    fi
+    case "${get_mode}" in
       present) printf '%s\n' 'configmap/rustfs-rustfs-configuration' ;;
       absent) : ;;
       fail) exit 41 ;;
@@ -52,6 +60,8 @@ EOF
 
     export PATH="${mock_bin}:${PATH}"
     export KUBECTL_CALL_LOG="${call_log}"
+    export KUBECTL_GET_COUNT_FILE="${case_dir}/kubectl.get-count"
+    printf '0\n' >"${KUBECTL_GET_COUNT_FILE}" || return $?
     export RUSTFS_COMP_REPLICAS=8
   }
 
@@ -64,6 +74,7 @@ EOF
       KUBECTL_READ_MODE="${2:-success}" \
       KUBECTL_CREATE_MODE="${3:-success}" \
       KUBECTL_PATCH_MODE="${4:-success}" \
+      KUBECTL_RECHECK_MODE="${5:-}" \
       "${SHELLSPEC_SHELL}" "${case_dir}/replicas-history-config.sh"
   }
 
@@ -111,6 +122,27 @@ EOF
     The status should be failure
     The stderr should include "Failed to write RUSTFS_REPLICAS_HISTORY"
     The output should not include "written to the local file"
+    The path "${history_file}" should not be exist
+  End
+
+  It "continues when another pod creates the missing ConfigMap concurrently"
+    When call run_case absent success fail success present
+    The status should be success
+    The output should include "updated successfully"
+    The contents of file "${history_file}" should eq "[4,8]"
+  End
+
+  It "fails closed when create fails and the ConfigMap remains absent"
+    When call run_case absent success fail success absent
+    The status should be failure
+    The stderr should include "Failed to create ConfigMap"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed when create fails and existence cannot be rechecked"
+    When call run_case absent success fail success fail
+    The status should be failure
+    The stderr should include "Failed to create ConfigMap"
     The path "${history_file}" should not be exist
   End
 End

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -115,6 +115,7 @@ EOF
     The status should be success
     The output should include "updated successfully"
     The contents of file "${history_file}" should eq "[4,8]"
+    The contents of file "${call_log}" should include 'patch configmap rustfs-rustfs-configuration -n test --type strategic -p {"metadata":{"resourceVersion":"1"},"data":{"RUSTFS_REPLICAS_HISTORY":"[4,8]"}}'
   End
 
   It "creates a missing ConfigMap and writes the initial history snapshot"
@@ -188,6 +189,7 @@ EOF
     The status should be success
     The output should include "RUSTFS_REPLICAS_HISTORY=[4,12]"
     The contents of file "${history_file}" should eq "[4,12]"
+    The contents of file "${call_log}" should include 'patch configmap rustfs-rustfs-configuration -n test --type strategic -p {"metadata":{"resourceVersion":"2"},"data":{"RUSTFS_REPLICAS_HISTORY":"[4,12]"}}'
   End
 
   It "fails closed when create fails and the ConfigMap remains absent"

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -160,6 +160,38 @@ EOF
     The path "${history_file}" should not be exist
   End
 
+  It "fails closed before patching a malformed replicas history"
+    When call run_case present success success success '' 'garbage'
+    The status should be failure
+    The stderr should include "Failed to parse RUSTFS_REPLICAS_HISTORY history"
+    The contents of file "${call_log}" should not include "patch configmap"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed before patching duplicate replicas history"
+    When call run_case present success success success '' '[4,4]'
+    The status should be failure
+    The stderr should include "Failed to parse RUSTFS_REPLICAS_HISTORY history"
+    The contents of file "${call_log}" should not include "patch configmap"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed before patching descending replicas history"
+    When call run_case present success success success '' '[8,4]'
+    The status should be failure
+    The stderr should include "Failed to parse RUSTFS_REPLICAS_HISTORY history"
+    The contents of file "${call_log}" should not include "patch configmap"
+    The path "${history_file}" should not be exist
+  End
+
+  It "fails closed before patching replicas history outside shell integer range"
+    When call run_case present success success success '' '[999999999999999999999999999999]'
+    The status should be failure
+    The stderr should include "Failed to parse RUSTFS_REPLICAS_HISTORY history"
+    The contents of file "${call_log}" should not include "patch configmap"
+    The path "${history_file}" should not be exist
+  End
+
   It "fails closed when a missing ConfigMap cannot be created"
     When call run_case absent success fail success
     The status should be failure

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -5,6 +5,7 @@ Describe "RustFS replicas history ConfigMap contract"
     case_dir=$(mktemp -d -t rustfs-replicas-history-XXXXXX) || return $?
     mock_bin="${case_dir}/bin"
     call_log="${case_dir}/kubectl.calls"
+    create_manifest="${case_dir}/create-manifest.yaml"
     history_dir="${case_dir}/history"
     history_file="${history_dir}/RUSTFS_REPLICAS_HISTORY"
     mkdir -p "${mock_bin}" "${history_dir}" || return $?
@@ -49,7 +50,7 @@ case "$*" in
     esac
     ;;
   "create -f -")
-    cat >/dev/null
+    cat >"${KUBECTL_CREATE_MANIFEST}"
     [ "${KUBECTL_CREATE_MODE:-success}" = success ] || exit 43
     ;;
   "patch configmap rustfs-rustfs-configuration -n test --type strategic -p "*)
@@ -80,12 +81,17 @@ EOF
       -e "s|replicas_history_file=\"/rustfs-config/RUSTFS_REPLICAS_HISTORY\"|replicas_history_file=\"${history_file}\"|" \
       -e 's/namespace={{ .CLUSTER_NAMESPACE }}/namespace=test/' \
       -e 's/name={{ .RUSTFS_COMPONENT_NAME }}-rustfs-configuration/name=rustfs-rustfs-configuration/' \
+      -e 's/{{ .CLUSTER_NAMESPACE }}/test/g' \
+      -e 's/{{ .RUSTFS_COMPONENT_NAME }}/rustfs/g' \
+      -e 's/{{ .CLUSTER_NAME }}/rustfs/g' \
+      -e 's/{{ .CLUSTER_COMPONENT_NAME }}/rustfs/g' \
       "${SHELLSPEC_CWD}/addons/rustfs/scripts/replicas-history-config.sh" \
       >"${case_dir}/replicas-history-config.sh" || return $?
     chmod +x "${case_dir}/replicas-history-config.sh" || return $?
 
     export PATH="${mock_bin}:${PATH}"
     export KUBECTL_CALL_LOG="${call_log}"
+    export KUBECTL_CREATE_MANIFEST="${create_manifest}"
     export KUBECTL_GET_COUNT_FILE="${case_dir}/kubectl.get-count"
     printf '0\n' >"${KUBECTL_GET_COUNT_FILE}" || return $?
     export KUBECTL_RACE_PHASE_FILE="${case_dir}/kubectl.race-phase"
@@ -123,6 +129,13 @@ EOF
     The status should be success
     The output should include "updated successfully"
     The contents of file "${history_file}" should eq "[8]"
+    The contents of file "${create_manifest}" should include "apiVersion: v1"
+    The contents of file "${create_manifest}" should include "kind: ConfigMap"
+    The contents of file "${create_manifest}" should include "namespace: test"
+    The contents of file "${create_manifest}" should include "name: rustfs-rustfs-configuration"
+    The contents of file "${create_manifest}" should include "app.kubernetes.io/managed-by: kubeblocks"
+    The contents of file "${create_manifest}" should include "app.kubernetes.io/instance: rustfs"
+    The contents of file "${create_manifest}" should include "apps.kubeblocks.io/component-name: rustfs"
   End
 
   It "replaces the local snapshot when an init container retries"

--- a/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
+++ b/addons/rustfs/scripts-ut-spec/replicas_history_config_spec.sh
@@ -41,7 +41,24 @@ case "$*" in
       success)
         case "${KUBECTL_PATCH_MODE:-success}:$(cat "${KUBECTL_RACE_PHASE_FILE}")" in
           race:1) printf '2\t[4,12]' ;;
+          race:2) printf '3\t[4,12]' ;;
           post_patch_race:1) printf '2\t[4,8,12]' ;;
+          post_confirm_race:0) printf '1\t[4]' ;;
+          post_confirm_race:1)
+            printf '2\n' >"${KUBECTL_RACE_PHASE_FILE}"
+            printf '2\t[4,8]'
+            ;;
+          post_confirm_race:3) printf '3\t[4,8,12]' ;;
+          post_confirm_race:4) printf '4\t[4,8,12]' ;;
+          fence_fail:*)
+            phase=$(cat "${KUBECTL_RACE_PHASE_FILE}")
+            resource_version=$((phase + 1))
+            if [ "${phase}" -eq 0 ]; then
+              printf '%s\t[4]' "${resource_version}"
+            else
+              printf '%s\t[4,8]' "${resource_version}"
+            fi
+            ;;
           *)
             if [ -s "${KUBECTL_PATCHED_VALUE_FILE}" ]; then
               case "${KUBECTL_CONFIRM_MODE:-success}" in
@@ -81,13 +98,40 @@ case "$*" in
             ;;
           *'"resourceVersion":"2"'*)
             printf '%s' "$*" | sed -n 's/.*"RUSTFS_REPLICAS_HISTORY":"\([^"]*\)".*/\1/p' >"${KUBECTL_PATCHED_VALUE_FILE}"
+            printf '2\n' >"${KUBECTL_RACE_PHASE_FILE}"
             ;;
+          *'"resourceVersion":"3"'*) : ;;
           *) : ;;
         esac
         ;;
       post_patch_race)
         printf '%s' "$*" | sed -n 's/.*"RUSTFS_REPLICAS_HISTORY":"\([^"]*\)".*/\1/p' >"${KUBECTL_PATCHED_VALUE_FILE}"
         printf '1\n' >"${KUBECTL_RACE_PHASE_FILE}"
+        ;;
+      post_confirm_race)
+        case "$*" in
+          *'"resourceVersion":"1"'*)
+            printf '1\n' >"${KUBECTL_RACE_PHASE_FILE}"
+            ;;
+          *'"resourceVersion":"2"'*)
+            printf '3\n' >"${KUBECTL_RACE_PHASE_FILE}"
+            exit 44
+            ;;
+          *'"resourceVersion":"3"'*)
+            printf '4\n' >"${KUBECTL_RACE_PHASE_FILE}"
+            ;;
+          *'"resourceVersion":"4"'*) : ;;
+          *) exit 48 ;;
+        esac
+        ;;
+      fence_fail)
+        resource_version=$(printf '%s' "$*" | sed -n 's/.*"resourceVersion":"\([0-9]*\)".*/\1/p')
+        printf '%s\n' "${resource_version}" >"${KUBECTL_RACE_PHASE_FILE}"
+        case "${resource_version}" in
+          1|3|5|7|9) : ;;
+          2|4|6|8|10) exit 44 ;;
+          *) exit 49 ;;
+        esac
         ;;
       *) exit 44 ;;
     esac
@@ -279,6 +323,14 @@ EOF
     The contents of file "${history_file}" should eq "[4,8,12]"
   End
 
+  It "retries when another pod advances history after confirmation but before the local write fence"
+    When call run_case present success success post_confirm_race
+    The status should be success
+    The output should include "RUSTFS_REPLICAS_HISTORY=[4,8,12]"
+    The contents of file "${history_file}" should eq "[4,8,12]"
+    The contents of file "${call_log}" should include '"resourceVersion":"4"'
+  End
+
   It "fails closed when the patched ConfigMap cannot be confirmed"
     When call run_case present success success success '' '[4]' fail
     The status should be failure
@@ -297,6 +349,13 @@ EOF
     When call run_case present success success success '' '[4]' stale
     The status should be failure
     The stderr should include "does not contain replicas 8"
+    The path "${history_file}" should not be exist
+  End
+
+  It "removes an unfenced local history when confirmation conflicts exhaust retries"
+    When call run_case present success success fence_fail
+    The status should be failure
+    The stderr should include "after 5 attempts"
     The path "${history_file}" should not be exist
   End
 

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -47,6 +47,34 @@ get_cm_key_snapshot() {
   printf '%s' "$value"
 }
 
+parse_cm_key_history() {
+  raw="$1"
+
+  if [ -z "$raw" ]; then
+    return 0
+  fi
+  case "$raw" in
+    \[*\]) value=${raw#\[}; value=${value%\]} ;;
+    *) return 1 ;;
+  esac
+  case "$value" in
+    ''|,*|*,|*,,*|*[!0-9,]*) return 1 ;;
+  esac
+
+  previous=0
+  old_ifs="$IFS"
+  IFS=','
+  for item in $value; do
+    if ! [ "$item" -gt "$previous" ] 2>/dev/null; then
+      IFS="$old_ifs"
+      return 1
+    fi
+    previous="$item"
+  done
+  IFS="$old_ifs"
+  printf '%s' "$value"
+}
+
 update_cm_key_value() {
   name="$1"
   namespace="$2"
@@ -95,8 +123,11 @@ update_configmap_and_sync_to_local_file() {
         ;;
     esac
     resource_version=${snapshot%%"$tab"*}
-    cur=${snapshot#*"$tab"}
-    cur=$(printf '%s' "$cur" | tr -d '[]')
+    raw_cur=${snapshot#*"$tab"}
+    cur=$(parse_cm_key_history "$raw_cur") || {
+      echo "Failed to parse $key history from ConfigMap $namespace/$name." >&2
+      return 1
+    }
     new=$(get_cm_key_new_value "$cur" "$replicas")
 
     if update_cm_key_value "$name" "$namespace" "$key" "$new" "$resource_version"; then

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -93,7 +93,7 @@ get_cm_key_new_value() {
   if [ -z "$cur" ]; then
     printf "[%s]" "$replicas"
   else
-    max=$(echo "$cur" | tr ',' '\n' | awk 'BEGIN{m=0} {if($1+0>m)m=$1+0} END{print m}')
+    max=${cur##*,}
     if [ "$replicas" -le "$max" ]; then
       printf "[%s]" "$cur"
     else

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -89,7 +89,7 @@ update_configmap_and_sync_to_local_file() {
   update_cm_key_value "$name" "$namespace" "$key" "$new" || return $?
   echo "configmap/$name updated successfully with $key=$new"
 
-  printf '%s\n' "$new" >>"$replicas_history_file" || {
+  printf '%s\n' "$new" >"$replicas_history_file" || {
     echo "Failed to write $key to local file $replicas_history_file." >&2
     return 1
   }

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -24,6 +24,10 @@ metadata:
 EOF
     create_status=$?
     if [ "$create_status" -ne 0 ]; then
+      existing=$(kubectl get configmaps "$name" -n "$namespace" --ignore-not-found -o name) || existing=""
+      if [ -n "$existing" ]; then
+        return 0
+      fi
       echo "Failed to create ConfigMap $namespace/$name." >&2
       return "$create_status"
     fi

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -34,16 +34,17 @@ EOF
   fi
 }
 
-get_cm_key_value() {
+get_cm_key_snapshot() {
   name="$1"
   namespace="$2"
   key="$3"
 
-  value=$(kubectl get configmaps "$name" -n "$namespace" -o jsonpath="{.data.$key}") || {
+  value=$(kubectl get configmaps "$name" -n "$namespace" \
+    -o "jsonpath={.metadata.resourceVersion}{'\\t'}{.data.$key}") || {
     echo "Failed to read $key from ConfigMap $namespace/$name." >&2
     return 1
   }
-  printf '%s' "$value" | tr -d '[]'
+  printf '%s' "$value"
 }
 
 update_cm_key_value() {
@@ -51,12 +52,10 @@ update_cm_key_value() {
   namespace="$2"
   key="$3"
   new_value="$4"
+  resource_version="$5"
 
   kubectl patch configmap "$name" -n "$namespace" --type strategic \
-    -p "{\"data\":{\"$key\":\"$new_value\"}}" || {
-    echo "Failed to update $key in ConfigMap $namespace/$name." >&2
-    return 1
-  }
+    -p "{\"metadata\":{\"resourceVersion\":\"$resource_version\"},\"data\":{\"$key\":\"$new_value\"}}"
 }
 
 get_cm_key_new_value() {
@@ -83,10 +82,32 @@ update_configmap_and_sync_to_local_file() {
 
   create_cm_if_not_exist "$name" "$namespace" || return $?
 
-  cur=$(get_cm_key_value "$name" "$namespace" "$key") || return $?
-  new=$(get_cm_key_new_value "$cur" "$replicas")
+  attempt=1
+  max_attempts=5
+  tab=$(printf '\t')
+  while [ "$attempt" -le "$max_attempts" ]; do
+    snapshot=$(get_cm_key_snapshot "$name" "$namespace" "$key") || return $?
+    case "$snapshot" in
+      *"$tab"*) ;;
+      *)
+        echo "Failed to parse $key snapshot from ConfigMap $namespace/$name." >&2
+        return 1
+        ;;
+    esac
+    resource_version=${snapshot%%"$tab"*}
+    cur=${snapshot#*"$tab"}
+    cur=$(printf '%s' "$cur" | tr -d '[]')
+    new=$(get_cm_key_new_value "$cur" "$replicas")
 
-  update_cm_key_value "$name" "$namespace" "$key" "$new" || return $?
+    if update_cm_key_value "$name" "$namespace" "$key" "$new" "$resource_version"; then
+      break
+    fi
+    attempt=$((attempt + 1))
+  done
+  if [ "$attempt" -gt "$max_attempts" ]; then
+    echo "Failed to update $key in ConfigMap $namespace/$name after $max_attempts attempts." >&2
+    return 1
+  fi
   echo "configmap/$name updated successfully with $key=$new"
 
   printf '%s\n' "$new" >"$replicas_history_file" || {

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -6,8 +6,11 @@ create_cm_if_not_exist() {
   name="$1"
   namespace="$2"
 
-  kubectl get configmaps "$name" -n "$namespace"
-  if [ $? -ne 0 ]; then
+  existing=$(kubectl get configmaps "$name" -n "$namespace" --ignore-not-found -o name) || {
+    echo "Failed to check ConfigMap $namespace/$name." >&2
+    return 1
+  }
+  if [ -z "$existing" ]; then
     cat <<EOF | kubectl create -f -
 apiVersion: v1
 kind: ConfigMap
@@ -19,6 +22,11 @@ metadata:
     app.kubernetes.io/instance: {{ .CLUSTER_NAME }}
     apps.kubeblocks.io/component-name: {{ .CLUSTER_COMPONENT_NAME }}
 EOF
+    create_status=$?
+    if [ "$create_status" -ne 0 ]; then
+      echo "Failed to create ConfigMap $namespace/$name." >&2
+      return "$create_status"
+    fi
   fi
 }
 
@@ -27,7 +35,11 @@ get_cm_key_value() {
   namespace="$2"
   key="$3"
 
-  kubectl get configmaps "$name" -n "$namespace" -o jsonpath="{.data.$key}" | tr -d '[]'
+  value=$(kubectl get configmaps "$name" -n "$namespace" -o jsonpath="{.data.$key}") || {
+    echo "Failed to read $key from ConfigMap $namespace/$name." >&2
+    return 1
+  }
+  printf '%s' "$value" | tr -d '[]'
 }
 
 update_cm_key_value() {
@@ -36,7 +48,11 @@ update_cm_key_value() {
   key="$3"
   new_value="$4"
 
-  kubectl patch configmap "$name" -n "$namespace" --type strategic -p "{\"data\":{\"$key\":\"$new_value\"}}"
+  kubectl patch configmap "$name" -n "$namespace" --type strategic \
+    -p "{\"data\":{\"$key\":\"$new_value\"}}" || {
+    echo "Failed to update $key in ConfigMap $namespace/$name." >&2
+    return 1
+  }
 }
 
 get_cm_key_new_value() {
@@ -61,12 +77,12 @@ update_configmap_and_sync_to_local_file() {
   key="RUSTFS_REPLICAS_HISTORY"
   replicas="$RUSTFS_COMP_REPLICAS"
 
-  create_cm_if_not_exist "$name" "$namespace"
+  create_cm_if_not_exist "$name" "$namespace" || return $?
 
-  cur=$(get_cm_key_value "$name" "$namespace" "$key")
+  cur=$(get_cm_key_value "$name" "$namespace" "$key") || return $?
   new=$(get_cm_key_new_value "$cur" "$replicas")
 
-  update_cm_key_value "$name" "$namespace" "$key" "$new"
+  update_cm_key_value "$name" "$namespace" "$key" "$new" || return $?
   echo "configmap/$name updated successfully with $key=$new"
 
   echo $new >> $replicas_history_file

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -85,7 +85,10 @@ update_configmap_and_sync_to_local_file() {
   update_cm_key_value "$name" "$namespace" "$key" "$new" || return $?
   echo "configmap/$name updated successfully with $key=$new"
 
-  echo $new >> $replicas_history_file
+  printf '%s\n' "$new" >>"$replicas_history_file" || {
+    echo "Failed to write $key to local file $replicas_history_file." >&2
+    return 1
+  }
   echo "the new value $new has been written to the local file $replicas_history_file"
 }
 

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -102,6 +102,34 @@ get_cm_key_new_value() {
   fi
 }
 
+get_confirmed_cm_key_value() {
+  name="$1"
+  namespace="$2"
+  key="$3"
+  replicas="$4"
+  tab=$(printf '\t')
+
+  snapshot=$(get_cm_key_snapshot "$name" "$namespace" "$key") || return $?
+  case "$snapshot" in
+    *"$tab"*) ;;
+    *)
+      echo "Failed to parse confirmed $key snapshot from ConfigMap $namespace/$name." >&2
+      return 1
+      ;;
+  esac
+  raw_cur=${snapshot#*"$tab"}
+  cur=$(parse_cm_key_history "$raw_cur") || {
+    echo "Failed to parse confirmed $key history from ConfigMap $namespace/$name." >&2
+    return 1
+  }
+  confirmed=$(get_cm_key_new_value "$cur" "$replicas")
+  if [ "$confirmed" != "[$cur]" ]; then
+    echo "Confirmed $key in ConfigMap $namespace/$name does not contain replicas $replicas." >&2
+    return 1
+  fi
+  printf '%s' "$confirmed"
+}
+
 update_configmap_and_sync_to_local_file() {
   namespace={{ .CLUSTER_NAMESPACE }}
   name={{ .RUSTFS_COMPONENT_NAME }}-rustfs-configuration
@@ -131,6 +159,7 @@ update_configmap_and_sync_to_local_file() {
     new=$(get_cm_key_new_value "$cur" "$replicas")
 
     if update_cm_key_value "$name" "$namespace" "$key" "$new" "$resource_version"; then
+      new=$(get_confirmed_cm_key_value "$name" "$namespace" "$key" "$replicas") || return $?
       break
     fi
     attempt=$((attempt + 1))

--- a/addons/rustfs/scripts/replicas-history-config.sh
+++ b/addons/rustfs/scripts/replicas-history-config.sh
@@ -117,6 +117,7 @@ get_confirmed_cm_key_value() {
       return 1
       ;;
   esac
+  resource_version=${snapshot%%"$tab"*}
   raw_cur=${snapshot#*"$tab"}
   cur=$(parse_cm_key_history "$raw_cur") || {
     echo "Failed to parse confirmed $key history from ConfigMap $namespace/$name." >&2
@@ -127,7 +128,7 @@ get_confirmed_cm_key_value() {
     echo "Confirmed $key in ConfigMap $namespace/$name does not contain replicas $replicas." >&2
     return 1
   fi
-  printf '%s' "$confirmed"
+  printf '%s\t%s' "$resource_version" "$confirmed"
 }
 
 update_configmap_and_sync_to_local_file() {
@@ -159,21 +160,25 @@ update_configmap_and_sync_to_local_file() {
     new=$(get_cm_key_new_value "$cur" "$replicas")
 
     if update_cm_key_value "$name" "$namespace" "$key" "$new" "$resource_version"; then
-      new=$(get_confirmed_cm_key_value "$name" "$namespace" "$key" "$replicas") || return $?
-      break
+      confirmed_snapshot=$(get_confirmed_cm_key_value "$name" "$namespace" "$key" "$replicas") || return $?
+      confirmed_resource_version=${confirmed_snapshot%%"$tab"*}
+      new=${confirmed_snapshot#*"$tab"}
+      printf '%s\n' "$new" >"$replicas_history_file" || {
+        echo "Failed to write $key to local file $replicas_history_file." >&2
+        return 1
+      }
+      if update_cm_key_value "$name" "$namespace" "$key" "$new" "$confirmed_resource_version"; then
+        break
+      fi
     fi
     attempt=$((attempt + 1))
   done
   if [ "$attempt" -gt "$max_attempts" ]; then
+    rm -f "$replicas_history_file"
     echo "Failed to update $key in ConfigMap $namespace/$name after $max_attempts attempts." >&2
     return 1
   fi
   echo "configmap/$name updated successfully with $key=$new"
-
-  printf '%s\n' "$new" >"$replicas_history_file" || {
-    echo "Failed to write $key to local file $replicas_history_file." >&2
-    return 1
-  }
   echo "the new value $new has been written to the local file $replicas_history_file"
 }
 


### PR DESCRIPTION
## Summary

- fail closed on replicas-history ConfigMap and local-write failures
- preserve concurrent history with resourceVersion-bound compare-and-retry
- confirm the ConfigMap after patch success and fence the subsequent local write
- reject malformed/non-increasing snapshots before mutation
- preserve the largest signed shell integer without awk precision loss
- bind focused tests to exact create/patch payloads and retry limits

## Exact identity

- target/base: `main@cecd2c59cbe385dbd0680caded519b8e0efc86e2`
- target tree: `852ea38cd51ab797aa9ac8224fbb6aa797caed40`
- child branch/head/tree: `jessica/rustfs-replicas-history-failclosed-20260813@e11ca9c0bc2032d1cd4ca026829ccc0fccfc27e7` / `ea4a1b42e66a7f60dd0acfadc55fdeccb8af635b`
- child parent: `be42dbad38d5b9800db903c4234352978fc0bd2f`
- PR #3311 merged into main; the 12-commit child series was rebased with `range-diff` 12/12 `=`

## Causal evidence

- original API fail-closed RED: 4 examples, 3 failures
- concurrent-update RED: 12 examples, 1 failure; stale `[4,8]` overwrote concurrent `[4,12]`
- post-patch confirmation RED: 19 examples, 1 failure; ConfigMap advanced to `[4,8,12]` while local history remained `[4,8]`
- confirmation fix: read and validate a fresh snapshot after patch success, write only its confirmed history, and fail closed on read/parse/current-replica mismatch
- local-write fence RED: 23 examples, 1 failure; higher history committed after the confirmation GET and local remained `[4,8]`
- fence fix: after writing locally, issue a same-value resourceVersion CAS; conflict retries from the higher snapshot, and exhaustion removes the unfenced local file
- malformed-history closure rejects malformed/non-increasing snapshots
- large-value fix preserves `9223372036854775807` using POSIX shell parameter expansion
- payload, retry-budget, and create-manifest mutation checks kill their targeted mutations

## Fresh source gate

- focused replicas-history ShellSpec on Bash 3.2: 24 examples, 0 failures
- full RustFS script suite on Bash 5.3: 84 examples, 0 failures
- rendered POSIX ShellCheck: PASS
- addon and cluster Helm lint: 1/0 each
- `git diff --check origin/main..HEAD`: PASS
- hosted checks on exact `e11ca9c0...`: 8/8 SUCCESS; ShellSpec run
  `31996736114`, job `95289626653`; no old-head CI migrates
- independent review on exact `e11ca9c0...`: APPROVED, review `4948681258`
- review-triggered checks on exact `e11ca9c0...`: 5/5 SUCCESS; ShellSpec run
  `31997888772`, job `95292741765`
- reviews `4948310687` and `4948547310` apply only to old heads

Evidence: `artifacts/rustfs-pr3314-post-patch-confirmation-be42dbad.md`, SHA256 `2fd6f16298098202ba9dfdd7615b0af48d1eda8b4b32e3887617f45ddd264846`; `artifacts/rustfs-pr3314-local-write-fence-e11ca9c0.md`, SHA256 `3c7fa33093b50cb55907364c2e04a3e5d4fb3c55437443f3fbb122f8a99949c1`.

Source/code-test scope only. No Test package, Kubernetes runtime, P/F/S, cleanup, residue, or formal-N claim.
