### PR TITLE
fix(postgresql): use DP credentials for pgdump restore

### DIFF
--- a/addons/postgresql/dataprotection/pgdump-restore.sh
+++ b/addons/postgresql/dataprotection/pgdump-restore.sh
@@ -3,9 +3,9 @@ set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
-export PGPASSWORD=${POSTGRES_PASSWORD}
+export PGPASSWORD=${DP_DB_PASSWORD}
 BACKUP_DIR=$BACKUP_DIR/${DP_BACKUP_NAME}
-psql_cmd="psql -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT}"
+psql_cmd="psql -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT}"
 mkdir -p $BACKUP_DIR
 trap "[ -d $BACKUP_DIR ] && rm -rf $BACKUP_DIR" EXIT
 
@@ -88,7 +88,7 @@ echo "parameters: $params"
 # so /tmp/pg_restore.log is guaranteed complete before it is grepped below.
 exec 3>&1
 set +e
-pg_restore -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT} ${params} $BACKUP_DIR 2>&1 1>&3 | tee /tmp/pg_restore.log >&2
+pg_restore -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT} ${params} $BACKUP_DIR 2>&1 1>&3 | tee /tmp/pg_restore.log >&2
 exit_code=${PIPESTATUS[0]}
 set -e
 exec 3>&-

--- a/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
@@ -17,13 +17,13 @@ Describe "dataprotection/pgdump-restore.sh"
     DP_DATASAFED_BIN_PATH="${bindir}"
     DP_BACKUP_BASE_PATH="/backup"
     DP_BACKUP_NAME="backup-test"
-    POSTGRES_PASSWORD="secret"
-    POSTGRES_USER="postgres"
+    DP_DB_PASSWORD="dp-secret"
+    DP_DB_USER="kbdataprotection"
     DP_DB_HOST="localhost"
     DP_DB_PORT="5432"
     BACKUP_DIR="${tmpdir}/restore-workdir"
     export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
-      DP_BACKUP_NAME POSTGRES_PASSWORD POSTGRES_USER DP_DB_HOST DP_DB_PORT BACKUP_DIR
+      DP_BACKUP_NAME DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT BACKUP_DIR
     unset DATASAFED_LIST_OUT DATASAFED_PULL_EXIT PG_RESTORE_EXIT PG_RESTORE_STDERR \
       jobs database schemas tables schema_only conflict_policy 2>/dev/null || true
     write_stubs
@@ -59,12 +59,12 @@ cat > /dev/null
 EOF
     cat > "${bindir}/psql" <<'EOF'
 #!/bin/sh
-printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+printf 'psql PGPASSWORD=%s args=%s\n' "${PGPASSWORD}" "$*" >> "${CALL_LOG}"
 exit 0
 EOF
     cat > "${bindir}/pg_restore" <<'EOF'
 #!/bin/sh
-printf 'pg_restore %s\n' "$*" >> "${CALL_LOG}"
+printf 'pg_restore PGPASSWORD=%s args=%s\n' "${PGPASSWORD}" "$*" >> "${CALL_LOG}"
 if [ -n "${PG_RESTORE_STDERR:-}" ]; then
   printf '%s\n' "${PG_RESTORE_STDERR}" >&2
 fi
@@ -83,6 +83,15 @@ EOF
     The status should be failure
     The error should include "backup-test.tar not found"
     The result of function call_log should not include "pg_restore"
+  End
+
+  It "uses the DataProtection user and password for psql and pg_restore"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export database="application"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The result of function call_log should include "psql PGPASSWORD=dp-secret args=-h localhost -U kbdataprotection -p 5432"
+    The result of function call_log should include "pg_restore PGPASSWORD=dp-secret args=-h localhost -U kbdataprotection -p 5432"
   End
 
   It "restores successfully when the backup exists and pg_restore succeeds"


### PR DESCRIPTION
## Summary

- use the DataProtection-injected `DP_DB_USER` and `DP_DB_PASSWORD` in selective pgdump restore
- align both the pre-restore `psql` calls and `pg_restore` with the same credential tuple used by pgdump backup and pgdumpall restore
- test the final process environment seen by both database clients

This Draft development candidate is stacked on candidate #3343 exact base `44ee6c840f67c6b22f18ec1799c2a3c3a9900ea9`. Its exact head is `8c4368d9eedbf96ee91fe3d313f9a1035bcce719` and tree is `4c98fec7e5d4175092d09f7f6c1353b71a17862b`.

## Contract

- `kubeblocks-addon-docs/docs/addon-api/07-accounts-and-tls.md:80,86` requires Backup/Restore jobs to receive the correct account and treats each restore job as its own credential execution surface.
- `kubeblocks-addon-docs/docs/addon-api/09a-backup-basic.md:92,115` requires ActionSet restore inputs and the final merged restore env to be validated.
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires backup/restore env behavior to be checked at the final workload and explicitly observable in tests.

## TDD evidence

RED against the previous implementation: 7 examples / 1 failure / 2 failed assertions. With only `DP_DB_USER` and `DP_DB_PASSWORD` provided, both `psql` and `pg_restore` received an empty `PGPASSWORD` and empty `-U` argument.

GREEN:

- focused pgdump restore contract on Bash 3.2: 7 examples / 0 failures
- focused pgdump restore contract on Bash 5.3: 7 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 189 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 992220 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned.
