### PR TITLE
fix(postgresql): stop pgbouncer after setup failure

### DIFF
--- a/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
@@ -1,0 +1,64 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317,SC2329
+
+Describe "PostgreSQL Pgbouncer setup fail-fast contract"
+  Include ../scripts/pgbouncer-setup.sh
+
+  setup() {
+    test_dir=$(mktemp -d -t pgbouncer-failfast-XXXXXX)
+    pgbouncer_template_conf_file="../config/pgbouncer-ini.tpl"
+    pgbouncer_conf_dir="$test_dir/conf/"
+    pgbouncer_log_dir="$test_dir/logs/"
+    pgbouncer_tmp_dir="$test_dir/tmp/"
+    pgbouncer_conf_file="$test_dir/conf/pgbouncer.ini"
+    pgbouncer_user_list_file="$test_dir/conf/userlist.txt"
+    POSTGRESQL_USERNAME=postgres
+    POSTGRESQL_PASSWORD=secret
+    CURRENT_POD_IP=127.0.0.1
+  }
+
+  cleanup() {
+    rm -rf "$test_dir"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  is_empty() {
+    test -z "${1:-}"
+  }
+
+  Mock useradd
+    exit 0
+  End
+
+  Mock load_common_library
+    exit 0
+  End
+
+  Mock id
+    if test "${1:-}" = "-g"; then
+      printf '%s\n' 1001
+    fi
+    exit 0
+  End
+
+  Mock getent
+    exit 0
+  End
+
+  Mock chown
+    exit 42
+  End
+
+  Mock start_pgbouncer
+    printf '%s\n' start-called
+    exit 0
+  End
+
+  It "does not start Pgbouncer after ownership setup fails"
+    When call main
+    The status should be failure
+    The output should not include "start-called"
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
@@ -29,6 +29,14 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
     test -z "${1:-}"
   }
 
+  printf() {
+    if test "$PGB_FAIL_STEP" = "database_header" && test "${1:-}" = '\n[databases]\n'; then
+      return 42
+    fi
+    # shellcheck disable=SC2059
+    builtin printf "$@"
+  }
+
   Mock useradd
     exit 0
   End
@@ -75,6 +83,13 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
 
   It "does not start Pgbouncer after copying the template fails"
     export PGB_FAIL_STEP=cp
+    When call main
+    The status should be failure
+    The output should not include "start-called"
+  End
+
+  It "does not start Pgbouncer after an early database config write fails"
+    export PGB_FAIL_STEP=database_header
     When call main
     The status should be failure
     The output should not include "start-called"

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
@@ -15,6 +15,7 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
     POSTGRESQL_USERNAME=postgres
     POSTGRESQL_PASSWORD=secret
     CURRENT_POD_IP=127.0.0.1
+    export PGB_FAIL_STEP=chown
   }
 
   cleanup() {
@@ -47,8 +48,18 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
     exit 0
   End
 
+  Mock cp
+    if test "$PGB_FAIL_STEP" = "cp"; then
+      exit 42
+    fi
+    /bin/cp "$@"
+  End
+
   Mock chown
-    exit 42
+    if test "$PGB_FAIL_STEP" = "chown"; then
+      exit 42
+    fi
+    exit 0
   End
 
   Mock start_pgbouncer
@@ -57,6 +68,13 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
   End
 
   It "does not start Pgbouncer after ownership setup fails"
+    When call main
+    The status should be failure
+    The output should not include "start-called"
+  End
+
+  It "does not start Pgbouncer after copying the template fails"
+    export PGB_FAIL_STEP=cp
     When call main
     The status should be failure
     The output should not include "start-called"

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -89,6 +89,12 @@ start_pgbouncer() {
   su pgbouncer -c "/opt/bitnami/scripts/pgbouncer/run.sh"
 }
 
+main() {
+  load_common_library || return $?
+  build_pgbouncer_conf || return $?
+  start_pgbouncer
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -96,7 +102,4 @@ start_pgbouncer() {
 # end here. The script path is assigned to the __SOURCED__ variable.
 ${__SOURCED__:+false} : || return 0
 
-# main
-load_common_library
-build_pgbouncer_conf
-start_pgbouncer
+main

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -20,15 +20,16 @@ build_pgbouncer_conf() {
     exit 1
   fi
 
-  mkdir -p $pgbouncer_conf_dir $pgbouncer_log_dir $pgbouncer_tmp_dir
-  cp $pgbouncer_template_conf_file $pgbouncer_conf_dir
-  echo "\"$POSTGRESQL_USERNAME\" \"$POSTGRESQL_PASSWORD\"" > $pgbouncer_user_list_file
-  # shellcheck disable=SC2129
-  echo -e "\\n[databases]" >> $pgbouncer_conf_file
-  echo "postgres=host=$CURRENT_POD_IP port=5432 dbname=postgres" >> $pgbouncer_conf_file
-  echo "*=host=$CURRENT_POD_IP port=5432" >> $pgbouncer_conf_file
-  chmod 644 $pgbouncer_conf_file
-  chmod 600 $pgbouncer_user_list_file
+  mkdir -p "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir" || return $?
+  cp "$pgbouncer_template_conf_file" "$pgbouncer_conf_dir" || return $?
+  printf '"%s" "%s"\n' "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" > "$pgbouncer_user_list_file" || return $?
+  {
+    printf '\n[databases]\n'
+    printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP"
+    printf '*=host=%s port=5432\n' "$CURRENT_POD_IP"
+  } >> "$pgbouncer_conf_file" || return $?
+  chmod 644 "$pgbouncer_conf_file" || return $?
+  chmod 600 "$pgbouncer_user_list_file" || return $?
 
   # Try to add user
   useradd pgbouncer 2>/dev/null || true
@@ -51,7 +52,7 @@ build_pgbouncer_conf() {
       next_uid=$((next_uid + 1))
 
       # Add user to /etc/passwd
-      echo "pgbouncer:x:$next_uid:$next_uid:pgbouncer user:/nonexistent:/bin/false" >> /etc/passwd
+      printf 'pgbouncer:x:%s:%s:pgbouncer user:/nonexistent:/bin/false\n' "$next_uid" "$next_uid" >> /etc/passwd || return $?
       echo "Added pgbouncer user to /etc/passwd"
   fi
 
@@ -62,13 +63,13 @@ build_pgbouncer_conf() {
       # Get the user's GID if user exists
       if id "pgbouncer" >/dev/null 2>&1; then
           user_gid=$(id -g pgbouncer)
-          echo "pgbouncer:x:$user_gid:" >> /etc/group
+          printf 'pgbouncer:x:%s:\n' "$user_gid" >> /etc/group || return $?
           echo "Added pgbouncer group with GID $user_gid to /etc/group"
       else
           # Fallback: use next available GID
           next_gid=$(awk -F: '$3 >= 1000 && $3 < 65534 {print $3}' /etc/group | sort -n | tail -1)
           next_gid=$((next_gid + 1))
-          echo "pgbouncer:x:$next_gid:" >> /etc/group
+          printf 'pgbouncer:x:%s:\n' "$next_gid" >> /etc/group || return $?
           echo "Added pgbouncer group with GID $next_gid to /etc/group"
       fi
   fi
@@ -81,7 +82,7 @@ build_pgbouncer_conf() {
       exit 1
   fi
 
-  chown -R pgbouncer:pgbouncer $pgbouncer_conf_dir $pgbouncer_log_dir $pgbouncer_tmp_dir
+  chown -R pgbouncer:pgbouncer "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir"
 }
 
 start_pgbouncer() {

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -23,11 +23,10 @@ build_pgbouncer_conf() {
   mkdir -p "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir" || return $?
   cp "$pgbouncer_template_conf_file" "$pgbouncer_conf_dir" || return $?
   printf '"%s" "%s"\n' "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" > "$pgbouncer_user_list_file" || return $?
-  {
-    printf '\n[databases]\n'
-    printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP"
-    printf '*=host=%s port=5432\n' "$CURRENT_POD_IP"
-  } >> "$pgbouncer_conf_file" || return $?
+  # shellcheck disable=SC2129
+  printf '\n[databases]\n' >> "$pgbouncer_conf_file" || return $?
+  printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP" >> "$pgbouncer_conf_file" || return $?
+  printf '*=host=%s port=5432\n' "$CURRENT_POD_IP" >> "$pgbouncer_conf_file" || return $?
   chmod 644 "$pgbouncer_conf_file" || return $?
   chmod 600 "$pgbouncer_user_list_file" || return $?
 


### PR DESCRIPTION
## What changed

- Add a real `main()` entry point to `pgbouncer-setup.sh`.
- Return immediately when the common library or any generated configuration
  setup step fails, including directory creation, template copy, file writes,
  permission changes, account-file writes, and ownership setup.
- Add focused ShellSpecs proving Pgbouncer is not started after template-copy
  or ownership setup fails.

## Why

`build_pgbouncer_conf` returned the failing `chown` status, but the top-level
script ignored it and still called `start_pgbouncer`. This could hide the causal
ownership error behind a later startup failure and attempt to start with invalid
directory ownership.

The isolated pre-fix result was `build_rc=42 start_called=1`. The first
dedicated pre-fix ShellSpec failed because the setup sequence returned success
and emitted `start-called` after the mocked `chown` failure. Review then exposed
the same masking problem for intermediate commands: with mocked `cp=42` and a
successful later `chown`, the added RED case returned success and still emitted
`start-called`. A second review RED then fault-injected the first database
config `printf`; the grouped write returned the final successful `printf`
status and again allowed startup with a partial config.

## Candidate identity

- Target branch: `main`
- Fresh target commit: `474b3d76af28d13737aa2fb51f28a6b19a116f22`
- Fresh target tree: `9c47cae0a702af202ec0069236653ca70f863d1c`
- Fresh PostgreSQL subtree: `0e56df6327674c446de618ad3409839e05b293a1`
- Fresh base Pgbouncer blob: `f6f16ed301d79f152114a91c3f4078169b062470`
- Candidate commit: `dc0be5e2f8b2c7e74f9a09842c42639cefe3e5c7`
- Candidate tree: `e2f283c7de953d00ad5101c0a2c7fb08e05ae4b2`
- Scope: 2 files

Open-PR audit: draft #3117 is excluded because its PostgreSQL change is only a
repository-wide KubeBlocks compatibility annotation bump and does not intersect
this Pgbouncer source/test fix. Closed #3292 remains excluded; merged #3309 is
already included in target history.

## Validation

- Focused pre-fix ShellSpec: 1 failure, exit 101
- Review RED for intermediate `cp` failure: 2 examples, 1 failure, exit 101
- Review RED for an early grouped config write: 3 examples, 1 failure, exit 101
- Focused post-fix ShellSpec: 3 passed, 0 failed
- Full PostgreSQL ShellSpec on Bash 5.3.9: 160 passed, 0 failed
- Changed-file ShellCheck: exit 0
- Bash syntax checks: exit 0
- Helm lint: 1 passed, 0 failed
- Helm render: 41 documents, 987611 bytes
- `git diff --check`: exit 0
- Worktree: tracked clean

## Runtime boundary

This PR contains source/static evidence only. It does not claim Test-owned
runtime, package, KubeBlocks, DataProtection, syncer, vcluster, cleanup,
residue, or release-N evidence.
