### PR TITLE
fix(postgresql): fail oldest WAL workdir setup early

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -130,7 +130,10 @@ function DP_analyze_start_time_from_datasafed() {
     local get_start_time_from_file="${2:?missing get_start_time_from_file function}"
     local datasafed_pull="${3:?missing datasafed_pull function}"
     local info_file="${KB_BACKUP_WORKDIR}/dp_oldest_file.info"
-    mkdir -p ${KB_BACKUP_WORKDIR} && cd ${KB_BACKUP_WORKDIR}
+    if ! mkdir -p "${KB_BACKUP_WORKDIR}" || ! cd "${KB_BACKUP_WORKDIR}"; then
+      DP_error_log "failed to prepare oldest WAL workdir: ${KB_BACKUP_WORKDIR}" >&2
+      return 1
+    fi
     if [ -f ${info_file} ]; then
       last_oldest_file=$(cat ${info_file})
       last_oldest_file_name=$(DP_get_file_name_without_ext ${last_oldest_file})

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -376,6 +376,19 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "fails before pulling when the oldest-WAL workdir cannot be prepared"
+      blocked_workdir="${tmpdir}/blocked-workdir"
+      printf 'not a directory\n' > "${blocked_workdir}"
+      KB_BACKUP_WORKDIR="${blocked_workdir}"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to prepare oldest WAL workdir"
+      The result of function call_log should not include "datasafed pull "
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "ignores an older timeline-history object when deriving the WAL start"
       history_path="/00000002.history.zst"
       wal_path="/20260816/000000010000000000000001.zst"

--- a/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/walg_archive_spec.sh
@@ -322,6 +322,19 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "fails before pulling when the oldest-WAL workdir cannot be prepared"
+      blocked_workdir="${tmpdir}/blocked-workdir"
+      printf 'not a directory\n' > "${blocked_workdir}"
+      KB_BACKUP_WORKDIR="${blocked_workdir}"
+      export DATASAFED_STAT_OUT="TotalSize: 4096"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000001.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      When call save_backup_status
+      The status should be failure
+      The error should include "failed to prepare oldest WAL workdir"
+      The result of function call_log should not include "datasafed pull "
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "fails without publishing when oldest WAL analysis fails"
       wal_path="/20260816/000000010000000000000001.zst"
       wal_name="000000010000000000000001"


### PR DESCRIPTION
## Summary
- require the oldest-WAL cache directory to be created and entered successfully
- fail with a targeted diagnostic before any remote WAL pull
- cover the shared behavior through both legacy and WAL-G Continuous producers

## TDD evidence
- base: PR #3367 exact `4280cf92cb42b4791fdfaf55364a882a5fc1af50`
- RED: `b34df87db`; legacy 26/1 and WAL-G 24/1, both proving a blocked workdir still triggered `datasafed pull`
- GREEN: focused two-producer 50/0; full PostgreSQL ShellSpec 239/0
- static: ShellCheck severity=error, Bash syntax, `git diff --check` pass
- chart: Helm lint 1/0; render 41 docs / 1,007,857 bytes

## Boundary
This is source-level validation only. Runtime/package/environment/cleanup/formal-N evidence remains Test-owned and is not claimed here.
