### PR TITLE
fix(mysql): escape ORC bootstrap SQL literals

### DIFF
--- a/addons/mysql/scripts-ut-spec/orc_bootstrap_sql_literal_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/orc_bootstrap_sql_literal_contract_spec.sh
@@ -1,0 +1,74 @@
+# shellcheck shell=bash
+
+Describe "MySQL ORC bootstrap SQL literal contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mysql/scripts/init-mysql-instance-for-orc.sh" "$(repo_root)"
+  }
+
+  prepare_mysql_capture() {
+    tmp_dir=$(mktemp -d)
+    sql_file="$tmp_dir/sql"
+
+    cat >"$tmp_dir/mysql" <<'SH'
+#!/bin/sh
+cat >"${MYSQL_SQL_FILE:?}"
+SH
+    cat >"$tmp_dir/date" <<'SH'
+#!/bin/sh
+printf '%s\n' '2026-08-15 00:00:00+00:00'
+SH
+    chmod +x "$tmp_dir/mysql" "$tmp_dir/date"
+  }
+
+  run_create_mysql_user() {
+    prepare_mysql_capture
+
+    PATH="$tmp_dir:$PATH" \
+      MYSQL_SQL_FILE="$sql_file" \
+      MYSQL_ROOT_USER="root" \
+      MYSQL_ROOT_PASSWORD="root password" \
+      ORC_TOPOLOGY_USER="orc'user" \
+      ORC_TOPOLOGY_PASSWORD="pa'ss" \
+      bash -c 'source "$1"; create_mysql_user >/dev/null' bash "$(script_path)"
+    rc=$?
+
+    cat "$sql_file"
+    rm -rf "$tmp_dir"
+    return "$rc"
+  }
+
+  run_change_master() {
+    prepare_mysql_capture
+
+    PATH="$tmp_dir:$PATH" \
+      MYSQL_SQL_FILE="$sql_file" \
+      MYSQL_MAJOR="8.0" \
+      MYSQL_ROOT_USER="ro'ot" \
+      MYSQL_ROOT_PASSWORD="root'pass" \
+      bash -c 'source "$1"; change_master "mysql-0'"'"'host" >/dev/null' bash "$(script_path)"
+    rc=$?
+
+    cat "$sql_file"
+    rm -rf "$tmp_dir"
+    return "$rc"
+  }
+
+  It "escapes ORC topology credentials before embedding them in account SQL"
+    When call run_create_mysql_user
+    The status should be success
+    The output should include "CREATE USER IF NOT EXISTS 'orc''user'@'%' IDENTIFIED BY 'pa''ss';"
+    The output should include "ALTER USER 'orc''user'@'%' IDENTIFIED BY 'pa''ss';"
+  End
+
+  It "escapes replication host and credentials before embedding them in CHANGE MASTER SQL"
+    When call run_change_master
+    The status should be success
+    The output should include "MASTER_HOST='mysql-0''host',"
+    The output should include "MASTER_USER='ro''ot',"
+    The output should include "MASTER_PASSWORD='root''pass';"
+  End
+End

--- a/addons/mysql/scripts/init-mysql-instance-for-orc.sh
+++ b/addons/mysql/scripts/init-mysql-instance-for-orc.sh
@@ -20,17 +20,27 @@ mysql_error() {
 	exit 1
 }
 
+mysql_escape_string_literal() {
+  local value="$1"
+  printf '%s' "$value" | sed "s/'/''/g"
+}
+
 # create orchestrator user in mysql
 create_mysql_user() {
   mysql_note "Create MySQL User and Grant Permissions..."
 
+  local topology_user
+  local topology_password
+  topology_user=$(mysql_escape_string_literal "$ORC_TOPOLOGY_USER")
+  topology_password=$(mysql_escape_string_literal "$ORC_TOPOLOGY_PASSWORD")
+
   mysql -P 3306 -u "$MYSQL_ROOT_USER" -p"$MYSQL_ROOT_PASSWORD" << EOF
 set SQL_LOG_BIN=off;
-CREATE USER IF NOT EXISTS '$ORC_TOPOLOGY_USER'@'%' IDENTIFIED BY '$ORC_TOPOLOGY_PASSWORD';
-ALTER USER '$ORC_TOPOLOGY_USER'@'%' IDENTIFIED BY '$ORC_TOPOLOGY_PASSWORD';
-GRANT SUPER, PROCESS, REPLICATION SLAVE, REPLICATION CLIENT, RELOAD ON *.* TO '$ORC_TOPOLOGY_USER'@'%';
-GRANT SELECT ON mysql.slave_master_info TO '$ORC_TOPOLOGY_USER'@'%';
-GRANT DROP ON _pseudo_gtid_.* to '$ORC_TOPOLOGY_USER'@'%';
+CREATE USER IF NOT EXISTS '$topology_user'@'%' IDENTIFIED BY '$topology_password';
+ALTER USER '$topology_user'@'%' IDENTIFIED BY '$topology_password';
+GRANT SUPER, PROCESS, REPLICATION SLAVE, REPLICATION CLIENT, RELOAD ON *.* TO '$topology_user'@'%';
+GRANT SELECT ON mysql.slave_master_info TO '$topology_user'@'%';
+GRANT DROP ON _pseudo_gtid_.* to '$topology_user'@'%';
 FLUSH PRIVILEGES;
 set SQL_LOG_BIN=on;
 EOF
@@ -157,6 +167,13 @@ EOF
 change_master() {
   local master_host=$1
   local master_port=3306
+  local escaped_master_host
+  local escaped_root_user
+  local escaped_root_password
+
+  escaped_master_host=$(mysql_escape_string_literal "$master_host")
+  escaped_root_user=$(mysql_escape_string_literal "$MYSQL_ROOT_USER")
+  escaped_root_password=$(mysql_escape_string_literal "$MYSQL_ROOT_PASSWORD")
 
   mysql_note "Change master"
 
@@ -169,10 +186,10 @@ CHANGE MASTER TO
 MASTER_AUTO_POSITION=1,
 MASTER_CONNECT_RETRY=1,
 MASTER_RETRY_COUNT=86400,
-MASTER_HOST='$master_host',
+MASTER_HOST='$escaped_master_host',
 MASTER_PORT=$master_port,
-MASTER_USER='$MYSQL_ROOT_USER',
-MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
+MASTER_USER='$escaped_root_user',
+MASTER_PASSWORD='$escaped_root_password';
 START SLAVE;
 EOF
   else
@@ -185,10 +202,10 @@ SOURCE_AUTO_POSITION=1,
 SOURCE_SSL=1,
 MASTER_CONNECT_RETRY=1,
 MASTER_RETRY_COUNT=86400,
-MASTER_HOST='$master_host',
+MASTER_HOST='$escaped_master_host',
 MASTER_PORT=$master_port,
-MASTER_USER='$MYSQL_ROOT_USER',
-MASTER_PASSWORD='$MYSQL_ROOT_PASSWORD';
+MASTER_USER='$escaped_root_user',
+MASTER_PASSWORD='$escaped_root_password';
 START SLAVE;
 EOF
   fi


### PR DESCRIPTION
## Summary
- escape apostrophes before embedding ORC topology credentials in account SQL
- apply the same boundary to replication host and root credentials in CHANGE MASTER
- add executable mysql-stdin regressions for both SQL surfaces

## Contract
- kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md:55,65,78,86

## Validation
- regression RED: 2 examples, 2 failures
- focused ShellSpec: 2 examples, 0 failures
- full MySQL ShellSpec: 57 examples, 0 failures
- Bash syntax: pass
- ShellCheck severity error: pass
- strict Helm lint: pass
- git diff --check: pass

Base candidate: 677cbeda1a4a8d37e9fd4f5e31934e35e7a469da