### PR TITLE
fix(postgresql): fail oldest WAL analysis errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -89,7 +89,16 @@ function upload_wal_log() {
 # get start time of the wal log
 function get_wal_log_start_time() {
     local file="${1:?missing wal log name to analyze}"
-    local START_TIME=$(pg_waldump $file --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |head -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+    local wal_dump_output
+    local wal_dump_status
+    local START_TIME
+    wal_dump_output=$(pg_waldump "${file}" --rmgr=Transaction 2>/dev/null)
+    wal_dump_status=$?
+    START_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |head -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+    if [[ ${wal_dump_status} -ne 0 && -z ${START_TIME} ]]; then
+       DP_error_log "failed to analyze oldest WAL: ${file}" >&2
+       return 1
+    fi
     if [[ ! -z ${START_TIME} ]];then
        START_TIME=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
        echo $START_TIME

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -54,7 +54,16 @@ function config_wal_g() {
 # get start time of the wal log
 function get_wal_log_start_time() {
     local file="${1:?missing wal log name to analyze}"
-    local START_TIME=$(pg_waldump $file --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |head -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+    local wal_dump_output
+    local wal_dump_status
+    local START_TIME
+    wal_dump_output=$(pg_waldump "${file}" --rmgr=Transaction 2>/dev/null)
+    wal_dump_status=$?
+    START_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |head -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+    if [[ ${wal_dump_status} -ne 0 && -z ${START_TIME} ]]; then
+       DP_error_log "failed to analyze oldest WAL: ${file}" >&2
+       return 1
+    fi
     if [[ ! -z ${START_TIME} ]];then
        START_TIME=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
        echo $START_TIME

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -26,7 +26,8 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
-      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT MV_EXIT PSQL_EXIT 2>/dev/null || true
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_OUT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
+      MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
     build_shim
@@ -74,7 +75,16 @@ echo "f"
 EOF
     cat > "${bindir}/pg_waldump" <<'EOF'
 #!/bin/sh
-exit 0
+printf '%s' "${PG_WALDUMP_OUT:-}"
+exit "${PG_WALDUMP_EXIT:-0}"
+EOF
+    cat > "${bindir}/date" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
+  printf '%s\n' "${DATE_D_OUT}"
+else
+  exec /bin/date "$@"
+fi
 EOF
     cat > "${bindir}/mv" <<'EOF'
 #!/bin/sh
@@ -84,7 +94,8 @@ if [ "${MV_EXIT:-0}" -ne 0 ]; then
 fi
 exec /bin/mv "$@"
 EOF
-    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump" "${bindir}/mv"
+    chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump" \
+      "${bindir}/date" "${bindir}/mv"
   }
 
   build_shim() {
@@ -271,6 +282,27 @@ EOF
       The error should include "failed to pull oldest WAL"
       The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+
+    It "fails without publishing when oldest WAL analysis fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export PG_WALDUMP_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to analyze oldest WAL"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "uses a commit record from a partial oldest WAL despite pg_waldump's final nonzero status"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16T00:00:00Z; origin: node'
+      export PG_WALDUMP_EXIT=17
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call get_start_time_for_range
+      The status should eq 0
+      The output should eq "2026-08-16T00:00:00Z"
     End
 
     It "refreshes a matching oldest-WAL cache when its local artifact is missing"

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -305,6 +305,38 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "fails without publishing when oldest WAL analysis fails"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export PG_WALDUMP_FAIL_ON_CALL=1 PG_WALDUMP_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to analyze oldest WAL"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "uses a commit record from a partial oldest WAL despite pg_waldump's final nonzero status"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16 00:00:00 UTC; origin: node'
+      export PG_WALDUMP_FAIL_ON_CALL=1 PG_WALDUMP_EXIT=17
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call save_backup_status
+      The status should eq 0
+      The output should include "start time of the oldest wal: 2026-08-16T00:00:00Z"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[],"timeRange":{"start":"2026-08-16T00:00:00Z","end":"2026-08-16T00:00:00Z"}}'
+    End
+
     It "fails without publishing when the latest WAL pull fails"
       wal_path="/20260816/000000010000000000000001.zst"
       wal_name="000000010000000000000001"


### PR DESCRIPTION
## Summary
- preserve oldest-WAL `pg_waldump` status in both legacy and WAL-G Continuous producers
- reject nonzero analysis with no usable COMMIT before metadata publication/progress commits
- retain partial-WAL compatibility when a usable COMMIT precedes `pg_waldump`'s final nonzero status

## Evidence
- exact base: PR #3361 head `c93608343b6ee0c6ef0d0cdcb2e4bf5c75879201`
- RED: focused two-producer suite 38 examples / 2 failures, with 7 failed assertions proving both producers returned success, emitted no diagnostic, and published metadata after analyzer rc17/no record
- GREEN: focused two-producer 38/0; full PostgreSQL Bash 5 ShellSpec 226/0
- changed-file ShellCheck (`--severity=error`), Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart / 0 failures
- Helm render: 41 documents / 1,003,257 bytes

## Contract
`kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md` requires observable sync progress for Continuous methods (line 31), payload-backed restore artifacts (line 35), legal empty/no-change handling distinct from tool failures (line 37), and an interpretable Continuous `timeRange`/PITR window (line 43). Failed oldest-WAL analysis with no usable record must not be published as valid progress.

## Boundary
This is source and unit-test evidence only. Runtime packaging, environment execution, cleanup, and formal N remain Test-owned and unproven by this PR.
