### PR TITLE
fix(mysql): constrain mydumper parameter schema

### DIFF
--- a/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/xtrabackup_action_image_contract_spec.sh
@@ -421,6 +421,29 @@ $(render_template actionset-xtrabackup-inc-v2.yaml)" || return 1
     [ "${status}" -eq 42 ]
   }
 
+  verify_mydumper_parameter_schema() {
+    render_template actionset-mydumper.yaml | awk '
+      /^        [a-z_]+:$/ {
+        parameter = $1
+        sub(/:$/, "", parameter)
+      }
+      parameter == "threads" && $1 == "type:" && $2 == "integer" {
+        integer_threads = 1
+      }
+      parameter == "threads" && $1 == "minimum:" && $2 == "1" {
+        positive_threads = 1
+      }
+      parameter == "drop_table" && $1 == "enum:" {
+        line = $0
+        sub(/^[[:space:]]+/, "", line)
+        if (line == "enum: [DROP, FAIL, NONE, TRUNCATE, DELETE]") {
+          drop_modes = 1
+        }
+      }
+      END { exit !(integer_threads && positive_threads && drop_modes) }
+    '
+  }
+
   verify_restore_markers_are_terminal() {
     for script in restore.sh xtrabackup-incremental-restore.sh; do
       awk '
@@ -525,6 +548,11 @@ $(render_template actionset-xtrabackup-inc-v2.yaml)" || return 1
 
   It "preserves the original mydumper failure when its marker cannot be written"
     When call verify_mydumper_marker_write_failure_preserves_original_exit_code
+    The status should be success
+  End
+
+  It "constrains mydumper parameters in the rendered ActionSet schema"
+    When call verify_mydumper_parameter_schema
     The status should be success
   End
 

--- a/addons/mysql/templates/actionset-mydumper.yaml
+++ b/addons/mysql/templates/actionset-mydumper.yaml
@@ -20,7 +20,8 @@ spec:
           type: string
           description: "The tables to backup, separated by comma. Table name must include database name. For instance: test.t1,test.t2"
         threads:
-          type: number
+          type: integer
+          minimum: 1
           description: "The number of threads to use for the backup."
           default: 4
         no_data:
@@ -28,6 +29,7 @@ spec:
           description: "Whether to backup table structure only without data."
         drop_table:
           type: string
+          enum: [DROP, FAIL, NONE, TRUNCATE, DELETE]
           description: "-o, --drop-table Executes or simulates a DROP TABLE if the table already exists. The drop modes can be: FAIL, NONE, DROP, TRUNCATE and DELETE. If the option is not set, the default is set to: FAIL. If the option is used without a parameter, the default is: DROP."
   backup:
     preBackup: []


### PR DESCRIPTION
## Summary
- declare `threads` as an integer with minimum 1 in the mydumper ActionSet schema
- constrain `drop_table` to `DROP`, `FAIL`, `NONE`, `TRUNCATE`, or `DELETE`
- add a rendered ActionSet contract regression

## Contract
`kubeblocks-addon-docs/docs/addon-api/09a-backup-basic.md:110` requires ActionSet `parametersSchema/withParameters` validation while retaining script-side value validation. This PR is the admission/schema half; PR #3318 independently guards the script execution surface.

## TDD and validation
- RED: focused ShellSpec `1/37` failed with all 36 prior examples passing
- focused ShellSpec: `37/37`
- full MySQL ShellSpec: `56/56`
- `bash -n`: 6 dataprotection scripts
- `helm lint --strict addons/mysql`
- `git diff --check`

Base: exact PR3182 head `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da`.