### PR TITLE
fix(mysql): escape account provision passwords

### DIFF
--- a/addons/mysql/scripts-ut-spec/account_provision_sql_literal_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/account_provision_sql_literal_contract_spec.sh
@@ -1,0 +1,63 @@
+# shellcheck shell=bash
+
+Describe "MySQL accountProvision SQL literal contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  chart_path() {
+    printf "%s/addons/mysql" "$(repo_root)"
+  }
+
+  helm_not_available() { ! command -v helm >/dev/null 2>&1; }
+  Skip if "helm not available" helm_not_available
+
+  extract_account_provision_script() {
+    helm template test "$(chart_path)" --show-only "templates/$1" |
+      awk '
+        /^    accountProvision:$/ { in_action = 1 }
+        in_action && /^          - \|$/ { in_script = 1; next }
+        in_script && /^        targetPodSelector:/ { exit }
+        in_script { sub(/^            /, ""); print }
+      '
+  }
+
+  run_account_provision() {
+    template=$1
+    tmp_dir=$(mktemp -d)
+
+    cat >"${tmp_dir}/mysql" <<'SH'
+#!/bin/sh
+for arg do
+  query=$arg
+done
+printf '%s\n' "$query"
+SH
+    chmod +x "${tmp_dir}/mysql"
+
+    script=$(extract_account_provision_script "${template}") || return
+    PATH="${tmp_dir}:${PATH}" \
+      MYSQL_ROOT_USER=root \
+      MYSQL_ROOT_PASSWORD=root-password \
+      KB_ACCOUNT_NAME=kbprobe \
+      KB_ACCOUNT_PASSWORD="pa'ss" \
+      KB_ACCOUNT_STATEMENT="CREATE USER \${KB_ACCOUNT_NAME} IDENTIFIED BY '\${KB_ACCOUNT_PASSWORD}';" \
+      bash -c "${script}" 2>/dev/null
+    rc=$?
+
+    rm -rf "${tmp_dir}"
+    return "${rc}"
+  }
+
+  It "escapes an overridden account password in standard accountProvision SQL"
+    When call run_account_provision cmpd-mysql80.yaml
+    The status should be success
+    The output should include "CREATE USER kbprobe IDENTIFIED BY 'pa''ss';"
+  End
+
+  It "escapes an overridden account password in ORC accountProvision SQL"
+    When call run_account_provision cmpd-mysql80-orc.yaml
+    The status should be success
+    The output should include "CREATE USER kbprobe IDENTIFIED BY 'pa''ss';"
+  End
+End

--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -216,6 +216,8 @@ lifecycleActions:
           # captured explicitly via $? -- if it stayed on, set -e would exit before the
           # rc-save line on any non-zero result.
           { previous_state=$(set +o); set +ex; } 2>/dev/null
+          # statement.create embeds this value in a single-quoted MySQL literal.
+          KB_ACCOUNT_PASSWORD=${KB_ACCOUNT_PASSWORD//\'/\'\'}
           eval statement=\"${KB_ACCOUNT_STATEMENT}\"
           mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement}"
           mysql_rc=$?

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -177,6 +177,8 @@ accountProvision:
         # captured explicitly via $? -- if it stayed on, set -e would exit before the
         # rc-save line on any non-zero result.
         { previous_state=$(set +o); set +ex; } 2>/dev/null
+        # statement.create embeds this value in a single-quoted MySQL literal.
+        KB_ACCOUNT_PASSWORD=${KB_ACCOUNT_PASSWORD//\'/\'\'}
         eval statement=\"${KB_ACCOUNT_STATEMENT}\"
         mysql -u${MYSQL_ROOT_USER} -p${MYSQL_ROOT_PASSWORD} -P3306 -h127.0.0.1 -e "${statement};"
         mysql_rc=$?


### PR DESCRIPTION
## Summary
- escape apostrophes in account passwords before expanding standard accountProvision statements
- apply the same boundary to ORC accountProvision
- cover both rendered action scripts with executable mysql-shim regressions

## Contract
- kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md:55,64,67

## Verification
- executable RED: 2 examples, 2 failures
- focused ShellSpec: 2 examples, 0 failures
- full MySQL ShellSpec: 57 examples, 0 failures
- error-level ShellCheck, strict Helm lint, git diff --check: pass