### PR TITLE
fix(postgresql): publish WAL-G metadata atomically

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -75,6 +75,23 @@ function writeSentinelInBaseBackupPath() {
   export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 }
 
+function publish_backup_info() {
+  local backup_name="$1"
+  local total_size="$2"
+  local start_time="$3"
+  local stop_time="$4"
+  local backup_info_tmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
+  if ! printf '{"totalSize":"%s","extras":[{"wal-g-backup-name":"%s"}],"timeRange":{"start":"%s","end":"%s"}}\n' \
+      "${total_size}" "${backup_name}" "${start_time}" "${stop_time}" > "${backup_info_tmp}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+  if ! mv -f "${backup_info_tmp}" "${DP_BACKUP_INFO_FILE}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+}
+
 trap handle_exit EXIT
 set -e
 
@@ -115,4 +132,4 @@ START_TIME=$(echo $result_json | jq -r ".StartTime")
 TOTAL_SIZE=$(echo $result_json | jq -r ".CompressedSize")
 
 # 5. update backup status
-echo "{\"totalSize\":\"$TOTAL_SIZE\",\"extras\":[{\"wal-g-backup-name\":\"${backupName}\"}],\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
+publish_backup_info "${backupName}" "${TOTAL_SIZE}" "${START_TIME}" "${STOP_TIME}"

--- a/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
@@ -82,6 +82,23 @@ function writeSentinelInBaseBackupPath() {
   export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 }
 
+function publish_backup_info() {
+  local backup_name="$1"
+  local total_size="$2"
+  local start_time="$3"
+  local stop_time="$4"
+  local backup_info_tmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
+  if ! printf '{"totalSize":"%s","extras":[{"wal-g-backup-name":"%s"}],"timeRange":{"start":"%s","end":"%s"}}\n' \
+      "${total_size}" "${backup_name}" "${start_time}" "${stop_time}" > "${backup_info_tmp}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+  if ! mv -f "${backup_info_tmp}" "${DP_BACKUP_INFO_FILE}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+}
+
 function get_backup_name() {
   local parent_wal_g_backup_name=${1}
   line=$(cat result.txt | tail -n 1)
@@ -155,4 +172,4 @@ if [[ "${backupName}" == "${parentWalGBackupName}" ]]; then
 fi
 
 # 5. update backup status
-echo "{\"totalSize\":\"$TOTAL_SIZE\",\"extras\":[{\"wal-g-backup-name\":\"${backupName}\"}],\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
+publish_backup_info "${backupName}" "${TOTAL_SIZE}" "${START_TIME}" "${STOP_TIME}"

--- a/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
@@ -24,7 +24,7 @@ Describe "WAL-G backup connection contract"
       DP_BACKUP_NAME DP_PARENT_BACKUP_NAME DP_BACKUP_INFO_FILE \
       DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT VOLUME_DATA_DIR DATA_DIR
     unset DATASAFED_LIST_EXIT FAIL_BACKUP_PUSH FAIL_REPO_SENTINEL_PUSH \
-      FAIL_SWITCH_WAL 2>/dev/null || true
+      FAIL_SWITCH_WAL MV_EXIT 2>/dev/null || true
     write_stubs
   }
 
@@ -94,8 +94,15 @@ case "$*" in
   *CompressedSize*) printf '%s\n' '42' ;;
 esac
 EOF
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
     chmod +x "${bindir}/cp" "${bindir}/psql" "${bindir}/wal-g" \
-      "${bindir}/datasafed" "${bindir}/jq"
+      "${bindir}/datasafed" "${bindir}/jq" "${bindir}/mv"
   }
 
   call_log() {
@@ -104,6 +111,42 @@ EOF
 
   run_backup() {
     (cd "${tmpdir}" && bash "${dataprotection_dir}/$1")
+  }
+
+  run_backup_with_existence_observer() {
+    local script="$1"
+    (
+      cd "${tmpdir}" || exit 1
+      echo() {
+        case "$1" in
+          '{"totalSize"'*) /bin/sleep 0.2 ;;
+        esac
+        builtin echo "$@"
+      }
+      (
+        for _ in {1..200}; do
+          if [[ -e "${DP_BACKUP_INFO_FILE}" ]]; then
+            /usr/bin/wc -c < "${DP_BACKUP_INFO_FILE}" > "${tmpdir}/observed-bytes"
+            exit 0
+          fi
+          /bin/sleep 0.01
+        done
+        printf '0\n' > "${tmpdir}/observed-bytes"
+        exit 1
+      ) &
+      observer_pid=$!
+      # shellcheck disable=SC1090
+      . "${dataprotection_dir}/${script}"
+      wait "${observer_pid}"
+    )
+  }
+
+  observed_bytes() {
+    tr -d '[:space:]' < "${tmpdir}/observed-bytes"
+  }
+
+  backup_info_temp_count() {
+    find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
   }
 
   It "executes full backup and WAL switch against the ActionSet endpoint"
@@ -160,5 +203,37 @@ EOF
     The status should be failure
     The output should include "failed with exit code 2"
     The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+  End
+
+  It "publishes complete full-backup metadata before the final path is visible"
+    When call run_backup_with_existence_observer "wal-g-backup.sh"
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"wal-g-backup-name":"base_000000010000000000000001"'
+  End
+
+  It "publishes complete incremental metadata before the final path is visible"
+    When call run_backup_with_existence_observer "wal-g-incremental-backup.sh"
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"wal-g-backup-name":"base_000000010000000000000001"'
+  End
+
+  It "fails full metadata publication without leaving final or temporary metadata"
+    export MV_EXIT=7
+    When call run_backup "wal-g-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function backup_info_temp_count should eq 0
+  End
+
+  It "fails incremental metadata publication without leaving final or temporary metadata"
+    export MV_EXIT=7
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function backup_info_temp_count should eq 0
   End
 End


### PR DESCRIPTION
## Summary

- write WAL-G full and incremental backup metadata to sibling temporary files
- atomically rename complete JSON into `DP_BACKUP_INFO_FILE`
- propagate publication failures and remove temporary metadata
- deterministically cover both observer races and both rename-failure paths

This Draft development candidate is stacked on candidate #3347 exact base `b8e7e83ee53f803528407ae747ed91e17701b927`. Its exact head is `e2bde8efda420ee0d6d94308230ddd3920323158` and tree is `32c1bd576aa668c3a6aa4eec02c2d5c175b3f6bc`.

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires observable backup size/progress evidence when `syncProgress.enabled=true`. The sync-progress observer can read the configured final path as soon as it exists, so WAL-G producers must not expose a truncated document while writing it. Atomic rename is the scoped implementation choice, not an additional addon API requirement.

## TDD evidence

RED against the previous implementation: 11 examples / 4 failures / 8 failed assertions. Both full and incremental observers read the visible final path at 0 bytes; injected rename failures were bypassed because each script wrote the final path directly and returned success.

GREEN:

- focused WAL-G backup contract on Bash 3.2: 11 examples / 0 failures
- focused WAL-G backup contract on Bash 5.3: 11 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 198 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 995182 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned.
