### PR TITLE
fix(mysql): preserve mydumper filter arguments

### DIFF
--- a/addons/mysql/dataprotection/mysql-mydumper.sh
+++ b/addons/mysql/dataprotection/mysql-mydumper.sh
@@ -18,24 +18,26 @@ trap handle_exit EXIT
 if [ -z "$threads" ]; then
   threads=4
 fi
-params="--threads=$threads --triggers --routines"
+set -- "--threads=$threads" --triggers --routines
 if [ -n "$tables" ]; then
-  params="$params -T $tables"
+  set -- "$@" -T "$tables"
 fi
 if [ "$trx_tables" == "true" ]; then
-  params="$params --trx-tables"
+  set -- "$@" --trx-tables
 fi
 if [ "${no_data}" == "true" ]; then
-  params="${params} --no-data"
+  set -- "$@" --no-data
 fi
 if [ -n "$databases" ]; then
-  params="${params} -B $databases"
+  set -- "$@" -B "$databases"
 fi
 
-echo "parameters: $params"
+printf 'parameters:'
+printf ' <%s>' "$@"
+printf '\n'
 
 mydumper -h ${DP_DB_HOST} -u ${DP_DB_USER} -p ${DP_DB_PASSWORD} -P ${DP_DB_PORT}  \
-  --stream --build-empty-files --chunk-filesize 256 ${params} \
+  --stream --build-empty-files --chunk-filesize 256 "$@" \
   2> >(tee /tmp/mydumper.log >&2) | datasafed push -z zstd-fastest - "/${DP_BACKUP_NAME}.mydumper.zst"
 
 TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')

--- a/addons/mysql/dataprotection/mysql-myloader.sh
+++ b/addons/mysql/dataprotection/mysql-myloader.sh
@@ -19,23 +19,25 @@ trap handle_exit EXIT
 if [ -z "$threads" ]; then
   threads=4
 fi
-params="--threads=$threads"
+set -- "--threads=$threads"
 if [ -n "${tables}" ]; then
-  params="${params} -T ${tables}"
+  set -- "$@" -T "${tables}"
 fi
 # DROP, FAIL(default), NONE, TRUNCATE and DELETE
 if [ -n "$drop_table" ]; then
-  params="${params} -o $drop_table"
+  set -- "$@" -o "$drop_table"
 fi
 if [ "${no_data}" == "true" ]; then
-  params="${params} --no-data"
+  set -- "$@" --no-data
 fi
 #if [ -n "$databases" ]; then
 #  params="${params} -s $databases"
 #fi
 
-echo "parameters: $params"
+printf 'parameters:'
+printf ' <%s>' "$@"
+printf '\n'
 
 datasafed pull -d zstd-fastest "${DP_BACKUP_NAME}.mydumper.zst" - | myloader --stream  \
   -h ${DP_DB_HOST} -u ${MYSQL_ADMIN_USER} -p ${MYSQL_ADMIN_PASSWORD} -P ${DP_DB_PORT} --regex '^(?!(kubeblocks\.kb_health_check$))' \
-  ${params}
+  "$@"

--- a/addons/mysql/scripts-ut-spec/mydumper_filter_argument_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/mydumper_filter_argument_contract_spec.sh
@@ -1,0 +1,116 @@
+# shellcheck shell=bash
+
+Describe "MySQL mydumper filter argument contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  write_mock_tools() {
+    mock_bin=$1
+
+    mkdir -p "${mock_bin}" || return 1
+    printf '%s\n' \
+      '#!/bin/sh' \
+      ': >"${TOOL_ARGS:?}"' \
+      'for arg do printf "<%s>\\n" "$arg" >>"${TOOL_ARGS}"; done' \
+      'printf payload' >"${mock_bin}/mydumper" || return 1
+    printf '%s\n' \
+      '#!/bin/sh' \
+      ': >"${TOOL_ARGS:?}"' \
+      'for arg do printf "<%s>\\n" "$arg" >>"${TOOL_ARGS}"; done' \
+      'cat >/dev/null' >"${mock_bin}/myloader" || return 1
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'case "$1" in' \
+      '  push) cat >/dev/null ;;' \
+      '  pull) printf payload ;;' \
+      '  stat) printf "TotalSize 7\\n" ;;' \
+      'esac' >"${mock_bin}/datasafed" || return 1
+    chmod +x "${mock_bin}/mydumper" "${mock_bin}/myloader" "${mock_bin}/datasafed"
+  }
+
+  argument_after() {
+    option=$1
+    args_file=$2
+    awk -v option="<${option}>" '
+      $0 == option { getline; print; found = 1; exit }
+      END { if (!found) exit 1 }
+    ' "${args_file}"
+  }
+
+  verify_mydumper_preserves_filter_arguments() {
+    root=$(mktemp -d "${TMPDIR:-/tmp}/mysql-mydumper-argv.XXXXXX") || return 1
+    write_mock_tools "${root}/bin" || return 1
+    touch "${root}/db.table_one" "${root}/db.table_two"
+
+    (
+      cd "${root}" || exit 1
+      export PATH="${root}/bin:${PATH}"
+      export TOOL_ARGS="${root}/mydumper.args"
+      export DP_DATASAFED_BIN_PATH="${root}/bin"
+      export DP_BACKUP_BASE_PATH="/repo/current"
+      export DP_BACKUP_NAME="current"
+      export DP_BACKUP_INFO_FILE="${root}/progress"
+      export DP_DB_HOST="mysql"
+      export DP_DB_PORT="3306"
+      export DP_DB_USER="backup"
+      export DP_DB_PASSWORD="secret"
+      export threads="4"
+      export tables="db.table*"
+      export trx_tables="false"
+      export no_data="false"
+      export databases="sales archive"
+      bash "$(chart_path)/dataprotection/mysql-mydumper.sh" >/dev/null 2>&1
+    ) || return 1
+
+    [ "$(argument_after -T "${root}/mydumper.args")" = '<db.table*>' ] &&
+      [ "$(argument_after -B "${root}/mydumper.args")" = '<sales archive>' ]
+    status=$?
+    rm -rf "${root}"
+    return "${status}"
+  }
+
+  verify_myloader_preserves_filter_arguments() {
+    root=$(mktemp -d "${TMPDIR:-/tmp}/mysql-myloader-argv.XXXXXX") || return 1
+    write_mock_tools "${root}/bin" || return 1
+    touch "${root}/db.table_one" "${root}/db.table_two"
+
+    (
+      cd "${root}" || exit 1
+      export PATH="${root}/bin:${PATH}"
+      export TOOL_ARGS="${root}/myloader.args"
+      export DP_DATASAFED_BIN_PATH="${root}/bin"
+      export DP_BACKUP_BASE_PATH="/repo/current"
+      export DP_BACKUP_NAME="current"
+      export DP_BACKUP_INFO_FILE="${root}/progress"
+      export DP_DB_HOST="mysql"
+      export DP_DB_PORT="3306"
+      export MYSQL_ADMIN_USER="root"
+      export MYSQL_ADMIN_PASSWORD="secret"
+      export threads="4"
+      export tables="db.table*"
+      export drop_table="FAIL"
+      export no_data="false"
+      bash "$(chart_path)/dataprotection/mysql-myloader.sh" >/dev/null 2>&1
+    ) || return 1
+
+    [ "$(argument_after -T "${root}/myloader.args")" = '<db.table*>' ]
+    status=$?
+    rm -rf "${root}"
+    return "${status}"
+  }
+
+  It "passes each mydumper database and table filter as one literal argument"
+    When call verify_mydumper_preserves_filter_arguments
+    The status should be success
+  End
+
+  It "passes each myloader table filter as one literal argument"
+    When call verify_myloader_preserves_filter_arguments
+    The status should be success
+  End
+End


### PR DESCRIPTION
## Summary

- build mydumper and myloader optional parameters as positional arguments instead of a shell-expanded string
- preserve database and table filter values containing whitespace or glob characters as one literal tool argument
- add executable regressions for both backup and restore paths, invoking the existing Bash script contract explicitly

This is a child PR against PR #3182's development branch at exact base `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da`. It does not change that active runtime candidate until reviewed and merged.

Contract audit anchor: `kubeblocks-addon-docs/docs/addon-api/09a-backup-basic.md:110` assigns Backup/Restore parameter value handling to the script layer.

## Verification

- RED before fix: 2 examples, 2 failures
- focused ShellSpec after fix: 2 examples, 0 failures
- full MySQL ShellSpec after fix: 57 examples, 0 failures
- `bash -n`: mydumper, myloader, and regression spec
- error-level ShellCheck: 3 changed shell files
- `helm lint --strict addons/mysql`: 1 chart, 0 failures
- `git diff --check`: clean

The first hosted run exposed a test-harness portability issue: the regression invoked the existing Bash-only restore script through Ubuntu `sh`/`dash`, which fails at its pre-existing `pipefail` declaration before testing argv. The regression now invokes Bash explicitly; no product-source failure was observed.
