### PR TITLE
fix(postgresql): fail pre-setup on initialization errors

### DIFF
--- a/addons/postgresql/scripts-ut-spec/postgres_pre_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/postgres_pre_setup_spec.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2317,SC2329
 
 # validate_shell_type_and_version defined in shellspec/spec_helper.sh used to validate the expected shell type and version this script needs to run.
 if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
@@ -11,22 +11,51 @@ Describe "PostgreSQL Configuration Script Tests"
 
   Include ../scripts/postgres-pre-setup.sh
 
+  mkdir() {
+    if test "${PRESETUP_FAIL_STEP:-}" = "mkdir"; then
+      return 42
+    fi
+    command mkdir "$@"
+  }
+
+  cp() {
+    if test "${PRESETUP_FAIL_STEP:-}" = "cp"; then
+      return 42
+    fi
+    if test "${PRESETUP_STUB_CP_SUCCESS:-0}" = "1"; then
+      return 0
+    fi
+    command cp "$@"
+  }
+
+  touch() {
+    if test "${PRESETUP_FAIL_STEP:-}" = "touch"; then
+      return 42
+    fi
+    command touch "$@"
+  }
+
   init() {
     postgres_template_conf_file="./postgresql.conf"
     postgres_conf_dir="./pgdata/"
     postgres_conf_file="./pgdata/postgresql.conf"
-    touch $postgres_template_conf_file
+    postgres_log_dir="./pgdata/logs/"
+    postgres_scripts_log_file="${postgres_log_dir}/scripts.log"
+    postgres_walg_dir="./pgdata/wal-g"
+    touch "$postgres_template_conf_file"
+    mkdir -p "$postgres_log_dir" "$postgres_walg_dir"
+    touch "$postgres_conf_file" "$postgres_scripts_log_file"
     echo "listen_addresses = '*'
           port = '5432'
           archive_command = '/bin/true'
           archive_mode = 'on'
           auto_explain.log_analyze = 'False'
-          auto_explain.log_buffers = 'False'" > $postgres_template_conf_file
+          auto_explain.log_buffers = 'False'" > "$postgres_template_conf_file"
   }
   BeforeAll "init"
 
   cleanup() {
-    rm -rf $postgres_template_conf_file $postgres_conf_dir $postgres_conf_file
+    rm -rf "$postgres_template_conf_file" "$postgres_conf_dir" "$postgres_conf_file"
   }
   AfterAll 'cleanup'
 
@@ -39,6 +68,54 @@ Describe "PostgreSQL Configuration Script Tests"
       The contents of file "$postgres_conf_file" should include "listen_addresses = '*'"
       The contents of file "$postgres_conf_file" should include "port = '5432'"
       The contents of file "$postgres_conf_file" should include "archive_command = '/bin/true'"
+    End
+  End
+
+  Describe "build_real_postgres_conf() failure"
+    It "preserves a template copy failure"
+      export PRESETUP_FAIL_STEP=cp
+      When call build_real_postgres_conf
+      The status should equal 42
+    End
+  End
+
+  Describe "init_postgres_log() failure"
+    It "preserves a log-file creation failure"
+      export PRESETUP_FAIL_STEP=touch
+      When call init_postgres_log
+      The status should equal 42
+    End
+  End
+
+  Describe "copy_necessary_binaries() failure"
+    It "preserves a WAL-G directory creation failure"
+      export PRESETUP_FAIL_STEP=mkdir
+      export PRESETUP_STUB_CP_SUCCESS=1
+      When call copy_necessary_binaries
+      The status should equal 42
+    End
+  End
+
+  Describe "main()"
+    Mock build_real_postgres_conf
+      exit 42
+    End
+
+    Mock init_postgres_log
+      echo init-called
+      exit 0
+    End
+
+    Mock copy_necessary_binaries
+      echo copy-called
+      exit 0
+    End
+
+    It "stops after configuration setup fails"
+      When call main
+      The status should equal 42
+      The output should not include "init-called"
+      The output should not include "copy-called"
     End
   End
 End

--- a/addons/postgresql/scripts/postgres-pre-setup.sh
+++ b/addons/postgresql/scripts/postgres-pre-setup.sh
@@ -8,32 +8,32 @@ postgres_scripts_log_file="${postgres_log_dir}/scripts.log"
 postgres_walg_dir="/home/postgres/pgdata/wal-g"
 
 build_real_postgres_conf() {
-  mkdir -p "$postgres_conf_dir"
+  mkdir -p "$postgres_conf_dir" || return $?
 
   # Copy the template config file first
-  cp "$postgres_template_conf_file" "$postgres_conf_dir"
+  cp "$postgres_template_conf_file" "$postgres_conf_dir" || return $?
 
   # Set permissions
-  chmod 755 "$postgres_conf_dir"
-  chmod 664 "$postgres_conf_file"
+  chmod 755 "$postgres_conf_dir" || return $?
+  chmod 664 "$postgres_conf_file" || return $?
 }
 
 init_postgres_log() {
-  mkdir -p "$postgres_log_dir"
-  chmod -R 777 "$postgres_log_dir"
-  touch "$postgres_scripts_log_file"
-  chmod 666 "$postgres_scripts_log_file"
+  mkdir -p "$postgres_log_dir" || return $?
+  chmod -R 777 "$postgres_log_dir" || return $?
+  touch "$postgres_scripts_log_file" || return $?
+  chmod 666 "$postgres_scripts_log_file" || return $?
 }
 
 copy_necessary_binaries() {
-  mkdir -p "$postgres_walg_dir"
-  cp /spilo-init/bin/wal-g ${postgres_walg_dir}/wal-g
+  mkdir -p "$postgres_walg_dir" || return $?
+  cp /spilo-init/bin/wal-g "${postgres_walg_dir}/wal-g" || return $?
 }
 
 main() {
-  build_real_postgres_conf
-  init_postgres_log
-  copy_necessary_binaries
+  build_real_postgres_conf || return $?
+  init_postgres_log || return $?
+  copy_necessary_binaries || return $?
 }
 
 # This is magic for shellspec ut framework.

--- a/addons/postgresql/scripts/postgres-pre-setup.sh
+++ b/addons/postgresql/scripts/postgres-pre-setup.sh
@@ -30,6 +30,12 @@ copy_necessary_binaries() {
   cp /spilo-init/bin/wal-g ${postgres_walg_dir}/wal-g
 }
 
+main() {
+  build_real_postgres_conf
+  init_postgres_log
+  copy_necessary_binaries
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -37,7 +43,4 @@ copy_necessary_binaries() {
 # end here. The script path is assigned to the __SOURCED__ variable.
 ${__SOURCED__:+false} : || return 0
 
-# main
-build_real_postgres_conf
-init_postgres_log
-copy_necessary_binaries
+main


### PR DESCRIPTION
## Summary

- preserve failures from PostgreSQL config, log, and WAL-G setup operations
- stop later pre-setup phases after the first failure
- add deterministic ShellSpec fault injection for helper and phase-level masking

The init-container script previously returned only the last command's status. A failed config copy, log-file creation, or WAL-G directory creation could be followed by a successful `chmod`, `cp`, or later phase, returning exit 0 with incomplete or stale startup state.

Contract anchors:

- `docs/addon-api/02-component-definition.md:71`: data-directory initialization is part of the ComponentDefinition contract.
- `docs/addon-api/11-troubleshooting.md:57`: startup-script exit status and readiness must agree.

## Candidate Boundary

- target: `main` at `e919d97a0ae0d6e887da7e02e9ab1df6cb6520d8`
- target tree: `eb1f2c961fcd5a87e50f9f312368b6e92d6b344f`
- candidate head: `b2083b9154cf9744f5fbf8f2d1739800b17961e4`
- candidate tree: `21266d34c9f3ea922be8729b60284082c82bab33`
- exact compare: ahead 3 / behind 0 / merge-base equals target
- included PostgreSQL PR: this Draft candidate only
- excluded PostgreSQL PRs: none; #3331 and #3333 are already in target `main`

The candidate diff is limited to `postgres-pre-setup.sh` and its existing ShellSpec.

## TDD Evidence

- zero-behavior `main()` extraction commit: `45bbe52290cd07f0417eaa22fd9689088c0df800`
- RED commit `bc7e334b7b41d7a32f6a2b49b5e2cd66bdf6a68a`: 5 examples / 4 failures / 6 failed assertions; early failures expected status 42 but got 0, and later phases still ran
- GREEN head `b2083b9154cf9744f5fbf8f2d1739800b17961e4`: focused ShellSpec 5/0
- full PostgreSQL ShellSpec with Bash 5.3: 165/0
- ShellCheck error severity: pass
- Bash syntax and `git diff --check`: pass
- Helm lint: 1/0

Runtime, package, cleanup, and formal acceptance evidence are not claimed by this source-only Draft candidate.
