### PR TITLE
fix(postgresql): retry continuous metadata publication

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -122,9 +122,11 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
        return
     fi
-    global_old_size=${TOTAL_SIZE}
     local START_TIME=$(get_start_time_for_range)
-    DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${global_stop_time}"
+    if ! DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${global_stop_time}"; then
+       return 1
+    fi
+    global_old_size=${TOTAL_SIZE}
 }
 
 function check_pg_process() {

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -92,7 +92,6 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
        return
     fi
-    GLOBAL_OLD_SIZE=${TOTAL_SIZE}
     local wal_files=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) |.[] |.path')
     local OLDEST_FILE=$(echo $wal_files | tr ' ' '\n' |head -n 1)
     local START_TIME=
@@ -110,7 +109,10 @@ function save_backup_status() {
       done
     fi
     DP_log "start time of the oldest wal: ${START_TIME}, end time of the latest wal: ${END_TIME}, total size: ${TOTAL_SIZE}"
-    DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${END_TIME}"
+    if ! DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${END_TIME}"; then
+       return 1
+    fi
+    GLOBAL_OLD_SIZE=${TOTAL_SIZE}
 }
 
 # Upload historical .history files that are marked as .done but not yet uploaded to remote

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -68,7 +68,15 @@ EOF
 #!/bin/sh
 exit 0
 EOF
-    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump"
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+printf 'mv %s\n' "$*" >> "${CALL_LOG}"
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump" "${bindir}/mv"
   }
 
   build_shim() {
@@ -83,6 +91,16 @@ EOF
 
   call_log() {
     cat "${CALL_LOG}"
+  }
+
+  retry_same_size_after_publication_failure() {
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export MV_EXIT=17
+    if save_backup_status; then
+      return 90
+    fi
+    export MV_EXIT=0
+    save_backup_status
   }
 
   Describe "upload_wal_log()"
@@ -138,6 +156,12 @@ EOF
       The status should be failure
       The error should include "datasafed stat failed"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "retries the same size after an atomic publication failure"
+      When call retry_same_size_after_publication_failure
+      The status should eq 0
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT WALG_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -89,7 +89,15 @@ else
   exec /bin/date "$@"
 fi
 EOF
-    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" "${bindir}/date"
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+printf 'mv %s\n' "$*" >> "${CALL_LOG}"
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" "${bindir}/date" "${bindir}/mv"
   }
 
   build_shim() {
@@ -117,6 +125,16 @@ EOF
       in_loop && /uploadDoneHistoryWALs/ { calls++ }
       END { print calls + 0 }
     ' ../dataprotection/wal-g-archive.sh
+  }
+
+  retry_same_size_after_publication_failure() {
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export MV_EXIT=17
+    if save_backup_status; then
+      return 90
+    fi
+    export MV_EXIT=0
+    save_backup_status
   }
 
   Describe "uploadDoneHistoryWALs()"
@@ -222,6 +240,13 @@ EOF
       The status should be failure
       The error should include "invalid TotalSize"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "retries the same size after an atomic publication failure"
+      When call retry_same_size_after_publication_failure
+      The status should eq 0
+      The output should include "total size: 4096"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
     End
   End
 End


### PR DESCRIPTION
## Summary

- advance each Continuous producer's cached size only after backup metadata is published successfully
- propagate atomic publication failures to the caller
- retry the same observed size after a transient publication failure
- add focused failure/retry coverage for both legacy producers

This Draft development candidate is stacked on candidate #3350 exact base `aa3e952225f6801966a6a592125166c6f28165f8`. Its exact head is `6385bc7d0181889e1ac4fbd19931c31892c2bbf1` and tree is `f055babbbf283b29f40f5f1c7acf9697e0950fc3`.

## Contract

`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires observable backup progress/size when `syncProgress.enabled=true`. A failed publication is not an observed progress checkpoint: caching that size before publication suppresses the retry and leaves the observer without metadata for the current size.

The scoped design retains the existing metadata shapes and shared publication helper. It changes only when each producer commits its in-memory checkpoint.

## TDD evidence

- RED on the rebased candidate with only the previous checkpoint ordering restored: 19 examples / 2 failures
  - PostgreSQL PITR Continuous metadata was absent after a failed rename followed by the same size
  - WAL-G Continuous metadata was absent after a failed rename followed by the same size
- GREEN focused suite:
  - Bash 3.2: 19 examples / 0 failures
  - Bash 5.3: 19 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 207 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 998342 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned and unproven by this source gate.

<!-- nopick: stacked Draft candidate; do not auto-pick -->
