### PR TITLE
fix(postgresql): publish continuous metadata atomically

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -29,15 +29,27 @@ function DP_save_backup_status_info() {
     local timeZone=$4
     local extras=$5
     local timeZoneStr=""
+    local backupInfo
+    local backupInfoTmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
     if [ ! -z ${timeZone} ]; then
        timeZoneStr=",\"timeZone\":\"${timeZone}\""
     fi
     if [ -z "${stopTime}" ];then
-      echo "{\"totalSize\":\"${totalSize}\"}" > ${DP_BACKUP_INFO_FILE}
+      printf -v backupInfo '{"totalSize":"%s"}' "${totalSize}"
     elif [ -z "${startTime}" ];then
-      echo "{\"totalSize\":\"${totalSize}\",\"extras\":[${extras}],\"timeRange\":{\"end\":\"${stopTime}\"${timeZoneStr}}}" > ${DP_BACKUP_INFO_FILE}
+      printf -v backupInfo '{"totalSize":"%s","extras":[%s],"timeRange":{"end":"%s"%s}}' \
+        "${totalSize}" "${extras}" "${stopTime}" "${timeZoneStr}"
     else
-      echo "{\"totalSize\":\"${totalSize}\",\"extras\":[${extras}],\"timeRange\":{\"start\":\"${startTime}\",\"end\":\"${stopTime}\"${timeZoneStr}}}" > ${DP_BACKUP_INFO_FILE}
+      printf -v backupInfo '{"totalSize":"%s","extras":[%s],"timeRange":{"start":"%s","end":"%s"%s}}' \
+        "${totalSize}" "${extras}" "${startTime}" "${stopTime}" "${timeZoneStr}"
+    fi
+    if ! printf '%s\n' "${backupInfo}" > "${backupInfoTmp}"; then
+      rm -f "${backupInfoTmp}"
+      return 1
+    fi
+    if ! mv -f "${backupInfoTmp}" "${DP_BACKUP_INFO_FILE}"; then
+      rm -f "${backupInfoTmp}"
+      return 1
     fi
 }
 
@@ -116,4 +128,3 @@ function getTimeZoneOffset() {
    fi
    echo "${symbol}${offset}:00"
 }
-

--- a/addons/postgresql/scripts-ut-spec/common_scripts_backup_info_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/common_scripts_backup_info_spec.sh
@@ -1,0 +1,97 @@
+# shellcheck shell=bash
+
+Describe "dataprotection/common-scripts.sh backup-info publication"
+  Include ../dataprotection/common-scripts.sh
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-common-backup-info-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
+    export PATH DP_BACKUP_INFO_FILE
+    unset MV_EXIT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${bindir}/mv"
+  }
+
+  publish_with_existence_observer() {
+    (
+      echo() {
+        case "$1" in
+          '{"totalSize"'*) /bin/sleep 0.2 ;;
+        esac
+        builtin echo "$@"
+      }
+      (
+        for _ in {1..200}; do
+          if [[ -e "${DP_BACKUP_INFO_FILE}" ]]; then
+            /usr/bin/wc -c < "${DP_BACKUP_INFO_FILE}" > "${tmpdir}/observed-bytes"
+            exit 0
+          fi
+          /bin/sleep 0.01
+        done
+        printf '0\n' > "${tmpdir}/observed-bytes"
+        exit 1
+      ) &
+      observer_pid=$!
+      DP_save_backup_status_info "4096" "2026-08-15T17:00:00Z" \
+        "2026-08-15T17:01:00Z"
+      wait "${observer_pid}"
+    )
+  }
+
+  observed_bytes() {
+    tr -d '[:space:]' < "${tmpdir}/observed-bytes"
+  }
+
+  backup_info_temp_count() {
+    find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
+  }
+
+  It "publishes a complete document before the final path is visible"
+    When call publish_with_existence_observer
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[],"timeRange":{"start":"2026-08-15T17:00:00Z","end":"2026-08-15T17:01:00Z"}}'
+  End
+
+  It "preserves the size-only document shape"
+    When call DP_save_backup_status_info "0"
+    The status should eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"0"}'
+  End
+
+  It "preserves end time, timezone, and extras without a start time"
+    When call DP_save_backup_status_info "4096" "" "2026-08-15T17:01:00Z" \
+      "+08:00" '{"source":"archive"}'
+    The status should eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[{"source":"archive"}],"timeRange":{"end":"2026-08-15T17:01:00Z","timeZone":"+08:00"}}'
+  End
+
+  It "fails without leaving metadata when atomic publication fails"
+    export MV_EXIT=7
+    When call DP_save_backup_status_info "4096" "2026-08-15T17:00:00Z" \
+      "2026-08-15T17:01:00Z"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The result of function backup_info_temp_count should eq 0
+  End
+End


### PR DESCRIPTION
## Summary

- build each legacy Continuous backup-info JSON shape before touching the filesystem
- write metadata to a sibling temporary file and atomically rename it into `DP_BACKUP_INFO_FILE`
- propagate publication failures and remove temporary metadata
- add a dedicated shared-helper contract suite covering all shapes, observer visibility, and rename failure

This Draft development candidate is stacked on candidate #3348 exact base `e2bde8efda420ee0d6d94308230ddd3920323158`. Its exact head is `cfaf948b3227d424e3b635e3368fb317e1bcfbd2` and tree is `2bf1966e46be1bb7b55544f8b909fdd01643ea1e`.

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires observable backup size/progress evidence when `syncProgress.enabled=true`. Both PostgreSQL Continuous ActionSets use `DP_save_backup_status_info`; the sync-progress sidecar must not observe a truncated final document while that shared helper is writing it. Atomic rename is the scoped implementation choice, not an additional addon API requirement.

## TDD evidence

RED against the previous implementation: 4 examples / 2 failures / 3 failed assertions. The existence observer read the visible final path at 0 bytes, and injected rename failure was bypassed because the helper wrote the final path directly and returned success. Both compatibility-only JSON-shape examples passed before the fix.

GREEN:

- focused shared backup-info helper contract on Bash 3.2: 4 examples / 0 failures
- focused shared backup-info helper contract on Bash 5.3: 4 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 202 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 996418 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned.
