### PR TITLE
fix(postgresql): reject missing WAL sources

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -172,7 +172,7 @@ function uploadMissingLogs() {
     OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
     OLDEST_FILE=$(basename $OLDEST_FILE)
     DP_log "oldest uploaded wal: ${OLDEST_FILE}"
-    local upload_failed=false
+    local reconciliation_failed=false
     for i in $(find ./archive_status -type f | sort | grep .done); do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
@@ -186,11 +186,14 @@ function uploadMissingLogs() {
         DP_log "upload ${wal_name}"
         if ! datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
           DP_error_log "failed to upload ${wal_name}, will retry reconciliation"
-          upload_failed=true
+          reconciliation_failed=true
         fi
+      else
+        DP_error_log "cannot reconcile ${wal_name}: local WAL file is missing"
+        reconciliation_failed=true
       fi
     done
-    if [[ ${upload_failed} == "true" ]]; then
+    if [[ ${reconciliation_failed} == "true" ]]; then
       return 1
     fi
     save_backup_status

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -196,6 +196,16 @@ EOF
       The output should include "failed to upload 000000010000000000000001, will retry reconciliation"
       The output should include "push-count=2"
     End
+
+    It "fails when a remotely missing done WAL has no local source file"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.done"
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "cannot reconcile 000000010000000000000001: local WAL file is missing"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
   End
 
   Describe "save_backup_status()"


### PR DESCRIPTION
## Summary
- fail reconciliation when a remotely missing done WAL no longer has a local source file
- prevent successful Continuous metadata publication from masking the unrecoverable artifact gap
- keep the reconciliation failure explicit for operator diagnosis

## Exact identities
- exact parent PR: #3354
- exact parent head: `f3e35525b0b4875fcebb1f8e14e35b6aab719257`
- candidate head: `e9e0975193b8ad8978878fe28cbedbfcc53f6975`
- candidate tree: `00d07c4f4ec1a8aef4aa6090065c65b6209dbd60`
- compare: ahead 1, behind 0; merge-base equals exact parent

## TDD evidence
- RED: focused Bash 3.2 and 5.3 ShellSpec 12 examples / 1 failure with 3 assertions each
- GREEN: focused Bash 3.2 and 5.3 ShellSpec 12/0 each
- GREEN: full PostgreSQL Bash 5.3 ShellSpec 214/0
- static: ShellCheck error severity, Bash syntax, and `git diff --check` pass
- chart: Helm lint 1/0; render 41 documents / 1,001,231 bytes
- hosted CI: 7/7 SUCCESS; hosted ShellSpec completed in 5m55s

## Contract
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35,43`

## Scope and review
- keep this PR Draft and retain `nopick`
- runtime, package/environment, cleanup, and formal acceptance evidence remain Test-owned
