### PR TITLE
fix(mysql): preserve proxysql admin credentials

### DIFF
--- a/addons/mysql/scripts-ut-spec/configre_proxysql_spec.sh
+++ b/addons/mysql/scripts-ut-spec/configre_proxysql_spec.sh
@@ -52,6 +52,51 @@ Describe "ProxySQL Configuration Script Tests"
     End
   End
 
+  Describe "ProxySQL Admin Exec Function Tests"
+    run_configure_proxysql_with_admin_password() {
+      local status
+      MYSQL_ARG_LOG=$(mktemp)
+      export MYSQL_ARG_LOG
+
+      mysql() {
+        local arg
+        for arg in "$@"; do
+          printf '<%s>\n' "$arg" >> "$MYSQL_ARG_LOG"
+        done
+
+        case "$*" in
+          *"select 1;"*) printf '1\n' ;;
+          *"super_read_only"*) printf '0\n' ;;
+          *"group_replication_group_name"*) printf 'NULL\n' ;;
+          *"@@version"*) printf '8.0.0\n' ;;
+        esac
+      }
+      export -f mysql
+
+      MYSQL_ROOT_USER=root
+      MYSQL_ROOT_PASSWORD='root password[*]'
+      PROXYSQL_ADMIN_PASSWORD='alpha beta[*]'
+      BACKEND_SERVER=mysql-0
+      MYSQL_FQDNS=mysql-0
+      MYSQL_PORT=3306
+      BACKEND_TLS_ENABLED=false
+      export MYSQL_ROOT_USER MYSQL_ROOT_PASSWORD PROXYSQL_ADMIN_PASSWORD
+      export BACKEND_SERVER MYSQL_FQDNS MYSQL_PORT BACKEND_TLS_ENABLED
+
+      bash ../scripts/configure-proxysql.sh >/dev/null 2>&1
+      status=$?
+      cat "$MYSQL_ARG_LOG"
+      rm -f "$MYSQL_ARG_LOG"
+      return "$status"
+    }
+
+    It "preserves the admin password as one mysql argument"
+      When call run_configure_proxysql_with_admin_password
+      The status should be success
+      The stdout should include "<-palpha beta[*]>"
+    End
+  End
+
   Describe "Wait for MySQL Function Tests"
     setup() {
       # Mock the mysql_exec function to simulate MySQL responses

--- a/addons/mysql/scripts/configure-proxysql.sh
+++ b/addons/mysql/scripts/configure-proxysql.sh
@@ -40,6 +40,13 @@ function mysql_exec() {
     mysql $exec_opt ${pass_ssl} --user=${user} --password=${pass} --host=${server} -P${port} -NBe "${query}"
 }
 
+function proxysql_admin_exec() {
+    local pass="$1"
+    local query="$2"
+
+    mysql -uadmin "-p${pass}" -h127.0.0.1 -P6032 -vvve "$query"
+}
+
 function wait_for_mysql() {
     local user="$1"
     local pass="$2"
@@ -201,14 +208,14 @@ select * from runtime_proxysql_servers;
 
 "
 
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "$configuration_sql"
+proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "$configuration_sql"
 
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "delete from mysql_query_rules;insert into mysql_query_rules (rule_id,active,match_digest,destination_hostgroup,apply,re_modifiers) values (1,1,'^SELECT.*FOR UPDATE$',1,1,'CASELESS'),(2,1,'^SELECT',2,1,'CASELESS');LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_users (username,password,default_hostgroup) values ('$MYSQL_ROOT_USER','$MYSQL_ROOT_PASSWORD',1);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;"
+proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "delete from mysql_query_rules;insert into mysql_query_rules (rule_id,active,match_digest,destination_hostgroup,apply,re_modifiers) values (1,1,'^SELECT.*FOR UPDATE$',1,1,'CASELESS'),(2,1,'^SELECT',2,1,'CASELESS');LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
+proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "insert or replace into mysql_users (username,password,default_hostgroup) values ('$MYSQL_ROOT_USER','$MYSQL_ROOT_PASSWORD',1);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;"
 if is_group_replication_backend "$writable_mysql_server"; then
-    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_group_replication_hostgroups (writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) values (1,4,2,3,1,1,0,100,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
-    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "select * from runtime_mysql_group_replication_hostgroups; select * from mysql_group_replication_hostgroups;"
+    proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "insert or replace into mysql_group_replication_hostgroups (writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) values (1,4,2,3,1,1,0,100,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
+    proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "select * from runtime_mysql_group_replication_hostgroups; select * from mysql_group_replication_hostgroups;"
 else
-    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_replication_hostgroups (writer_hostgroup,reader_hostgroup,comment) values (1,2,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
-    mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "select * from main.runtime_mysql_replication_hostgroups; select * from main.mysql_replication_hostgroups; select * from mysql_replication_hostgroups;"
+    proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "insert or replace into mysql_replication_hostgroups (writer_hostgroup,reader_hostgroup,comment) values (1,2,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
+    proxysql_admin_exec "$PROXYSQL_ADMIN_PASSWORD" "select * from main.runtime_mysql_replication_hostgroups; select * from main.mysql_replication_hostgroups; select * from mysql_replication_hostgroups;"
 fi


### PR DESCRIPTION
## Summary
- add a single ProxySQL admin mysql argv boundary
- preserve passwords containing whitespace or glob characters as one argument
- cover the full configure-proxysql execution path with a controlled mysql shim

## Contract
- kubeblocks-addon-docs `docs/addon-api/07-accounts-and-tls.md:55,65,79,86`

## Verification
- RED: focused ShellSpec `7 examples, 1 failure`
- GREEN: focused ShellSpec `7/0`
- MySQL ShellSpec `56/0`
- `bash -n` PASS
- ShellCheck `--severity=error` PASS
- `helm lint --strict addons/mysql` PASS
- `git diff --check` PASS

Base: PR #3182 exact `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da`.