### PR TITLE
fix(postgresql): retry missing WAL pushes

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -172,6 +172,7 @@ function uploadMissingLogs() {
     OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
     OLDEST_FILE=$(basename $OLDEST_FILE)
     DP_log "oldest uploaded wal: ${OLDEST_FILE}"
+    local upload_failed=false
     for i in $(find ./archive_status -type f | sort | grep .done); do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
@@ -183,9 +184,15 @@ function uploadMissingLogs() {
       fi
       if [ -f ${wal_name} ]; then
         DP_log "upload ${wal_name}"
-        datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst" || DP_error_log "failed to upload ${wal_name}"
+        if ! datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
+          DP_error_log "failed to upload ${wal_name}, will retry reconciliation"
+          upload_failed=true
+        fi
       fi
     done
+    if [[ ${upload_failed} == "true" ]]; then
+      return 1
+    fi
     save_backup_status
 }
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -117,6 +117,19 @@ EOF
     save_backup_status
   }
 
+  retry_missing_wal_push_after_failure() {
+    export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
+    touch "${LOG_DIR}/000000010000000000000001"
+    touch "${LOG_DIR}/archive_status/000000010000000000000001.done"
+    export DATASAFED_PUSH_EXIT=17
+    if uploadMissingLogs; then
+      return 90
+    fi
+    export DATASAFED_PUSH_EXIT=0
+    uploadMissingLogs || return
+    printf 'push-count=%s\n' "$(grep -c '^datasafed push ' "${CALL_LOG}")"
+  }
+
   Describe "upload_wal_log()"
     It "does not mark the WAL segment done when the upload fails"
       touch "${LOG_DIR}/000000010000000000000001"
@@ -175,6 +188,13 @@ EOF
     It "keeps a retry path inside the archive loop after a startup failure"
       When call missing_wal_reconciliation_calls_inside_loop
       The output should eq 1
+    End
+
+    It "retries a missing WAL after its first push fails"
+      When call retry_missing_wal_push_after_failure
+      The status should eq 0
+      The output should include "failed to upload 000000010000000000000001, will retry reconciliation"
+      The output should include "push-count=2"
     End
   End
 


### PR DESCRIPTION
## Summary
- propagate legacy missing-WAL push failures from reconciliation
- keep scanning the local done set while aggregating failed uploads
- retry reconciliation until every missing WAL push and metadata publication succeeds

## Exact identities
- exact parent PR: #3353
- exact parent head: `d84fce9df2474448674798c200059c4a2e4c3f8e`
- candidate head: `f3e35525b0b4875fcebb1f8e14e35b6aab719257`
- candidate tree: `9e6ab1cedbe80458213b639c2a7ffb1ea5990c29`
- compare: ahead 1, behind 0; merge-base equals exact parent

## TDD evidence
- RED: focused Bash 3.2 and 5.3 ShellSpec 11 examples / 1 failure with 3 assertions each
- GREEN: focused Bash 3.2 and 5.3 ShellSpec 11/0 each
- GREEN: full PostgreSQL Bash 5.3 ShellSpec 213/0
- static: ShellCheck error severity, Bash syntax, and `git diff --check` pass
- chart: Helm lint 1/0; render 41 documents / 1,001,058 bytes
- hosted CI: 7/7 SUCCESS; hosted ShellSpec completed in 6m32s

## Contract
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35,43`

## Scope and review
- keep this PR Draft and retain `nopick`
- runtime, package/environment, cleanup, and formal acceptance evidence remain Test-owned
