### PR TITLE
fix(postgresql): reconcile WALs into empty repos

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -166,17 +166,17 @@ function uploadMissingLogs() {
     if ! uploadedLogs=$(DP_list_backup_files_by_mtime); then
       return 1
     fi
-    if [[ -z ${uploadedLogs} ]]; then
-      return
+    local OLDEST_FILE=
+    if [[ -n ${uploadedLogs} ]]; then
+      OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
+      OLDEST_FILE=$(basename $OLDEST_FILE)
+      DP_log "oldest uploaded wal: ${OLDEST_FILE}"
     fi
-    OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
-    OLDEST_FILE=$(basename $OLDEST_FILE)
-    DP_log "oldest uploaded wal: ${OLDEST_FILE}"
     local reconciliation_failed=false
     for i in $(find ./archive_status -type f | sort | grep .done); do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
-      if [[ "$wal_name" < "$OLDEST_FILE" ]]; then
+      if [[ -n ${OLDEST_FILE} && "$wal_name" < "$OLDEST_FILE" ]]; then
         continue
       fi
       if echo "$uploadedLogs" | grep -qE "${wal_name}\.(zst|partial\.zst)";then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -130,6 +130,15 @@ EOF
     printf 'push-count=%s\n' "$(grep -c '^datasafed push ' "${CALL_LOG}")"
   }
 
+  reconcile_wal_into_empty_repository() {
+    touch "${LOG_DIR}/000000010000000000000001"
+    touch "${LOG_DIR}/archive_status/000000010000000000000001.done"
+    uploadMissingLogs || return
+    local push_count
+    push_count=$(grep -c '^datasafed push ' "${CALL_LOG}" || true)
+    printf 'push-count=%s\n' "${push_count}"
+  }
+
   Describe "upload_wal_log()"
     It "does not mark the WAL segment done when the upload fails"
       touch "${LOG_DIR}/000000010000000000000001"
@@ -205,6 +214,12 @@ EOF
       The status should be failure
       The output should include "cannot reconcile 000000010000000000000001: local WAL file is missing"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "uploads local done WALs when the repository is empty"
+      When call reconcile_wal_into_empty_repository
+      The status should eq 0
+      The output should include "push-count=1"
     End
   End
 


### PR DESCRIPTION
## Summary
- treat a valid empty repository listing as an empty remote set, not a completed reconciliation
- upload every locally done WAL when no remote oldest artifact exists
- preserve existing push-failure and missing-source failure semantics

## Candidate identity
- target: parent PR #3355
- exact parent head: `e9e0975193b8ad8978878fe28cbedbfcc53f6975`
- candidate branch: `easton/pg-pitr-empty-repo-reconcile`
- candidate head: `cee5040d9d44db5826d4cc9ee91f1f19b29a4013`
- candidate tree: `ea5dd2ded93f2ced9cede6935ae7895782603234`
- exact compare: ahead 1 / behind 0 / merge-base is the parent
- candidate remains Draft and retains `nopick`

## TDD evidence
- RED: focused Bash 3.2 ShellSpec 13 examples / 1 failure
- RED: focused Bash 5.3 ShellSpec 13 examples / 1 failure
- GREEN: focused Bash 3.2 ShellSpec 13/0
- GREEN: focused Bash 5.3 ShellSpec 13/0
- GREEN: full PostgreSQL Bash 5.3 ShellSpec 215/0
- static: ShellCheck error severity, Bash syntax, and `git diff --check` all pass
- chart: Helm lint 1/0; render 41 documents / 1001044 bytes

## Contract
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35,37,43`
