### PR TITLE
fix postgresql continuous wal object listing

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -35,7 +35,13 @@ function DP_list_backup_files_by_mtime() {
       DP_error_log "datasafed WAL listing failed" >&2
       return 1
     fi
-    if ! sortedFiles=$(printf '%s\n' "${listOutput}" | jq -s -r '.[] | sort_by(.mtime) | .[] | .path'); then
+    if ! sortedFiles=$(printf '%s\n' "${listOutput}" | jq -s -r '
+      .[]
+      | map(select(.path | test("/[0-9A-F]{24}(\\.partial)?\\.zst$")))
+      | sort_by(.mtime)
+      | .[]
+      | .path
+    '); then
       DP_error_log "datasafed WAL listing returned invalid JSON" >&2
       return 1
     fi

--- a/addons/postgresql/scripts-ut-spec/common_scripts_backup_info_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/common_scripts_backup_info_spec.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-Describe "dataprotection/common-scripts.sh backup-info publication"
+Describe "dataprotection/common-scripts.sh backup metadata"
   Include ../dataprotection/common-scripts.sh
 
   setup() {
@@ -10,7 +10,7 @@ Describe "dataprotection/common-scripts.sh backup-info publication"
     PATH="${bindir}:${PATH}"
     DP_BACKUP_INFO_FILE="${tmpdir}/backup-info"
     export PATH DP_BACKUP_INFO_FILE
-    unset MV_EXIT 2>/dev/null || true
+    unset DATASAFED_LIST_OUT MV_EXIT 2>/dev/null || true
     write_stubs
   }
 
@@ -29,7 +29,13 @@ if [ "${MV_EXIT:-0}" -ne 0 ]; then
 fi
 exec /bin/mv "$@"
 EOF
-    chmod +x "${bindir}/mv"
+    cat > "${bindir}/datasafed" <<'EOF'
+#!/bin/sh
+if [ "$1" = "list" ]; then
+  printf '%s' "${DATASAFED_LIST_OUT:-}"
+fi
+EOF
+    chmod +x "${bindir}/datasafed" "${bindir}/mv"
   }
 
   publish_with_existence_observer() {
@@ -65,6 +71,19 @@ EOF
   backup_info_temp_count() {
     find "${tmpdir}" -maxdepth 1 -name 'backup-info.tmp.*' -print | wc -l | tr -d '[:space:]'
   }
+
+  It "returns only mtime-sorted PostgreSQL WAL archive objects"
+    export DATASAFED_LIST_OUT='[
+      {"path":"/00000002.history.zst","mtime":"2026-08-15T16:59:00Z"},
+      {"path":"/20260815/not-a-wal.zst","mtime":"2026-08-15T16:59:30Z"},
+      {"path":"/20260815/000000010000000000000002.partial.zst","mtime":"2026-08-15T17:01:00Z"},
+      {"path":"/20260815/000000010000000000000001.zst","mtime":"2026-08-15T17:00:00Z"}
+    ]'
+    When call DP_list_backup_files_by_mtime
+    The status should eq 0
+    The output should eq "/20260815/000000010000000000000001.zst
+/20260815/000000010000000000000002.partial.zst"
+  End
 
   It "publishes a complete document before the final path is visible"
     When call publish_with_existence_observer

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -26,7 +26,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     export PATH CALL_LOG LOG_DIR KB_BACKUP_WORKDIR DP_BACKUP_INFO_FILE \
       DP_TARGET_POD_NAME TARGET_POD_ROLE
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
-      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT \
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_TODAY_OUT \
       PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT PSQL_EXIT 2>/dev/null || true
 
@@ -86,6 +86,8 @@ if [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
     exit "${DATE_D_EXIT}"
   fi
   printf '%s\n' "${DATE_D_OUT}"
+elif [ "$1" = "+%Y%m%d" ] && [ -n "${DATE_TODAY_OUT:-}" ]; then
+  printf '%s\n' "${DATE_TODAY_OUT}"
 else
   exec /bin/date "$@"
 fi
@@ -258,6 +260,7 @@ EOF
         {"path":"/00000002.history.zst","mtime":"2026-08-15T23:59:00Z"},
         {"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}
       ]'
+      export DATE_TODAY_OUT="20260816"
       touch "${LOG_DIR}/${wal_name}"
       touch "${LOG_DIR}/archive_status/${wal_name}.done"
       When call uploadMissingLogs

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -251,6 +251,19 @@ EOF
       The status should eq 0
       The output should include "push-count=1"
     End
+
+    It "does not let a timeline-history object hide a missing WAL"
+      wal_name="000000010000000000000001"
+      export DATASAFED_LIST_OUT='[
+        {"path":"/00000002.history.zst","mtime":"2026-08-15T23:59:00Z"},
+        {"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}
+      ]'
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.done"
+      When call uploadMissingLogs
+      The status should eq 0
+      The result of function call_log should include "datasafed push -z zstd ${wal_name} /20260816/${wal_name}.zst"
+    End
   End
 
   Describe "save_backup_status()"
@@ -286,6 +299,23 @@ EOF
       The error should include "failed to pull oldest WAL"
       The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "ignores an older timeline-history object when deriving the WAL start"
+      history_path="/00000002.history.zst"
+      wal_path="/20260816/000000010000000000000001.zst"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{
+        \"path\":\"${history_path}\",\"mtime\":\"2026-08-15T23:59:00Z\"
+      },{
+        \"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"
+      }]"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16T00:00:00Z; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call save_backup_status
+      The status should eq 0
+      The result of function call_log should not include "${history_path}"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096"}'
     End
 
 

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -294,6 +294,23 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "ignores an older timeline-history object when deriving the WAL range"
+      history_path="/00000002.history.zst"
+      wal_path="/20260816/000000010000000000000001.zst"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT="[{
+        \"path\":\"${history_path}\",\"mtime\":\"2026-08-15T23:59:00Z\"
+      },{
+        \"path\":\"${wal_path}\",\"mtime\":\"2026-08-16T00:00:00Z\"
+      }]"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16 00:00:00 UTC; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call save_backup_status
+      The status should eq 0
+      The result of function call_log should not include "${history_path}"
+      The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"4096","extras":[],"timeRange":{"start":"2026-08-16T00:00:00Z","end":"2026-08-16T00:00:00Z"}}'
+    End
+
     It "fails without caching or publishing when the oldest WAL pull fails"
       export DATASAFED_STAT_OUT="TotalSize: 4096"
       export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'


### PR DESCRIPTION
## What changed

- select only PostgreSQL WAL and partial-WAL `.zst` objects from the Continuous repository listing
- keep timeline-history and unrelated repository artifacts out of time-range analysis
- prevent timeline-history names from suppressing missing-WAL reconciliation

## Verification

- RED: focused Bash 5 ShellSpec 48 examples, 4 failures
- GREEN: focused Bash 5 ShellSpec 48 examples, 0 failures
- full PostgreSQL Bash 5 ShellSpec 232 examples, 0 failures
- ShellCheck severity=error, Bash syntax, and `git diff --check`
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,004,122 bytes
