### PR TITLE
fix(postgresql): fail continuous WAL pull errors

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -127,7 +127,10 @@ function DP_analyze_start_time_from_datasafed() {
       fi
     fi
     # pull file
-    ${datasafed_pull} ${oldest_file}
+    if ! ${datasafed_pull} ${oldest_file}; then
+      DP_error_log "failed to pull oldest WAL" >&2
+      return 1
+    fi
     # record last oldest file
     echo ${oldest_file} > ${info_file}
     oldest_file_name=$(DP_get_file_name_without_ext ${oldest_file})

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -112,7 +112,10 @@ function get_start_time_for_range() {
    fi
    local OLDEST_FILE="${WAL_FILES%%$'\n'*}"
    if [ ! -z ${OLDEST_FILE} ]; then
-     START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log)
+     local START_TIME
+     if ! START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log); then
+       return 1
+     fi
      echo ${START_TIME}
    fi
 }

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -100,7 +100,9 @@ function save_backup_status() {
     local START_TIME=
     local END_TIME=
     if [ ! -z ${OLDEST_FILE} ]; then
-       START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log)
+       if ! START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log); then
+         return 1
+       fi
     fi
     if [ -n "${wal_files}" ]; then
       # get the end time from the latest 10 files

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PUSH_EXIT \
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
       DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
@@ -52,6 +52,9 @@ printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
   push)
     exit "${DATASAFED_PUSH_EXIT:-0}"
+    ;;
+  pull)
+    exit "${DATASAFED_PULL_EXIT:-0}"
     ;;
   stat)
     printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
@@ -244,6 +247,17 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "datasafed WAL listing failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without caching or publishing when the oldest WAL pull fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_PULL_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to pull oldest WAL"
+      The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_STAT_EXIT \
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_STAT_EXIT \
       DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
@@ -79,6 +79,9 @@ case "$1" in
   list)
     printf '%s' "${DATASAFED_LIST_OUT:-}"
     exit "${DATASAFED_LIST_EXIT:-0}"
+    ;;
+  pull)
+    exit "${DATASAFED_PULL_EXIT:-0}"
     ;;
 esac
 EOF
@@ -269,6 +272,17 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "datasafed WAL listing returned invalid JSON"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without caching or publishing when the oldest WAL pull fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_PULL_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to pull oldest WAL"
+      The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End


### PR DESCRIPTION
## Summary
- fail the shared oldest-WAL analyzer when the repository pull fails
- avoid caching an oldest artifact that was never downloaded
- propagate pull failures through both legacy and WAL-G Continuous metadata producers

## Candidate identity
- target: parent PR #3356
- exact parent head: `cee5040d9d44db5826d4cc9ee91f1f19b29a4013`
- candidate branch: `easton/pg-continuous-pull-failfast`
- candidate head: `adafd4713d8e543b93848a577fefe299bdf5854d`
- candidate tree: `2f7fcc34bfd27f0bc7329bb62eea9685f416e89e`
- exact compare: ahead 1 / behind 0 / merge-base is the parent
- candidate remains Draft and retains `nopick`

## TDD evidence
- RED: focused Bash 5 ShellSpec 14 examples / 1 failure (4 assertions)
- GREEN: focused legacy + WAL-G Bash 3.2 ShellSpec 29/0
- GREEN: focused legacy + WAL-G Bash 5.3 ShellSpec 29/0
- GREEN: full PostgreSQL Bash 5.3 ShellSpec 217/0
- static: ShellCheck error severity, Bash syntax, and `git diff --check` all pass
- chart: Helm lint 1/0; render 41 documents / 1001504 bytes

## Contract
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35,43`
