### PR TITLE
fix(mysql): validate mydumper boolean parameters

### DIFF
--- a/addons/mysql/dataprotection/mysql-mydumper.sh
+++ b/addons/mysql/dataprotection/mysql-mydumper.sh
@@ -18,6 +18,20 @@ trap handle_exit EXIT
 if [ -z "$threads" ]; then
   threads=4
 fi
+case "${trx_tables}" in
+  "" | true | false) ;;
+  *)
+    echo "trx_tables must be true or false" >&2
+    exit 1
+    ;;
+esac
+case "${no_data}" in
+  "" | true | false) ;;
+  *)
+    echo "no_data must be true or false" >&2
+    exit 1
+    ;;
+esac
 params="--threads=$threads --triggers --routines"
 if [ -n "$tables" ]; then
   params="$params -T $tables"

--- a/addons/mysql/scripts-ut-spec/mydumper_parameter_validation_spec.sh
+++ b/addons/mysql/scripts-ut-spec/mydumper_parameter_validation_spec.sh
@@ -1,0 +1,60 @@
+# shellcheck shell=bash disable=SC2329
+
+Describe "MySQL mydumper parameter validation"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  verify_invalid_booleans_fail_before_tool_invocation() {
+    for parameter in trx_tables no_data; do
+      root=$(mktemp -d "${TMPDIR:-/tmp}/mysql-mydumper-boolean.XXXXXX") || return 1
+
+      (
+        datasafed() {
+          if [ "$1" = "push" ]; then
+            cat >/dev/null
+          fi
+        }
+        mydumper() {
+          touch "${TOOL_CALLED}"
+        }
+        export -f datasafed mydumper
+        export TOOL_CALLED="${root}/mydumper-called"
+        export DP_DATASAFED_BIN_PATH="/bin"
+        export DP_BACKUP_BASE_PATH="/repo/current"
+        export DP_BACKUP_NAME="current"
+        export DP_BACKUP_INFO_FILE="${root}/progress"
+        export DP_DB_HOST="mysql"
+        export DP_DB_PORT="3306"
+        export DP_DB_USER="backup"
+        export DP_DB_PASSWORD="secret"
+        export threads=""
+        export tables=""
+        export trx_tables="false"
+        export no_data="false"
+        export databases=""
+        case "${parameter}" in
+          trx_tables) export trx_tables="invalid" ;;
+          no_data) export no_data="invalid" ;;
+        esac
+        bash "$(chart_path)/dataprotection/mysql-mydumper.sh" >/dev/null 2>&1
+      )
+      status=$?
+
+      [ "${status}" -ne 0 ] && [ ! -e "${root}/mydumper-called" ] || {
+        rm -rf "${root}"
+        return 1
+      }
+      rm -rf "${root}"
+    done
+  }
+
+  It "rejects malformed boolean values before invoking mydumper"
+    When call verify_invalid_booleans_fail_before_tool_invocation
+    The status should be success
+  End
+End


### PR DESCRIPTION
## Summary
- reject malformed `trx_tables` values before invoking mydumper
- reject malformed `no_data` values before invoking mydumper
- preserve empty, `true`, and `false` behavior
- add executable pre-invocation regressions for both parameters

## Contract
`kubeblocks-addon-docs/docs/addon-api/09a-backup-basic.md:110` requires scripts to validate parameter values rather than relying only on the ActionSet schema. Exact677 silently treated malformed booleans as false, which could change backup consistency or contents.

## TDD and validation
- RED: focused ShellSpec `1/1` failed
- focused ShellSpec: `1/1`
- full MySQL ShellSpec: `56/56`
- `bash -n`: 6 dataprotection scripts plus the new spec
- ShellCheck: new spec
- `helm lint --strict addons/mysql`
- `git diff --check`

Base: exact PR3182 head `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da`.