### PR TITLE
fix(postgresql): publish backup info atomically

### DIFF
--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -20,7 +20,16 @@ function stat_and_save_backup_info() {
     echo "ERROR: datasafed stat returned an invalid TotalSize" >&2
     return 1
   fi
-  echo "{\"totalSize\":\"$TOTAL_SIZE\",\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
+  local backup_info_tmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
+  if ! printf '{"totalSize":"%s","timeRange":{"start":"%s","end":"%s"}}\n' \
+      "${TOTAL_SIZE}" "${START_TIME}" "${STOP_TIME}" >"${backup_info_tmp}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+  if ! mv -f "${backup_info_tmp}" "${DP_BACKUP_INFO_FILE}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
 }
 
 # if the script exits with a non-zero exit code, touch a file to indicate that the backup failed,

--- a/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
@@ -16,7 +16,7 @@ Describe "dataprotection/backup-info-collector.sh"
     DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
     export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT \
       DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH DP_BACKUP_INFO_FILE
-    unset DATASAFED_STAT_OUT 2>/dev/null || true
+    unset DATASAFED_STAT_OUT MV_EXIT 2>/dev/null || true
     write_stubs
     . ../dataprotection/backup-info-collector.sh
   }
@@ -49,11 +49,45 @@ if [ "$1" = "stat" ]; then
   printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 4096}"
 fi
 EOF
-    chmod +x "${bindir}/psql" "${bindir}/date" "${bindir}/datasafed"
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${bindir}/psql" "${bindir}/date" "${bindir}/datasafed" "${bindir}/mv"
   }
 
   call_log() {
     cat "${CALL_LOG}"
+  }
+
+  publish_with_existence_observer() {
+    echo() {
+      case "$1" in
+        '{"totalSize"'*) /bin/sleep 0.2 ;;
+      esac
+      builtin echo "$@"
+    }
+
+    (
+      while [[ ! -e "${DP_BACKUP_INFO_FILE}" ]]; do
+        /bin/sleep 0.01
+      done
+      /usr/bin/wc -c < "${DP_BACKUP_INFO_FILE}" > "${tmpdir}/observed-bytes"
+    ) &
+    observer_pid=$!
+    stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    wait "${observer_pid}"
+  }
+
+  observed_bytes() {
+    tr -d '[:space:]' < "${tmpdir}/observed-bytes"
+  }
+
+  backup_info_temp_count() {
+    find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
   }
 
   It "queries time through the ActionSet-injected database port"
@@ -78,5 +112,22 @@ EOF
     The status should be failure
     The error should include "datasafed stat returned an invalid TotalSize"
     The path "${DP_BACKUP_INFO_FILE}" should not be exist
+  End
+
+  It "publishes a complete backup-info document before it becomes visible"
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    When call publish_with_existence_observer
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"totalSize":"4096"'
+  End
+
+  It "fails without leaving metadata when atomic publication fails"
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export MV_EXIT=7
+    When call stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The result of function backup_info_temp_count should eq 0
   End
 End


### PR DESCRIPTION
## Summary

- write the complete backup-info JSON to a sibling temporary file
- atomically rename the temporary file into `DP_BACKUP_INFO_FILE`
- fail cleanly without leaving partial or temporary metadata when publication fails
- cover the sync-progress observer race with deterministic source-level tests

This Draft development candidate is stacked on candidate #3346 exact base `548e737cd0b0bd2aeba92fa21622e6e662394f22`. Its exact head is `b8e7e83ee53f803528407ae747ed91e17701b927` and tree is `ccdd3016ae4626dcf0a5addfb5c518a99a5fdd09`.

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires backup status size/progress evidence when `syncProgress.enabled=true`. The sync-progress observer can read the configured metadata path as soon as it exists, so this implementation prevents it from consuming a truncated document. Atomic rename is the scoped implementation choice, not an additional addon API requirement.

## TDD evidence

RED against the previous implementation: 5 examples / 2 failures / 3 failed assertions. The deterministic existence observer saw a 0-byte final file, and an injected publication failure still returned success while leaving final metadata behind.

GREEN:

- focused backup-info collector contract on Bash 3.2: 5 examples / 0 failures
- focused backup-info collector contract on Bash 5.3: 5 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 194 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 993924 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned.
