### PR TITLE
fix(postgresql): retry missing WAL reconciliation

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -12,6 +12,7 @@ global_last_purge_time=$(date +%s)
 global_switch_wal_interval=300
 global_stop_time=
 global_old_size=0
+global_missing_logs_reconciled=false
 
 if [[ ${SWITCH_WAL_INTERVAL_SECONDS} =~ ^[0-9]+$ ]];then
   global_switch_wal_interval=${SWITCH_WAL_INTERVAL_SECONDS}
@@ -161,7 +162,10 @@ function uploadMissingLogs() {
     DP_log "start to upload the wal log which maybe misses"
     local TODAY_INCR_LOG=$(date +%Y%m%d)
     cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
-    uploadedLogs=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) | .[] | .path')
+    local uploadedLogs
+    if ! uploadedLogs=$(DP_list_backup_files_by_mtime); then
+      return 1
+    fi
     if [[ -z ${uploadedLogs} ]]; then
       return
     fi
@@ -187,13 +191,26 @@ function uploadMissingLogs() {
 
 # trap term signal
 trap "echo 'Terminating...' && sync && exit 0" TERM
-uploadMissingLogs
+if uploadMissingLogs; then
+  global_missing_logs_reconciled=true
+else
+  DP_error_log "missing WAL reconciliation incomplete; will retry"
+fi
 
 DP_log "start to archive wal logs"
 while true; do
 
   # check if pg process is ok
   check_pg_process
+
+  # Retry startup reconciliation until one complete repository read succeeds.
+  if [[ ${global_missing_logs_reconciled} == "false" ]]; then
+    if uploadMissingLogs; then
+      global_missing_logs_reconciled=true
+    else
+      DP_error_log "missing WAL reconciliation incomplete; will retry"
+    fi
+  fi
 
   # switch wal log
   switch_wal_log

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -98,6 +98,15 @@ EOF
     cat "${CALL_LOG}"
   }
 
+  missing_wal_reconciliation_calls_inside_loop() {
+    awk '
+      /^while true; do$/ { in_loop = 1; next }
+      in_loop && /^done$/ { in_loop = 0 }
+      in_loop && /uploadMissingLogs/ { calls++ }
+      END { print calls + 0 }
+    ' ../dataprotection/postgresql-pitr-backup.sh
+  }
+
   retry_same_size_after_publication_failure() {
     export DATASAFED_STAT_OUT="TotalSize: 4096"
     export MV_EXIT=17
@@ -151,6 +160,21 @@ EOF
       The status should be failure
       The output should include "retry detection!"
       The output should include "Before switching to a new instance, back up any remaining WAL logs."
+    End
+  End
+
+  Describe "uploadMissingLogs()"
+    It "fails when the remote WAL listing is unavailable"
+      export DATASAFED_LIST_EXIT=17
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "start to upload the wal log which maybe misses"
+      The error should include "datasafed WAL listing failed"
+    End
+
+    It "keeps a retry path inside the archive loop after a startup failure"
+      When call missing_wal_reconciliation_calls_inside_loop
+      The output should eq 1
     End
   End
 


### PR DESCRIPTION
## Summary
- fail legacy missing-WAL reconciliation when the repository listing is unavailable
- retry startup reconciliation from the archive loop until one complete repository read succeeds
- keep a successful reconciliation single-shot for the process lifetime

## Exact identities
- exact parent PR: #3352
- exact parent head: `4fb87c93a65b297f114a25320056d3eb35a12972`
- candidate head: `d84fce9df2474448674798c200059c4a2e4c3f8e`
- candidate tree: `560adf15ae5a9becbaea7337cb066c733efcb4dd`
- compare: ahead 1, behind 0; merge-base equals exact parent

## TDD evidence
- RED: focused Bash 3.2 and 5.3 ShellSpec 10 examples / 2 failures each
- GREEN: focused Bash 3.2 and 5.3 ShellSpec 10/0 each
- GREEN: full PostgreSQL Bash 5.3 ShellSpec 212/0
- static: ShellCheck error severity, Bash syntax, and `git diff --check` pass
- chart: Helm lint 1/0; render 41 documents / 1,000,819 bytes
- hosted CI: 7/7 SUCCESS; hosted ShellSpec completed in 6m19s

## Contract
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35,43`

## Scope and review
- keep this PR Draft and retain `nopick`
- runtime, package/environment, cleanup, and formal acceptance evidence remain Test-owned
