### PR TITLE
fix(postgresql): commit PITR stop time after WAL upload

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -103,15 +103,15 @@ function upload_wal_log() {
     for i in $(ls -tr ./archive_status/ | grep .ready); do
       wal_name=${i%.*}
       LOG_STOP_TIME=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
-      if [[ ! -z $LOG_STOP_TIME ]];then
-         global_stop_time=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
-      fi
       if [ -f ${wal_name} ]; then
         DP_log "upload ${wal_name}"
         # Rename .ready to .done only after a successful upload. Marking a
         # failed upload as .done lets PostgreSQL recycle a WAL segment that
         # never reached the repository, leaving a hole in the PITR chain.
         if datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
+          if [[ ! -z $LOG_STOP_TIME ]];then
+            global_stop_time=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
+          fi
           mv -f ./archive_status/${i} ./archive_status/${wal_name}.done;
         else
           DP_error_log "failed to upload ${wal_name}, keeping ${i} for retry"

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -206,6 +206,14 @@ EOF
     return "${status}"
   }
 
+  upload_and_report_stop_time() {
+    global_stop_time="2026-08-15T23:59:00Z"
+    local status=0
+    upload_wal_log || status=$?
+    printf 'stop-time=%s\n' "${global_stop_time}"
+    return "${status}"
+  }
+
   Describe "switch_wal_log()"
     It "fails without advancing the checkpoint when the switch request fails"
       export DATE_EPOCH_OUT=456 PG_WALDUMP_OUT="transaction record"
@@ -299,6 +307,28 @@ EOF
   End
 
   Describe "upload_wal_log()"
+    It "does not advance the metadata stop time when the upload fails"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16T00:00:00Z; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z" DATASAFED_PUSH_EXIT=17
+      When call upload_and_report_stop_time
+      The status should eq 0
+      The output should include "stop-time=2026-08-15T23:59:00Z"
+    End
+
+    It "advances the metadata stop time after a successful upload"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16T00:00:00Z; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call upload_and_report_stop_time
+      The status should eq 0
+      The output should include "stop-time=2026-08-16T00:00:00Z"
+    End
+
     It "does not mark the WAL segment done when the upload fails"
       touch "${LOG_DIR}/000000010000000000000001"
       touch "${LOG_DIR}/archive_status/000000010000000000000001.ready"


### PR DESCRIPTION
## What changed

- keep the published PITR stop time unchanged when a WAL upload fails
- advance it only after `datasafed push` confirms the WAL reached the repository
- preserve tolerant per-file upload failure handling and `.ready` retry behavior

## TDD evidence

- RED commit `5b7b2fc48`: focused ShellSpec 32 examples, 1 expected failure; failed push advanced `2026-08-15T23:59:00Z` to `2026-08-16T00:00:00Z`
- GREEN commit `d56f42aa8`: focused ShellSpec 32/0; full PostgreSQL ShellSpec 245/0
- ShellCheck severity error, Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1009164 bytes

## Scope

Exact base is PR #3370 head `db6684b5a40d36a13770ee29f4147adfd8d4ccbb`. This is product code and code-level test evidence only; runtime/package/environment/cleanup/formal-N validation remains tester-owned and is not claimed here.
