### PR TITLE
fix(postgresql): retry WAL-G timeline history uploads

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -113,12 +113,18 @@ function save_backup_status() {
 # Upload historical .history files that are marked as .done but not yet uploaded to remote
 # These are timeline history files (e.g., 00000002.history) that are critical for PITR recovery
 function uploadDoneHistoryWALs() {
+  local upload_failed=false
   DP_log "Checking for historical .history files with .done status to upload..."
 
   # Find all .done status files for .history files in archive_status directory
   for done_file in $(find "${LOG_DIR}/archive_status/" -name "*.history.done" -type f | sort); do
     history_name=$(basename "$done_file" .done)
     history_path="${LOG_DIR}/${history_name}"
+    uploaded_marker="${done_file}.walg-uploaded"
+
+    if [ -f "${uploaded_marker}" ]; then
+      continue
+    fi
 
     # Check if the actual .history file still exists
     if [ -f "$history_path" ]; then
@@ -128,14 +134,23 @@ function uploadDoneHistoryWALs() {
       envdir "${VOLUME_DATA_DIR}/wal-g/env" "${VOLUME_DATA_DIR}/wal-g/wal-g" wal-push "${history_path}"
       exit_code=$?
       if [ "$exit_code" -eq 0 ]; then
-        DP_log "Successfully uploaded file: ${history_name}"
+        if touch "${uploaded_marker}"; then
+          DP_log "Successfully uploaded file: ${history_name}"
+        else
+          DP_error_log "Uploaded ${history_name} but failed to persist its success marker"
+          upload_failed=true
+        fi
       else
         DP_error_log "Failed to upload file: ${history_name}, exit code: ${exit_code}"
+        upload_failed=true
       fi
     fi
   done
 
   DP_log "Completed uploading historical .history files"
+  if [ "${upload_failed}" == "true" ]; then
+    return 1
+  fi
 }
 
 # Upload missing ready WAL files and rename the ready file to done.
@@ -212,12 +227,12 @@ trap "echo 'Terminating...' && exit 0" TERM
 DP_log "start to archive and update wal infos"
 config_wal_g "$(dirname "${DP_BACKUP_BASE_PATH}")/wal-g"
 
-# Upload historical .history files on first run
-uploadDoneHistoryWALs
-
 while true; do
   # check if pg process is ok
   check_pg_process
+  # Retry timeline history uploads until each local file has a persisted
+  # success marker; cross-timeline PITR depends on these files.
+  uploadDoneHistoryWALs || DP_error_log "timeline history upload incomplete; will retry"
   # upload wal logs
   uploadMissingLogs
   # save backup status which will be updated to `backup` CR by the sidecar

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -103,6 +103,48 @@ EOF
     cat "${CALL_LOG}"
   }
 
+  wal_g_call_count() {
+    awk '/^wal-g / { calls++ } END { print calls + 0 }' "${CALL_LOG}"
+  }
+
+  history_upload_calls_inside_loop() {
+    awk '
+      /^while true; do$/ { in_loop = 1; next }
+      in_loop && /^done$/ { in_loop = 0 }
+      in_loop && /uploadDoneHistoryWALs/ { calls++ }
+      END { print calls + 0 }
+    ' ../dataprotection/wal-g-archive.sh
+  }
+
+  Describe "uploadDoneHistoryWALs()"
+    It "reports failure and retains timeline history for retry when wal-push fails"
+      touch "${LOG_DIR}/00000002.history"
+      touch "${LOG_DIR}/archive_status/00000002.history.done"
+      export WALG_EXIT=41
+      When call uploadDoneHistoryWALs
+      The status should be failure
+      The output should include "Failed to upload file: 00000002.history"
+      The path "${LOG_DIR}/00000002.history" should be exist
+      The path "${LOG_DIR}/archive_status/00000002.history.done" should be exist
+      The path "${LOG_DIR}/archive_status/00000002.history.done.walg-uploaded" should not be exist
+    End
+
+    It "persists success and does not upload the same timeline history twice"
+      touch "${LOG_DIR}/00000002.history"
+      touch "${LOG_DIR}/archive_status/00000002.history.done"
+      uploadDoneHistoryWALs
+      When call uploadDoneHistoryWALs
+      The status should eq 0
+      The path "${LOG_DIR}/archive_status/00000002.history.done.walg-uploaded" should be exist
+      The result of function wal_g_call_count should eq 1
+    End
+
+    It "is invoked from every archive loop iteration"
+      When call history_upload_calls_inside_loop
+      The output should eq 1
+    End
+  End
+
   Describe "uploadMissingLogs()"
     It "keeps the .ready file and the tracking file when wal-push fails"
       touch "${LOG_DIR}/000000010000000000000001"


### PR DESCRIPTION
## Summary

- report a failed WAL-G upload of a completed PostgreSQL timeline history file as incomplete
- retry unarchived `.history.done` files on every archive cycle
- persist a per-file success marker so completed history files are not pushed repeatedly
- retain local history/status files on failure for a later retry

This Draft development candidate is stacked on #3342 exact head `2bea67f65153db4f4285cbe5a81fe4efedb6ba13` (tree `da52f2cc1fda2239361c12a2b9b519fc386e2a7a`). Its exact head is `44ee6c840f67c6b22f18ec1799c2a3c3a9900ea9` (tree `e2f9f3f17c6376acdbd6e7fc96abb801c4ed3ceb`).

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:33,35,43` requires payload-level validation, complete restore-consumable artifacts, and explainable continuous/PITR archive output. Timeline history files are required for cross-timeline restore; a transient upload failure cannot silently become a process-lifetime gap.

## Validation

- fresh RED on this rebased candidate with only prior one-shot history behavior restored: 9 examples, 3 failures; failed upload returned 0, successful history had no persisted marker and uploaded twice, and static control-flow evidence found no history-upload call inside the archive loop
- focused GREEN with Bash 3.2: 9 examples, 0 failures
- focused GREEN with Bash 5.3: 9 examples, 0 failures
- full PostgreSQL ShellSpec with Bash 5.3: 188 examples, 0 failures
- changed-file ShellCheck severity-error: pass
- Bash syntax and `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- `helm template`: 41 documents, 991995 bytes

Runtime, package, environment, cleanup, and formal acceptance are not claimed by this source-only candidate.
