### PR TITLE
fix(postgresql): fail continuous WAL listing errors

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -28,6 +28,20 @@ function DP_get_backup_total_size() {
     printf '%s\n' "${totalSize}"
 }
 
+function DP_list_backup_files_by_mtime() {
+    local listOutput
+    local sortedFiles
+    if ! listOutput=$(datasafed list -f --recursive / -o json); then
+      DP_error_log "datasafed WAL listing failed" >&2
+      return 1
+    fi
+    if ! sortedFiles=$(printf '%s\n' "${listOutput}" | jq -s -r '.[] | sort_by(.mtime) | .[] | .path'); then
+      DP_error_log "datasafed WAL listing returned invalid JSON" >&2
+      return 1
+    fi
+    printf '%s\n' "${sortedFiles}"
+}
+
 # Get file names without extensions based on the incoming file path
 function DP_get_file_name_without_ext() {
     local fileName=$1

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -105,7 +105,11 @@ function pull_wal_log() {
 
 # get the start time for backup.status.timeRange
 function get_start_time_for_range() {
-   local OLDEST_FILE=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) | .[] | .path' |head -n 1)
+   local WAL_FILES
+   if ! WAL_FILES=$(DP_list_backup_files_by_mtime); then
+     return 1
+   fi
+   local OLDEST_FILE="${WAL_FILES%%$'\n'*}"
    if [ ! -z ${OLDEST_FILE} ]; then
      START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log)
      echo ${START_TIME}
@@ -122,7 +126,10 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
        return
     fi
-    local START_TIME=$(get_start_time_for_range)
+    local START_TIME
+    if ! START_TIME=$(get_start_time_for_range); then
+       return 1
+    fi
     if ! DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${global_stop_time}"; then
        return 1
     fi

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -92,7 +92,10 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
        return
     fi
-    local wal_files=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) |.[] |.path')
+    local wal_files
+    if ! wal_files=$(DP_list_backup_files_by_mtime); then
+       return 1
+    fi
     local OLDEST_FILE=$(echo $wal_files | tr ' ' '\n' |head -n 1)
     local START_TIME=
     local END_TIME=

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,8 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PUSH_EXIT \
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -55,6 +56,10 @@ case "$1" in
   stat)
     printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
     exit "${DATASAFED_STAT_EXIT:-0}"
+    ;;
+  list)
+    printf '%s' "${DATASAFED_LIST_OUT:-}"
+    exit "${DATASAFED_LIST_EXIT:-0}"
     ;;
 esac
 EOF
@@ -162,6 +167,15 @@ EOF
       When call retry_same_size_after_publication_failure
       The status should eq 0
       The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
+    End
+
+    It "fails without publishing metadata when the WAL repository listing fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed WAL listing failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,8 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_STAT_EXIT \
+      DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -74,6 +75,10 @@ case "$1" in
   stat)
     printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
     exit "${DATASAFED_STAT_EXIT:-0}"
+    ;;
+  list)
+    printf '%s' "${DATASAFED_LIST_OUT:-}"
+    exit "${DATASAFED_LIST_EXIT:-0}"
     ;;
 esac
 EOF
@@ -247,6 +252,24 @@ EOF
       The status should eq 0
       The output should include "total size: 4096"
       The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
+    End
+
+    It "fails without publishing metadata when the WAL repository listing fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed WAL listing failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "rejects malformed WAL listing JSON before publishing metadata"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="not-json"
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed WAL listing returned invalid JSON"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End


### PR DESCRIPTION
## Summary

- fail closed when the shared `datasafed list` WAL repository query fails
- reject malformed WAL-list JSON before computing backup progress metadata
- reuse one checked, mtime-sorted listing in both PostgreSQL Continuous producers
- add focused failure coverage for listing exit and parse failures

This Draft development candidate is stacked on candidate #3351 exact base `6385bc7d0181889e1ac4fbd19931c31892c2bbf1`. Its exact head is `4fb87c93a65b297f114a25320056d3eb35a12972` and tree is `eee9678ad96264ee417f5d75a9e445b919f40c6c`.

## Contract

- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:31` requires observable backup progress/size when sync progress is enabled
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:43` requires Continuous/PITR status and recovery windows to remain interpretable

An unavailable or malformed WAL listing cannot produce interpretable time-range metadata. The scoped design adds one checked shared listing helper and preserves the existing metadata format and producer behavior after a valid listing.

## TDD evidence

- RED on the rebased candidate with previous listing handling restored: 22 examples / 3 failures
  - PostgreSQL PITR Continuous masked `datasafed list` rc=17 and still published metadata
  - WAL-G Continuous masked the same listing failure and still published metadata
  - WAL-G Continuous accepted malformed listing JSON and still published metadata
- GREEN focused suite:
  - Bash 3.2: 22 examples / 0 failures
  - Bash 5.3: 22 examples / 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 210 examples / 0 failures
- changed-file ShellCheck at severity error: pass
- Bash 3.2/Bash 5.3 syntax and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 1000221 bytes

## Ownership boundary

This candidate changes addon source and code-level tests only. Runtime packaging, environment execution, cleanup, and formal repeated acceptance remain Test-owned and unproven by this source gate.

<!-- nopick: stacked Draft candidate; do not auto-pick -->
