### PR TITLE
fix(postgresql): escape pgbouncer auth file fields

### DIFF
--- a/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317,SC2329
+
+Describe "PostgreSQL Pgbouncer auth-file contract"
+  Include ../scripts/pgbouncer-setup.sh
+
+  setup() {
+    test_dir=$(mktemp -d -t pgbouncer-authfile-XXXXXX)
+    pgbouncer_template_conf_file="../config/pgbouncer-ini.tpl"
+    pgbouncer_conf_dir="$test_dir/conf/"
+    pgbouncer_log_dir="$test_dir/logs/"
+    pgbouncer_tmp_dir="$test_dir/tmp/"
+    pgbouncer_conf_file="$test_dir/conf/pgbouncer.ini"
+    pgbouncer_user_list_file="$test_dir/conf/userlist.txt"
+    POSTGRESQL_USERNAME=postgres
+    POSTGRESQL_PASSWORD='pa"ss'
+    CURRENT_POD_IP=127.0.0.1
+  }
+
+  cleanup() {
+    rm -rf "$test_dir"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  is_empty() {
+    test -z "${1:-}"
+  }
+
+  Mock useradd
+    exit 0
+  End
+
+  Mock id
+    exit 0
+  End
+
+  Mock getent
+    exit 0
+  End
+
+  Mock chown
+    exit 0
+  End
+
+  It "doubles quotes in overridden passwords for the PgBouncer auth file"
+    When call build_pgbouncer_conf
+    The status should be success
+    The path "$pgbouncer_user_list_file" should be file
+    The contents of file "$pgbouncer_user_list_file" should equal '"postgres" "pa""ss"'
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
@@ -47,6 +47,7 @@ Describe "PostgreSQL Pgbouncer auth-file contract"
   It "doubles quotes in overridden passwords for the PgBouncer auth file"
     When call build_pgbouncer_conf
     The status should be success
+    The output should include "pgbouncer user and group are ready"
     The path "$pgbouncer_user_list_file" should be file
     The contents of file "$pgbouncer_user_list_file" should equal '"postgres" "pa""ss"'
   End

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -20,9 +20,12 @@ build_pgbouncer_conf() {
     exit 1
   fi
 
+  local escaped_username="${POSTGRESQL_USERNAME//\"/\"\"}"
+  local escaped_password="${POSTGRESQL_PASSWORD//\"/\"\"}"
+
   mkdir -p "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir" || return $?
   cp "$pgbouncer_template_conf_file" "$pgbouncer_conf_dir" || return $?
-  printf '"%s" "%s"\n' "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" > "$pgbouncer_user_list_file" || return $?
+  printf '"%s" "%s"\n' "$escaped_username" "$escaped_password" > "$pgbouncer_user_list_file" || return $?
   # shellcheck disable=SC2129
   printf '\n[databases]\n' >> "$pgbouncer_conf_file" || return $?
   printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP" >> "$pgbouncer_conf_file" || return $?


### PR DESCRIPTION
## Summary

- escape embedded double quotes in PgBouncer auth-file username and password fields by doubling them
- add a focused ShellSpec for an overridden PostgreSQL password containing `"`

PgBouncer's auth-file grammar requires `"` inside a field to be serialized as `""`. The previous raw interpolation wrote `pa"ss` as `"pa"ss"`, so PgBouncer parsed a different password. This matters for user password overrides and `secretRef` inputs covered by `docs/addon-api/07-accounts-and-tls.md` lines 64 and 67-68.

## Candidate boundary

- target branch: `easton/pg-pgbouncer-failfast`
- target commit / included PR #3331: `dc0be5e2f8b2c7e74f9a09842c42639cefe3e5c7`
- repository main at freeze: `474b3d76af28d13737aa2fb51f28a6b19a116f22`
- candidate head: `4b9581979cf41cd70703b712805c10533f8580b2`
- candidate tree: `cb2966acc7232ba438f02c56b22062b14f8adabf`
- open `weicao` PostgreSQL PR audit: #3331 included; other open `weicao` PRs are outside PostgreSQL

This is intentionally stacked on #3331 because both changes touch `pgbouncer-setup.sh`. After #3331 merges, this PR can be retargeted to `main` without mixing its already-approved fail-fast scope.

## TDD evidence

- RED on exact included head: focused `1/1`; expected `"postgres" "pa""ss"`, got `"postgres" "pa"ss"`
- GREEN: focused ShellSpec `1/0`
- full PostgreSQL ShellSpec with Bash 5.3: `161/0`
- ShellCheck on changed files: pass
- Bash syntax and `git diff --check`: pass
- Helm lint: `1/0`
- Helm render: `41` documents / `987775` bytes

Runtime/package/cleanup evidence is not claimed by this source-only PR.
