### PR TITLE
fix(postgresql): preserve WAL on PITR stop time errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -99,18 +99,26 @@ function switch_wal_log() {
 # upload wal log
 function upload_wal_log() {
     local TODAY_INCR_LOG=$(date +%Y%m%d);
+    local normalized_stop_time
     cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
     for i in $(ls -tr ./archive_status/ | grep .ready); do
       wal_name=${i%.*}
       LOG_STOP_TIME=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+      normalized_stop_time=
+      if [[ ! -z $LOG_STOP_TIME ]];then
+        if ! normalized_stop_time=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ'); then
+          DP_error_log "failed to normalize stop time for ${wal_name}, keeping ${i} for retry"
+          break
+        fi
+      fi
       if [ -f ${wal_name} ]; then
         DP_log "upload ${wal_name}"
         # Rename .ready to .done only after a successful upload. Marking a
         # failed upload as .done lets PostgreSQL recycle a WAL segment that
         # never reached the repository, leaving a hole in the PITR chain.
         if datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
-          if [[ ! -z $LOG_STOP_TIME ]];then
-            global_stop_time=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
+          if [[ ! -z $normalized_stop_time ]];then
+            global_stop_time=${normalized_stop_time}
           fi
           mv -f ./archive_status/${i} ./archive_status/${wal_name}.done;
         else

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -311,6 +311,21 @@ EOF
   End
 
   Describe "upload_wal_log()"
+    It "keeps the WAL retryable when its stop time cannot be normalized"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT invalid-time; origin: node'
+      export DATE_D_OUT="unused" DATE_D_EXIT=17
+      When call upload_and_report_stop_time
+      The status should eq 0
+      The output should include "failed to normalize stop time for ${wal_name}, keeping ${wal_name}.ready for retry"
+      The output should include "stop-time=2026-08-15T23:59:00Z"
+      The contents of file "${CALL_LOG}" should not include "datasafed push"
+      The path "${LOG_DIR}/archive_status/${wal_name}.ready" should be exist
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should not be exist
+    End
+
     It "does not upload or publish past the first failed WAL segment"
       first_wal="000000010000000000000001"
       second_wal="000000010000000000000002"


### PR DESCRIPTION
## What changed

- normalize a parsed WAL COMMIT timestamp before uploading the segment
- on normalization failure, diagnose the exact WAL and stop the chronological batch
- retain the prior metadata stop time and leave the WAL `.ready` for retry
- publish the normalized value only after the repository push succeeds
- preserve the tolerant `upload_wal_log` return contract used by the outer archive loop

## TDD evidence

- RED commit `9d5a70977`: focused ShellSpec 34 examples, 1 failure with 5 assertions; normalization rc17 cleared the prior stop time, still pushed the WAL, and renamed it `.done`
- GREEN commit `82f585a18`: focused ShellSpec 34/0; full PostgreSQL ShellSpec 247/0
- ShellCheck severity error, Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1009553 bytes

## Scope

Exact base is PR #3372 head `6b49cd9bae6b86a10d3210732636828291821c06`. This is product code and code-level test evidence only; runtime/package/environment/cleanup/formal-N validation remains tester-owned and is not claimed here.
