### PR TITLE
fix(mysql): preserve lifecycle credential arguments

### DIFF
--- a/addons/mysql/scripts-ut-spec/lifecycle_mysql_argv_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/lifecycle_mysql_argv_contract_spec.sh
@@ -1,0 +1,103 @@
+# shellcheck shell=sh
+
+Describe "MySQL lifecycle client argv contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  extract_account_provision_script() {
+    helm template test "$(chart_path)" --show-only "templates/$1" |
+      awk '
+        /^    accountProvision:$/ { in_action = 1 }
+        in_action && /^          - \|$/ { in_script = 1; next }
+        in_script && /^        targetPodSelector:/ { exit }
+        in_script { sub(/^            /, ""); print }
+      '
+  }
+
+  extract_readiness_script() {
+    helm template test "$(chart_path)" --show-only "templates/$1" |
+      awk '
+        /^        readinessProbe:$/ { in_probe = 1 }
+        in_probe && /^              - \|$/ { in_script = 1; next }
+        in_script && /^          initialDelaySeconds:/ { exit }
+        in_script { sub(/^                /, ""); print }
+      '
+  }
+
+  run_with_mysql_capture() {
+    mode=$1
+    template=$2
+    tmp_dir=$(mktemp -d)
+    argv_file="$tmp_dir/argv"
+
+    cat >"$tmp_dir/mysql" <<'SH'
+#!/bin/sh
+index=0
+for arg do
+  printf '%s=%s\n' "$index" "$arg"
+  index=$((index + 1))
+done >"${MYSQL_ARGV_FILE:?}"
+SH
+    chmod +x "$tmp_dir/mysql"
+
+    if [ "$mode" = account ]; then
+      script=$(extract_account_provision_script "$template")
+    else
+      script=$(extract_readiness_script "$template")
+    fi
+
+    PATH="$tmp_dir:$PATH" \
+      MYSQL_ARGV_FILE="$argv_file" \
+      MYSQL_ROOT_USER=root \
+      MYSQL_ROOT_PASSWORD='alpha beta[*]' \
+      KB_ACCOUNT_STATEMENT='SELECT 1' \
+      bash -c "$script" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      cat "$argv_file"
+    fi
+    rm -rf "$tmp_dir"
+    return "$rc"
+  }
+
+  It "preserves credentials as single mysql arguments in accountProvision"
+    When call run_with_mysql_capture account cmpd-mysql80.yaml
+    The status should be success
+    The output should include "0=--user=root"
+    The output should include "1=--password=alpha beta[*]"
+    The output should include "2=--port=3306"
+    The output should include "3=--host=127.0.0.1"
+    The output should include "4=--execute=SELECT 1"
+    The lines of output should equal 5
+  End
+
+  It "preserves credentials as single mysql arguments in ORC accountProvision"
+    When call run_with_mysql_capture account cmpd-mysql80-orc.yaml
+    The status should be success
+    The output should include "0=--user=root"
+    The output should include "1=--password=alpha beta[*]"
+    The output should include "2=--port=3306"
+    The output should include "3=--host=127.0.0.1"
+    The output should include "4=--execute=SELECT 1;"
+    The lines of output should equal 5
+  End
+
+  It "preserves credentials as single mysql arguments in ORC readiness"
+    When call run_with_mysql_capture readiness cmpd-mysql80-orc.yaml
+    The status should be success
+    The output should include "0=--user=root"
+    The output should include "1=--password=alpha beta[*]"
+    The output should include "2=--port=3306"
+    The output should include "3=--host=127.0.0.1"
+    The output should include "4=--execute=SELECT 1;"
+    The lines of output should equal 5
+  End
+End

--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -210,14 +210,14 @@ lifecycleActions:
           ALL_DB='*.*'
           # Suppress xtrace AND errexit so the password-bearing expansion is not echoed
           # to pod stderr. KB_ACCOUNT_STATEMENT itself contains CREATE USER ... IDENTIFIED
-          # BY '<password>' (account password), and the mysql -p${MYSQL_ROOT_PASSWORD}
+          # BY '<password>' (account password), and the mysql password argument
           # invocation contains the root password; both would land in `kubectl logs` if
           # xtrace stayed on. errexit is suppressed too so accountProvision failure can be
           # captured explicitly via $? -- if it stayed on, set -e would exit before the
           # rc-save line on any non-zero result.
           { previous_state=$(set +o); set +ex; } 2>/dev/null
           eval statement=\"${KB_ACCOUNT_STATEMENT}\"
-          mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement}"
+          mysql --user="${MYSQL_ROOT_USER}" --password="${MYSQL_ROOT_PASSWORD}" --port=3306 --host=127.0.0.1 --execute="${statement}"
           mysql_rc=$?
           eval "$previous_state"
           exit $mysql_rc

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -171,14 +171,14 @@ accountProvision:
         ALL_DB='*.*'
         # Suppress xtrace AND errexit so the password-bearing expansion is not echoed
         # to pod stderr. KB_ACCOUNT_STATEMENT itself contains CREATE USER ... IDENTIFIED
-        # BY '<password>' (account password), and the mysql -p${MYSQL_ROOT_PASSWORD}
+        # BY '<password>' (account password), and the mysql password argument
         # invocation contains the root password; both would land in `kubectl logs` if
         # xtrace stayed on. errexit is suppressed too so accountProvision failure can be
         # captured explicitly via $? -- if it stayed on, set -e would exit before the
         # rc-save line on any non-zero result.
         { previous_state=$(set +o); set +ex; } 2>/dev/null
         eval statement=\"${KB_ACCOUNT_STATEMENT}\"
-        mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement};"
+        mysql --user="${MYSQL_ROOT_USER}" --password="${MYSQL_ROOT_PASSWORD}" --port=3306 --host=127.0.0.1 --execute="${statement};"
         mysql_rc=$?
         eval "$previous_state"
         exit $mysql_rc
@@ -350,7 +350,7 @@ readinessProbe:
       - /bin/bash
       - -c
       - |
-        mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "SELECT 1;"
+        mysql --user="${MYSQL_ROOT_USER}" --password="${MYSQL_ROOT_PASSWORD}" --port=3306 --host=127.0.0.1 --execute="SELECT 1;"
   initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 2


### PR DESCRIPTION
## Summary

- preserve MySQL username/password boundaries in shared accountProvision commands
- apply the same argv-safe form to the Orchestrator readiness probe
- add executable tests against rendered ComponentDefinition command blocks

## Contract

`kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md:55,65,78,86` requires credential escaping boundaries and treats lifecycle actions as an independent credential execution surface.

## Reproduction

The rendered commands split `MYSQL_ROOT_PASSWORD='alpha beta[*]'` into `-palpha` and `beta[*]`.

Focused RED: 3 examples, 3 failures.

## Validation

- focused ShellSpec: 3 examples, 0 failures
- full MySQL ShellSpec: 58 examples, 0 failures
- `bash -n`: pass
- error-level ShellCheck: pass
- `helm lint addons/mysql --strict`: 1 chart, 0 failures
- `git diff --check`: pass

Base: PR #3182 exact `677cbeda1a4a8d37e9fd4f5e31934e35e7a469da`.
