### PR TITLE
fix(mysql): remove ignored restore parameters

### DIFF
--- a/addons/mysql/scripts-ut-spec/mydumper_action_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/mydumper_action_contract_spec.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=sh
+
+Describe "MySQL mydumper ActionSet contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  restore_parameters() {
+    helm template test "$(chart_path)" \
+      --show-only templates/actionset-mydumper.yaml | awk '
+        /^  restore:$/ { in_restore = 1; next }
+        in_restore && /^    withParameters:$/ { in_parameters = 1; next }
+        in_parameters && /^      - / { print $2; next }
+        in_parameters { exit }
+        END { if (!in_parameters) exit 1 }
+      '
+  }
+
+  verify_restore_parameters_are_consumed() {
+    parameters=$(restore_parameters) || return 1
+    expected=$(printf '%s\n' threads tables drop_table)
+    [ "${parameters}" = "${expected}" ] || return 1
+
+    script=$(awk '!/^[[:space:]]*#/' "$(chart_path)/dataprotection/mysql-myloader.sh") || return 1
+    for parameter in ${parameters}; do
+      printf '%s\n' "${script}" |
+        grep -Eq '[$][{]?'"${parameter}"'([}]|[^A-Za-z0-9_])' || return 1
+    done
+  }
+
+  It "advertises only parameters consumed by the myloader restore script"
+    When call verify_restore_parameters_are_consumed
+    The status should be success
+  End
+End

--- a/addons/mysql/templates/actionset-mydumper.yaml
+++ b/addons/mysql/templates/actionset-mydumper.yaml
@@ -53,8 +53,6 @@ spec:
     withParameters:
       - threads
       - tables
-      - databases
-      - trx_tables
       - drop_table
     postReady:
     - job:


### PR DESCRIPTION
## Summary
- stop advertising `databases` and `trx_tables` as mydumper restore parameters because the embedded myloader script consumes neither
- keep both parameters available to the backup phase
- add a rendered ActionSet contract spec that checks the exact restore parameter set and proves every advertised parameter is referenced by the script

## Contract
`kubeblocks-addon-docs/docs/addon-api/09a-backup-basic.md:110` defines ActionSet `parametersSchema/withParameters` as Backup/Restore parameter-name validation. Advertising no-op restore parameters silently accepts user intent that the restore implementation ignores.

## TDD and validation
- RED: focused ShellSpec `1/1` failed
- focused ShellSpec: `1/1`
- full MySQL ShellSpec: `56/56`
- `bash -n`: 6 dataprotection scripts plus the new spec
- ShellCheck: new spec
- `helm lint --strict addons/mysql`
- `git diff --check`

Base: exact PR3182 head `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da`.