### PR TITLE
fix(mysql): validate dynamic parameter updates

### DIFF
--- a/addons/mysql/scripts-ut-spec/update_parameter_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/update_parameter_contract_spec.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+
+Describe "MySQL dynamic parameter update contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mysql/scripts/update-parameter.sh" "$(repo_root)"
+  }
+
+  prepare_mysql_shim() {
+    tmp_dir=$(mktemp -d)
+    query_file="${tmp_dir}/query"
+    call_file="${tmp_dir}/called"
+
+    cat >"${tmp_dir}/mysql" <<'SH'
+#!/bin/sh
+: >"${MYSQL_CALL_FILE:?}"
+for arg do
+  query=$arg
+done
+printf '%s\n' "$query" >"${MYSQL_QUERY_FILE:?}"
+
+if [ "${MYSQL_SHIM_ERROR:-}" = "true" ]; then
+  printf '%s\n' 'ERROR 1238 (HY000): Variable is read only' >&2
+  exit 1
+fi
+SH
+    chmod +x "${tmp_dir}/mysql"
+  }
+
+  cleanup_mysql_shim() {
+    rm -rf "${tmp_dir}"
+  }
+
+  run_parameter_update() {
+    param_name=$1
+    param_value=$2
+    shim_error=${3:-false}
+    prepare_mysql_shim || return
+
+    PATH="${tmp_dir}:${PATH}" \
+      MYSQL_CALL_FILE="${call_file}" \
+      MYSQL_QUERY_FILE="${query_file}" \
+      MYSQL_SHIM_ERROR="${shim_error}" \
+      MYSQL_ADMIN_USER="root" \
+      MYSQL_ADMIN_PASSWORD="root password" \
+      bash "$(script_path)" "${param_name}" "${param_value}"
+    rc=$?
+
+    if [ -f "${query_file}" ]; then
+      cat "${query_file}"
+    fi
+    cleanup_mysql_shim
+    return "${rc}"
+  }
+
+  reject_invalid_parameter_name() {
+    prepare_mysql_shim || return
+
+    PATH="${tmp_dir}:${PATH}" \
+      MYSQL_CALL_FILE="${call_file}" \
+      MYSQL_QUERY_FILE="${query_file}" \
+      MYSQL_ADMIN_USER="root" \
+      MYSQL_ADMIN_PASSWORD="root password" \
+      bash "$(script_path)" 'max_connections; SELECT 1' '100' >/dev/null 2>&1
+    rc=$?
+
+    [ "${rc}" -ne 0 ] && [ ! -e "${call_file}" ]
+    result=$?
+    cleanup_mysql_shim
+    return "${result}"
+  }
+
+  It "escapes apostrophes before embedding a string value in SQL"
+    When call run_parameter_update sql_mode "O'Reilly"
+    The status should be success
+    The output should include "SET GLOBAL sql_mode = 'O''Reilly';"
+  End
+
+  It "rejects an invalid parameter name before invoking mysql"
+    When call reject_invalid_parameter_name
+    The status should be success
+  End
+
+  It "returns failure for non-authentication MySQL errors"
+    When call run_parameter_update read_only ON true
+    The status should be failure
+    The output should include "ERROR 1238 (HY000): Variable is read only"
+  End
+End

--- a/addons/mysql/scripts/update-parameter.sh
+++ b/addons/mysql/scripts/update-parameter.sh
@@ -12,6 +12,10 @@ if echo "${paramName}" | grep -q "^loose_"; then
     paramName=${paramName//"loose_"/}
 fi
 paramName=$(echo "${paramName}" | tr '-' '_')
+if [[ ! "${paramName}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Invalid parameter name: ${paramName}"
+    exit 1
+fi
 
 var_int=-1
 if [[ "${paramValue}" =~ ^[0-9]+$ ]]; then
@@ -34,17 +38,14 @@ if [ "${var_int}" -ge 0 ]; then
     ret=$(mysql_exec "SET GLOBAL ${paramName} = ${var_int};" 2>&1)
     status=$?
 else
-    ret=$(mysql_exec "SET GLOBAL ${paramName} = '${paramValue}';" 2>&1)
+    escaped_param_value=${paramValue//\'/\'\'}
+    ret=$(mysql_exec "SET GLOBAL ${paramName} = '${escaped_param_value}';" 2>&1)
     status=$?
 fi
 
 if [ $status -ne 0 ]; then
-    if echo "${ret}" | grep -q "ERROR 1045 (28000)"; then
-        echo "Failed to set parameter ${paramName} to value ${paramValue}, result: ${ret}"
-        exit 1
-    fi
-    # Ignore other errors
+    echo "Failed to set parameter ${paramName} to value ${paramValue}, result: ${ret}"
+    exit 1
 else
     echo "Set parameter ${paramName} to value ${paramValue}, result: ${ret}"
 fi
-


### PR DESCRIPTION
## Summary
- reject normalized dynamic parameter names outside the MySQL identifier allowlist
- escape apostrophes before embedding string values in SET GLOBAL
- propagate every mysql execution error instead of ignoring non-1045 failures

## Contract
- kubeblocks-addon-docs/docs/addon-api/08-parameters-and-config.md:97 requires reconfigure scripts to validate inputs and avoid corrupting configuration

## Verification
- executable mysql-shim RED: 3 examples, 3 failures
- focused ShellSpec: 3 examples, 0 failures
- full MySQL ShellSpec: 58 examples, 0 failures
- bash syntax, error-level ShellCheck, strict Helm lint, git diff --check: pass