### PR TITLE
fix(postgresql): retry PITR purge metadata publication

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -36,13 +36,15 @@ function purge_expired_files() {
        return 1
     fi
     if [ ! -z "${info}" ]; then
-       global_last_purge_time=${currentUnix}
        DP_log "cleanup expired wal-log files: ${info}"
        local TOTAL_SIZE
        if ! TOTAL_SIZE=$(DP_get_backup_total_size); then
          return 1
        fi
-       DP_save_backup_status_info "${TOTAL_SIZE}"
+       if ! DP_save_backup_status_info "${TOTAL_SIZE}"; then
+         return 1
+       fi
+       global_last_purge_time=${currentUnix}
     fi
 }
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -220,6 +220,27 @@ EOF
       The output should include "cleanup expired wal-log files: ${expired_wal}"
       The contents of file "${DP_BACKUP_INFO_FILE}" should eq '{"totalSize":"2048"}'
     End
+
+    It "keeps the checkpoint when reduced-size lookup fails"
+      expired_wal="/20260816/000000010000000000000001.zst"
+      export DP_TTL_SECONDS=3600 DATASAFED_LIST_OUT="${expired_wal}"
+      export DATASAFED_STAT_EXIT=17
+      When call purge_and_report_checkpoint
+      The status should be failure
+      The error should include "datasafed stat failed"
+      The output should include "purge-checkpoint=123"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "keeps the checkpoint when reduced-size publication fails"
+      expired_wal="/20260816/000000010000000000000001.zst"
+      export DP_TTL_SECONDS=3600 DATASAFED_LIST_OUT="${expired_wal}"
+      export DATASAFED_STAT_OUT="TotalSize: 2048" MV_EXIT=17
+      When call purge_and_report_checkpoint
+      The status should be failure
+      The output should include "purge-checkpoint=123"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
   End
 
   Describe "upload_wal_log()"


### PR DESCRIPTION
## Summary
- keep the PITR purge checkpoint unchanged when reduced-size lookup fails
- propagate atomic backup metadata publication failures
- advance the purge checkpoint only after metadata is durably published

## TDD evidence
- base: PR #3365 exact `4515bb2e9ad57ed8ec0809ce882307014671af29`
- RED: `39044900d` focused ShellSpec 25 examples / 2 failures; both stat and metadata `mv` failures advanced checkpoint `123`
- GREEN: focused ShellSpec 25/0; full PostgreSQL ShellSpec 237/0
- static: ShellCheck severity=error, Bash syntax, `git diff --check` pass
- chart: Helm lint 1/0; render 41 docs / 1,005,643 bytes

## Boundary
This is source-level validation only. Runtime/package/environment/cleanup/formal-N evidence remains Test-owned and is not claimed here.
