### PR TITLE
fix(postgresql): fail PITR WAL switch inspection errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -55,7 +55,24 @@ function switch_wal_log() {
     if [[ ${diff_time} -lt ${global_switch_wal_interval} ]]; then
        return
     fi
-    LAST_TRANS=$(pg_waldump $(${PSQL} -Atc "select pg_walfile_name(pg_current_wal_lsn())") --rmgr=Transaction 2>/dev/null |tail -n 1)
+    local current_wal
+    local current_wal_status
+    current_wal=$(${PSQL} -Atc "select pg_walfile_name(pg_current_wal_lsn())")
+    current_wal_status=$?
+    if [[ ${current_wal_status} -ne 0 || -z ${current_wal} ]]; then
+      DP_error_log "failed to resolve current WAL for switch" >&2
+      return 1
+    fi
+    local wal_dump_output
+    local wal_dump_status
+    local LAST_TRANS
+    wal_dump_output=$(pg_waldump "${current_wal}" --rmgr=Transaction 2>/dev/null)
+    wal_dump_status=$?
+    LAST_TRANS=$(printf '%s\n' "${wal_dump_output}" | tail -n 1)
+    if [[ ${wal_dump_status} -ne 0 && -z ${LAST_TRANS} ]]; then
+      DP_error_log "failed to inspect current WAL for switch: ${current_wal}" >&2
+      return 1
+    fi
     if [ "${LAST_TRANS}" != "" ] && [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" = "" ]; then
       DP_log "start to switch wal file"
       if ! ${PSQL} -c "select pg_switch_wal()"; then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -209,10 +209,26 @@ EOF
   Describe "switch_wal_log()"
     It "fails without advancing the checkpoint when the switch request fails"
       export DATE_EPOCH_OUT=456 PG_WALDUMP_OUT="transaction record"
-      export PSQL_FAIL_ON_CALL=2 PSQL_EXIT=17
+      export PG_WALDUMP_EXIT=17 PSQL_FAIL_ON_CALL=2 PSQL_EXIT=17
       When call switch_and_report_checkpoint
       The status should be failure
       The output should include "pg_switch_wal failed, will retry on the next round"
+      The output should include "switch-checkpoint=123"
+    End
+
+    It "fails without advancing the checkpoint when the current WAL lookup fails"
+      export DATE_EPOCH_OUT=456 PSQL_FAIL_ON_CALL=1 PSQL_EXIT=17
+      When call switch_and_report_checkpoint
+      The status should be failure
+      The error should include "failed to resolve current WAL for switch"
+      The output should include "switch-checkpoint=123"
+    End
+
+    It "fails without advancing the checkpoint when current WAL analysis has no usable record"
+      export DATE_EPOCH_OUT=456 PG_WALDUMP_EXIT=17
+      When call switch_and_report_checkpoint
+      The status should be failure
+      The error should include "failed to inspect current WAL for switch: f"
       The output should include "switch-checkpoint=123"
     End
 


### PR DESCRIPTION
## Summary
- propagate current-WAL SQL lookup failures before switch throttling
- preserve `pg_waldump` status separately from its output
- reject nonzero analysis with no usable record while preserving usable partial-WAL output

## TDD evidence
- base: PR #3369 exact `8a497319ffa974c22f5a584b3ac99b1c178e0e94`
- RED: `4d4ae7573`; focused 30/2, proving lookup and unusable analysis failures returned success and advanced checkpoint `123` to `456`
- GREEN: focused 30/0; full PostgreSQL ShellSpec 243/0
- static: ShellCheck severity=error, Bash syntax, `git diff --check` pass
- chart: Helm lint 1/0; render 41 docs / 1,008,929 bytes

## Boundary
This is source-level validation only. Runtime/package/environment/cleanup/formal-N evidence remains Test-owned and is not claimed here.
