### PR TITLE
fix(postgresql): validate continuous backup size

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -13,6 +13,21 @@ function DP_error_log() {
     echo "${curr_date} ERROR: $msg"
 }
 
+function DP_get_backup_total_size() {
+    local statOutput
+    local totalSize
+    if ! statOutput=$(datasafed stat /); then
+      DP_error_log "datasafed stat failed" >&2
+      return 1
+    fi
+    totalSize=$(printf '%s\n' "${statOutput}" | awk '/TotalSize/ { print $2; exit }')
+    if [[ ! ${totalSize} =~ ^[0-9]+$ ]]; then
+      DP_error_log "datasafed stat returned an invalid TotalSize" >&2
+      return 1
+    fi
+    printf '%s\n' "${totalSize}"
+}
+
 # Get file names without extensions based on the incoming file path
 function DP_get_file_name_without_ext() {
     local fileName=$1

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -31,7 +31,10 @@ function purge_expired_files() {
     if [ ! -z "${info}" ]; then
        global_last_purge_time=${currentUnix}
        DP_log "cleanup expired wal-log files: ${info}"
-       local TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+       local TOTAL_SIZE
+       if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
+         return 1
+       fi
        DP_save_backup_status_info "${TOTAL_SIZE}"
     fi
 }
@@ -111,9 +114,12 @@ function get_start_time_for_range() {
 
 # save backup status info to sync file
 function save_backup_status() {
-    local TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+    local TOTAL_SIZE
+    if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
+       return 1
+    fi
     # if no size changes, return
-    if [[ -z ${TOTAL_SIZE} || ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
+    if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
        return
     fi
     global_old_size=${TOTAL_SIZE}

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -84,9 +84,12 @@ function get_wal_log_end_time() {
 
 # save backup status info to sync file
 function save_backup_status() {
-    local TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+    local TOTAL_SIZE
+    if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
+       return 1
+    fi
     # if no size changes, return
-    if [[ -z ${TOTAL_SIZE} || ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
+    if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
        return
     fi
     GLOBAL_OLD_SIZE=${TOTAL_SIZE}

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_PUSH_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -53,7 +53,8 @@ case "$1" in
     exit "${DATASAFED_PUSH_EXIT:-0}"
     ;;
   stat)
-    echo "TotalSize 0"
+    printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
+    exit "${DATASAFED_STAT_EXIT:-0}"
     ;;
 esac
 EOF
@@ -127,6 +128,16 @@ EOF
       The status should be failure
       The output should include "retry detection!"
       The output should include "Before switching to a new instance, back up any remaining WAL logs."
+    End
+  End
+
+  Describe "save_backup_status()"
+    It "fails clearly when datasafed stat fails instead of retaining stale progress silently"
+      export DATASAFED_STAT_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed stat failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset WALG_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -71,7 +71,10 @@ EOF
 #!/bin/sh
 printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
-  stat) echo "TotalSize 0" ;;
+  stat)
+    printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
+    exit "${DATASAFED_STAT_EXIT:-0}"
+    ;;
 esac
 EOF
     # `date -r <file> +%s` is GNU-only; make it portable for local macOS runs
@@ -201,6 +204,24 @@ EOF
       When run config_wal_g "some/path"
       The status should be failure
       The output should include "wal-g binary not found"
+    End
+  End
+
+  Describe "save_backup_status()"
+    It "publishes the byte count from the real datasafed TotalSize format"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      When call save_backup_status
+      The status should eq 0
+      The output should include "total size: 4096"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
+    End
+
+    It "rejects malformed successful datasafed size output instead of retaining stale progress silently"
+      export DATASAFED_STAT_OUT="TotalSize: unknown"
+      When call save_backup_status
+      The status should be failure
+      The error should include "invalid TotalSize"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End


### PR DESCRIPTION
## Summary

- preserve `datasafed stat` failures instead of treating them as unchanged progress
- validate the real `TotalSize: <integer>` output before publishing Continuous backup metadata
- share the parser across PostgreSQL PITR and WAL-G archive producers

This Draft development candidate is stacked on candidate #3349 exact base `cfaf948b3227d424e3b635e3368fb317e1bcfbd2`. Its exact head is `aa3e952225f6801966a6a592125166c6f28165f8` and tree is `7127e7e722673132dedab86d36b7b2a80f7a92d1`.

## Contract

- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires observable backup size/progress evidence when `syncProgress.enabled=true`
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:43` requires Continuous/PITR status and recovery windows to remain interpretable
- `kubeblocks-addon-docs/docs/troubleshoot/addon-dataprotection-datasafed-stat-totalsize-parsing-trap-guide.md` records the real `TotalSize: <integer>` format

## TDD evidence

- RED: focused ShellSpec 17 examples, 2 failures
  - `datasafed stat` rc=17 returned success with no diagnostic
  - malformed `TotalSize: unknown` returned success with no diagnostic
- GREEN: focused ShellSpec 17 examples, 0 failures
  - Bash 3.2: 17 examples, 0 failures
  - Bash 5.3: 17 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3: 205 examples, 0 failures
- ShellCheck at severity error, Bash 3.2/Bash 5.3 syntax, and `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- render: 41 documents, 998252 bytes

## Boundary

This is source/unit/static/render evidence only. Runtime package, environment, execution, cleanup, and formal N remain Test-owned and unproven.

<!-- nopick: stacked Draft candidate; do not auto-pick -->
