### PR TITLE
fix(postgresql): fail latest WAL pull errors

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -72,7 +72,10 @@ function pull_wal_log() {
 function get_wal_log_end_time() {
     wal_file="${1:?missing file name to pull}"
     mkdir -p "${KB_BACKUP_WORKDIR}" && cd "${KB_BACKUP_WORKDIR}" || return 1
-    pull_wal_log ${wal_file}
+    if ! pull_wal_log "${wal_file}"; then
+       DP_error_log "failed to pull latest WAL: ${wal_file}" >&2
+       return 1
+    fi
     wal_file_name=$(DP_get_file_name_without_ext "$(basename "${wal_file}")")
     local END_TIME=$(pg_waldump $wal_file_name --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
     if [[ ! -z ${END_TIME} ]];then
@@ -107,7 +110,9 @@ function save_backup_status() {
     if [ -n "${wal_files}" ]; then
       # get the end time from the latest 10 files
       for file in $(echo $wal_files | tr ' ' '\n' | tail -n 10 | tac); do
-         END_TIME=$(get_wal_log_end_time ${file})
+         if ! END_TIME=$(get_wal_log_end_time "${file}"); then
+           return 1
+         fi
          if [ -n "${END_TIME}" ];then
              break
          fi

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -285,5 +285,20 @@ EOF
       The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
+
+    It "fails without publishing when the latest WAL pull fails"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export DATASAFED_PULL_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to pull latest WAL"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
   End
 End


### PR DESCRIPTION
## Summary
- propagate `datasafed pull` failures while deriving the latest WAL end time
- stop Continuous metadata publication and progress commits when that pull fails
- cover the producer path with deterministic ShellSpec fault injection

## Evidence
- exact base: PR #3358 head `949e0c5a46033f7927c212a3a9a8b516959d278c`
- RED: focused WAL-G archive suite 16 examples / 1 failure, with 4 failed assertions proving rc17 returned success, emitted no diagnostic, and created `backup.info`
- GREEN: focused 16/0; full PostgreSQL Bash 5 ShellSpec 219/0
- changed-file ShellCheck (`--severity=error`), Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 1,001,795 bytes

## Contract
`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md` requires observable sync progress for Continuous methods (line 31), payload-backed restore artifacts (line 35), legal empty/no-change handling distinct from repository errors (line 37), and an interpretable Continuous `timeRange`/PITR window (line 43). A failed latest-WAL read must not be published as valid progress.

## Boundary
This is source and unit-test evidence only. Runtime packaging, environment execution, cleanup, and formal N remain Test-owned and unproven by this PR.
