### PR TITLE
fix(mysql): escape ProxySQL credential SQL literals

### DIFF
--- a/addons/mysql/scripts-ut-spec/configre_proxysql_spec.sh
+++ b/addons/mysql/scripts-ut-spec/configre_proxysql_spec.sh
@@ -52,6 +52,55 @@ Describe "ProxySQL Configuration Script Tests"
     End
   End
 
+  Describe "ProxySQL User Configuration Tests"
+    run_configure_proxysql_with_quoted_credentials() {
+      local status
+      MYSQL_SQL_LOG=$(mktemp)
+      export MYSQL_SQL_LOG
+
+      mysql() {
+        local arg
+        for arg in "$@"; do
+          case "$arg" in
+            *"insert or replace into mysql_users"*)
+              printf '%s\n' "$arg" >> "$MYSQL_SQL_LOG"
+              ;;
+          esac
+        done
+
+        case "$*" in
+          *"select 1;"*) printf '1\n' ;;
+          *"super_read_only"*) printf '0\n' ;;
+          *"group_replication_group_name"*) printf 'NULL\n' ;;
+          *"@@version"*) printf '8.0.0\n' ;;
+        esac
+      }
+      export -f mysql
+
+      MYSQL_ROOT_USER="ro'ot"
+      MYSQL_ROOT_PASSWORD="pa'ss"
+      PROXYSQL_ADMIN_PASSWORD=admin
+      BACKEND_SERVER=mysql-0
+      MYSQL_FQDNS=mysql-0
+      MYSQL_PORT=3306
+      BACKEND_TLS_ENABLED=false
+      export MYSQL_ROOT_USER MYSQL_ROOT_PASSWORD PROXYSQL_ADMIN_PASSWORD
+      export BACKEND_SERVER MYSQL_FQDNS MYSQL_PORT BACKEND_TLS_ENABLED
+
+      bash ../scripts/configure-proxysql.sh >/dev/null 2>&1
+      status=$?
+      cat "$MYSQL_SQL_LOG"
+      rm -f "$MYSQL_SQL_LOG"
+      return "$status"
+    }
+
+    It "escapes root credentials used as SQL literals"
+      When call run_configure_proxysql_with_quoted_credentials
+      The status should be success
+      The stdout should include "values ('ro''ot','pa''ss',1)"
+    End
+  End
+
   Describe "Wait for MySQL Function Tests"
     setup() {
       # Mock the mysql_exec function to simulate MySQL responses

--- a/addons/mysql/scripts/configure-proxysql.sh
+++ b/addons/mysql/scripts/configure-proxysql.sh
@@ -40,6 +40,14 @@ function mysql_exec() {
     mysql $exec_opt ${pass_ssl} --user=${user} --password=${pass} --host=${server} -P${port} -NBe "${query}"
 }
 
+function escape_sql_literal() {
+    local value="$1"
+    local quote="'"
+    local escaped_quote="''"
+
+    printf '%s' "${value//$quote/$escaped_quote}"
+}
+
 function wait_for_mysql() {
     local user="$1"
     local pass="$2"
@@ -204,7 +212,9 @@ select * from runtime_proxysql_servers;
 mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "$configuration_sql"
 
 mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "delete from mysql_query_rules;insert into mysql_query_rules (rule_id,active,match_digest,destination_hostgroup,apply,re_modifiers) values (1,1,'^SELECT.*FOR UPDATE$',1,1,'CASELESS'),(2,1,'^SELECT',2,1,'CASELESS');LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
-mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_users (username,password,default_hostgroup) values ('$MYSQL_ROOT_USER','$MYSQL_ROOT_PASSWORD',1);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;"
+mysql_root_user_sql=$(escape_sql_literal "$MYSQL_ROOT_USER")
+mysql_root_password_sql=$(escape_sql_literal "$MYSQL_ROOT_PASSWORD")
+mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_users (username,password,default_hostgroup) values ('$mysql_root_user_sql','$mysql_root_password_sql',1);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;"
 if is_group_replication_backend "$writable_mysql_server"; then
     mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "insert or replace into mysql_group_replication_hostgroups (writer_hostgroup,backup_writer_hostgroup,reader_hostgroup,offline_hostgroup,active,max_writers,writer_is_also_reader,max_transactions_behind,comment) values (1,4,2,3,1,1,0,100,'proxy');LOAD MYSQL SERVERS TO RUNTIME;SAVE MYSQL SERVERS TO DISK;"
     mysql -uadmin -p${PROXYSQL_ADMIN_PASSWORD} -h127.0.0.1 -P6032 -vvve "select * from runtime_mysql_group_replication_hostgroups; select * from mysql_group_replication_hostgroups;"


### PR DESCRIPTION
## What

- escape single quotes in the MySQL root username and password before embedding them in ProxySQL `mysql_users` SQL
- add a full-script ShellSpec regression for quote-containing credentials

## Why

The addon account contract requires scripts that construct SQL from credentials to define and preserve their escaping boundary (`docs/addon-api/07-accounts-and-tls.md:55,65,79,86`). PR3182 exact head `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da` emitted `values ('ro'ot','pa'ss',1)`, which terminates both SQL string literals early.

## Validation

- RED: focused ShellSpec `7 examples, 1 failure`
- GREEN: focused ShellSpec `7 examples, 0 failures`
- full MySQL ShellSpec `56 examples, 0 failures`
- `bash -n` on changed script/spec
- error-level ShellCheck on changed script/spec
- `helm lint --strict addons/mysql`
- `git diff --check`

This child is intentionally based on PR3182 exact677 and does not include the separate argv-boundary fixes from PR3323/PR3324.
