### PR TITLE
fix(postgresql): allow empty reconfigure values

### DIFF
--- a/addons/postgresql/reloader/update-parameter.sh
+++ b/addons/postgresql/reloader/update-parameter.sh
@@ -51,7 +51,11 @@ update_parameter() {
 
     command="reload"
     paramName="${1:?missing param name}"
-    paramValue="${2:?missing value}"
+    if [ "$#" -lt 2 ]; then
+        echo "missing value" >&2
+        return 1
+    fi
+    paramValue=$2
     case "$paramValue" in
         \'*\')
             paramValue=${paramValue#\'}

--- a/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
@@ -76,6 +76,13 @@ EOF
       The result of function curl_log should not include '"archive_command": "'\''/bin/true'\''"'
     End
 
+    It "passes an explicit empty PostgreSQL GUC value to Patroni"
+      When run sh "$(script_path)" "archive_command" ""
+      The status should eq 0
+      The result of function curl_log should include '"archive_command": ""'
+      The result of function curl_log should include 'http://localhost:8008/reload'
+    End
+
     It "routes a patroni DCS parameter at top level and reloads"
       When run sh "$(script_path)" "loop_wait" "10"
       The status should eq 0


### PR DESCRIPTION
## Summary

- distinguish a missing reconfigure value argument from an explicitly empty value
- pass valid empty PostgreSQL GUC values to Patroni instead of failing before the API call
- retain the existing failure for a missing second argument

## Candidate identity

This remains a Draft development candidate stacked directly on Draft #3337.

- base branch: `easton/pg-reconfigure-quote-preservation`
- exact base: `4f0a4f7a394f3a0703cec384d096e3b98cf4add1`
- exact base tree: `e99f8583146439a17893e0dab2bc3edd2ea89f17`
- exact candidate head: `04c23b22178e642d58724b46daf72d2d81f6d25a`
- exact candidate tree: `7ca5d5a6a2fc311b62b242e0e8552832b607ca5b`
- boundary: one commit ahead, zero behind, merge-base equals the exact base

## Contract and failure mode

`docs/addon-api/08-parameters-and-config.md:60` requires parameter input to distinguish default/missing, explicit empty string, and deletion, with separate schema, renderer, and reconfigure-script coverage. Lines 97 and 103 require value validation plus runtime configuration/process evidence rather than treating an OpsRequest as proof. `docs/addon-api/11-troubleshooting.md:46` likewise requires file/action/process evidence for reconfigure value behavior.

The previous `${2:?missing value}` treated an explicitly supplied empty string as a missing argument. `archive_command` is a schema-supported string and PostgreSQL accepts an empty value to disable the command. The candidate checks argument count and then preserves the supplied value, including empty.

## Fresh TDD evidence

- RED at the same rebased candidate with only `${2:?missing value}` restored: focused `12` examples / `1` failure; explicit empty returned `1`, emitted no empty PATCH value, and made no Patroni reload call
- GREEN focused on exact head with Bash `3.2.57` and `5.3.9`: `12/0` on each
- full PostgreSQL ShellSpec with Bash `5.3.9`: `169/0`
- ShellCheck severity-error, Bash syntax, and `git diff --check`: pass
- Helm lint: `1/0`
- Helm render: `41` documents / `988458` bytes

## Boundary

This closes source-level distinction between a missing argument and an explicit empty reconfigure value. Runtime packaging, environment execution, actual Patroni/SQL value readback, cleanup, and formal acceptance are not produced by this developer-side candidate.
