### PR TITLE
fix(postgresql): fail latest WAL analysis errors

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -77,12 +77,22 @@ function get_wal_log_end_time() {
        return 1
     fi
     wal_file_name=$(DP_get_file_name_without_ext "$(basename "${wal_file}")")
-    local END_TIME=$(pg_waldump $wal_file_name --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+    local wal_dump_output
+    local wal_dump_status
+    local END_TIME
+    wal_dump_output=$(pg_waldump "${wal_file_name}" --rmgr=Transaction 2>/dev/null)
+    wal_dump_status=$?
+    END_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+    if [[ ${wal_dump_status} -ne 0 && -z ${END_TIME} ]]; then
+       DP_error_log "failed to analyze latest WAL: ${wal_file}" >&2
+       rm -rf "${wal_file_name}"
+       return 1
+    fi
     if [[ ! -z ${END_TIME} ]];then
        END_TIME=$(date -d "${END_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
        echo $END_TIME
     fi
-    rm -rf $wal_file_name
+    rm -rf "${wal_file_name}"
 }
 
 # save backup status info to sync file

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -29,7 +29,8 @@ Describe "dataprotection/wal-g-archive.sh"
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_STAT_EXIT \
-      DATASAFED_STAT_OUT MV_EXIT WALG_EXIT PSQL_EXIT 2>/dev/null || true
+      DATASAFED_STAT_OUT DATE_D_OUT MV_EXIT PG_WALDUMP_EXIT PG_WALDUMP_FAIL_ON_CALL \
+      PG_WALDUMP_OUT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -53,6 +54,15 @@ Describe "dataprotection/wal-g-archive.sh"
 #!/bin/sh
 printf 'wal-g %s\n' "$*" >> "${CALL_LOG}"
 exit "${WALG_EXIT:-0}"
+EOF
+    cat > "${bindir}/pg_waldump" <<'EOF'
+#!/bin/sh
+printf 'pg_waldump %s\n' "$*" >> "${CALL_LOG}"
+call_count=$(awk '/^pg_waldump / { calls++ } END { print calls + 0 }' "${CALL_LOG}")
+printf '%s' "${PG_WALDUMP_OUT:-}"
+if [ "${PG_WALDUMP_FAIL_ON_CALL:-0}" -eq "${call_count}" ]; then
+  exit "${PG_WALDUMP_EXIT:-17}"
+fi
 EOF
     # the script invokes wal-g through envdir (daemontools), which the test
     # host may not have: pass through to the wrapped command, skipping the dir
@@ -88,7 +98,9 @@ EOF
     # `date -r <file> +%s` is GNU-only; make it portable for local macOS runs
     cat > "${bindir}/date" <<'EOF'
 #!/bin/sh
-if [ "$1" = "-r" ]; then
+if [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
+  printf '%s\n' "${DATE_D_OUT}"
+elif [ "$1" = "-r" ]; then
   f=$2
   # GNU form first: on GNU, `stat -f %m <file>` is not an error — it prints
   # the filesystem mount point — so a BSD-first chain returns garbage.
@@ -105,7 +117,8 @@ if [ "${MV_EXIT:-0}" -ne 0 ]; then
 fi
 exec /bin/mv "$@"
 EOF
-    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" "${bindir}/date" "${bindir}/mv"
+    chmod +x "${VOLUME_DATA_DIR}/wal-g/wal-g" "${bindir}/psql" "${bindir}/datasafed" \
+      "${bindir}/date" "${bindir}/mv" "${bindir}/pg_waldump"
   }
 
   build_shim() {
@@ -299,6 +312,38 @@ EOF
       The status should be failure
       The error should include "failed to pull latest WAL"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without publishing when latest WAL analysis fails"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export PG_WALDUMP_FAIL_ON_CALL=2 PG_WALDUMP_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to analyze latest WAL"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "uses a commit record from a partial latest WAL despite pg_waldump's final nonzero status"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16 00:00:00 UTC; origin: node'
+      export PG_WALDUMP_FAIL_ON_CALL=2 PG_WALDUMP_EXIT=17
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call save_backup_status
+      The status should eq 0
+      The output should include "end time of the latest wal: 2026-08-16T00:00:00Z"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[],"timeRange":{"start":"2026-08-16T00:00:00Z","end":"2026-08-16T00:00:00Z"}}'
     End
   End
 End


### PR DESCRIPTION
## Summary
- preserve `pg_waldump` status while deriving the latest Continuous WAL end time
- reject nonzero analysis with no usable COMMIT record before metadata publication
- retain partial-WAL compatibility when `pg_waldump` returns a usable COMMIT before its final nonzero status

## Evidence
- exact base: PR #3359 head `0b1be265dbded613c7cd043a7943db19dca92a71`
- RED: focused WAL-G archive suite 17 examples / 1 failure, with 4 failed assertions proving analyzer rc17 returned success, emitted no diagnostic, and created `backup.info`
- GREEN: focused 18/0; full PostgreSQL Bash 5 ShellSpec 221/0
- changed-file ShellCheck (`--severity=error`), Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 1,002,215 bytes

## Contract
`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md` requires observable sync progress for Continuous methods (line 31), payload-backed restore artifacts (line 35), legal empty/no-change handling distinct from tool failures (line 37), and an interpretable Continuous `timeRange`/PITR window (line 43). A failed analyzer with no usable record must not be published as valid progress.

## Boundary
This is source and unit-test evidence only. Runtime packaging, environment execution, cleanup, and formal N remain Test-owned and unproven by this PR.
