### PR TITLE
fix(postgresql): refresh stale WAL cache

### DIFF
--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -2,20 +2,24 @@
 
 function get_current_time() {
   curr_time=$(psql -U "${DP_DB_USER}" -h "${DP_DB_HOST}" -p "${DP_DB_PORT}" -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
-  echo $curr_time
+  printf '%s\n' "${curr_time}"
 }
 
 function stat_and_save_backup_info() {
   export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
   export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
-  START_TIME=$1
-  STOP_TIME=$2
-  if [ -z $STOP_TIME ]; then
+  START_TIME="$1"
+  STOP_TIME="${2:-}"
+  if [[ -z "${STOP_TIME}" ]]; then
     STOP_TIME=$(get_current_time)
   fi
   START_TIME=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
   STOP_TIME=$(date -d "${STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
   TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+  if [[ ! "${TOTAL_SIZE}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: datasafed stat returned an invalid TotalSize" >&2
+    return 1
+  fi
   echo "{\"totalSize\":\"$TOTAL_SIZE\",\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
 }
 

--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -20,7 +20,16 @@ function stat_and_save_backup_info() {
     echo "ERROR: datasafed stat returned an invalid TotalSize" >&2
     return 1
   fi
-  echo "{\"totalSize\":\"$TOTAL_SIZE\",\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
+  local backup_info_tmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
+  if ! printf '{"totalSize":"%s","timeRange":{"start":"%s","end":"%s"}}\n' \
+      "${TOTAL_SIZE}" "${START_TIME}" "${STOP_TIME}" >"${backup_info_tmp}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+  if ! mv -f "${backup_info_tmp}" "${DP_BACKUP_INFO_FILE}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
 }
 
 # if the script exits with a non-zero exit code, touch a file to indicate that the backup failed,

--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 function get_current_time() {
   curr_time=$(psql -U "${DP_DB_USER}" -h "${DP_DB_HOST}" -p "${DP_DB_PORT}" -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
   echo $curr_time

--- a/addons/postgresql/dataprotection/backup-info-collector.sh
+++ b/addons/postgresql/dataprotection/backup-info-collector.sh
@@ -1,5 +1,5 @@
 function get_current_time() {
-  curr_time=$(psql -U ${DP_DB_USER} -h ${DP_DB_HOST} -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
+  curr_time=$(psql -U "${DP_DB_USER}" -h "${DP_DB_HOST}" -p "${DP_DB_PORT}" -d postgres -t -c "SELECT now() AT TIME ZONE 'UTC'")
   echo $curr_time
 }
 

--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -116,7 +116,7 @@ function DP_analyze_start_time_from_datasafed() {
     if [ -f ${info_file} ]; then
       last_oldest_file=$(cat ${info_file})
       last_oldest_file_name=$(DP_get_file_name_without_ext ${last_oldest_file})
-      if [ "$last_oldest_file" == "${oldest_file}" ]; then
+      if [ "$last_oldest_file" == "${oldest_file}" ] && [ -f ${last_oldest_file_name} ]; then
         # oldest file no changed.
         ${get_start_time_from_file} $last_oldest_file_name
         return

--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -13,6 +13,21 @@ function DP_error_log() {
     echo "${curr_date} ERROR: $msg"
 }
 
+function DP_get_backup_total_size() {
+    local statOutput
+    local totalSize
+    if ! statOutput=$(datasafed stat /); then
+      DP_error_log "datasafed stat failed" >&2
+      return 1
+    fi
+    totalSize=$(printf '%s\n' "${statOutput}" | awk '/TotalSize/ { print $2; exit }')
+    if [[ ! ${totalSize} =~ ^[0-9]+$ ]]; then
+      DP_error_log "datasafed stat returned an invalid TotalSize" >&2
+      return 1
+    fi
+    printf '%s\n' "${totalSize}"
+}
+
 # Get file names without extensions based on the incoming file path
 function DP_get_file_name_without_ext() {
     local fileName=$1

--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -127,7 +127,10 @@ function DP_analyze_start_time_from_datasafed() {
       fi
     fi
     # pull file
-    ${datasafed_pull} ${oldest_file}
+    if ! ${datasafed_pull} ${oldest_file}; then
+      DP_error_log "failed to pull oldest WAL" >&2
+      return 1
+    fi
     # record last oldest file
     echo ${oldest_file} > ${info_file}
     oldest_file_name=$(DP_get_file_name_without_ext ${oldest_file})

--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -29,15 +29,27 @@ function DP_save_backup_status_info() {
     local timeZone=$4
     local extras=$5
     local timeZoneStr=""
+    local backupInfo
+    local backupInfoTmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
     if [ ! -z ${timeZone} ]; then
        timeZoneStr=",\"timeZone\":\"${timeZone}\""
     fi
     if [ -z "${stopTime}" ];then
-      echo "{\"totalSize\":\"${totalSize}\"}" > ${DP_BACKUP_INFO_FILE}
+      printf -v backupInfo '{"totalSize":"%s"}' "${totalSize}"
     elif [ -z "${startTime}" ];then
-      echo "{\"totalSize\":\"${totalSize}\",\"extras\":[${extras}],\"timeRange\":{\"end\":\"${stopTime}\"${timeZoneStr}}}" > ${DP_BACKUP_INFO_FILE}
+      printf -v backupInfo '{"totalSize":"%s","extras":[%s],"timeRange":{"end":"%s"%s}}' \
+        "${totalSize}" "${extras}" "${stopTime}" "${timeZoneStr}"
     else
-      echo "{\"totalSize\":\"${totalSize}\",\"extras\":[${extras}],\"timeRange\":{\"start\":\"${startTime}\",\"end\":\"${stopTime}\"${timeZoneStr}}}" > ${DP_BACKUP_INFO_FILE}
+      printf -v backupInfo '{"totalSize":"%s","extras":[%s],"timeRange":{"start":"%s","end":"%s"%s}}' \
+        "${totalSize}" "${extras}" "${startTime}" "${stopTime}" "${timeZoneStr}"
+    fi
+    if ! printf '%s\n' "${backupInfo}" > "${backupInfoTmp}"; then
+      rm -f "${backupInfoTmp}"
+      return 1
+    fi
+    if ! mv -f "${backupInfoTmp}" "${DP_BACKUP_INFO_FILE}"; then
+      rm -f "${backupInfoTmp}"
+      return 1
     fi
 }
 
@@ -116,4 +128,3 @@ function getTimeZoneOffset() {
    fi
    echo "${symbol}${offset}:00"
 }
-

--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -28,6 +28,20 @@ function DP_get_backup_total_size() {
     printf '%s\n' "${totalSize}"
 }
 
+function DP_list_backup_files_by_mtime() {
+    local listOutput
+    local sortedFiles
+    if ! listOutput=$(datasafed list -f --recursive / -o json); then
+      DP_error_log "datasafed WAL listing failed" >&2
+      return 1
+    fi
+    if ! sortedFiles=$(printf '%s\n' "${listOutput}" | jq -s -r '.[] | sort_by(.mtime) | .[] | .path'); then
+      DP_error_log "datasafed WAL listing returned invalid JSON" >&2
+      return 1
+    fi
+    printf '%s\n' "${sortedFiles}"
+}
+
 # Get file names without extensions based on the incoming file path
 function DP_get_file_name_without_ext() {
     local fileName=$1

--- a/addons/postgresql/dataprotection/pgdump-restore.sh
+++ b/addons/postgresql/dataprotection/pgdump-restore.sh
@@ -3,9 +3,9 @@ set -e
 set -o pipefail
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
-export PGPASSWORD=${POSTGRES_PASSWORD}
+export PGPASSWORD=${DP_DB_PASSWORD}
 BACKUP_DIR=$BACKUP_DIR/${DP_BACKUP_NAME}
-psql_cmd="psql -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT}"
+psql_cmd="psql -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT}"
 mkdir -p $BACKUP_DIR
 trap "[ -d $BACKUP_DIR ] && rm -rf $BACKUP_DIR" EXIT
 
@@ -88,7 +88,7 @@ echo "parameters: $params"
 # so /tmp/pg_restore.log is guaranteed complete before it is grepped below.
 exec 3>&1
 set +e
-pg_restore -h ${DP_DB_HOST} -U ${POSTGRES_USER} -p ${DP_DB_PORT} ${params} $BACKUP_DIR 2>&1 1>&3 | tee /tmp/pg_restore.log >&2
+pg_restore -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT} ${params} $BACKUP_DIR 2>&1 1>&3 | tee /tmp/pg_restore.log >&2
 exit_code=${PIPESTATUS[0]}
 set -e
 exec 3>&-

--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -13,20 +13,28 @@ function fetch-wal-log(){
     DP_log "PITR: $pitr"
 
     exit_fetch_wal=0 && mkdir -p $wal_destination_dir
-    for dir_name in $(datasafed list /) ; do
+    if ! dir_names=$(datasafed list /); then
+       DP_error_log "failed to list the WAL archive root"
+       return 1
+    fi
+    for dir_name in $dir_names ; do
       if [[ $exit_fetch_wal -eq 1 ]]; then
          break
       fi
 
+      if ! dir_files=$(datasafed list "${dir_name}"); then
+         DP_error_log "failed to list WAL archive directory ${dir_name}"
+         return 1
+      fi
       # check if the latest_wal_log after the start_wal_log
-      latest_wal=$(datasafed list ${dir_name} | tail -n 1)
+      latest_wal=$(printf '%s\n' "${dir_files}" | tail -n 1)
       latest_wal_name=$(get_wal_name ${latest_wal})
       if [[ ${latest_wal_name} < $start_wal_name ]]; then
          continue
       fi
 
       DP_log "start to fetch wal logs from ${dir_name}"
-      for file in $(datasafed list ${dir_name} | grep ".zst"); do
+      for file in $(printf '%s\n' "${dir_files}" | grep ".zst"); do
          wal_name=$(get_wal_name ${file})
          if [[ $wal_name < $start_wal_name ]]; then
             continue

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -172,6 +172,7 @@ function uploadMissingLogs() {
     OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
     OLDEST_FILE=$(basename $OLDEST_FILE)
     DP_log "oldest uploaded wal: ${OLDEST_FILE}"
+    local upload_failed=false
     for i in $(find ./archive_status -type f | sort | grep .done); do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
@@ -183,9 +184,15 @@ function uploadMissingLogs() {
       fi
       if [ -f ${wal_name} ]; then
         DP_log "upload ${wal_name}"
-        datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst" || DP_error_log "failed to upload ${wal_name}"
+        if ! datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
+          DP_error_log "failed to upload ${wal_name}, will retry reconciliation"
+          upload_failed=true
+        fi
       fi
     done
+    if [[ ${upload_failed} == "true" ]]; then
+      return 1
+    fi
     save_backup_status
 }
 

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -12,6 +12,7 @@ global_last_purge_time=$(date +%s)
 global_switch_wal_interval=300
 global_stop_time=
 global_old_size=0
+global_missing_logs_reconciled=false
 
 if [[ ${SWITCH_WAL_INTERVAL_SECONDS} =~ ^[0-9]+$ ]];then
   global_switch_wal_interval=${SWITCH_WAL_INTERVAL_SECONDS}
@@ -161,7 +162,10 @@ function uploadMissingLogs() {
     DP_log "start to upload the wal log which maybe misses"
     local TODAY_INCR_LOG=$(date +%Y%m%d)
     cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
-    uploadedLogs=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) | .[] | .path')
+    local uploadedLogs
+    if ! uploadedLogs=$(DP_list_backup_files_by_mtime); then
+      return 1
+    fi
     if [[ -z ${uploadedLogs} ]]; then
       return
     fi
@@ -187,13 +191,26 @@ function uploadMissingLogs() {
 
 # trap term signal
 trap "echo 'Terminating...' && sync && exit 0" TERM
-uploadMissingLogs
+if uploadMissingLogs; then
+  global_missing_logs_reconciled=true
+else
+  DP_error_log "missing WAL reconciliation incomplete; will retry"
+fi
 
 DP_log "start to archive wal logs"
 while true; do
 
   # check if pg process is ok
   check_pg_process
+
+  # Retry startup reconciliation until one complete repository read succeeds.
+  if [[ ${global_missing_logs_reconciled} == "false" ]]; then
+    if uploadMissingLogs; then
+      global_missing_logs_reconciled=true
+    else
+      DP_error_log "missing WAL reconciliation incomplete; will retry"
+    fi
+  fi
 
   # switch wal log
   switch_wal_log

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -105,7 +105,11 @@ function pull_wal_log() {
 
 # get the start time for backup.status.timeRange
 function get_start_time_for_range() {
-   local OLDEST_FILE=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) | .[] | .path' |head -n 1)
+   local WAL_FILES
+   if ! WAL_FILES=$(DP_list_backup_files_by_mtime); then
+     return 1
+   fi
+   local OLDEST_FILE="${WAL_FILES%%$'\n'*}"
    if [ ! -z ${OLDEST_FILE} ]; then
      START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log)
      echo ${START_TIME}
@@ -122,7 +126,10 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
        return
     fi
-    local START_TIME=$(get_start_time_for_range)
+    local START_TIME
+    if ! START_TIME=$(get_start_time_for_range); then
+       return 1
+    fi
     if ! DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${global_stop_time}"; then
        return 1
     fi

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -31,7 +31,10 @@ function purge_expired_files() {
     if [ ! -z "${info}" ]; then
        global_last_purge_time=${currentUnix}
        DP_log "cleanup expired wal-log files: ${info}"
-       local TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+       local TOTAL_SIZE
+       if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
+         return 1
+       fi
        DP_save_backup_status_info "${TOTAL_SIZE}"
     fi
 }
@@ -111,9 +114,12 @@ function get_start_time_for_range() {
 
 # save backup status info to sync file
 function save_backup_status() {
-    local TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+    local TOTAL_SIZE
+    if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
+       return 1
+    fi
     # if no size changes, return
-    if [[ -z ${TOTAL_SIZE} || ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
+    if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
        return
     fi
     global_old_size=${TOTAL_SIZE}

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -122,9 +122,11 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == ${global_old_size} ]];then
        return
     fi
-    global_old_size=${TOTAL_SIZE}
     local START_TIME=$(get_start_time_for_range)
-    DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${global_stop_time}"
+    if ! DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${global_stop_time}"; then
+       return 1
+    fi
+    global_old_size=${TOTAL_SIZE}
 }
 
 function check_pg_process() {

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -172,7 +172,7 @@ function uploadMissingLogs() {
     OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
     OLDEST_FILE=$(basename $OLDEST_FILE)
     DP_log "oldest uploaded wal: ${OLDEST_FILE}"
-    local upload_failed=false
+    local reconciliation_failed=false
     for i in $(find ./archive_status -type f | sort | grep .done); do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
@@ -186,11 +186,14 @@ function uploadMissingLogs() {
         DP_log "upload ${wal_name}"
         if ! datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
           DP_error_log "failed to upload ${wal_name}, will retry reconciliation"
-          upload_failed=true
+          reconciliation_failed=true
         fi
+      else
+        DP_error_log "cannot reconcile ${wal_name}: local WAL file is missing"
+        reconciliation_failed=true
       fi
     done
-    if [[ ${upload_failed} == "true" ]]; then
+    if [[ ${reconciliation_failed} == "true" ]]; then
       return 1
     fi
     save_backup_status

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -112,7 +112,10 @@ function get_start_time_for_range() {
    fi
    local OLDEST_FILE="${WAL_FILES%%$'\n'*}"
    if [ ! -z ${OLDEST_FILE} ]; then
-     START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log)
+     local START_TIME
+     if ! START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log); then
+       return 1
+     fi
      echo ${START_TIME}
    fi
 }

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -166,17 +166,17 @@ function uploadMissingLogs() {
     if ! uploadedLogs=$(DP_list_backup_files_by_mtime); then
       return 1
     fi
-    if [[ -z ${uploadedLogs} ]]; then
-      return
+    local OLDEST_FILE=
+    if [[ -n ${uploadedLogs} ]]; then
+      OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
+      OLDEST_FILE=$(basename $OLDEST_FILE)
+      DP_log "oldest uploaded wal: ${OLDEST_FILE}"
     fi
-    OLDEST_FILE=$(echo $uploadedLogs | awk '{print $1}')
-    OLDEST_FILE=$(basename $OLDEST_FILE)
-    DP_log "oldest uploaded wal: ${OLDEST_FILE}"
     local reconciliation_failed=false
     for i in $(find ./archive_status -type f | sort | grep .done); do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
-      if [[ "$wal_name" < "$OLDEST_FILE" ]]; then
+      if [[ -n ${OLDEST_FILE} && "$wal_name" < "$OLDEST_FILE" ]]; then
         continue
       fi
       if echo "$uploadedLogs" | grep -qE "${wal_name}\.(zst|partial\.zst)";then

--- a/addons/postgresql/dataprotection/wal-g-archive-delete.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive-delete.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+set -o pipefail
+
 backup_base_path="$(dirname $DP_BACKUP_BASE_PATH)/wal-g"
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -113,12 +113,18 @@ function save_backup_status() {
 # Upload historical .history files that are marked as .done but not yet uploaded to remote
 # These are timeline history files (e.g., 00000002.history) that are critical for PITR recovery
 function uploadDoneHistoryWALs() {
+  local upload_failed=false
   DP_log "Checking for historical .history files with .done status to upload..."
 
   # Find all .done status files for .history files in archive_status directory
   for done_file in $(find "${LOG_DIR}/archive_status/" -name "*.history.done" -type f | sort); do
     history_name=$(basename "$done_file" .done)
     history_path="${LOG_DIR}/${history_name}"
+    uploaded_marker="${done_file}.walg-uploaded"
+
+    if [ -f "${uploaded_marker}" ]; then
+      continue
+    fi
 
     # Check if the actual .history file still exists
     if [ -f "$history_path" ]; then
@@ -128,14 +134,23 @@ function uploadDoneHistoryWALs() {
       envdir "${VOLUME_DATA_DIR}/wal-g/env" "${VOLUME_DATA_DIR}/wal-g/wal-g" wal-push "${history_path}"
       exit_code=$?
       if [ "$exit_code" -eq 0 ]; then
-        DP_log "Successfully uploaded file: ${history_name}"
+        if touch "${uploaded_marker}"; then
+          DP_log "Successfully uploaded file: ${history_name}"
+        else
+          DP_error_log "Uploaded ${history_name} but failed to persist its success marker"
+          upload_failed=true
+        fi
       else
         DP_error_log "Failed to upload file: ${history_name}, exit code: ${exit_code}"
+        upload_failed=true
       fi
     fi
   done
 
   DP_log "Completed uploading historical .history files"
+  if [ "${upload_failed}" == "true" ]; then
+    return 1
+  fi
 }
 
 # Upload missing ready WAL files and rename the ready file to done.
@@ -212,12 +227,12 @@ trap "echo 'Terminating...' && exit 0" TERM
 DP_log "start to archive and update wal infos"
 config_wal_g "$(dirname "${DP_BACKUP_BASE_PATH}")/wal-g"
 
-# Upload historical .history files on first run
-uploadDoneHistoryWALs
-
 while true; do
   # check if pg process is ok
   check_pg_process
+  # Retry timeline history uploads until each local file has a persisted
+  # success marker; cross-timeline PITR depends on these files.
+  uploadDoneHistoryWALs || DP_error_log "timeline history upload incomplete; will retry"
   # upload wal logs
   uploadMissingLogs
   # save backup status which will be updated to `backup` CR by the sidecar

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -100,7 +100,9 @@ function save_backup_status() {
     local START_TIME=
     local END_TIME=
     if [ ! -z ${OLDEST_FILE} ]; then
-       START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log)
+       if ! START_TIME=$(DP_analyze_start_time_from_datasafed ${OLDEST_FILE} get_wal_log_start_time pull_wal_log); then
+         return 1
+       fi
     fi
     if [ -n "${wal_files}" ]; then
       # get the end time from the latest 10 files

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -92,7 +92,6 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
        return
     fi
-    GLOBAL_OLD_SIZE=${TOTAL_SIZE}
     local wal_files=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) |.[] |.path')
     local OLDEST_FILE=$(echo $wal_files | tr ' ' '\n' |head -n 1)
     local START_TIME=
@@ -110,7 +109,10 @@ function save_backup_status() {
       done
     fi
     DP_log "start time of the oldest wal: ${START_TIME}, end time of the latest wal: ${END_TIME}, total size: ${TOTAL_SIZE}"
-    DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${END_TIME}"
+    if ! DP_save_backup_status_info "${TOTAL_SIZE}" "${START_TIME}" "${END_TIME}"; then
+       return 1
+    fi
+    GLOBAL_OLD_SIZE=${TOTAL_SIZE}
 }
 
 # Upload historical .history files that are marked as .done but not yet uploaded to remote

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -84,9 +84,12 @@ function get_wal_log_end_time() {
 
 # save backup status info to sync file
 function save_backup_status() {
-    local TOTAL_SIZE=$(datasafed stat / | grep TotalSize | awk '{print $2}')
+    local TOTAL_SIZE
+    if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
+       return 1
+    fi
     # if no size changes, return
-    if [[ -z ${TOTAL_SIZE} || ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
+    if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
        return
     fi
     GLOBAL_OLD_SIZE=${TOTAL_SIZE}

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -92,7 +92,10 @@ function save_backup_status() {
     if [[ ${TOTAL_SIZE} -eq 0 || ${TOTAL_SIZE} == "${GLOBAL_OLD_SIZE}" ]];then
        return
     fi
-    local wal_files=$(datasafed list -f --recursive / -o json | jq -s -r '.[] | sort_by(.mtime) |.[] |.path')
+    local wal_files
+    if ! wal_files=$(DP_list_backup_files_by_mtime); then
+       return 1
+    fi
     local OLDEST_FILE=$(echo $wal_files | tr ' ' '\n' |head -n 1)
     local START_TIME=
     local END_TIME=

--- a/addons/postgresql/dataprotection/wal-g-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-backup.sh
@@ -75,6 +75,23 @@ function writeSentinelInBaseBackupPath() {
   export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 }
 
+function publish_backup_info() {
+  local backup_name="$1"
+  local total_size="$2"
+  local start_time="$3"
+  local stop_time="$4"
+  local backup_info_tmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
+  if ! printf '{"totalSize":"%s","extras":[{"wal-g-backup-name":"%s"}],"timeRange":{"start":"%s","end":"%s"}}\n' \
+      "${total_size}" "${backup_name}" "${start_time}" "${stop_time}" > "${backup_info_tmp}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+  if ! mv -f "${backup_info_tmp}" "${DP_BACKUP_INFO_FILE}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+}
+
 trap handle_exit EXIT
 set -e
 
@@ -115,4 +132,4 @@ START_TIME=$(echo $result_json | jq -r ".StartTime")
 TOTAL_SIZE=$(echo $result_json | jq -r ".CompressedSize")
 
 # 5. update backup status
-echo "{\"totalSize\":\"$TOTAL_SIZE\",\"extras\":[{\"wal-g-backup-name\":\"${backupName}\"}],\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
+publish_backup_info "${backupName}" "${TOTAL_SIZE}" "${START_TIME}" "${STOP_TIME}"

--- a/addons/postgresql/dataprotection/wal-g-delete.sh
+++ b/addons/postgresql/dataprotection/wal-g-delete.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
+set -e
+set -o pipefail
+
 export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 function getWalGSentinelInfo() {
   local sentinelFile=${1}
-  local out=$(datasafed list ${sentinelFile})
+  local out
+  out=$(datasafed list "${sentinelFile}") || return $?
   if [ "${out}" == "${sentinelFile}" ]; then
-     datasafed pull "${sentinelFile}" ${sentinelFile}
-     echo "$(cat ${sentinelFile})"
+     datasafed pull "${sentinelFile}" "${sentinelFile}" || return $?
+     cat "${sentinelFile}" || return $?
      return
   fi
 }
@@ -47,5 +51,3 @@ else
   echo "INFO: no other full backup, delete all wal archives."
   datasafed rm -r /wal_005
 fi
-
-

--- a/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
@@ -82,6 +82,23 @@ function writeSentinelInBaseBackupPath() {
   export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 }
 
+function publish_backup_info() {
+  local backup_name="$1"
+  local total_size="$2"
+  local start_time="$3"
+  local stop_time="$4"
+  local backup_info_tmp="${DP_BACKUP_INFO_FILE}.tmp.$$"
+  if ! printf '{"totalSize":"%s","extras":[{"wal-g-backup-name":"%s"}],"timeRange":{"start":"%s","end":"%s"}}\n' \
+      "${total_size}" "${backup_name}" "${start_time}" "${stop_time}" > "${backup_info_tmp}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+  if ! mv -f "${backup_info_tmp}" "${DP_BACKUP_INFO_FILE}"; then
+    rm -f "${backup_info_tmp}"
+    return 1
+  fi
+}
+
 function get_backup_name() {
   local parent_wal_g_backup_name=${1}
   line=$(cat result.txt | tail -n 1)
@@ -155,4 +172,4 @@ if [[ "${backupName}" == "${parentWalGBackupName}" ]]; then
 fi
 
 # 5. update backup status
-echo "{\"totalSize\":\"$TOTAL_SIZE\",\"extras\":[{\"wal-g-backup-name\":\"${backupName}\"}],\"timeRange\":{\"start\":\"${START_TIME}\",\"end\":\"${STOP_TIME}\"}}" >"${DP_BACKUP_INFO_FILE}"
+publish_backup_info "${backupName}" "${TOTAL_SIZE}" "${START_TIME}" "${STOP_TIME}"

--- a/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
+++ b/addons/postgresql/dataprotection/wal-g-incremental-backup.sh
@@ -50,19 +50,35 @@ function config_wal_g() {
 
 function getWalGSentinelInfo() {
   local sentinelFile=${1}
-  local out=$(datasafed list ${sentinelFile})
-  if [ "${out}" == "${sentinelFile}" ]; then
-     datasafed pull "${sentinelFile}" ${sentinelFile}
-     echo "$(cat ${sentinelFile})"
-     return
+  local out
+  local value
+  if ! out=$(datasafed list "${sentinelFile}"); then
+    echo "ERROR: failed to list parent WAL-G sentinel ${sentinelFile}" >&2
+    return 1
   fi
+  if [ "${out}" != "${sentinelFile}" ]; then
+    echo "ERROR: parent WAL-G sentinel ${sentinelFile} not found" >&2
+    return 1
+  fi
+  if ! datasafed pull "${sentinelFile}" "${sentinelFile}"; then
+    echo "ERROR: failed to pull parent WAL-G sentinel ${sentinelFile}" >&2
+    return 1
+  fi
+  if ! value=$(cat "${sentinelFile}"); then
+    echo "ERROR: failed to read parent WAL-G sentinel ${sentinelFile}" >&2
+    return 1
+  fi
+  printf '%s\n' "${value}"
 }
 
 function writeSentinelInBaseBackupPath() {
   content=${1}
   fileName=${2}
   export DATASAFED_BACKEND_BASE_PATH=${DP_BACKUP_BASE_PATH}
-  echo "${content}" | datasafed push - "${fileName}"
+  if ! echo "${content}" | datasafed push - "${fileName}"; then
+    echo "ERROR: failed to publish WAL-G sentinel ${fileName}" >&2
+    return 1
+  fi
   export DATASAFED_BACKEND_BASE_PATH=${backup_base_path}
 }
 
@@ -93,12 +109,21 @@ config_wal_g "$(dirname $DP_BACKUP_BASE_PATH)/wal-g"
 
 # 2. parent backup name of the wal-g
 export DATASAFED_BACKEND_BASE_PATH=$(dirname ${DP_BACKUP_BASE_PATH})/${DP_PARENT_BACKUP_NAME}
-parentWalGBackupName=$(getWalGSentinelInfo "wal-g-backup-name")
+if ! parentWalGBackupName=$(getWalGSentinelInfo "wal-g-backup-name"); then
+  exit 1
+fi
+if [[ -z ${parentWalGBackupName} ]]; then
+  echo "ERROR: parent WAL-G backup name is empty" >&2
+  exit 1
+fi
 
 # 1. incremental backup
-set +e
 writeSentinelInBaseBackupPath "${backup_base_path}" "wal-g-backup-repo.path"
-PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=${DP_DB_PORT} wal-g backup-push ${DATA_DIR} --delta-from-name ${parentWalGBackupName} 2>&1 | tee result.txt
+if ! PGHOST=${DP_DB_HOST} PGUSER=${DP_DB_USER} PGPORT=${DP_DB_PORT} \
+  wal-g backup-push "${DATA_DIR}" --delta-from-name "${parentWalGBackupName}" 2>&1 | tee result.txt; then
+  echo "ERROR: WAL-G incremental backup-push failed" >&2
+  exit 1
+fi
 
 # 2. get backup name of the wal-g
 backupName=$(get_backup_name "${parentWalGBackupName}")
@@ -107,7 +132,6 @@ if [[ -z ${backupName} ]] || [[ ${backupName} != "base_"* ]];then
    exit 1
 fi
 
-set -e
 echo "switch wal log"
 PSQL="psql -h ${DP_DB_HOST} -U ${DP_DB_USER} -p ${DP_DB_PORT} -d postgres"
 ${PSQL} -c "select pg_switch_wal();"

--- a/addons/postgresql/dataprotection/wal-g-restore.sh
+++ b/addons/postgresql/dataprotection/wal-g-restore.sh
@@ -10,11 +10,22 @@ export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
 function getWalGSentinelInfo() {
   local sentinelFile=${1}
-  local out=$(datasafed list ${sentinelFile})
+  local out
+  local value
+  if ! out=$(datasafed list "${sentinelFile}"); then
+     echo "ERROR: failed to list WAL-G sentinel ${sentinelFile}" >&2
+     return 1
+  fi
   if [ "${out}" == "${sentinelFile}" ]; then
-     datasafed pull "${sentinelFile}" ${sentinelFile}
-     echo "$(cat ${sentinelFile})"
-     return
+     if ! datasafed pull "${sentinelFile}" "${sentinelFile}"; then
+        echo "ERROR: failed to pull WAL-G sentinel ${sentinelFile}" >&2
+        return 1
+     fi
+     if ! value=$(cat "${sentinelFile}"); then
+        echo "ERROR: failed to read WAL-G sentinel ${sentinelFile}" >&2
+        return 1
+     fi
+     printf '%s\n' "${value}"
   fi
 }
 
@@ -45,7 +56,15 @@ function config_wal_g_for_fetch_wal_log() {
 
 # 1. get restore info
 backupRepoPath=$(getWalGSentinelInfo "wal-g-backup-repo.path")
+if [[ -z "${backupRepoPath}" ]]; then
+  echo "ERROR: missing WAL-G backup repository sentinel" >&2
+  exit 1
+fi
 backupName=$(getWalGSentinelInfo "wal-g-backup-name")
+if [[ -z "${backupName}" ]]; then
+  echo "ERROR: missing WAL-G backup name sentinel" >&2
+  exit 1
+fi
 
 # 2. fetch base backup
 export DATASAFED_BACKEND_BASE_PATH="${backupRepoPath}"

--- a/addons/postgresql/reloader/update-parameter.sh
+++ b/addons/postgresql/reloader/update-parameter.sh
@@ -52,7 +52,12 @@ update_parameter() {
     command="reload"
     paramName="${1:?missing param name}"
     paramValue="${2:?missing value}"
-    paramValue=$(echo "$paramValue" | sed "s/'//g")
+    case "$paramValue" in
+        \'*\')
+            paramValue=${paramValue#\'}
+            paramValue=${paramValue%\'}
+            ;;
+    esac
 
     json_params="{}"
     if in_array "$paramName" "$patroni_params"; then

--- a/addons/postgresql/reloader/update-parameter.sh
+++ b/addons/postgresql/reloader/update-parameter.sh
@@ -51,7 +51,11 @@ update_parameter() {
 
     command="reload"
     paramName="${1:?missing param name}"
-    paramValue="${2:?missing value}"
+    if [ "$#" -lt 2 ]; then
+        echo "missing value" >&2
+        return 1
+    fi
+    paramValue=$2
     case "$paramValue" in
         \'*\')
             paramValue=${paramValue#\'}

--- a/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+
+Describe "dataprotection/backup-info-collector.sh"
+  setup() {
+    tmpdir=$(mktemp -d -t pg-backup-info-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DP_DB_USER="kbdataprotection"
+    DP_DB_HOST="postgres.example.test"
+    DP_DB_PORT="6432"
+    export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT
+    write_stubs
+    . ../dataprotection/backup-info-collector.sh
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/psql" <<'EOF'
+#!/bin/sh
+printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+printf '%s\n' '2026-08-15 15:00:00'
+EOF
+    chmod +x "${bindir}/psql"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "queries time through the ActionSet-injected database port"
+    When call get_current_time
+    The status should eq 0
+    The output should eq "2026-08-15 15:00:00"
+    The result of function call_log should include "psql -U kbdataprotection -h postgres.example.test -p 6432 -d postgres"
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
@@ -11,7 +11,12 @@ Describe "dataprotection/backup-info-collector.sh"
     DP_DB_USER="kbdataprotection"
     DP_DB_HOST="postgres.example.test"
     DP_DB_PORT="6432"
-    export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/repository/backup-test"
+    DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
+    export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT \
+      DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH DP_BACKUP_INFO_FILE
+    unset DATASAFED_STAT_OUT 2>/dev/null || true
     write_stubs
     . ../dataprotection/backup-info-collector.sh
   }
@@ -29,7 +34,22 @@ Describe "dataprotection/backup-info-collector.sh"
 printf 'psql %s\n' "$*" >> "${CALL_LOG}"
 printf '%s\n' '2026-08-15 15:00:00'
 EOF
-    chmod +x "${bindir}/psql"
+    cat > "${bindir}/date" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *15:00:00*) printf '%s\n' '2026-08-15T15:00:00Z' ;;
+  *15:01:00*) printf '%s\n' '2026-08-15T15:01:00Z' ;;
+  *) exit 2 ;;
+esac
+EOF
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+if [ "$1" = "stat" ]; then
+  printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 4096}"
+fi
+EOF
+    chmod +x "${bindir}/psql" "${bindir}/date" "${bindir}/datasafed"
   }
 
   call_log() {
@@ -41,5 +61,22 @@ EOF
     The status should eq 0
     The output should eq "2026-08-15 15:00:00"
     The result of function call_log should include "psql -U kbdataprotection -h postgres.example.test -p 6432 -d postgres"
+  End
+
+  It "writes the byte count from the real datasafed TotalSize format"
+    # apecloud/datasafed cmd/stat.go emits: TotalSize: <integer>
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    When call stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    The status should eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"totalSize":"4096"'
+    The result of function call_log should include "datasafed stat /"
+  End
+
+  It "rejects a successful datasafed response without a numeric byte count"
+    export DATASAFED_STAT_OUT="TotalSize:"
+    When call stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    The status should be failure
+    The error should include "datasafed stat returned an invalid TotalSize"
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
   End
 End

--- a/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/backup_info_collector_spec.sh
@@ -16,7 +16,7 @@ Describe "dataprotection/backup-info-collector.sh"
     DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
     export PATH CALL_LOG DP_DB_USER DP_DB_HOST DP_DB_PORT \
       DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH DP_BACKUP_INFO_FILE
-    unset DATASAFED_STAT_OUT 2>/dev/null || true
+    unset DATASAFED_STAT_OUT MV_EXIT 2>/dev/null || true
     write_stubs
     . ../dataprotection/backup-info-collector.sh
   }
@@ -49,11 +49,45 @@ if [ "$1" = "stat" ]; then
   printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 4096}"
 fi
 EOF
-    chmod +x "${bindir}/psql" "${bindir}/date" "${bindir}/datasafed"
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${bindir}/psql" "${bindir}/date" "${bindir}/datasafed" "${bindir}/mv"
   }
 
   call_log() {
     cat "${CALL_LOG}"
+  }
+
+  publish_with_existence_observer() {
+    echo() {
+      case "$1" in
+        '{"totalSize"'*) /bin/sleep 0.2 ;;
+      esac
+      builtin echo "$@"
+    }
+
+    (
+      while [[ ! -e "${DP_BACKUP_INFO_FILE}" ]]; do
+        /bin/sleep 0.01
+      done
+      /usr/bin/wc -c < "${DP_BACKUP_INFO_FILE}" > "${tmpdir}/observed-bytes"
+    ) &
+    observer_pid=$!
+    stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    wait "${observer_pid}"
+  }
+
+  observed_bytes() {
+    tr -d '[:space:]' < "${tmpdir}/observed-bytes"
+  }
+
+  backup_info_temp_count() {
+    find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
   }
 
   It "queries time through the ActionSet-injected database port"
@@ -78,5 +112,22 @@ EOF
     The status should be failure
     The error should include "datasafed stat returned an invalid TotalSize"
     The path "${DP_BACKUP_INFO_FILE}" should not be exist
+  End
+
+  It "publishes a complete backup-info document before it becomes visible"
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    When call publish_with_existence_observer
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"totalSize":"4096"'
+  End
+
+  It "fails without leaving metadata when atomic publication fails"
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export MV_EXIT=7
+    When call stat_and_save_backup_info "2026-08-15 15:00:00" "2026-08-15 15:01:00"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The result of function backup_info_temp_count should eq 0
   End
 End

--- a/addons/postgresql/scripts-ut-spec/common_scripts_backup_info_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/common_scripts_backup_info_spec.sh
@@ -1,0 +1,97 @@
+# shellcheck shell=bash
+
+Describe "dataprotection/common-scripts.sh backup-info publication"
+  Include ../dataprotection/common-scripts.sh
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-common-backup-info-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
+    export PATH DP_BACKUP_INFO_FILE
+    unset MV_EXIT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${bindir}/mv"
+  }
+
+  publish_with_existence_observer() {
+    (
+      echo() {
+        case "$1" in
+          '{"totalSize"'*) /bin/sleep 0.2 ;;
+        esac
+        builtin echo "$@"
+      }
+      (
+        for _ in {1..200}; do
+          if [[ -e "${DP_BACKUP_INFO_FILE}" ]]; then
+            /usr/bin/wc -c < "${DP_BACKUP_INFO_FILE}" > "${tmpdir}/observed-bytes"
+            exit 0
+          fi
+          /bin/sleep 0.01
+        done
+        printf '0\n' > "${tmpdir}/observed-bytes"
+        exit 1
+      ) &
+      observer_pid=$!
+      DP_save_backup_status_info "4096" "2026-08-15T17:00:00Z" \
+        "2026-08-15T17:01:00Z"
+      wait "${observer_pid}"
+    )
+  }
+
+  observed_bytes() {
+    tr -d '[:space:]' < "${tmpdir}/observed-bytes"
+  }
+
+  backup_info_temp_count() {
+    find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
+  }
+
+  It "publishes a complete document before the final path is visible"
+    When call publish_with_existence_observer
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[],"timeRange":{"start":"2026-08-15T17:00:00Z","end":"2026-08-15T17:01:00Z"}}'
+  End
+
+  It "preserves the size-only document shape"
+    When call DP_save_backup_status_info "0"
+    The status should eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"0"}'
+  End
+
+  It "preserves end time, timezone, and extras without a start time"
+    When call DP_save_backup_status_info "4096" "" "2026-08-15T17:01:00Z" \
+      "+08:00" '{"source":"archive"}'
+    The status should eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[{"source":"archive"}],"timeRange":{"end":"2026-08-15T17:01:00Z","timeZone":"+08:00"}}'
+  End
+
+  It "fails without leaving metadata when atomic publication fails"
+    export MV_EXIT=7
+    When call DP_save_backup_status_info "4096" "2026-08-15T17:00:00Z" \
+      "2026-08-15T17:01:00Z"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The result of function backup_info_temp_count should eq 0
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/kb_api_contract_spec.sh
@@ -23,6 +23,38 @@ Describe "PostgreSQL KubeBlocks API contract"
     render_chart | grep -c "$pattern" || true
   }
 
+  etcd_service_ref_contract_count() {
+    render_chart | ruby -ryaml -e '
+      versions = YAML.load_file("../../etcd/values.yaml")
+        .fetch("etcdVersions")
+        .map { |entry| entry.fetch("version").to_s }
+      definitions = YAML.load_stream(ARGF.read).compact.select do |document|
+        document["kind"] == "ComponentDefinition"
+      end
+
+      count = definitions.count do |definition|
+        declarations = definition.dig("spec", "serviceRefDeclarations") || []
+        declarations = declarations.select { |declaration| declaration["name"] == "etcd" }
+        next false unless declarations.length == 1
+
+        specs = declarations.first["serviceRefDeclarationSpecs"] || []
+        next false unless specs.length == 1 && specs.first["serviceKind"] == "etcd"
+
+        pattern = specs.first["serviceVersion"].to_s
+        regex = begin
+          Regexp.new(pattern)
+        rescue RegexpError
+          nil
+        end
+        matches = lambda { |version| regex ? regex.match?(version) : version == pattern }
+
+        versions.all? { |version| matches.call(version) } &&
+          ["2.3.8", "4.0.0"].none? { |version| matches.call(version) }
+      end
+      puts count
+    '
+  }
+
   component_definitions_with_pod_list_rbac() {
     render_chart | ruby -ryaml -e '
       definitions = YAML.load_stream(ARGF.read).compact.select do |document|
@@ -213,6 +245,12 @@ EOF
 
   It "uses an exec role probe supported by KubeBlocks main"
     When call component_definitions_with_exec_role_probe
+    The status should eq 0
+    The output should eq "7"
+  End
+
+  It "accepts supported ETCD v3 ServiceDescriptors and rejects other majors"
+    When call etcd_service_ref_contract_count
     The status should eq 0
     The output should eq "7"
   End

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317,SC2329
+
+Describe "PostgreSQL Pgbouncer auth-file contract"
+  Include ../scripts/pgbouncer-setup.sh
+
+  setup() {
+    test_dir=$(mktemp -d -t pgbouncer-authfile-XXXXXX)
+    pgbouncer_template_conf_file="../config/pgbouncer-ini.tpl"
+    pgbouncer_conf_dir="$test_dir/conf/"
+    pgbouncer_log_dir="$test_dir/logs/"
+    pgbouncer_tmp_dir="$test_dir/tmp/"
+    pgbouncer_conf_file="$test_dir/conf/pgbouncer.ini"
+    pgbouncer_user_list_file="$test_dir/conf/userlist.txt"
+    POSTGRESQL_USERNAME=postgres
+    POSTGRESQL_PASSWORD='pa"ss'
+    CURRENT_POD_IP=127.0.0.1
+  }
+
+  cleanup() {
+    rm -rf "$test_dir"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  is_empty() {
+    test -z "${1:-}"
+  }
+
+  Mock useradd
+    exit 0
+  End
+
+  Mock id
+    exit 0
+  End
+
+  Mock getent
+    exit 0
+  End
+
+  Mock chown
+    exit 0
+  End
+
+  It "doubles quotes in overridden passwords for the PgBouncer auth file"
+    When call build_pgbouncer_conf
+    The status should be success
+    The path "$pgbouncer_user_list_file" should be file
+    The contents of file "$pgbouncer_user_list_file" should equal '"postgres" "pa""ss"'
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_authfile_spec.sh
@@ -47,6 +47,7 @@ Describe "PostgreSQL Pgbouncer auth-file contract"
   It "doubles quotes in overridden passwords for the PgBouncer auth file"
     When call build_pgbouncer_conf
     The status should be success
+    The output should include "pgbouncer user and group are ready"
     The path "$pgbouncer_user_list_file" should be file
     The contents of file "$pgbouncer_user_list_file" should equal '"postgres" "pa""ss"'
   End

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
@@ -1,0 +1,64 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2317,SC2329
+
+Describe "PostgreSQL Pgbouncer setup fail-fast contract"
+  Include ../scripts/pgbouncer-setup.sh
+
+  setup() {
+    test_dir=$(mktemp -d -t pgbouncer-failfast-XXXXXX)
+    pgbouncer_template_conf_file="../config/pgbouncer-ini.tpl"
+    pgbouncer_conf_dir="$test_dir/conf/"
+    pgbouncer_log_dir="$test_dir/logs/"
+    pgbouncer_tmp_dir="$test_dir/tmp/"
+    pgbouncer_conf_file="$test_dir/conf/pgbouncer.ini"
+    pgbouncer_user_list_file="$test_dir/conf/userlist.txt"
+    POSTGRESQL_USERNAME=postgres
+    POSTGRESQL_PASSWORD=secret
+    CURRENT_POD_IP=127.0.0.1
+  }
+
+  cleanup() {
+    rm -rf "$test_dir"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  is_empty() {
+    test -z "${1:-}"
+  }
+
+  Mock useradd
+    exit 0
+  End
+
+  Mock load_common_library
+    exit 0
+  End
+
+  Mock id
+    if test "${1:-}" = "-g"; then
+      printf '%s\n' 1001
+    fi
+    exit 0
+  End
+
+  Mock getent
+    exit 0
+  End
+
+  Mock chown
+    exit 42
+  End
+
+  Mock start_pgbouncer
+    printf '%s\n' start-called
+    exit 0
+  End
+
+  It "does not start Pgbouncer after ownership setup fails"
+    When call main
+    The status should be failure
+    The output should not include "start-called"
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
@@ -29,6 +29,14 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
     test -z "${1:-}"
   }
 
+  printf() {
+    if test "$PGB_FAIL_STEP" = "database_header" && test "${1:-}" = '\n[databases]\n'; then
+      return 42
+    fi
+    # shellcheck disable=SC2059
+    builtin printf "$@"
+  }
+
   Mock useradd
     exit 0
   End
@@ -75,6 +83,13 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
 
   It "does not start Pgbouncer after copying the template fails"
     export PGB_FAIL_STEP=cp
+    When call main
+    The status should be failure
+    The output should not include "start-called"
+  End
+
+  It "does not start Pgbouncer after an early database config write fails"
+    export PGB_FAIL_STEP=database_header
     When call main
     The status should be failure
     The output should not include "start-called"

--- a/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgbouncer_setup_spec.sh
@@ -15,6 +15,7 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
     POSTGRESQL_USERNAME=postgres
     POSTGRESQL_PASSWORD=secret
     CURRENT_POD_IP=127.0.0.1
+    export PGB_FAIL_STEP=chown
   }
 
   cleanup() {
@@ -47,8 +48,18 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
     exit 0
   End
 
+  Mock cp
+    if test "$PGB_FAIL_STEP" = "cp"; then
+      exit 42
+    fi
+    /bin/cp "$@"
+  End
+
   Mock chown
-    exit 42
+    if test "$PGB_FAIL_STEP" = "chown"; then
+      exit 42
+    fi
+    exit 0
   End
 
   Mock start_pgbouncer
@@ -57,6 +68,13 @@ Describe "PostgreSQL Pgbouncer setup fail-fast contract"
   End
 
   It "does not start Pgbouncer after ownership setup fails"
+    When call main
+    The status should be failure
+    The output should not include "start-called"
+  End
+
+  It "does not start Pgbouncer after copying the template fails"
+    export PGB_FAIL_STEP=cp
     When call main
     The status should be failure
     The output should not include "start-called"

--- a/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pgdump_restore_spec.sh
@@ -17,13 +17,13 @@ Describe "dataprotection/pgdump-restore.sh"
     DP_DATASAFED_BIN_PATH="${bindir}"
     DP_BACKUP_BASE_PATH="/backup"
     DP_BACKUP_NAME="backup-test"
-    POSTGRES_PASSWORD="secret"
-    POSTGRES_USER="postgres"
+    DP_DB_PASSWORD="dp-secret"
+    DP_DB_USER="kbdataprotection"
     DP_DB_HOST="localhost"
     DP_DB_PORT="5432"
     BACKUP_DIR="${tmpdir}/restore-workdir"
     export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
-      DP_BACKUP_NAME POSTGRES_PASSWORD POSTGRES_USER DP_DB_HOST DP_DB_PORT BACKUP_DIR
+      DP_BACKUP_NAME DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT BACKUP_DIR
     unset DATASAFED_LIST_OUT DATASAFED_PULL_EXIT PG_RESTORE_EXIT PG_RESTORE_STDERR \
       jobs database schemas tables schema_only conflict_policy 2>/dev/null || true
     write_stubs
@@ -59,12 +59,12 @@ cat > /dev/null
 EOF
     cat > "${bindir}/psql" <<'EOF'
 #!/bin/sh
-printf 'psql %s\n' "$*" >> "${CALL_LOG}"
+printf 'psql PGPASSWORD=%s args=%s\n' "${PGPASSWORD}" "$*" >> "${CALL_LOG}"
 exit 0
 EOF
     cat > "${bindir}/pg_restore" <<'EOF'
 #!/bin/sh
-printf 'pg_restore %s\n' "$*" >> "${CALL_LOG}"
+printf 'pg_restore PGPASSWORD=%s args=%s\n' "${PGPASSWORD}" "$*" >> "${CALL_LOG}"
 if [ -n "${PG_RESTORE_STDERR:-}" ]; then
   printf '%s\n' "${PG_RESTORE_STDERR}" >&2
 fi
@@ -83,6 +83,15 @@ EOF
     The status should be failure
     The error should include "backup-test.tar not found"
     The result of function call_log should not include "pg_restore"
+  End
+
+  It "uses the DataProtection user and password for psql and pg_restore"
+    export DATASAFED_LIST_OUT="backup-test.tar"
+    export database="application"
+    When run bash "$(script_path)"
+    The status should eq 0
+    The result of function call_log should include "psql PGPASSWORD=dp-secret args=-h localhost -U kbdataprotection -p 5432"
+    The result of function call_log should include "pg_restore PGPASSWORD=dp-secret args=-h localhost -U kbdataprotection -p 5432"
   End
 
   It "restores successfully when the backup exists and pg_restore succeeds"

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -98,6 +98,15 @@ EOF
     cat "${CALL_LOG}"
   }
 
+  missing_wal_reconciliation_calls_inside_loop() {
+    awk '
+      /^while true; do$/ { in_loop = 1; next }
+      in_loop && /^done$/ { in_loop = 0 }
+      in_loop && /uploadMissingLogs/ { calls++ }
+      END { print calls + 0 }
+    ' ../dataprotection/postgresql-pitr-backup.sh
+  }
+
   retry_same_size_after_publication_failure() {
     export DATASAFED_STAT_OUT="TotalSize: 4096"
     export MV_EXIT=17
@@ -151,6 +160,21 @@ EOF
       The status should be failure
       The output should include "retry detection!"
       The output should include "Before switching to a new instance, back up any remaining WAL logs."
+    End
+  End
+
+  Describe "uploadMissingLogs()"
+    It "fails when the remote WAL listing is unavailable"
+      export DATASAFED_LIST_EXIT=17
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "start to upload the wal log which maybe misses"
+      The error should include "datasafed WAL listing failed"
+    End
+
+    It "keeps a retry path inside the archive loop after a startup failure"
+      When call missing_wal_reconciliation_calls_inside_loop
+      The output should eq 1
     End
   End
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -142,6 +142,18 @@ EOF
     printf 'push-count=%s\n' "${push_count}"
   }
 
+  refresh_missing_cached_oldest_wal() {
+    local oldest_wal="/20260816/000000010000000000000001.zst"
+    mkdir -p "${KB_BACKUP_WORKDIR}"
+    printf '%s\n' "${oldest_wal}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export DATASAFED_LIST_OUT="[{\"path\":\"${oldest_wal}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+    save_backup_status || return
+    local pull_count
+    pull_count=$(grep -c '^datasafed pull ' "${CALL_LOG}" || true)
+    printf 'pull-count=%s\n' "${pull_count}"
+  }
+
   Describe "upload_wal_log()"
     It "does not mark the WAL segment done when the upload fails"
       touch "${LOG_DIR}/000000010000000000000001"
@@ -259,6 +271,12 @@ EOF
       The error should include "failed to pull oldest WAL"
       The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "refreshes a matching oldest-WAL cache when its local artifact is missing"
+      When call refresh_missing_cached_oldest_wal
+      The status should eq 0
+      The output should include "pull-count=1"
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -117,6 +117,19 @@ EOF
     save_backup_status
   }
 
+  retry_missing_wal_push_after_failure() {
+    export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
+    touch "${LOG_DIR}/000000010000000000000001"
+    touch "${LOG_DIR}/archive_status/000000010000000000000001.done"
+    export DATASAFED_PUSH_EXIT=17
+    if uploadMissingLogs; then
+      return 90
+    fi
+    export DATASAFED_PUSH_EXIT=0
+    uploadMissingLogs || return
+    printf 'push-count=%s\n' "$(grep -c '^datasafed push ' "${CALL_LOG}")"
+  }
+
   Describe "upload_wal_log()"
     It "does not mark the WAL segment done when the upload fails"
       touch "${LOG_DIR}/000000010000000000000001"
@@ -175,6 +188,13 @@ EOF
     It "keeps a retry path inside the archive loop after a startup failure"
       When call missing_wal_reconciliation_calls_inside_loop
       The output should eq 1
+    End
+
+    It "retries a missing WAL after its first push fails"
+      When call retry_missing_wal_push_after_failure
+      The status should eq 0
+      The output should include "failed to upload 000000010000000000000001, will retry reconciliation"
+      The output should include "push-count=2"
     End
   End
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PUSH_EXIT \
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
       DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
@@ -52,6 +52,9 @@ printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
   push)
     exit "${DATASAFED_PUSH_EXIT:-0}"
+    ;;
+  pull)
+    exit "${DATASAFED_PULL_EXIT:-0}"
     ;;
   stat)
     printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
@@ -244,6 +247,17 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "datasafed WAL listing failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without caching or publishing when the oldest WAL pull fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_PULL_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to pull oldest WAL"
+      The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_PUSH_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -53,7 +53,8 @@ case "$1" in
     exit "${DATASAFED_PUSH_EXIT:-0}"
     ;;
   stat)
-    echo "TotalSize 0"
+    printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
+    exit "${DATASAFED_STAT_EXIT:-0}"
     ;;
 esac
 EOF
@@ -127,6 +128,16 @@ EOF
       The status should be failure
       The output should include "retry detection!"
       The output should include "Before switching to a new instance, back up any remaining WAL logs."
+    End
+  End
+
+  Describe "save_backup_status()"
+    It "fails clearly when datasafed stat fails instead of retaining stale progress silently"
+      export DATASAFED_STAT_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed stat failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,8 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PUSH_EXIT \
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -55,6 +56,10 @@ case "$1" in
   stat)
     printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
     exit "${DATASAFED_STAT_EXIT:-0}"
+    ;;
+  list)
+    printf '%s' "${DATASAFED_LIST_OUT:-}"
+    exit "${DATASAFED_LIST_EXIT:-0}"
     ;;
 esac
 EOF
@@ -162,6 +167,15 @@ EOF
       When call retry_same_size_after_publication_failure
       The status should eq 0
       The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
+    End
+
+    It "fails without publishing metadata when the WAL repository listing fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed WAL listing failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -130,6 +130,15 @@ EOF
     printf 'push-count=%s\n' "$(grep -c '^datasafed push ' "${CALL_LOG}")"
   }
 
+  reconcile_wal_into_empty_repository() {
+    touch "${LOG_DIR}/000000010000000000000001"
+    touch "${LOG_DIR}/archive_status/000000010000000000000001.done"
+    uploadMissingLogs || return
+    local push_count
+    push_count=$(grep -c '^datasafed push ' "${CALL_LOG}" || true)
+    printf 'push-count=%s\n' "${push_count}"
+  }
+
   Describe "upload_wal_log()"
     It "does not mark the WAL segment done when the upload fails"
       touch "${LOG_DIR}/000000010000000000000001"
@@ -205,6 +214,12 @@ EOF
       The status should be failure
       The output should include "cannot reconcile 000000010000000000000001: local WAL file is missing"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "uploads local done WALs when the repository is empty"
+      When call reconcile_wal_into_empty_repository
+      The status should eq 0
+      The output should include "push-count=1"
     End
   End
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -25,7 +25,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     mkdir -p "${LOG_DIR}/archive_status"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_PUSH_EXIT DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -68,7 +68,15 @@ EOF
 #!/bin/sh
 exit 0
 EOF
-    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump"
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+printf 'mv %s\n' "$*" >> "${CALL_LOG}"
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump" "${bindir}/mv"
   }
 
   build_shim() {
@@ -83,6 +91,16 @@ EOF
 
   call_log() {
     cat "${CALL_LOG}"
+  }
+
+  retry_same_size_after_publication_failure() {
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export MV_EXIT=17
+    if save_backup_status; then
+      return 90
+    fi
+    export MV_EXIT=0
+    save_backup_status
   }
 
   Describe "upload_wal_log()"
@@ -138,6 +156,12 @@ EOF
       The status should be failure
       The error should include "datasafed stat failed"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "retries the same size after an atomic publication failure"
+      When call retry_same_size_after_publication_failure
+      The status should eq 0
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -196,6 +196,16 @@ EOF
       The output should include "failed to upload 000000010000000000000001, will retry reconciliation"
       The output should include "push-count=2"
     End
+
+    It "fails when a remotely missing done WAL has no local source file"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      touch "${LOG_DIR}/archive_status/000000010000000000000001.done"
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "cannot reconcile 000000010000000000000001: local WAL file is missing"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
   End
 
   Describe "save_backup_status()"

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -25,7 +25,8 @@ Describe "dataprotection PITR restore"
     DP_DATASAFED_BIN_PATH="${bindir}"
     export PATH CALL_LOG DATA_DIR PITR_DIR CONF_DIR RESTORE_SCRIPT_DIR \
       DP_RESTORE_TIME DP_RESTORE_TIMESTAMP DP_BACKUP_BASE_PATH DP_DATASAFED_BIN_PATH
-    unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR 2>/dev/null || true
+    unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_ROOT_LIST_EXIT \
+      DATASAFED_DIR_LIST_EXIT 2>/dev/null || true
 
     write_stubs
     build_concat
@@ -45,8 +46,14 @@ printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
   list)
     if [ "$2" = "/" ]; then
+      if [ "${DATASAFED_ROOT_LIST_EXIT:-0}" -ne 0 ]; then
+        exit "${DATASAFED_ROOT_LIST_EXIT}"
+      fi
       printf '%s\n' "${DATASAFED_LIST_ROOT:-}"
     else
+      if [ "${DATASAFED_DIR_LIST_EXIT:-0}" -ne 0 ]; then
+        exit "${DATASAFED_DIR_LIST_EXIT}"
+      fi
       printf '%s\n' "${DATASAFED_LIST_DIR:-}"
     fi
     ;;
@@ -140,6 +147,29 @@ EOF
       The output should include "done."
       The path "${CONF_DIR}/recovery.conf" should be exist
       The path "${DATA_DIR}.old" should be exist
+    End
+
+    It "fails before staging data when the WAL repository root cannot be listed"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      export DATASAFED_ROOT_LIST_EXIT=42
+      When run bash "${concat}"
+      The status should be failure
+      The output should include "failed to list the WAL archive root"
+      The path "${DATA_DIR}" should be exist
+      The path "${DATA_DIR}.old" should not be exist
+    End
+
+    It "fails before staging data when a WAL archive directory cannot be listed"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      export DATASAFED_LIST_ROOT="waldir/"
+      export DATASAFED_DIR_LIST_EXIT=43
+      When run bash "${concat}"
+      The status should be failure
+      The output should include "failed to list WAL archive directory waldir/"
+      The path "${DATA_DIR}" should be exist
+      The path "${DATA_DIR}.old" should not be exist
     End
   End
 

--- a/addons/postgresql/scripts-ut-spec/postgres_pre_setup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/postgres_pre_setup_spec.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2317,SC2329
 
 # validate_shell_type_and_version defined in shellspec/spec_helper.sh used to validate the expected shell type and version this script needs to run.
 if ! validate_shell_type_and_version "bash" 4 &>/dev/null; then
@@ -11,22 +11,51 @@ Describe "PostgreSQL Configuration Script Tests"
 
   Include ../scripts/postgres-pre-setup.sh
 
+  mkdir() {
+    if test "${PRESETUP_FAIL_STEP:-}" = "mkdir"; then
+      return 42
+    fi
+    command mkdir "$@"
+  }
+
+  cp() {
+    if test "${PRESETUP_FAIL_STEP:-}" = "cp"; then
+      return 42
+    fi
+    if test "${PRESETUP_STUB_CP_SUCCESS:-0}" = "1"; then
+      return 0
+    fi
+    command cp "$@"
+  }
+
+  touch() {
+    if test "${PRESETUP_FAIL_STEP:-}" = "touch"; then
+      return 42
+    fi
+    command touch "$@"
+  }
+
   init() {
     postgres_template_conf_file="./postgresql.conf"
     postgres_conf_dir="./pgdata/"
     postgres_conf_file="./pgdata/postgresql.conf"
-    touch $postgres_template_conf_file
+    postgres_log_dir="./pgdata/logs/"
+    postgres_scripts_log_file="${postgres_log_dir}/scripts.log"
+    postgres_walg_dir="./pgdata/wal-g"
+    touch "$postgres_template_conf_file"
+    mkdir -p "$postgres_log_dir" "$postgres_walg_dir"
+    touch "$postgres_conf_file" "$postgres_scripts_log_file"
     echo "listen_addresses = '*'
           port = '5432'
           archive_command = '/bin/true'
           archive_mode = 'on'
           auto_explain.log_analyze = 'False'
-          auto_explain.log_buffers = 'False'" > $postgres_template_conf_file
+          auto_explain.log_buffers = 'False'" > "$postgres_template_conf_file"
   }
   BeforeAll "init"
 
   cleanup() {
-    rm -rf $postgres_template_conf_file $postgres_conf_dir $postgres_conf_file
+    rm -rf "$postgres_template_conf_file" "$postgres_conf_dir" "$postgres_conf_file"
   }
   AfterAll 'cleanup'
 
@@ -39,6 +68,54 @@ Describe "PostgreSQL Configuration Script Tests"
       The contents of file "$postgres_conf_file" should include "listen_addresses = '*'"
       The contents of file "$postgres_conf_file" should include "port = '5432'"
       The contents of file "$postgres_conf_file" should include "archive_command = '/bin/true'"
+    End
+  End
+
+  Describe "build_real_postgres_conf() failure"
+    It "preserves a template copy failure"
+      export PRESETUP_FAIL_STEP=cp
+      When call build_real_postgres_conf
+      The status should equal 42
+    End
+  End
+
+  Describe "init_postgres_log() failure"
+    It "preserves a log-file creation failure"
+      export PRESETUP_FAIL_STEP=touch
+      When call init_postgres_log
+      The status should equal 42
+    End
+  End
+
+  Describe "copy_necessary_binaries() failure"
+    It "preserves a WAL-G directory creation failure"
+      export PRESETUP_FAIL_STEP=mkdir
+      export PRESETUP_STUB_CP_SUCCESS=1
+      When call copy_necessary_binaries
+      The status should equal 42
+    End
+  End
+
+  Describe "main()"
+    Mock build_real_postgres_conf
+      exit 42
+    End
+
+    Mock init_postgres_log
+      echo init-called
+      exit 0
+    End
+
+    Mock copy_necessary_binaries
+      echo copy-called
+      exit 0
+    End
+
+    It "stops after configuration setup fails"
+      When call main
+      The status should equal 42
+      The output should not include "init-called"
+      The output should not include "copy-called"
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
@@ -76,6 +76,13 @@ EOF
       The result of function curl_log should not include '"archive_command": "'\''/bin/true'\''"'
     End
 
+    It "passes an explicit empty PostgreSQL GUC value to Patroni"
+      When run sh "$(script_path)" "archive_command" ""
+      The status should eq 0
+      The result of function curl_log should include '"archive_command": ""'
+      The result of function curl_log should include 'http://localhost:8008/reload'
+    End
+
     It "routes a patroni DCS parameter at top level and reloads"
       When run sh "$(script_path)" "loop_wait" "10"
       The status should eq 0

--- a/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/update_parameter_spec.sh
@@ -62,6 +62,20 @@ EOF
       The result of function curl_log should include 'http://localhost:8008/reload'
     End
 
+    It "preserves embedded single quotes in a PostgreSQL GUC value"
+      When run sh "$(script_path)" "archive_command" "test ! -f '/archive/%f' && cp '%p' '/archive/%f'"
+      The status should eq 0
+      The result of function curl_log should include '"archive_command": "test ! -f '\''/archive/%f'\'' && cp '\''%p'\'' '\''/archive/%f'\''"'
+      The result of function curl_log should include 'http://localhost:8008/reload'
+    End
+
+    It "removes one surrounding quote pair from a PostgreSQL literal"
+      When run sh "$(script_path)" "archive_command" "'/bin/true'"
+      The status should eq 0
+      The result of function curl_log should include '"archive_command": "/bin/true"'
+      The result of function curl_log should not include '"archive_command": "'\''/bin/true'\''"'
+    End
+
     It "routes a patroni DCS parameter at top level and reloads"
       When run sh "$(script_path)" "loop_wait" "10"
       The status should eq 0

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset WALG_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -71,7 +71,10 @@ EOF
 #!/bin/sh
 printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
-  stat) echo "TotalSize 0" ;;
+  stat)
+    printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
+    exit "${DATASAFED_STAT_EXIT:-0}"
+    ;;
 esac
 EOF
     # `date -r <file> +%s` is GNU-only; make it portable for local macOS runs
@@ -201,6 +204,24 @@ EOF
       When run config_wal_g "some/path"
       The status should be failure
       The output should include "wal-g binary not found"
+    End
+  End
+
+  Describe "save_backup_status()"
+    It "publishes the byte count from the real datasafed TotalSize format"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      When call save_backup_status
+      The status should eq 0
+      The output should include "total size: 4096"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
+    End
+
+    It "rejects malformed successful datasafed size output instead of retaining stale progress silently"
+      export DATASAFED_STAT_OUT="TotalSize: unknown"
+      When call save_backup_status
+      The status should be failure
+      The error should include "invalid TotalSize"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -103,6 +103,48 @@ EOF
     cat "${CALL_LOG}"
   }
 
+  wal_g_call_count() {
+    awk '/^wal-g / { calls++ } END { print calls + 0 }' "${CALL_LOG}"
+  }
+
+  history_upload_calls_inside_loop() {
+    awk '
+      /^while true; do$/ { in_loop = 1; next }
+      in_loop && /^done$/ { in_loop = 0 }
+      in_loop && /uploadDoneHistoryWALs/ { calls++ }
+      END { print calls + 0 }
+    ' ../dataprotection/wal-g-archive.sh
+  }
+
+  Describe "uploadDoneHistoryWALs()"
+    It "reports failure and retains timeline history for retry when wal-push fails"
+      touch "${LOG_DIR}/00000002.history"
+      touch "${LOG_DIR}/archive_status/00000002.history.done"
+      export WALG_EXIT=41
+      When call uploadDoneHistoryWALs
+      The status should be failure
+      The output should include "Failed to upload file: 00000002.history"
+      The path "${LOG_DIR}/00000002.history" should be exist
+      The path "${LOG_DIR}/archive_status/00000002.history.done" should be exist
+      The path "${LOG_DIR}/archive_status/00000002.history.done.walg-uploaded" should not be exist
+    End
+
+    It "persists success and does not upload the same timeline history twice"
+      touch "${LOG_DIR}/00000002.history"
+      touch "${LOG_DIR}/archive_status/00000002.history.done"
+      uploadDoneHistoryWALs
+      When call uploadDoneHistoryWALs
+      The status should eq 0
+      The path "${LOG_DIR}/archive_status/00000002.history.done.walg-uploaded" should be exist
+      The result of function wal_g_call_count should eq 1
+    End
+
+    It "is invoked from every archive loop iteration"
+      When call history_upload_calls_inside_loop
+      The output should eq 1
+    End
+  End
+
   Describe "uploadMissingLogs()"
     It "keeps the .ready file and the tracking file when wal-push fails"
       touch "${LOG_DIR}/000000010000000000000001"

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT WALG_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -89,7 +89,15 @@ else
   exec /bin/date "$@"
 fi
 EOF
-    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" "${bindir}/date"
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+printf 'mv %s\n' "$*" >> "${CALL_LOG}"
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
+    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" "${bindir}/date" "${bindir}/mv"
   }
 
   build_shim() {
@@ -117,6 +125,16 @@ EOF
       in_loop && /uploadDoneHistoryWALs/ { calls++ }
       END { print calls + 0 }
     ' ../dataprotection/wal-g-archive.sh
+  }
+
+  retry_same_size_after_publication_failure() {
+    export DATASAFED_STAT_OUT="TotalSize: 4096"
+    export MV_EXIT=17
+    if save_backup_status; then
+      return 90
+    fi
+    export MV_EXIT=0
+    save_backup_status
   }
 
   Describe "uploadDoneHistoryWALs()"
@@ -222,6 +240,13 @@ EOF
       The status should be failure
       The error should include "invalid TotalSize"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "retries the same size after an atomic publication failure"
+      When call retry_same_size_after_publication_failure
+      The status should eq 0
+      The output should include "total size: 4096"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,8 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_STAT_EXIT \
+      DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -74,6 +75,10 @@ case "$1" in
   stat)
     printf '%s\n' "${DATASAFED_STAT_OUT:-TotalSize: 0}"
     exit "${DATASAFED_STAT_EXIT:-0}"
+    ;;
+  list)
+    printf '%s' "${DATASAFED_LIST_OUT:-}"
+    exit "${DATASAFED_LIST_EXIT:-0}"
     ;;
 esac
 EOF
@@ -247,6 +252,24 @@ EOF
       The status should eq 0
       The output should include "total size: 4096"
       The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
+    End
+
+    It "fails without publishing metadata when the WAL repository listing fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed WAL listing failed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "rejects malformed WAL listing JSON before publishing metadata"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="not-json"
+      When call save_backup_status
+      The status should be failure
+      The error should include "datasafed WAL listing returned invalid JSON"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/wal-g-archive.sh"
     export PATH CALL_LOG VOLUME_DATA_DIR LOG_DIR KB_BACKUP_WORKDIR \
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
-    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_STAT_EXIT \
+    unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_STAT_EXIT \
       DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
@@ -79,6 +79,9 @@ case "$1" in
   list)
     printf '%s' "${DATASAFED_LIST_OUT:-}"
     exit "${DATASAFED_LIST_EXIT:-0}"
+    ;;
+  pull)
+    exit "${DATASAFED_PULL_EXIT:-0}"
     ;;
 esac
 EOF
@@ -269,6 +272,17 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "datasafed WAL listing returned invalid JSON"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without caching or publishing when the oldest WAL pull fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_PULL_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to pull oldest WAL"
+      The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
   End

--- a/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
@@ -23,7 +23,8 @@ Describe "WAL-G backup connection contract"
     export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
       DP_BACKUP_NAME DP_PARENT_BACKUP_NAME DP_BACKUP_INFO_FILE \
       DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT VOLUME_DATA_DIR DATA_DIR
-    unset FAIL_SWITCH_WAL 2>/dev/null || true
+    unset DATASAFED_LIST_EXIT FAIL_BACKUP_PUSH FAIL_REPO_SENTINEL_PUSH \
+      FAIL_SWITCH_WAL 2>/dev/null || true
     write_stubs
   }
 
@@ -57,13 +58,26 @@ EOF
 printf 'wal-g PGHOST=%s PGUSER=%s PGPORT=%s args=%s\n' \
   "${PGHOST}" "${PGUSER}" "${PGPORT}" "$*" >> "${CALL_LOG}"
 printf '%s\n' 'Wrote backup with name base_000000010000000000000001'
+if [ "${FAIL_BACKUP_PUSH:-0}" -eq 1 ]; then
+  exit 42
+fi
 EOF
     cat > "${bindir}/datasafed" <<'EOF'
 #!/bin/sh
 printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
 case "$1" in
-  list) printf '%s\n' "$2" ;;
-  push) cat > /dev/null ;;
+  list)
+    if [ "${DATASAFED_LIST_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_LIST_EXIT}"
+    fi
+    printf '%s\n' "$2"
+    ;;
+  push)
+    if [ "${FAIL_REPO_SENTINEL_PUSH:-0}" -eq 1 ] && [ "$3" = "wal-g-backup-repo.path" ]; then
+      exit 43
+    fi
+    cat > /dev/null
+    ;;
   pull)
     case "$2" in
       wal-g-backup-name) printf '%s\n' 'base_parent' > "$3" ;;
@@ -98,6 +112,30 @@ EOF
     The result of function call_log should include "psql -h postgres.example.test -U postgres -p 6432 -d postgres"
     The result of function call_log should include "wal-g PGHOST=postgres.example.test PGUSER=postgres PGPORT=6432"
     The result of function call_log should not include "CLUSTER_COMPONENT_NAME"
+  End
+
+  It "fails an incremental backup before publication when the parent sentinel lookup fails"
+    export DATASAFED_LIST_EXIT=41
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function call_log should not include "wal-g PGHOST="
+  End
+
+  It "fails an incremental backup before backup-push when repository sentinel publication fails"
+    export FAIL_REPO_SENTINEL_PUSH=1
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function call_log should not include "wal-g PGHOST="
+  End
+
+  It "fails an incremental backup when backup-push returns nonzero after writing a backup name"
+    export FAIL_BACKUP_PUSH=1
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function call_log should not include "pg_switch_wal"
   End
 
   It "executes incremental backup and WAL switch against the ActionSet endpoint"

--- a/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_backup_contract_spec.sh
@@ -24,7 +24,7 @@ Describe "WAL-G backup connection contract"
       DP_BACKUP_NAME DP_PARENT_BACKUP_NAME DP_BACKUP_INFO_FILE \
       DP_DB_PASSWORD DP_DB_USER DP_DB_HOST DP_DB_PORT VOLUME_DATA_DIR DATA_DIR
     unset DATASAFED_LIST_EXIT FAIL_BACKUP_PUSH FAIL_REPO_SENTINEL_PUSH \
-      FAIL_SWITCH_WAL 2>/dev/null || true
+      FAIL_SWITCH_WAL MV_EXIT 2>/dev/null || true
     write_stubs
   }
 
@@ -94,8 +94,15 @@ case "$*" in
   *CompressedSize*) printf '%s\n' '42' ;;
 esac
 EOF
+    cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+if [ "${MV_EXIT:-0}" -ne 0 ]; then
+  exit "${MV_EXIT}"
+fi
+exec /bin/mv "$@"
+EOF
     chmod +x "${bindir}/cp" "${bindir}/psql" "${bindir}/wal-g" \
-      "${bindir}/datasafed" "${bindir}/jq"
+      "${bindir}/datasafed" "${bindir}/jq" "${bindir}/mv"
   }
 
   call_log() {
@@ -104,6 +111,42 @@ EOF
 
   run_backup() {
     (cd "${tmpdir}" && bash "${dataprotection_dir}/$1")
+  }
+
+  run_backup_with_existence_observer() {
+    local script="$1"
+    (
+      cd "${tmpdir}" || exit 1
+      echo() {
+        case "$1" in
+          '{"totalSize"'*) /bin/sleep 0.2 ;;
+        esac
+        builtin echo "$@"
+      }
+      (
+        for _ in {1..200}; do
+          if [[ -e "${DP_BACKUP_INFO_FILE}" ]]; then
+            /usr/bin/wc -c < "${DP_BACKUP_INFO_FILE}" > "${tmpdir}/observed-bytes"
+            exit 0
+          fi
+          /bin/sleep 0.01
+        done
+        printf '0\n' > "${tmpdir}/observed-bytes"
+        exit 1
+      ) &
+      observer_pid=$!
+      # shellcheck disable=SC1090
+      . "${dataprotection_dir}/${script}"
+      wait "${observer_pid}"
+    )
+  }
+
+  observed_bytes() {
+    tr -d '[:space:]' < "${tmpdir}/observed-bytes"
+  }
+
+  backup_info_temp_count() {
+    find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
   }
 
   It "executes full backup and WAL switch against the ActionSet endpoint"
@@ -160,5 +203,37 @@ EOF
     The status should be failure
     The output should include "failed with exit code 2"
     The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+  End
+
+  It "publishes complete full-backup metadata before the final path is visible"
+    When call run_backup_with_existence_observer "wal-g-backup.sh"
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"wal-g-backup-name":"base_000000010000000000000001"'
+  End
+
+  It "publishes complete incremental metadata before the final path is visible"
+    When call run_backup_with_existence_observer "wal-g-incremental-backup.sh"
+    The status should eq 0
+    The result of function observed_bytes should not eq 0
+    The contents of file "${DP_BACKUP_INFO_FILE}" should include '"wal-g-backup-name":"base_000000010000000000000001"'
+  End
+
+  It "fails full metadata publication without leaving final or temporary metadata"
+    export MV_EXIT=7
+    When call run_backup "wal-g-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function backup_info_temp_count should eq 0
+  End
+
+  It "fails incremental metadata publication without leaving final or temporary metadata"
+    export MV_EXIT=7
+    When call run_backup "wal-g-incremental-backup.sh"
+    The status should be failure
+    The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    The path "${DP_BACKUP_INFO_FILE}.exit" should be file
+    The result of function backup_info_temp_count should eq 0
   End
 End

--- a/addons/postgresql/scripts-ut-spec/walg_delete_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_delete_spec.sh
@@ -1,0 +1,99 @@
+# shellcheck shell=sh
+
+Describe "PostgreSQL WAL-G preDelete failure propagation"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-walg-delete-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/repo/backup-test"
+    DP_BACKUP_NAME="backup-test"
+    dataprotection_dir=$(cd ../dataprotection && pwd)
+    export PATH CALL_LOG DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH \
+      DP_BACKUP_NAME
+    unset DATASAFED_LIST_EXIT WALG_TARGET_EXIT WALG_ARCHIVE_EXIT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+if [ "$1" = "list" ]; then
+  if [ "${DATASAFED_LIST_EXIT:-0}" -ne 0 ]; then
+    exit "${DATASAFED_LIST_EXIT}"
+  fi
+  case "$*" in
+    "list wal-g-backup-repo.path") printf '%s\n' wal-g-backup-repo.path ;;
+    "list wal-g-backup-name") printf '%s\n' wal-g-backup-name ;;
+    *"/basebackups_005"*) printf '%s\n' base_00000001 ;;
+  esac
+elif [ "$1" = "pull" ]; then
+  case "$2" in
+    wal-g-backup-repo.path) printf '%s\n' /repo/wal-g > "$3" ;;
+    wal-g-backup-name) printf '%s\n' base_00000001 > "$3" ;;
+  esac
+fi
+exit 0
+EOF
+    cat > "${bindir}/wal-g" <<'EOF'
+#!/bin/sh
+printf 'wal-g %s\n' "$*" >> "${CALL_LOG}"
+case "$*" in
+  "delete target "*) exit "${WALG_TARGET_EXIT:-0}" ;;
+  "delete garbage ARCHIVES --confirm") exit "${WALG_ARCHIVE_EXIT:-0}" ;;
+esac
+exit 0
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/wal-g"
+  }
+
+  run_full_delete() {
+    (cd "${tmpdir}" && bash "${dataprotection_dir}/wal-g-delete.sh")
+  }
+
+  run_archive_delete() {
+    (cd "${tmpdir}" && bash "${dataprotection_dir}/wal-g-archive-delete.sh")
+  }
+
+  It "fails when the full-backup repository lookup fails"
+    export DATASAFED_LIST_EXIT=41
+    When call run_full_delete
+    The status should eq 41
+  End
+
+  It "fails when deleting the referenced WAL-G base backup fails"
+    export WALG_TARGET_EXIT=42
+    When call run_full_delete
+    The status should eq 42
+    The output should include "delete base_00000001"
+  End
+
+  It "fails when archive garbage collection fails"
+    export WALG_ARCHIVE_EXIT=43
+    When call run_archive_delete
+    The status should eq 43
+  End
+
+  It "succeeds after all full-backup repository cleanup steps succeed"
+    When call run_full_delete
+    The status should eq 0
+    The output should include "delete outdated WAL archive"
+  End
+
+  It "succeeds after all archive repository cleanup steps succeed"
+    When call run_archive_delete
+    The status should eq 0
+  End
+End

--- a/addons/postgresql/scripts-ut-spec/walg_restore_preflight_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_restore_preflight_spec.sh
@@ -1,0 +1,134 @@
+# shellcheck shell=sh
+
+Describe "dataprotection/wal-g-restore.sh sentinel preflight"
+
+  setup() {
+    tmpdir=$(mktemp -d -t pg-walg-restore-preflight-XXXXXX)
+    bindir="${tmpdir}/bin"
+    mkdir -p "${bindir}"
+    PATH="${bindir}:${PATH}"
+    CALL_LOG="${tmpdir}/calls.log"
+    : > "${CALL_LOG}"
+    DATA_DIR="${tmpdir}/pgdata"
+    RESTORE_SCRIPT_DIR="${tmpdir}/restore-script"
+    VOLUME_DATA_DIR="${tmpdir}/volume"
+    DP_DATASAFED_BIN_PATH="${bindir}"
+    DP_BACKUP_BASE_PATH="/repo/backup-test"
+    DP_RESTORE_TIMESTAMP="1"
+    dataprotection_dir=$(cd ../dataprotection && pwd)
+    mkdir -p "${DATA_DIR}"
+    printf '%s\n' original > "${DATA_DIR}/original.marker"
+    export PATH CALL_LOG DATA_DIR RESTORE_SCRIPT_DIR VOLUME_DATA_DIR \
+      DP_DATASAFED_BIN_PATH DP_BACKUP_BASE_PATH DP_RESTORE_TIMESTAMP
+    unset DATASAFED_LIST_EXIT DATASAFED_PULL_EXIT DATASAFED_SKIP_WRITE \
+      MISSING_BACKUP_NAME SENTINELS_PRESENT 2>/dev/null || true
+    write_stubs
+  }
+
+  cleanup() {
+    rm -rf "${tmpdir}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  write_stubs() {
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+printf 'datasafed %s\n' "$*" >> "${CALL_LOG}"
+case "$1" in
+  list)
+    if [ "${DATASAFED_LIST_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_LIST_EXIT}"
+    fi
+    if [ "${SENTINELS_PRESENT:-0}" -eq 1 ]; then
+      if [ "${MISSING_BACKUP_NAME:-0}" -ne 1 ] || [ "$2" != "wal-g-backup-name" ]; then
+        printf '%s\n' "$2"
+      fi
+    fi
+    ;;
+  pull)
+    if [ "${DATASAFED_PULL_EXIT:-0}" -ne 0 ]; then
+      exit "${DATASAFED_PULL_EXIT}"
+    fi
+    if [ "${DATASAFED_SKIP_WRITE:-0}" -eq 1 ]; then
+      exit 0
+    fi
+    case "$2" in
+      wal-g-backup-repo.path) printf '%s\n' /repo/wal-g > "$3" ;;
+      wal-g-backup-name) printf '%s\n' base_00000001 > "$3" ;;
+    esac
+    ;;
+esac
+EOF
+    cat > "${bindir}/wal-g" <<'EOF'
+#!/bin/sh
+printf 'wal-g %s\n' "$*" >> "${CALL_LOG}"
+if [ "$1" = "backup-fetch" ]; then
+  mkdir -p "$2"
+  printf '%s\n' fetched > "$2/fetched.marker"
+fi
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/wal-g"
+  }
+
+  run_restore() {
+    (cd "${tmpdir}" && bash "${dataprotection_dir}/wal-g-restore.sh")
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
+  }
+
+  It "fails before replacing data when sentinel metadata is missing"
+    When call run_restore
+    The status should be failure
+    The error should include "missing WAL-G backup repository sentinel"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when the backup name sentinel is missing"
+    export SENTINELS_PRESENT=1 MISSING_BACKUP_NAME=1
+    When call run_restore
+    The status should be failure
+    The error should include "missing WAL-G backup name sentinel"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when sentinel lookup is unavailable"
+    export DATASAFED_LIST_EXIT=41
+    When call run_restore
+    The status should be failure
+    The error should include "failed to list WAL-G sentinel wal-g-backup-repo.path"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when sentinel download is unavailable"
+    export SENTINELS_PRESENT=1 DATASAFED_PULL_EXIT=42
+    When call run_restore
+    The status should be failure
+    The error should include "failed to pull WAL-G sentinel wal-g-backup-repo.path"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fails before replacing data when downloaded sentinel content cannot be read"
+    export SENTINELS_PRESENT=1 DATASAFED_SKIP_WRITE=1
+    When call run_restore
+    The status should be failure
+    The error should include "failed to read WAL-G sentinel wal-g-backup-repo.path"
+    The path "${DATA_DIR}/original.marker" should be exist
+    The result of function call_log should not include "wal-g backup-fetch"
+  End
+
+  It "fetches the named base backup after both sentinels are validated"
+    export SENTINELS_PRESENT=1
+    When call run_restore
+    The status should eq 0
+    The path "${DATA_DIR}/fetched.marker" should be exist
+    The result of function call_log should include "wal-g backup-fetch ${DATA_DIR} base_00000001"
+  End
+End

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -89,6 +89,12 @@ start_pgbouncer() {
   su pgbouncer -c "/opt/bitnami/scripts/pgbouncer/run.sh"
 }
 
+main() {
+  load_common_library || return $?
+  build_pgbouncer_conf || return $?
+  start_pgbouncer
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -96,7 +102,4 @@ start_pgbouncer() {
 # end here. The script path is assigned to the __SOURCED__ variable.
 ${__SOURCED__:+false} : || return 0
 
-# main
-load_common_library
-build_pgbouncer_conf
-start_pgbouncer
+main

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -20,15 +20,16 @@ build_pgbouncer_conf() {
     exit 1
   fi
 
-  mkdir -p $pgbouncer_conf_dir $pgbouncer_log_dir $pgbouncer_tmp_dir
-  cp $pgbouncer_template_conf_file $pgbouncer_conf_dir
-  echo "\"$POSTGRESQL_USERNAME\" \"$POSTGRESQL_PASSWORD\"" > $pgbouncer_user_list_file
-  # shellcheck disable=SC2129
-  echo -e "\\n[databases]" >> $pgbouncer_conf_file
-  echo "postgres=host=$CURRENT_POD_IP port=5432 dbname=postgres" >> $pgbouncer_conf_file
-  echo "*=host=$CURRENT_POD_IP port=5432" >> $pgbouncer_conf_file
-  chmod 644 $pgbouncer_conf_file
-  chmod 600 $pgbouncer_user_list_file
+  mkdir -p "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir" || return $?
+  cp "$pgbouncer_template_conf_file" "$pgbouncer_conf_dir" || return $?
+  printf '"%s" "%s"\n' "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" > "$pgbouncer_user_list_file" || return $?
+  {
+    printf '\n[databases]\n'
+    printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP"
+    printf '*=host=%s port=5432\n' "$CURRENT_POD_IP"
+  } >> "$pgbouncer_conf_file" || return $?
+  chmod 644 "$pgbouncer_conf_file" || return $?
+  chmod 600 "$pgbouncer_user_list_file" || return $?
 
   # Try to add user
   useradd pgbouncer 2>/dev/null || true
@@ -51,7 +52,7 @@ build_pgbouncer_conf() {
       next_uid=$((next_uid + 1))
 
       # Add user to /etc/passwd
-      echo "pgbouncer:x:$next_uid:$next_uid:pgbouncer user:/nonexistent:/bin/false" >> /etc/passwd
+      printf 'pgbouncer:x:%s:%s:pgbouncer user:/nonexistent:/bin/false\n' "$next_uid" "$next_uid" >> /etc/passwd || return $?
       echo "Added pgbouncer user to /etc/passwd"
   fi
 
@@ -62,13 +63,13 @@ build_pgbouncer_conf() {
       # Get the user's GID if user exists
       if id "pgbouncer" >/dev/null 2>&1; then
           user_gid=$(id -g pgbouncer)
-          echo "pgbouncer:x:$user_gid:" >> /etc/group
+          printf 'pgbouncer:x:%s:\n' "$user_gid" >> /etc/group || return $?
           echo "Added pgbouncer group with GID $user_gid to /etc/group"
       else
           # Fallback: use next available GID
           next_gid=$(awk -F: '$3 >= 1000 && $3 < 65534 {print $3}' /etc/group | sort -n | tail -1)
           next_gid=$((next_gid + 1))
-          echo "pgbouncer:x:$next_gid:" >> /etc/group
+          printf 'pgbouncer:x:%s:\n' "$next_gid" >> /etc/group || return $?
           echo "Added pgbouncer group with GID $next_gid to /etc/group"
       fi
   fi
@@ -81,7 +82,7 @@ build_pgbouncer_conf() {
       exit 1
   fi
 
-  chown -R pgbouncer:pgbouncer $pgbouncer_conf_dir $pgbouncer_log_dir $pgbouncer_tmp_dir
+  chown -R pgbouncer:pgbouncer "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir"
 }
 
 start_pgbouncer() {

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -23,11 +23,10 @@ build_pgbouncer_conf() {
   mkdir -p "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir" || return $?
   cp "$pgbouncer_template_conf_file" "$pgbouncer_conf_dir" || return $?
   printf '"%s" "%s"\n' "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" > "$pgbouncer_user_list_file" || return $?
-  {
-    printf '\n[databases]\n'
-    printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP"
-    printf '*=host=%s port=5432\n' "$CURRENT_POD_IP"
-  } >> "$pgbouncer_conf_file" || return $?
+  # shellcheck disable=SC2129
+  printf '\n[databases]\n' >> "$pgbouncer_conf_file" || return $?
+  printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP" >> "$pgbouncer_conf_file" || return $?
+  printf '*=host=%s port=5432\n' "$CURRENT_POD_IP" >> "$pgbouncer_conf_file" || return $?
   chmod 644 "$pgbouncer_conf_file" || return $?
   chmod 600 "$pgbouncer_user_list_file" || return $?
 

--- a/addons/postgresql/scripts/pgbouncer-setup.sh
+++ b/addons/postgresql/scripts/pgbouncer-setup.sh
@@ -20,9 +20,12 @@ build_pgbouncer_conf() {
     exit 1
   fi
 
+  local escaped_username="${POSTGRESQL_USERNAME//\"/\"\"}"
+  local escaped_password="${POSTGRESQL_PASSWORD//\"/\"\"}"
+
   mkdir -p "$pgbouncer_conf_dir" "$pgbouncer_log_dir" "$pgbouncer_tmp_dir" || return $?
   cp "$pgbouncer_template_conf_file" "$pgbouncer_conf_dir" || return $?
-  printf '"%s" "%s"\n' "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" > "$pgbouncer_user_list_file" || return $?
+  printf '"%s" "%s"\n' "$escaped_username" "$escaped_password" > "$pgbouncer_user_list_file" || return $?
   # shellcheck disable=SC2129
   printf '\n[databases]\n' >> "$pgbouncer_conf_file" || return $?
   printf 'postgres=host=%s port=5432 dbname=postgres\n' "$CURRENT_POD_IP" >> "$pgbouncer_conf_file" || return $?

--- a/addons/postgresql/scripts/postgres-pre-setup.sh
+++ b/addons/postgresql/scripts/postgres-pre-setup.sh
@@ -8,32 +8,32 @@ postgres_scripts_log_file="${postgres_log_dir}/scripts.log"
 postgres_walg_dir="/home/postgres/pgdata/wal-g"
 
 build_real_postgres_conf() {
-  mkdir -p "$postgres_conf_dir"
+  mkdir -p "$postgres_conf_dir" || return $?
 
   # Copy the template config file first
-  cp "$postgres_template_conf_file" "$postgres_conf_dir"
+  cp "$postgres_template_conf_file" "$postgres_conf_dir" || return $?
 
   # Set permissions
-  chmod 755 "$postgres_conf_dir"
-  chmod 664 "$postgres_conf_file"
+  chmod 755 "$postgres_conf_dir" || return $?
+  chmod 664 "$postgres_conf_file" || return $?
 }
 
 init_postgres_log() {
-  mkdir -p "$postgres_log_dir"
-  chmod -R 777 "$postgres_log_dir"
-  touch "$postgres_scripts_log_file"
-  chmod 666 "$postgres_scripts_log_file"
+  mkdir -p "$postgres_log_dir" || return $?
+  chmod -R 777 "$postgres_log_dir" || return $?
+  touch "$postgres_scripts_log_file" || return $?
+  chmod 666 "$postgres_scripts_log_file" || return $?
 }
 
 copy_necessary_binaries() {
-  mkdir -p "$postgres_walg_dir"
-  cp /spilo-init/bin/wal-g ${postgres_walg_dir}/wal-g
+  mkdir -p "$postgres_walg_dir" || return $?
+  cp /spilo-init/bin/wal-g "${postgres_walg_dir}/wal-g" || return $?
 }
 
 main() {
-  build_real_postgres_conf
-  init_postgres_log
-  copy_necessary_binaries
+  build_real_postgres_conf || return $?
+  init_postgres_log || return $?
+  copy_necessary_binaries || return $?
 }
 
 # This is magic for shellspec ut framework.

--- a/addons/postgresql/scripts/postgres-pre-setup.sh
+++ b/addons/postgresql/scripts/postgres-pre-setup.sh
@@ -30,6 +30,12 @@ copy_necessary_binaries() {
   cp /spilo-init/bin/wal-g ${postgres_walg_dir}/wal-g
 }
 
+main() {
+  build_real_postgres_conf
+  init_postgres_log
+  copy_necessary_binaries
+}
+
 # This is magic for shellspec ut framework.
 # Sometime, functions are defined in a single shell script.
 # You will want to test it. but you do not want to run the script.
@@ -37,7 +43,4 @@ copy_necessary_binaries() {
 # end here. The script path is assigned to the __SOURCED__ variable.
 ${__SOURCED__:+false} : || return 0
 
-# main
-build_real_postgres_conf
-init_postgres_log
-copy_necessary_binaries
+main

--- a/addons/postgresql/templates/cmpd.yaml
+++ b/addons/postgresql/templates/cmpd.yaml
@@ -18,7 +18,7 @@ spec:
     - name: etcd
       serviceRefDeclarationSpecs:
         - serviceKind: etcd
-          serviceVersion: "^*"
+          serviceVersion: "^3\\.\\d+\\.\\d+$"
       optional: true
     - name: remote-instances
       serviceRefDeclarationSpecs:


### PR DESCRIPTION
## Summary
- require the cached oldest-WAL artifact to exist locally before reusing it
- repull the same remote oldest WAL when its local analysis file has disappeared
- keep Continuous start-time metadata retryable after local cache loss

## Base
- parent PR: #3357
- exact parent head: `995bc16480b58d32c29cd8717ccb0592907b3842`

## TDD evidence
- RED: focused Bash 5 ShellSpec 15 examples / 1 failure
- GREEN: focused Bash 5 ShellSpec 15/0; full PostgreSQL Bash 5 ShellSpec 218/0
- static: ShellCheck error severity, Bash syntax, and `git diff --check` all pass
- chart: Helm lint 1/0; render 41 documents / 1001609 bytes

## Contract
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md:35,43`
