### PR TITLE
fix(mysql): validate mydumper parameters

### DIFF
--- a/addons/mysql/dataprotection/mysql-mydumper.sh
+++ b/addons/mysql/dataprotection/mysql-mydumper.sh
@@ -18,6 +18,12 @@ trap handle_exit EXIT
 if [ -z "$threads" ]; then
   threads=4
 fi
+case "${threads}" in
+  "" | 0* | *[!0-9]*)
+    echo "threads must be a positive integer" >&2
+    exit 2
+    ;;
+esac
 params="--threads=$threads --triggers --routines"
 if [ -n "$tables" ]; then
   params="$params -T $tables"

--- a/addons/mysql/dataprotection/mysql-myloader.sh
+++ b/addons/mysql/dataprotection/mysql-myloader.sh
@@ -19,14 +19,25 @@ trap handle_exit EXIT
 if [ -z "$threads" ]; then
   threads=4
 fi
+case "${threads}" in
+  "" | 0* | *[!0-9]*)
+    echo "threads must be a positive integer" >&2
+    exit 2
+    ;;
+esac
 params="--threads=$threads"
 if [ -n "${tables}" ]; then
   params="${params} -T ${tables}"
 fi
 # DROP, FAIL(default), NONE, TRUNCATE and DELETE
-if [ -n "$drop_table" ]; then
-  params="${params} -o $drop_table"
-fi
+case "${drop_table}" in
+  "") ;;
+  DROP | FAIL | NONE | TRUNCATE | DELETE) params="${params} -o $drop_table" ;;
+  *)
+    echo "drop_table must be one of DROP, FAIL, NONE, TRUNCATE, DELETE" >&2
+    exit 2
+    ;;
+esac
 if [ "${no_data}" == "true" ]; then
   params="${params} --no-data"
 fi

--- a/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
@@ -421,6 +421,89 @@ $(render_template actionset-xtrabackup-inc-v2.yaml)" || return 1
     [ "${status}" -eq 42 ]
   }
 
+  verify_mydumper_rejects_invalid_threads() {
+    root=$(mktemp -d "${TMPDIR:-/tmp}/mysql-mydumper-threads.XXXXXX") || return 1
+
+    (
+      datasafed() {
+        case "$1" in
+          push) cat >/dev/null ;;
+          stat) printf '%s\n' 'TotalSize 7' ;;
+        esac
+      }
+      mydumper() {
+        touch "${TOOL_CALLED}"
+      }
+      export -f datasafed mydumper
+      export TOOL_CALLED="${root}/mydumper-called"
+      export DP_DATASAFED_BIN_PATH="/bin"
+      export DP_BACKUP_BASE_PATH="/repo/current"
+      export DP_BACKUP_NAME="current"
+      export DP_BACKUP_INFO_FILE="${root}/progress"
+      export DP_DB_HOST="mysql"
+      export DP_DB_PORT="3306"
+      export DP_DB_USER="backup"
+      export DP_DB_PASSWORD="secret"
+      export threads="0"
+      export tables=""
+      export trx_tables="false"
+      export no_data="false"
+      export databases=""
+      bash "$(chart_path)/dataprotection/mysql-mydumper.sh" >/dev/null 2>&1
+    )
+    status=$?
+
+    [ "${status}" -ne 0 ] && [ ! -e "${root}/mydumper-called" ] || {
+      rm -rf "${root}"
+      return 1
+    }
+    rm -rf "${root}"
+  }
+
+  verify_myloader_rejects_invalid_parameters() {
+    for scenario in threads drop_table; do
+      root=$(mktemp -d "${TMPDIR:-/tmp}/mysql-myloader-parameter.XXXXXX") || return 1
+
+      (
+        datasafed() {
+          if [ "$1" = "pull" ]; then
+            printf '%s\n' 'dump'
+          fi
+        }
+        myloader() {
+          touch "${TOOL_CALLED}"
+          cat >/dev/null
+        }
+        export -f datasafed myloader
+        export TOOL_CALLED="${root}/myloader-called"
+        export DP_DATASAFED_BIN_PATH="/bin"
+        export DP_BACKUP_BASE_PATH="/repo/current"
+        export DP_BACKUP_NAME="current"
+        export DP_BACKUP_INFO_FILE="${root}/progress"
+        export DP_DB_HOST="mysql"
+        export DP_DB_PORT="3306"
+        export MYSQL_ADMIN_USER="root"
+        export MYSQL_ADMIN_PASSWORD="secret"
+        export threads="4"
+        export tables=""
+        export drop_table=""
+        export no_data="false"
+        case "${scenario}" in
+          threads) export threads="0" ;;
+          drop_table) export drop_table="INVALID" ;;
+        esac
+        sh "$(chart_path)/dataprotection/mysql-myloader.sh" >/dev/null 2>&1
+      )
+      status=$?
+
+      [ "${status}" -ne 0 ] && [ ! -e "${root}/myloader-called" ] || {
+        rm -rf "${root}"
+        return 1
+      }
+      rm -rf "${root}"
+    done
+  }
+
   verify_restore_markers_are_terminal() {
     for script in restore.sh xtrabackup-incremental-restore.sh; do
       awk '
@@ -525,6 +608,16 @@ $(render_template actionset-xtrabackup-inc-v2.yaml)" || return 1
 
   It "preserves the original mydumper failure when its marker cannot be written"
     When call verify_mydumper_marker_write_failure_preserves_original_exit_code
+    The status should be success
+  End
+
+  It "rejects a non-positive mydumper thread count before invoking the tool"
+    When call verify_mydumper_rejects_invalid_threads
+    The status should be success
+  End
+
+  It "rejects invalid myloader parameter values before invoking the tool"
+    When call verify_myloader_rejects_invalid_parameters
     The status should be success
   End
 


### PR DESCRIPTION
## Summary
- reject non-positive or non-integer thread counts before mydumper/myloader invocation
- reject unsupported myloader drop-table modes before reading the backup stream
- keep validation POSIX-compatible so this child PR remains independent of the pending Bash execution fix

## Contract
- kubeblocks-addon-docs docs/addon-api/09a-backup-basic.md:110

## Validation
- focused MySQL action contract ShellSpec: 38/38
- full MySQL ShellSpec: 57/57
- bash syntax: 6 scripts
- sh syntax: mysql-myloader.sh
- strict Helm lint: passed
- git diff check: passed