### PR TITLE
fix(postgresql): validate backup size metadata

### DIFF
--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -2,20 +2,24 @@
 
 function get_current_time() {
   curr_time=$(psql -U "${DP_DB_USER}" -h "${DP_DB_HOST}" -p "${DP_DB_PORT}" -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
-  echo $curr_time
+  printf '%s\n' "${curr_time}"
 }
 
 function stat_and_save_backup_info() {
   export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
   export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
-  START_TIME=$1
-  STOP_TIME=$2
-  if [ -z $STOP_TIME ]; then
+  START_TIME="$1"
+  STOP_TIME="${2:-}"
+  if [[ -z "${STOP_TIME}" ]]; then
     STOP_TIME=$(get_current_time)
   fi
   START_TIME=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
   STOP_TIME=$(date -d "${STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
   TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+  if [[ ! "${TOTAL_SIZE}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: datasafed stat returned an invalid TotalSize" >&2
+    return 1
+  fi
   echo "{\"totalSize\":\"$TOTAL_SIZE\",\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
 }
 

--- a/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
@@ -11,7 +11,12 @@ Describe "dataprotection/backup-info-collector.sh"
     DP_DB_USER="kbdataprotection"
     DP_DB_HOST="postgres.example.test"
     DP_DB_PORT="6432"
-    export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/repository/backup-test"
+    DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
+    export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT \
+      DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH DP_BACKUP_INFO_FILE
+    unset DATASAFED_STAT_OUT 2>/dev/null || true
     write_stubs
     . ../dataprotection/backup-info-collector.sh
   }
@@ -29,7 +34,22 @@ Describe "dataprotection/backup-info-collector.sh"
 printf 'psql %s\n' "$*" >> "${CALL_LOG}"
 printf '%s\n' '2026-08-15 15:00:00'
 EOF
-    chmod +x "${bindir}/psql"
+    cat > "${bindir}/date" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *15:00:00*) printf '%s\n' '2026-08-15T15:00:00Z' ;;
+  *15:01:00*) printf '%s\n' '2026-08-15T15:01:00Z' ;;
+  *) exit 2 ;;
+esac
+EOF
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+if [ "$1" = "stat" ]; then
+  printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 4096}"
+fi
+EOF
+    chmod +x "${bindir}/psql" "${bindir}/date" "${bindir}/datasafed"
   }
 
   call_log() {
@@ -41,5 +61,22 @@ EOF
     The status should eq 0
     The output should eq "2026-08-15 15:00:00"
     The result of function call_log should include "psql -U kbdataprotection -h postgres.example.test -p 6432 -d postgres"
+  End
+
+  It "writes the byte count from the real datasafed TotalSize format"
+    # apecloud/datasafed cmd/stat.go emits: TotalSize: <integer>
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    When call stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    The status should eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"totalSize":"4096"'
+    The result of function call_log should include "datasafed stat /"
+  End
+
+  It "rejects a successful datasafed response without a numeric byte count"
+    export DATASAFED_STAT_OUT="TotalSize:"
+    When call stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    The status should be failure
+    The error should include "datasafed stat returned an invalid TotalSize"
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
   End
 End


### PR DESCRIPTION
## Summary

- reject successful `datasafed stat` responses that do not contain a nonnegative integer `TotalSize`
- avoid publishing backup-info JSON with an empty or non-numeric size
- quote backup time inputs and preserve the current empty-backup contract (`TotalSize: 0` remains valid)
- test the real `datasafed` output shape documented from `cmd/stat.go`

This Draft development candidate is stacked on candidate #3345 exact base `6e9c1fbb9cec5cf2c632082ec66f93ddb70b0d24`. Its exact head is `548e737cd0b0bd2aeba92fa21622e6e662394f22` and tree is `eac9a4d22fcf5f990cd5263a13001dcf2a762cc8`.

## Contract

- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires backup status size/progress evidence when `syncProgress.enabled=true`.
- `kubeblocks-addon-docs/docs/test/addon-external-tool-output-fixture-fidelity-guide.md:30-34,40-42` requires fixtures to match a real output source and parsers to reject empty/default results that can otherwise look successful.

## TDD evidence

RED against the previous implementation: 3 examples / 1 failure / 3 failed assertions. A successful `datasafed stat` response containing only `TotalSize:` returned 0, wrote an empty `totalSize`, and the unquoted stop timestamp emitted a shell diagnostic instead of the required validation error.

GREEN:

- focused backup-info collector contract on Bash 3.2: 3 examples / 0 failures
- focused backup-info collector contract on Bash 5.3: 3 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 192 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 992985 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned.
