### PR TITLE
fix(postgresql): fail PITR WAL listing errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -13,20 +13,28 @@ function fetch-wal-log(){
     DP_log "PITR: $pitr"
 
     exit_fetch_wal=0 && mkdir -p $wal_destination_dir
-    for dir_name in $(datasafed list /) ; do
+    if ! dir_names=$(datasafed list /); then
+       DP_error_log "failed to list the WAL archive root"
+       return 1
+    fi
+    for dir_name in $dir_names ; do
       if [[ $exit_fetch_wal -eq 1 ]]; then
          break
       fi
 
+      if ! dir_files=$(datasafed list "${dir_name}"); then
+         DP_error_log "failed to list WAL archive directory ${dir_name}"
+         return 1
+      fi
       # check if the latest_wal_log after the start_wal_log
-      latest_wal=$(datasafed list ${dir_name} | tail -n 1)
+      latest_wal=$(printf '%s\n' "${dir_files}" | tail -n 1)
       latest_wal_name=$(get_wal_name ${latest_wal})
       if [[ ${latest_wal_name} < $start_wal_name ]]; then
          continue
       fi
 
       DP_log "start to fetch wal logs from ${dir_name}"
-      for file in $(datasafed list ${dir_name} | grep ".zst"); do
+      for file in $(printf '%s\n' "${dir_files}" | grep ".zst"); do
          wal_name=$(get_wal_name ${file})
          if [[ $wal_name < $start_wal_name ]]; then
             continue

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -25,7 +25,8 @@ Describe "dataprotection PITR restore"
     DP_DATASAFED_BIN_PATH="${bindir}"
     export PATH CALL_LOG DATA_DIR PITR_DIR CONF_DIR RESTORE_SCRIPT_DIR \
       DP_RESTORE_TIME DP_RESTORE_TIMESTAMP DP_BACKUP_BASE_PATH DP_DATASAFED_BIN_PATH
-    unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR 2>/dev/null || true
+    unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_ROOT_LIST_EXIT \
+      DATASAFED_DIR_LIST_EXIT 2>/dev/null || true
 
     write_stubs
     build_concat
@@ -45,8 +46,14 @@ printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
   list)
     if [ "$2" = "/" ]; then
+      if [ "${DATASAFED_ROOT_LIST_EXIT:-0}" -ne 0 ]; then
+        exit "${DATASAFED_ROOT_LIST_EXIT}"
+      fi
       printf '%s\n' "${DATASAFED_LIST_ROOT:-}"
     else
+      if [ "${DATASAFED_DIR_LIST_EXIT:-0}" -ne 0 ]; then
+        exit "${DATASAFED_DIR_LIST_EXIT}"
+      fi
       printf '%s\n' "${DATASAFED_LIST_DIR:-}"
     fi
     ;;
@@ -140,6 +147,29 @@ EOF
       The output should include "done."
       The path "${CONF_DIR}/recovery.conf" should be exist
       The path "${DATA_DIR}.old" should be exist
+    End
+
+    It "fails before staging data when the WAL repository root cannot be listed"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      export DATASAFED_ROOT_LIST_EXIT=42
+      When run bash "${concat}"
+      The status should be failure
+      The output should include "failed to list the WAL archive root"
+      The path "${DATA_DIR}" should be exist
+      The path "${DATA_DIR}.old" should not be exist
+    End
+
+    It "fails before staging data when a WAL archive directory cannot be listed"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      export DATASAFED_LIST_ROOT="waldir/"
+      export DATASAFED_DIR_LIST_EXIT=43
+      When run bash "${concat}"
+      The status should be failure
+      The output should include "failed to list WAL archive directory waldir/"
+      The path "${DATA_DIR}" should be exist
+      The path "${DATA_DIR}.old" should not be exist
     End
   End
 


### PR DESCRIPTION
## Summary

- fail PostgreSQL PITR `prepareData` when the WAL repository root cannot be listed
- fail when an individual archive directory cannot be listed
- reuse each verified directory listing for selection and download
- preserve the live `DATA_DIR` instead of staging it to `.old` after a repository error

This Draft development candidate is stacked on #3339 exact head `de4e6b646f4fcc5b1b229fce82f454023f4a3f6f` (tree `203b675577f49d5a827b50205f28a481a8f9a39a`). Its exact head is `6dabc7e5232ff23c8b25dc4b90961cedd0c46851` (tree `b0784b799b883089074fd1114977b85a21d4b24c`).

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35` requires restore preflight to fail clearly when artifacts or repository paths are unavailable, before PVC data is overwritten. `docs/addon-api/11-troubleshooting.md:47-48` requires repository artifact and restore evidence to be checked through the generated restore path.

Before this change, `datasafed list /` and `datasafed list <archive-dir>` ran inside shell substitutions whose failures were masked by `for`, `tail`, or `grep`. `prepareData` returned 0, wrote recovery state, moved `DATA_DIR` to `.old`, and printed `done.` without a verified WAL listing.

## Validation

- fresh RED on this rebased candidate with only prior production listing behavior restored: 6 examples, 2 failures; both injected listing errors returned 0, emitted no failure diagnostic, moved `DATA_DIR` to `.old`, and continued to `done.`
- focused GREEN with Bash 3.2: 6 examples, 0 failures
- focused GREEN with Bash 5.3: 6 examples, 0 failures
- full PostgreSQL ShellSpec with Bash 5.3: 176 examples, 0 failures
- changed-file ShellCheck severity-error: pass
- Bash syntax and `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- `helm template`: 41 documents, 988810 bytes

Runtime, package, environment, cleanup, and formal acceptance are not claimed by this source-only candidate.
