### PR TITLE
fix postgresql continuous oldest wal timestamp handling

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -92,6 +92,7 @@ function get_wal_log_start_time() {
     local wal_dump_output
     local wal_dump_status
     local START_TIME
+    local normalized_start_time
     wal_dump_output=$(pg_waldump "${file}" --rmgr=Transaction 2>/dev/null)
     wal_dump_status=$?
     START_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |head -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
@@ -100,8 +101,11 @@ function get_wal_log_start_time() {
        return 1
     fi
     if [[ ! -z ${START_TIME} ]];then
-       START_TIME=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
-       echo $START_TIME
+       if ! normalized_start_time=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ'); then
+          DP_error_log "failed to normalize oldest WAL timestamp: ${file}" >&2
+          return 1
+       fi
+       echo "${normalized_start_time}"
    fi
 }
 

--- a/addons/postgresql/dataprotection/wal-g-archive.sh
+++ b/addons/postgresql/dataprotection/wal-g-archive.sh
@@ -57,6 +57,7 @@ function get_wal_log_start_time() {
     local wal_dump_output
     local wal_dump_status
     local START_TIME
+    local normalized_start_time
     wal_dump_output=$(pg_waldump "${file}" --rmgr=Transaction 2>/dev/null)
     wal_dump_status=$?
     START_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |head -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
@@ -65,8 +66,11 @@ function get_wal_log_start_time() {
        return 1
     fi
     if [[ ! -z ${START_TIME} ]];then
-       START_TIME=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
-       echo $START_TIME
+       if ! normalized_start_time=$(date -d "${START_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ'); then
+          DP_error_log "failed to normalize oldest WAL timestamp: ${file}" >&2
+          return 1
+       fi
+       echo "${normalized_start_time}"
    fi
 }
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -26,7 +26,8 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
-      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_OUT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT \
+      PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT PSQL_EXIT 2>/dev/null || true
 
     write_stubs
@@ -81,6 +82,9 @@ EOF
     cat > "${bindir}/date" <<'EOF'
 #!/bin/sh
 if [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
+  if [ "${DATE_D_EXIT:-0}" -ne 0 ]; then
+    exit "${DATE_D_EXIT}"
+  fi
   printf '%s\n' "${DATE_D_OUT}"
 else
   exec /bin/date "$@"
@@ -292,6 +296,17 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "failed to analyze oldest WAL"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails without publishing when oldest WAL timestamp normalization fails"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16T00:00:00Z; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z" DATE_D_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to normalize oldest WAL timestamp"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -320,6 +320,23 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "fails without publishing when oldest WAL timestamp normalization fails"
+      wal_path="/20260816/000000010000000000000001.zst"
+      wal_name="000000010000000000000001"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{\"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"}]"
+      mkdir -p "${KB_BACKUP_WORKDIR}"
+      printf '%s\n' "${wal_path}" > "${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
+      touch "${KB_BACKUP_WORKDIR}/${wal_name}"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16 00:00:00 UTC; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      export DATE_D_FAIL_ON_CALL=1 DATE_D_EXIT=17
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to normalize oldest WAL timestamp"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "uses a commit record from a partial oldest WAL despite pg_waldump's final nonzero status"
       wal_path="/20260816/000000010000000000000001.zst"
       wal_name="000000010000000000000001"


### PR DESCRIPTION
## What changed

- fail WAL-G Continuous metadata collection when the oldest WAL timestamp cannot be normalized
- apply the same fail-fast behavior to the legacy Continuous producer
- cover both publication paths with regression tests

This prevents an empty `start` value from being published after `date -d` fails.

## Verification

- RED: focused Bash 5 ShellSpec 40 examples, 2 failures
- GREEN: focused Bash 5 ShellSpec 40 examples, 0 failures
- full PostgreSQL Bash 5 ShellSpec 228 examples, 0 failures
- ShellCheck severity=error, Bash syntax, and `git diff --check`
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,003,675 bytes
