### PR TITLE
fix(mysql): run myloader restore with bash

### DIFF
--- a/addons/mysql/dataprotection/mysql-myloader.sh
+++ b/addons/mysql/dataprotection/mysql-myloader.sh
@@ -10,8 +10,8 @@ function handle_exit() {
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
     echo "failed with exit code $exit_code"
-    touch "${DP_BACKUP_INFO_FILE}.exit"
-    exit 1
+    touch "${DP_BACKUP_INFO_FILE}.exit" || true
+    exit "${exit_code}"
   fi
 }
 trap handle_exit EXIT

--- a/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
@@ -421,6 +421,39 @@ $(render_template actionset-xtrabackup-inc-v2.yaml)" || return 1
     [ "${status}" -eq 42 ]
   }
 
+  verify_mydumper_action_shells() {
+    output=$(render_template actionset-mydumper.yaml) || return 1
+    [ "$(printf '%s\n' "$output" | grep -Ec '^[[:space:]]+- bash$')" -eq 2 ] || return 1
+    ! printf '%s\n' "$output" | grep -Eq '^[[:space:]]+- sh$'
+  }
+
+  verify_myloader_marker_write_failure_preserves_original_exit_code() {
+    root=$(mktemp -d "${TMPDIR:-/tmp}/mysql-myloader-exit.XXXXXX") || return 1
+
+    (
+      datasafed() { return 0; }
+      myloader() { return 42; }
+      export -f datasafed myloader
+      export DP_DATASAFED_BIN_PATH="/bin"
+      export DP_BACKUP_BASE_PATH="/repo/current"
+      export DP_BACKUP_NAME="current"
+      export DP_BACKUP_INFO_FILE="${root}/missing/progress"
+      export DP_DB_HOST="mysql"
+      export DP_DB_PORT="3306"
+      export MYSQL_ADMIN_USER="root"
+      export MYSQL_ADMIN_PASSWORD="secret"
+      export threads=""
+      export tables=""
+      export drop_table=""
+      export no_data="false"
+      bash "$(chart_path)/dataprotection/mysql-myloader.sh" >/dev/null 2>&1
+    )
+    status=$?
+
+    rm -rf "${root}"
+    [ "${status}" -eq 42 ]
+  }
+
   verify_restore_markers_are_terminal() {
     for script in restore.sh xtrabackup-incremental-restore.sh; do
       awk '
@@ -525,6 +558,16 @@ $(render_template actionset-xtrabackup-inc-v2.yaml)" || return 1
 
   It "preserves the original mydumper failure when its marker cannot be written"
     When call verify_mydumper_marker_write_failure_preserves_original_exit_code
+    The status should be success
+  End
+
+  It "runs both mydumper backup and restore scripts with bash"
+    When call verify_mydumper_action_shells
+    The status should be success
+  End
+
+  It "preserves the original myloader failure when its marker cannot be written"
+    When call verify_myloader_marker_write_failure_preserves_original_exit_code
     The status should be success
   End
 

--- a/addons/mysql/templates/actionset-mydumper.yaml
+++ b/addons/mysql/templates/actionset-mydumper.yaml
@@ -61,7 +61,7 @@ spec:
         image: {{ include "mysql.mydumper.image" . }}
         runOnTargetPodNode: true
         command:
-        - sh
+        - bash
         - -c
         - |
           {{- .Files.Get "dataprotection/mysql-myloader.sh" | nindent 10 }}


### PR DESCRIPTION
## Summary

- run the embedded myloader restore script with Bash, matching its Bash-only syntax and `pipefail` contract
- preserve the original myloader failure status even when publishing the failure marker also fails
- add render and executable regressions for both contracts

This is a child PR against PR #3182's development branch. It does not change the exact `677cbeda1` runtime candidate until reviewed and merged.

## Verification

- RED before fix: 2/38 focused ShellSpec failures
- focused ShellSpec: 38 examples, 0 failures
- full MySQL ShellSpec: 57 examples, 0 failures
- `bash -n`: 6 scripts
- `helm lint --strict addons/mysql`: 1 chart, 0 failures
- `git diff --check`: clean
