### PR TITLE
fix(mysql): escape 5.7 root SQL literals

### DIFF
--- a/addons/mysql/scripts-ut-spec/mysql57_root_sql_literal_contract_spec.sh
+++ b/addons/mysql/scripts-ut-spec/mysql57_root_sql_literal_contract_spec.sh
@@ -1,0 +1,43 @@
+# shellcheck shell=bash
+
+Describe "MySQL 5.7 root credential SQL literal contract"
+  repo_root() {
+    printf "%s" "${SHELLSPEC_CWD:?}"
+  }
+
+  script_path() {
+    printf "%s/addons/mysql/scripts/docker-entrypoint-5.7.sh" "$(repo_root)"
+  }
+
+  run_root_setup() {
+    tmp_dir=$(mktemp -d)
+    sql_file="$tmp_dir/sql"
+
+    MYSQL_INITDB_SKIP_TZINFO=1 \
+      MYSQL_ROOT_HOST="db'host[*]" \
+      MYSQL_ROOT_PASSWORD="pa'ss[*]" \
+      MYSQL_DATABASE='' \
+      MYSQL_USER='' \
+      MYSQL_PASSWORD='' \
+      SQL_FILE="$sql_file" \
+      bash -c '
+        source "$1"
+        docker_process_sql() {
+          cat >"${SQL_FILE:?}"
+        }
+        docker_setup_db
+      ' bash "$(script_path)" >/dev/null 2>&1
+    rc=$?
+
+    cat "$sql_file"
+    rm -rf "$tmp_dir"
+    return "$rc"
+  }
+
+  It "escapes root host and password before embedding them in initialization SQL"
+    When call run_root_setup
+    The status should be success
+    The output should include "CREATE USER 'root'@'db''host[*]' IDENTIFIED BY 'pa''ss[*]' ;"
+    The output should include "ALTER USER 'root'@'localhost' IDENTIFIED BY 'pa''ss[*]' ;"
+  End
+End

--- a/addons/mysql/scripts/docker-entrypoint-5.7.sh
+++ b/addons/mysql/scripts/docker-entrypoint-5.7.sh
@@ -21,6 +21,11 @@ mysql_error() {
 	exit 1
 }
 
+# Escape values before embedding them in a single-quoted MySQL string literal.
+mysql_escape_sql_literal() {
+	printf '%s' "$1" | sed "s/'/''/g"
+}
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
@@ -295,20 +300,24 @@ docker_setup_db() {
 	fi
 	# Sets root password and creates root users for non-localhost hosts
 	local rootCreate=
+	local escapedRootHost
+	local escapedRootPassword
+	escapedRootHost="$(mysql_escape_sql_literal "$MYSQL_ROOT_HOST")"
+	escapedRootPassword="$(mysql_escape_sql_literal "$MYSQL_ROOT_PASSWORD")"
 	# default root to listen for connections from anywhere
 	if [ -n "$MYSQL_ROOT_HOST" ] && [ "$MYSQL_ROOT_HOST" != 'localhost' ]; then
 		# no, we don't care if read finds a terminating character in this heredoc
 		# https://unix.stackexchange.com/questions/265149/why-is-set-o-errexit-breaking-this-read-heredoc-expression/265151#265151
 		read -r -d '' rootCreate <<-EOSQL || true
-			CREATE USER 'root'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-			GRANT ALL ON *.* TO 'root'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
+			CREATE USER 'root'@'${escapedRootHost}' IDENTIFIED BY '${escapedRootPassword}' ;
+			GRANT ALL ON *.* TO 'root'@'${escapedRootHost}' WITH GRANT OPTION ;
 		EOSQL
 	fi
 
 	local passwordSet=
 	# no, we don't care if read finds a terminating character in this heredoc (see above)
 	read -r -d '' passwordSet <<-EOSQL || true
-		ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+		ALTER USER 'root'@'localhost' IDENTIFIED BY '${escapedRootPassword}' ;
 	EOSQL
 
 	# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is just now being set


### PR DESCRIPTION
## Summary
- escape apostrophes in MySQL 5.7 root host and password before expanding initialization SQL
- apply the same literal boundary to remote root creation and localhost password updates
- cover both statements with an executable mysql-stdin regression

## Contract
- kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md:55,64,65,78

## Verification
- executable RED: 1 example, 1 failure
- focused ShellSpec: 1 example, 0 failures
- full MySQL ShellSpec: 56 examples, 0 failures
- bash syntax, error-level ShellCheck, strict Helm lint, git diff --check: pass
