### PR TITLE
fix(postgresql): commit oldest WAL cache after analysis

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -136,23 +136,37 @@ function DP_analyze_start_time_from_datasafed() {
       last_oldest_file_name=$(DP_get_file_name_without_ext ${last_oldest_file})
       if [ "$last_oldest_file" == "${oldest_file}" ] && [ -f ${last_oldest_file_name} ]; then
         # oldest file no changed.
-        ${get_start_time_from_file} $last_oldest_file_name
+        local cached_start_time
+        if ! cached_start_time=$(${get_start_time_from_file} "${last_oldest_file_name}"); then
+          rm -f "${info_file}" "${last_oldest_file_name}"
+          return 1
+        fi
+        printf '%s\n' "${cached_start_time}"
         return
       fi
-         # remove last oldest file
+      # remove last oldest file
       if [ -f ${last_oldest_file_name} ];then
-          rm -rf ${last_oldest_file_name}
+          rm -f ${last_oldest_file_name}
       fi
+      rm -f "${info_file}"
     fi
     # pull file
     if ! ${datasafed_pull} ${oldest_file}; then
       DP_error_log "failed to pull oldest WAL" >&2
       return 1
     fi
-    # record last oldest file
-    echo ${oldest_file} > ${info_file}
     oldest_file_name=$(DP_get_file_name_without_ext ${oldest_file})
-    ${get_start_time_from_file} ${oldest_file_name}
+    local start_time
+    if ! start_time=$(${get_start_time_from_file} "${oldest_file_name}"); then
+      rm -f "${oldest_file_name}"
+      return 1
+    fi
+    if ! printf '%s\n' "${oldest_file}" > "${info_file}"; then
+      DP_error_log "failed to cache oldest WAL" >&2
+      rm -f "${info_file}" "${oldest_file_name}"
+      return 1
+    fi
+    printf '%s\n' "${start_time}"
 }
 
 # get the timeZone offset for location, such as Asia/Shanghai

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -401,6 +401,7 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "failed to analyze oldest WAL"
+      The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -334,6 +334,8 @@ EOF
       When call save_backup_status
       The status should be failure
       The error should include "failed to analyze oldest WAL"
+      The path "${KB_BACKUP_WORKDIR}/dp_oldest_file.info" should not be exist
+      The path "${KB_BACKUP_WORKDIR}/${wal_name}" should not be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 


### PR DESCRIPTION
## Summary
- invalidate a cached oldest WAL when analysis fails so the next pass repulls it
- analyze a freshly pulled oldest WAL before publishing the cache marker
- fail and clean the local artifact when cache publication itself fails

## TDD evidence
- base: PR #3366 exact `b89f46807b4c9099d470e9c5ab27c142dadcef26`
- RED: `de54db90b`; focused legacy 25/1 and WAL-G 23/1, proving failed analysis retained the cache marker and cached artifact
- GREEN: focused two-producer 48/0; full PostgreSQL ShellSpec 237/0
- static: ShellCheck severity=error, Bash syntax, `git diff --check` pass
- chart: Helm lint 1/0; render 41 docs / 1,007,416 bytes

## Boundary
This is source-level validation only. Runtime/package/environment/cleanup/formal-N evidence remains Test-owned and is not claimed here.
