### PR TITLE
fix(mysql): preserve PITR restore replay arguments

### DIFF
--- a/addons/mysql/dataprotection/mysql-pitr-restore.sh
+++ b/addons/mysql/dataprotection/mysql-pitr-restore.sh
@@ -12,7 +12,7 @@ export WALG_MYSQL_CHECK_GTIDS=true
 export MYSQL_PWD=${MYSQL_ADMIN_PASSWORD}
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 export WALG_MYSQL_BINLOG_DST=${PITR_DIR}
-export WALG_MYSQL_BINLOG_REPLAY_COMMAND="mysqlbinlog --stop-datetime=\"\$WALG_MYSQL_BINLOG_END_TS\" \"\$WALG_MYSQL_CURRENT_BINLOG\" | mysql -u ${MYSQL_ADMIN_USER} -h ${DP_DB_HOST}"
+export WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql --user="$MYSQL_ADMIN_USER" --host="$DP_DB_HOST" --port="$DP_DB_PORT"'
 
 # If pitr logs dir exists, it may be created by previous failed restore.
 if [ -d "$WALG_MYSQL_BINLOG_DST" ]; then

--- a/addons/mysql/scripts-ut-spec/pitr_restore_mysql_argv_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/pitr_restore_mysql_argv_contract_spec.sh
@@ -1,0 +1,70 @@
+# shellcheck shell=sh
+
+Describe "MySQL PITR restore replay client argv contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  run_binlog_replay() {
+    tmp_dir=$(mktemp -d)
+    argv_file="$tmp_dir/argv"
+
+    cat >"$tmp_dir/DP_log" <<'SH'
+#!/bin/sh
+exit 0
+SH
+    cat >"$tmp_dir/mysqlbinlog" <<'SH'
+#!/bin/sh
+printf '%s\n' 'SELECT 1;'
+SH
+    cat >"$tmp_dir/mysql" <<'SH'
+#!/bin/sh
+index=0
+for arg do
+  printf '%s=%s\n' "$index" "$arg"
+  index=$((index + 1))
+done >"${MYSQL_ARGV_FILE:?}"
+cat >/dev/null
+SH
+    cat >"$tmp_dir/wal-g" <<'SH'
+#!/bin/sh
+WALG_MYSQL_BINLOG_END_TS='2026-08-15T00:00:00Z' \
+  WALG_MYSQL_CURRENT_BINLOG='/tmp/mysql binlog[*]' \
+  sh -c "${WALG_MYSQL_BINLOG_REPLAY_COMMAND:?}"
+SH
+    chmod +x "$tmp_dir/DP_log" "$tmp_dir/mysqlbinlog" "$tmp_dir/mysql" "$tmp_dir/wal-g"
+
+    PATH="$tmp_dir:$PATH" \
+      MYSQL_ARGV_FILE="$argv_file" \
+      MYSQL_ADMIN_USER='restore user[*]' \
+      MYSQL_ADMIN_PASSWORD='alpha beta[*]' \
+      DP_DB_HOST='mysql host[*]' \
+      DP_DB_PORT=3307 \
+      DP_DATASAFED_BIN_PATH=/bin \
+      DP_BACKUP_BASE_PATH=/backup \
+      PITR_DIR="$tmp_dir/pitr" \
+      DP_BASE_BACKUP_START_TIME='2026-08-14T00:00:00Z' \
+      DP_RESTORE_TIME='2026-08-15T00:00:00Z' \
+      bash "$(chart_path)/dataprotection/mysql-pitr-restore.sh" >/dev/null 2>&1
+    rc=$?
+
+    if [ -f "$argv_file" ]; then
+      cat "$argv_file"
+    fi
+    rm -rf "$tmp_dir"
+    return "$rc"
+  }
+
+  It "preserves restore connection identity as literal mysql arguments"
+    When call run_binlog_replay
+    The status should be success
+    The output should include "0=--user=restore user[*]"
+    The output should include "1=--host=mysql host[*]"
+    The output should include "2=--port=3307"
+    The lines of output should equal 3
+  End
+End


### PR DESCRIPTION
## Summary
- delay PITR replay command variable expansion until WAL-G executes it
- preserve MySQL user, host, and port as literal arguments
- add an executable ShellSpec regression for whitespace/glob-bearing values

## Contract
- kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md:55,65,80,86

## Validation
- regression RED: 1 example, 1 failure
- focused ShellSpec: 1 example, 0 failures
- full MySQL ShellSpec: 56 examples, 0 failures
- bash syntax: pass
- ShellCheck severity error: pass
- strict Helm lint: pass
- git diff --check: pass

Base candidate: 677cbeda1a4a8d37e9fd4f5e31934e35e7a469da