### PR TITLE
fix(postgresql): honor backup database port

### DIFF
--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 function get_current_time() {
   curr_time=$(psql -U "${DP_DB_USER}" -h "${DP_DB_HOST}" -p "${DP_DB_PORT}" -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
   echo $curr_time

--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -1,5 +1,5 @@
 function get_current_time() {
-  curr_time=$(psql -U ${DP_DB_USER} -h ${DP_DB_HOST} -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
+  curr_time=$(psql -U "${DP_DB_USER}" -h "${DP_DB_HOST}" -p "${DP_DB_PORT}" -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
   echo $curr_time
 }
 

--- a/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+
+Describe "dataprotection/backup-info-collector.sh"
+  setup() {
+    tmpdir=$(mktemp -d -t pg-backup-info-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DP_DB_USER="kbdataprotection"
+    DP_DB_HOST="postgres.example.test"
+    DP_DB_PORT="6432"
+    export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT
+    write_stubs
+    . ../dataprotection/backup-info-collector.sh
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/psql" <<'EOF'
+#!/bin/sh
+printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+printf '%s\n' '2026-08-15 15:00:00'
+EOF
+    chmod +x "${bindir}/psql"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "queries time through the ActionSet-injected database port"
+    When call get_current_time
+    The status should eq 0
+    The output should eq "2026-08-15 15:00:00"
+    The result of function call_log should include "psql -U kbdataprotection -h postgres.example.test -p 6432 -d postgres"
+  End
+End


### PR DESCRIPTION
## Summary

- pass the DataProtection-injected `DP_DB_PORT` to the shared backup metadata time query
- keep pgdump, pgdumpall, and pg-basebackup metadata collection on the same endpoint as their backup commands
- add a focused client-argument contract test for a non-default PostgreSQL port

This Draft development candidate is stacked on candidate #3344 exact base `8c4368d9eedbf96ee91fe3d313f9a1035bcce719`. Its exact head is `6e9c1fbb9cec5cf2c632082ec66f93ddb70b0d24` and tree is `6e0e77430427216fb591ec17dc700b82dadaeca1`.

## Contract

- `kubeblocks-addon-docs/docs/addon-api/09a-backup-basic.md:92,115` requires ActionSet inputs and the final merged backup/restore env to be validated.
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires backup action env behavior to be checked at the final workload. All three backup commands consumed `DP_DB_PORT`, but the shared `get_current_time()` metadata query silently used libpq's default port instead.

## TDD evidence

RED against the previous implementation: 1 example / 1 failure / 1 failed assertion. With `DP_DB_PORT=6432`, the collector called `psql` without `-p 6432`.

GREEN:

- focused backup-info collector contract on Bash 3.2: 1 example / 0 failures
- focused backup-info collector contract on Bash 5.3: 1 example / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 190 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 992412 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned.
