### PR TITLE
fix(postgresql): validate WAL-G restore sentinels

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -10,11 +10,22 @@ export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 function getWalGSentinelInfo() {
   local sentinelFile=${1}
-  local out=$(datasafed list ${sentinelFile})
+  local out
+  local value
+  if ! out=$(datasafed list "${sentinelFile}"); then
+     echo "ERROR: failed to list WAL-G sentinel ${sentinelFile}" >&2
+     return 1
+  fi
   if [ "${out}" == "${sentinelFile}" ]; then
-     datasafed pull "${sentinelFile}" ${sentinelFile}
-     echo "$(cat ${sentinelFile})"
-     return
+     if ! datasafed pull "${sentinelFile}" "${sentinelFile}"; then
+        echo "ERROR: failed to pull WAL-G sentinel ${sentinelFile}" >&2
+        return 1
+     fi
+     if ! value=$(cat "${sentinelFile}"); then
+        echo "ERROR: failed to read WAL-G sentinel ${sentinelFile}" >&2
+        return 1
+     fi
+     printf '%s\n' "${value}"
   fi
 }
 
@@ -45,7 +56,15 @@ function config_wal_g_for_fetch_wal_log() {
 
 # 1. get restore info
 backupRepoPath=$(getWalGSentinelInfo "wal-g-backup-repo.path")
+if [[ -z "${backupRepoPath}" ]]; then
+  echo "ERROR: missing WAL-G backup repository sentinel" >&2
+  exit 1
+fi
 backupName=$(getWalGSentinelInfo "wal-g-backup-name")
+if [[ -z "${backupName}" ]]; then
+  echo "ERROR: missing WAL-G backup name sentinel" >&2
+  exit 1
+fi
 
 # 2. fetch base backup
 export DATASAFED_BACKEND_BASE_PATH="${backupRepoPath}"

--- a/addons/postgresql/scripts-ut-spec/walg_restore_preflight_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_restore_preflight_spec.sh
@@ -1,0 +1,134 @@
+# shellcheck shell=sh
+
+Describe "dataprotection/wal-g-restore.sh sentinel preflight"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-walg-restore-preflight-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DATA_DIR="${tmpdir}/pgdata"
+    RESTORE_SCRIPT_DIR="${tmpdir}/restore-script"
+    VOLUME_DATA_DIR="${tmpdir}/volume"
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/repo/backup-test"
+    DP_RESTORE_TIMESTAMP="1"
+    dataprotection_dir=$(cd ../dataprotection && pwd)
+    mkdir -p "${DATA_DIR}"
+    printf '%s\n' original > "${DATA_DIR}/original.marker"
+    export PATH CALL_LOG DATA_DIR RESTORE_SCRIPT_DIR VOLUME_DATA_DIR \
+      DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH DP_RESTORE_TIMESTAMP
+    unset DATASAFED_LIST_EXIT DATASAFED_PULL_EXIT DATASAFED_SKIP_WRITE \
+      MISSING_BACKUP_NAME SENTINELS_PRESENT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+case "$1" in
+  list)
+    if [ "${DATASAFED_LIST_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_LIST_EXIT}"
+    fi
+    if [ "${SENTINELS_PRESENT:-0}" -eq 1 ]; then
+      if [ "${MISSING_BACKUP_NAME:-0}" -ne 1 ] || [ "$2" != "wal-g-backup-name" ]; then
+        printf '%s\n' "$2"
+      fi
+    fi
+    ;;
+  pull)
+    if [ "${DATASAFED_PULL_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_PULL_EXIT}"
+    fi
+    if [ "${DATASAFED_SKIP_WRITE:-0}" -eq 1 ]; then
+      exit 0
+    fi
+    case "$2" in
+      wal-g-backup-repo.path) printf '%s\n' /repo/wal-g > "$3" ;;
+      wal-g-backup-name) printf '%s\n' base_00000001 > "$3" ;;
+    esac
+    ;;
+esac
+EOF
+    cat > "${bindir}/wal-g" <<'EOF'
+#!/bin/sh
+printf 'wal-g %s\n' "$*" >> "${CALL_LOG}"
+if [ "$1" = "backup-fetch" ]; then
+  mkdir -p "$2"
+  printf '%s\n' fetched > "$2/fetched.marker"
+fi
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/wal-g"
+  }
+
+  run_restore() {
+    (cd "${tmpdir}" && bash "${dataprotection_dir}/wal-g-restore.sh")
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "fails before replacing data when sentinel metadata is missing"
+    When call run_restore
+    The status should be failure
+    The error should include "missing WAL-G backup repository sentinel"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when the backup name sentinel is missing"
+    export SENTINELS_PRESENT=1 MISSING_BACKUP_NAME=1
+    When call run_restore
+    The status should be failure
+    The error should include "missing WAL-G backup name sentinel"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when sentinel lookup is unavailable"
+    export DATASAFED_LIST_EXIT=41
+    When call run_restore
+    The status should be failure
+    The error should include "failed to list WAL-G sentinel wal-g-backup-repo.path"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when sentinel download is unavailable"
+    export SENTINELS_PRESENT=1 DATASAFED_PULL_EXIT=42
+    When call run_restore
+    The status should be failure
+    The error should include "failed to pull WAL-G sentinel wal-g-backup-repo.path"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when downloaded sentinel content cannot be read"
+    export SENTINELS_PRESENT=1 DATASAFED_SKIP_WRITE=1
+    When call run_restore
+    The status should be failure
+    The error should include "failed to read WAL-G sentinel wal-g-backup-repo.path"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fetches the named base backup after both sentinels are validated"
+    export SENTINELS_PRESENT=1
+    When call run_restore
+    The status should eq 0
+    The path "${DATA_DIR}/fetched.marker" should be exist
+    The result of function call_log should include "wal-g backup-fetch ${DATA_DIR} base_00000001"
+  End
+End


### PR DESCRIPTION
## Summary

- fail WAL-G restore before mutating `DATA_DIR` when the repository-path or backup-name sentinel is missing
- propagate sentinel list, pull, and read failures with explicit diagnostics
- run `wal-g backup-fetch` only after both sentinels are validated
- preserve existing data across every preflight failure

This Draft development candidate is stacked on #3340 exact head `6dabc7e5232ff23c8b25dc4b90961cedd0c46851` (tree `b0784b799b883089074fd1114977b85a21d4b24c`). Its exact head is `1df8427dec4770cc83067a7948063e6a2eed69c4` (tree `4e83997595e5471b95626c915f33db53cec4ebe1`).

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35` requires restore preflight to validate the artifact manifest before overwriting PVC data and to fail clearly when an artifact is missing or inconsistent. `docs/addon-api/09c-restore-and-rebuild.md:24` requires partial restore state and retry safety to be evaluated before data mutation.

Before this change, missing sentinels and sentinel list, pull, or read errors were masked by local assignment, command substitution, and a successful `echo`. Restore then removed the existing `DATA_DIR` contents and invoked `wal-g backup-fetch` with empty metadata.

## Validation

- fresh RED on this rebased candidate with only prior production sentinel behavior restored: 6 examples, 5 failures; every missing/list/pull/read case returned 0, deleted the original marker, and invoked `wal-g backup-fetch`
- focused GREEN with Bash 3.2: 6 examples, 0 failures
- focused GREEN with Bash 5.3: 6 examples, 0 failures
- full PostgreSQL ShellSpec with Bash 5.3: 182 examples, 0 failures
- changed-file ShellCheck severity-error: pass
- Bash syntax and `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- `helm template`: 41 documents, 990330 bytes

Runtime, package, environment, cleanup, and formal acceptance are not claimed by this source-only candidate.
