### PR TITLE
fix(postgresql): fail WAL timestamp errors

### DIFF
--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -89,7 +89,13 @@ function get_wal_log_end_time() {
        return 1
     fi
     if [[ ! -z ${END_TIME} ]];then
-       END_TIME=$(date -d "${END_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
+       local normalized_end_time
+       if ! normalized_end_time=$(date -d "${END_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ'); then
+          DP_error_log "failed to normalize latest WAL timestamp: ${wal_file}" >&2
+          rm -rf "${wal_file_name}"
+          return 1
+       fi
+       END_TIME="${normalized_end_time}"
        echo $END_TIME
     fi
     rm -rf "${wal_file_name}"

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -29,7 +29,8 @@ Describe "dataprotection/wal-g-archive.sh"
       DP_BACKUP_INFO_FILE UPLOAD_MISSING_LOGS_RETRY_INTERVAL \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_STAT_EXIT \
-      DATASAFED_STAT_OUT DATE_D_OUT MV_EXIT PG_WALDUMP_EXIT PG_WALDUMP_FAIL_ON_CALL \
+      DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_FAIL_ON_CALL DATE_D_OUT MV_EXIT \
+      PG_WALDUMP_EXIT PG_WALDUMP_FAIL_ON_CALL \
       PG_WALDUMP_OUT WALG_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
@@ -99,6 +100,11 @@ EOF
     cat > "${bindir}/date" <<'EOF'
 #!/bin/sh
 if [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
+  printf 'date %s\n' "$*" >> "${CALL_LOG}"
+  call_count=$(awk '/^date / { calls++ } END { print calls + 0 }' "${CALL_LOG}")
+  if [ "${DATE_D_FAIL_ON_CALL:-0}" -eq "${call_count}" ]; then
+    exit "${DATE_D_EXIT:-17}"
+  fi
   printf '%s\n' "${DATE_D_OUT}"
 elif [ "$1" = "-r" ]; then
   f=$2
@@ -326,6 +332,23 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "failed to analyze latest WAL"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without publishing when latest WAL timestamp normalization fails"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16 00:00:00 UTC; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      export DATE_D_FAIL_ON_CALL=2 DATE_D_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to normalize latest WAL timestamp"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 


### PR DESCRIPTION
## Summary
- preserve latest-WAL timestamp normalization failures
- stop Continuous metadata publication and progress commits when `date -d` cannot normalize the analyzed COMMIT time
- cover the producer path with sequenced analyzer/date fault injection

## Evidence
- exact base: PR #3360 head `1b4a0ebd9333a49dd486b9f0e981d2036f46c530`
- RED: focused WAL-G archive suite 19 examples / 1 failure, with 4 failed assertions proving the second `date -d` rc17 returned success, emitted no diagnostic, and created size-only `backup.info`
- GREEN: focused 19/0; full PostgreSQL Bash 5 ShellSpec 222/0
- changed-file ShellCheck (`--severity=error`), Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 1,002,507 bytes

## Contract
`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md` requires observable sync progress for Continuous methods (line 31), payload-backed restore artifacts (line 35), legal empty/no-change handling distinct from tool failures (line 37), and an interpretable Continuous `timeRange`/PITR window (line 43). An unnormalizable latest COMMIT time must not be published as valid progress.

## Boundary
This is source and unit-test evidence only. Runtime packaging, environment execution, cleanup, and formal N remain Test-owned and unproven by this PR.
