### PR TITLE
fix(postgresql): fail incremental backup publication errors

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
@@ -50,19 +50,35 @@ function config_wal_g() {
 
 function getWalGSentinelInfo() {
   local sentinelFile=${1}
-  local out=$(datasafed list ${sentinelFile})
-  if [ "${out}" == "${sentinelFile}" ]; then
-     datasafed pull "${sentinelFile}" ${sentinelFile}
-     echo "$(cat ${sentinelFile})"
-     return
+  local out
+  local value
+  if ! out=$(datasafed list "${sentinelFile}"); then
+    echo "ERROR: failed to list parent WAL-G sentinel ${sentinelFile}" >&2
+    return 1
   fi
+  if [ "${out}" != "${sentinelFile}" ]; then
+    echo "ERROR: parent WAL-G sentinel ${sentinelFile} not found" >&2
+    return 1
+  fi
+  if ! datasafed pull "${sentinelFile}" "${sentinelFile}"; then
+    echo "ERROR: failed to pull parent WAL-G sentinel ${sentinelFile}" >&2
+    return 1
+  fi
+  if ! value=$(cat "${sentinelFile}"); then
+    echo "ERROR: failed to read parent WAL-G sentinel ${sentinelFile}" >&2
+    return 1
+  fi
+  printf '%s\n' "${value}"
 }
 
 function writeSentinelInBaseBackupPath() {
   content=${1}
   fileName=${2}
   export DATASAFED_BACKEND_BASE_PATH=${DP_BACKUP_BASE_PATH}
-  echo "${content}" | datasafed push - "${fileName}"
+  if ! echo "${content}" | datasafed push - "${fileName}"; then
+    echo "ERROR: failed to publish WAL-G sentinel ${fileName}" >&2
+    return 1
+  fi
   export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 }
 
@@ -93,12 +109,21 @@ config_wal_g "$(dirname $DP_BACKUP_BASE_PATH)/wal-g"
 
 # 2. parent backup name of the wal-g
 export DATASAFED_BACKEND_BASE_PATH=$(dirname ${DP_BACKUP_BASE_PATH})/${DP_PARENT_BACKUP_NAME}
-parentWalGBackupName=$(getWalGSentinelInfo "wal-g-backup-name")
+if ! parentWalGBackupName=$(getWalGSentinelInfo "wal-g-backup-name"); then
+  exit 1
+fi
+if [[ -z ${parentWalGBackupName} ]]; then
+  echo "ERROR: parent WAL-G backup name is empty" >&2
+  exit 1
+fi
 
 # 1. incremental backup
-set +e
 writeSentinelInBaseBackupPath "${backup_base_path}" "wal-g-backup-repo.path"
-PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=${DP_DB_PORT} wal-g backup-push ${DATA_DIR} --delta-from-name ${parentWalGBackupName} 2>&1 | tee result.txt
+if ! PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=${DP_DB_PORT} \
+  wal-g backup-push "${DATA_DIR}" --delta-from-name "${parentWalGBackupName}" 2>&1 | tee result.txt; then
+  echo "ERROR: WAL-G incremental backup-push failed" >&2
+  exit 1
+fi
 
 # 2. get backup name of the wal-g
 backupName=$(get_backup_name "${parentWalGBackupName}")
@@ -107,7 +132,6 @@ if [[ -z ${backupName} ]] || [[ ${backupName} != "base_"* ]];then
    exit 1
 fi
 
-set -e
 echo "switch wal log"
 PSQL="psql -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT} -d postgres"
 ${PSQL} -c "select pg_switch_wal();"

--- a/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
@@ -23,7 +23,8 @@ Describe "WAL-G backup connection contract"
     export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
       DP_BACKUP_NAME DP_PARENT_BACKUP_NAME DP_BACKUP_INFO_FILE \
       DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT VOLUME_DATA_DIR DATA_DIR
-    unset FAIL_SWITCH_WAL 2>/dev/null || true
+    unset DATASAFED_LIST_EXIT FAIL_BACKUP_PUSH FAIL_REPO_SENTINEL_PUSH \
+      FAIL_SWITCH_WAL 2>/dev/null || true
     write_stubs
   }
 
@@ -57,13 +58,26 @@ EOF
 printf 'wal-g PGHOST=%s PGUSER=%s PGPORT=%s args=%s\n' \
   "${PGHOST}" "${PGUSER}" "${PGPORT}" "$*" >> "${CALL_LOG}"
 printf '%s\n' 'Wrote backup with name base_000000010000000000000001'
+if [ "${FAIL_BACKUP_PUSH:-0}" -eq 1 ]; then
+  exit 42
+fi
 EOF
     cat > "${bindir}/datasafed" <<'EOF'
 #!/bin/sh
 printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
-  list) printf '%s\n' "$2" ;;
-  push) cat > /dev/null ;;
+  list)
+    if [ "${DATASAFED_LIST_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_LIST_EXIT}"
+    fi
+    printf '%s\n' "$2"
+    ;;
+  push)
+    if [ "${FAIL_REPO_SENTINEL_PUSH:-0}" -eq 1 ] && [ "$3" = "wal-g-backup-repo.path" ]; then
+      exit 43
+    fi
+    cat > /dev/null
+    ;;
   pull)
     case "$2" in
       wal-g-backup-name) printf '%s\n' 'base_parent' > "$3" ;;
@@ -98,6 +112,30 @@ EOF
     The result of function call_log should include "psql -h postgres.example.test -U postgres -p 6432 -d postgres"
     The result of function call_log should include "wal-g PGHOST=postgres.example.test PGUSER=postgres PGPORT=6432"
     The result of function call_log should not include "CLUSTER_COMPONENT_NAME"
+  End
+
+  It "fails an incremental backup before publication when the parent sentinel lookup fails"
+    export DATASAFED_LIST_EXIT=41
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function call_log should not include "wal-g PGHOST="
+  End
+
+  It "fails an incremental backup before backup-push when repository sentinel publication fails"
+    export FAIL_REPO_SENTINEL_PUSH=1
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function call_log should not include "wal-g PGHOST="
+  End
+
+  It "fails an incremental backup when backup-push returns nonzero after writing a backup name"
+    export FAIL_BACKUP_PUSH=1
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function call_log should not include "pg_switch_wal"
   End
 
   It "executes incremental backup and WAL switch against the ActionSet endpoint"


### PR DESCRIPTION
## Summary

- fail incremental backup before child publication when the parent WAL-G backup-name sentinel cannot be listed, pulled, read, or resolved
- stop immediately when publishing the child repository sentinel fails
- propagate a nonzero `wal-g backup-push` pipeline even when its output contains a success-like backup name
- preserve the failure-marker contract and prevent WAL switch/status publication after a failed backup

This Draft development candidate is stacked on #3341 exact head `1df8427dec4770cc83067a7948063e6a2eed69c4` (tree `4e83997595e5471b95626c915f33db53cec4ebe1`). Its exact head is `2bea67f65153db4f4285cbe5a81fe4efedb6ba13` (tree `da52f2cc1fda2239361c12a2b9b519fc386e2a7a`).

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:33,35` requires payload-level backup validation plus a restore-consumable artifact manifest. `docs/addon-api/09a-backup-basic.md:83,111` requires dataprotection failure/status conventions and explicit failure exit semantics. A successful result cannot be published when the parent manifest lookup, child repository sentinel, or backup payload command failed.

## Validation

- fresh RED on this rebased candidate with only prior production failure handling restored: 7 examples, 3 failures; every injected error returned 0 and omitted `${DP_BACKUP_INFO_FILE}.exit`; parent lookup and repository-sentinel errors still ran backup-push, while failed backup-push advanced to WAL switch and metadata publication
- focused GREEN with Bash 3.2: 7 examples, 0 failures
- focused GREEN with Bash 5.3: 7 examples, 0 failures
- full PostgreSQL ShellSpec with Bash 5.3: 185 examples, 0 failures
- changed-file ShellCheck severity-error: pass
- Bash syntax and `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- `helm template`: 41 documents, 991300 bytes

Runtime, package, environment, cleanup, and formal acceptance are not claimed by this source-only candidate.
