### PR TITLE
fix(postgresql): preserve quotes in reconfigure values

### DIFF
--- a/addons/postgresql/reloader/update-parameter.sh
+++ b/addons/postgresql/reloader/update-parameter.sh
@@ -52,7 +52,12 @@ update_parameter() {
     command="reload"
     paramName="${1:?missing param name}"
     paramValue="${2:?missing value}"
-    paramValue=$(echo "$paramValue" | sed "s/'//g")
+    case "$paramValue" in
+        \'*\')
+            paramValue=${paramValue#\'}
+            paramValue=${paramValue%\'}
+            ;;
+    esac
 
     json_params="{}"
     if in_array "$paramName" "$patroni_params"; then

--- a/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
@@ -62,6 +62,20 @@ EOF
       The result of function curl_log should include 'http://localhost:8008/reload'
     End
 
+    It "preserves embedded single quotes in a PostgreSQL GUC value"
+      When run sh "$(script_path)" "archive_command" "test ! -f '/archive/%f' && cp '%p' '/archive/%f'"
+      The status should eq 0
+      The result of function curl_log should include '"archive_command": "test ! -f '\''/archive/%f'\'' && cp '\''%p'\'' '\''/archive/%f'\''"'
+      The result of function curl_log should include 'http://localhost:8008/reload'
+    End
+
+    It "removes one surrounding quote pair from a PostgreSQL literal"
+      When run sh "$(script_path)" "archive_command" "'/bin/true'"
+      The status should eq 0
+      The result of function curl_log should include '"archive_command": "/bin/true"'
+      The result of function curl_log should not include '"archive_command": "'\''/bin/true'\''"'
+    End
+
     It "routes a patroni DCS parameter at top level and reloads"
       When run sh "$(script_path)" "loop_wait" "10"
       The status should eq 0


### PR DESCRIPTION
## Summary

- preserve meaningful embedded single quotes when passing PostgreSQL parameter values to Patroni
- retain compatibility with the chart's existing single-quoted PostgreSQL literals by removing only one surrounding quote pair
- cover embedded and surrounding quote behavior with focused ShellSpec tests using `archive_command`

## Candidate identity

This remains a Draft development candidate stacked directly on Draft #3336.

- base branch: `easton/pg-etcd-service-version-regex`
- exact base: `2c665285816fa4856f717e8b4fccd6614f8178cb`
- exact base tree: `d898dfa08821f8dcd688b2aed8d59e75cf17c19c`
- exact candidate head: `4f0a4f7a394f3a0703cec384d096e3b98cf4add1`
- exact candidate tree: `e99f8583146439a17893e0dab2bc3edd2ea89f17`
- boundary: one commit ahead, zero behind, merge-base equals the exact base

## Contract and failure mode

`docs/addon-api/08-parameters-and-config.md:97` requires reconfigure scripts to validate parameter values and avoid corrupting configuration on repeat execution. Lines 103 and 124 require validation through the runtime configuration and actual process state rather than treating an OpsRequest as proof of effect. `docs/addon-api/11-troubleshooting.md:46` likewise requires file/action/process evidence for formatter and value behavior.

The previous global `sed "s/'//g"` changed:

```text
test ! -f '/archive/%f' && cp '%p' '/archive/%f'
```

into:

```text
test ! -f /archive/%f && cp %p /archive/%f
```

The candidate now removes only a matching outer quote pair and leaves embedded quotes intact.

## Fresh TDD evidence

- RED at the same rebased candidate with only the production behavior restored to global quote deletion: focused `11` examples / `1` failure; the recorded Patroni PATCH body lost every embedded quote
- GREEN focused on exact head: `11/0`
- full PostgreSQL ShellSpec with Bash `5.3.9`: `168/0`
- ShellCheck severity-error, Bash syntax, and `git diff --check`: pass
- Helm lint: `1/0`
- Helm render: `41` documents / `988377` bytes

## Boundary

This closes source-level argument preservation in the PostgreSQL reconfigure action. Runtime packaging, environment execution, actual Patroni/SQL value readback, cleanup, and formal acceptance are not produced by this developer-side candidate.
