### PR TITLE
fix(postgresql): validate etcd service versions

### DIFF
--- a/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
@@ -23,6 +23,38 @@ Describe "PostgreSQL KubeBlocks API contract"
     render_chart | grep -c "$pattern" || true
   }
 
+  etcd_service_ref_contract_count() {
+    render_chart | ruby -ryaml -e '
+      versions = YAML.load_file("../../etcd/values.yaml")
+        .fetch("etcdVersions")
+        .map { |entry| entry.fetch("version").to_s }
+      definitions = YAML.load_stream(ARGF.read).compact.select do |document|
+        document["kind"] == "ComponentDefinition"
+      end
+
+      count = definitions.count do |definition|
+        declarations = definition.dig("spec", "serviceRefDeclarations") || []
+        declarations = declarations.select { |declaration| declaration["name"] == "etcd" }
+        next false unless declarations.length == 1
+
+        specs = declarations.first["serviceRefDeclarationSpecs"] || []
+        next false unless specs.length == 1 && specs.first["serviceKind"] == "etcd"
+
+        pattern = specs.first["serviceVersion"].to_s
+        regex = begin
+          Regexp.new(pattern)
+        rescue RegexpError
+          nil
+        end
+        matches = lambda { |version| regex ? regex.match?(version) : version == pattern }
+
+        versions.all? { |version| matches.call(version) } &&
+          ["2.3.8", "4.0.0"].none? { |version| matches.call(version) }
+      end
+      puts count
+    '
+  }
+
   component_definitions_with_pod_list_rbac() {
     render_chart | ruby -ryaml -e '
       definitions = YAML.load_stream(ARGF.read).compact.select do |document|
@@ -213,6 +245,12 @@ EOF
 
   It "uses an exec role probe supported by KubeBlocks main"
     When call component_definitions_with_exec_role_probe
+    The status should eq 0
+    The output should eq "7"
+  End
+
+  It "accepts supported ETCD v3 ServiceDescriptors and rejects other majors"
+    When call etcd_service_ref_contract_count
     The status should eq 0
     The output should eq "7"
   End

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -18,7 +18,7 @@ spec:
     - name: etcd
       serviceRefDeclarationSpecs:
         - serviceKind: etcd
-          serviceVersion: "^*"
+          serviceVersion: "^3\\.\\d+\\.\\d+$"
       optional: true
     - name: remote-instances
       serviceRefDeclarationSpecs:


### PR DESCRIPTION
## Summary

- replace the invalid ETCD service-reference pattern `^*` with a bounded ETCD 3.x semantic-version regexp
- add a rendered ComponentDefinition contract test against every service version published by the ETCD addon
- reject ETCD 2.x and 4.x descriptors because Patroni uses the ETCD v3 API

## Candidate identity

This remains a Draft development candidate stacked directly on Draft #3335.

- base branch: `easton/pg-presetup-failfast`
- exact base: `b2083b9154cf9744f5fbf8f2d1739800b17961e4`
- exact base tree: `21266d34c9f3ea922be8729b60284082c82bab33`
- exact candidate head: `2c665285816fa4856f717e8b4fccd6614f8178cb`
- exact candidate tree: `d898dfa08821f8dcd688b2aed8d59e75cf17c19c`
- boundary: one commit ahead, zero behind, merge-base equals the exact base

## Contract and failure mode

`docs/addon-api/06-variables-and-services.md:95` states that direct `ServiceDescriptor` binding validates `serviceKind` and `serviceVersion`, with `serviceVersion` matched as a regexp. Its example at line 56 uses `^3\.`. The same contract distinguishes this from `clusterServiceSelector`, whose current path does not provide the same declaration validation. `docs/addon-api/01-define-scope.md:60` requires representative rendering across external ServiceRef and service-version combinations, and `docs/addon-api/11-troubleshooting.md:45` requires verification of final injected external-dependency values.

KubeBlocks compiles the declaration regexp and falls back to exact-string comparison when compilation fails. Therefore `^*` rejects real ETCD descriptors such as `3.5.6`.

## Fresh TDD evidence

- RED at the same rebased candidate with only the production regexp restored to `^*`: focused API contract `20` examples / `1` failure; the new contract expected `7` rendered ComponentDefinitions and got `0`
- GREEN focused API contract on exact head: `20/0`
- full PostgreSQL ShellSpec with Bash `5.3.9`: `166/0`
- ShellCheck severity-error, Bash syntax, and `git diff --check`: pass
- Helm lint: `1/0`
- Helm render: `41` documents / `988263` bytes

## Boundary

This closes source-level direct-ServiceDescriptor matching only. The `clusterServiceSelector` path has different controller behavior and is not claimed here. Runtime packaging, environment execution, cleanup, and formal acceptance are not produced by this developer-side candidate.
