### PR TITLE
fix(postgresql): fail WAL-G backup cleanup errors

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-archive-delete.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive-delete.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+set -o pipefail
+
 backup_base_path="$(dirname $DP_BACKUP_BASE_PATH)/wal-g"
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"

--- a/addons/postgresql/dataprotection/wal-g-delete.sh
+++ b/addons/postgresql/dataprotection/wal-g-delete.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
+set -e
+set -o pipefail
+
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 function getWalGSentinelInfo() {
   local sentinelFile=${1}
-  local out=$(datasafed list ${sentinelFile})
+  local out
+  out=$(datasafed list "${sentinelFile}") || return $?
   if [ "${out}" == "${sentinelFile}" ]; then
-     datasafed pull "${sentinelFile}" ${sentinelFile}
-     echo "$(cat ${sentinelFile})"
+     datasafed pull "${sentinelFile}" "${sentinelFile}" || return $?
+     cat "${sentinelFile}" || return $?
      return
   fi
 }
@@ -47,5 +51,3 @@ else
   echo "INFO: no other full backup, delete all wal archives."
   datasafed rm -r /wal_005
 fi
-
-

--- a/addons/postgresql/scripts-ut-spec/walg_delete_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_delete_spec.sh
@@ -1,0 +1,99 @@
+# shellcheck shell=sh
+
+Describe "PostgreSQL WAL-G preDelete failure propagation"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-walg-delete-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/repo/backup-test"
+    DP_BACKUP_NAME="backup-test"
+    dataprotection_dir=$(cd ../dataprotection && pwd)
+    export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
+      DP_BACKUP_NAME
+    unset DATASAFED_LIST_EXIT WALG_TARGET_EXIT WALG_ARCHIVE_EXIT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+if [ "$1" = "list" ]; then
+  if [ "${DATASAFED_LIST_EXIT:-0}" -ne 0 ]; then
+    exit "${DATASAFED_LIST_EXIT}"
+  fi
+  case "$*" in
+    "list wal-g-backup-repo.path") printf '%s\n' wal-g-backup-repo.path ;;
+    "list wal-g-backup-name") printf '%s\n' wal-g-backup-name ;;
+    *"/basebackups_005"*) printf '%s\n' base_00000001 ;;
+  esac
+elif [ "$1" = "pull" ]; then
+  case "$2" in
+    wal-g-backup-repo.path) printf '%s\n' /repo/wal-g > "$3" ;;
+    wal-g-backup-name) printf '%s\n' base_00000001 > "$3" ;;
+  esac
+fi
+exit 0
+EOF
+    cat > "${bindir}/wal-g" <<'EOF'
+#!/bin/sh
+printf 'wal-g %s\n' "$*" >> "${CALL_LOG}"
+case "$*" in
+  "delete target "*) exit "${WALG_TARGET_EXIT:-0}" ;;
+  "delete garbage ARCHIVES --confirm") exit "${WALG_ARCHIVE_EXIT:-0}" ;;
+esac
+exit 0
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/wal-g"
+  }
+
+  run_full_delete() {
+    (cd "${tmpdir}" && bash "${dataprotection_dir}/wal-g-delete.sh")
+  }
+
+  run_archive_delete() {
+    (cd "${tmpdir}" && bash "${dataprotection_dir}/wal-g-archive-delete.sh")
+  }
+
+  It "fails when the full-backup repository lookup fails"
+    export DATASAFED_LIST_EXIT=41
+    When call run_full_delete
+    The status should eq 41
+  End
+
+  It "fails when deleting the referenced WAL-G base backup fails"
+    export WALG_TARGET_EXIT=42
+    When call run_full_delete
+    The status should eq 42
+    The output should include "delete base_00000001"
+  End
+
+  It "fails when archive garbage collection fails"
+    export WALG_ARCHIVE_EXIT=43
+    When call run_archive_delete
+    The status should eq 43
+  End
+
+  It "succeeds after all full-backup repository cleanup steps succeed"
+    When call run_full_delete
+    The status should eq 0
+    The output should include "delete outdated WAL archive"
+  End
+
+  It "succeeds after all archive repository cleanup steps succeed"
+    When call run_archive_delete
+    The status should eq 0
+  End
+End


### PR DESCRIPTION
## Summary

- fail PostgreSQL WAL-G `preDelete` actions when repository cleanup commands fail
- preserve `datasafed list` failures through the sentinel helper instead of treating them as a missing sentinel
- cover full-backup and continuous-archive deletion paths with focused ShellSpec fault injection

## Candidate identity

This remains a Draft development candidate stacked directly on Draft #3338.

- base branch: `easton/pg-reconfigure-empty-value`
- exact base: `04c23b22178e642d58724b46daf72d2d81f6d25a`
- exact base tree: `7ca5d5a6a2fc311b62b242e0e8552832b607ca5b`
- exact candidate head: `de4e6b646f4fcc5b1b229fce82f454023f4a3f6f`
- exact candidate tree: `203b675577f49d5a827b50205f28a481a8f9a39a`
- boundary: one commit ahead, zero behind, merge-base equals the exact base

## Contract and failure mode

`docs/addon-api/09a-backup-basic.md:83` requires backup scripts to propagate failure instead of only logging and continuing. Line 111 requires explicit failure and retry-idempotency semantics for `preDelete`. `docs/addon-api/11-troubleshooting.md:39` distinguishes repository cleanup failure from Cluster/PVC retention behavior, and line 47 requires validation against the actual backup artifact path.

Before this candidate, a failed `datasafed list`, `wal-g delete target`, or `wal-g delete garbage ARCHIVES` could be followed by a successful command or conditional and the script would exit `0`. The Backup CR could then be removed while repository artifacts remained.

## Fresh TDD evidence

- RED at the same rebased candidate with only the prior production behavior restored: focused `5` examples / `3` failures; injected list, target deletion, and archive GC failures all returned `0`
- GREEN focused on exact head with Bash `3.2.57` and `5.3.9`: `5/0` on each
- full PostgreSQL ShellSpec with Bash `5.3.9`: `174/0`
- ShellCheck severity-error, Bash syntax, and `git diff --check`: pass
- Helm lint: `1/0`
- Helm render: `41` documents / `988689` bytes

## Boundary

This closes source-level failure propagation for the two PostgreSQL WAL-G preDelete scripts. Runtime packaging, environment execution, Backup deletion/finalizer behavior, repository residue inspection, cleanup, and formal acceptance are not produced by this developer-side candidate.
