### PR TITLE
fix(postgresql): preserve WAL on PITR analysis errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -100,10 +100,18 @@ function switch_wal_log() {
 function upload_wal_log() {
     local TODAY_INCR_LOG=$(date +%Y%m%d);
     local normalized_stop_time
+    local wal_dump_output
+    local wal_dump_status
     cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
     for i in $(ls -tr ./archive_status/ | grep .ready); do
       wal_name=${i%.*}
-      LOG_STOP_TIME=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+      wal_dump_output=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null)
+      wal_dump_status=$?
+      LOG_STOP_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+      if (( wal_dump_status != 0 )) && [[ -z $LOG_STOP_TIME ]]; then
+        DP_error_log "failed to inspect ${wal_name} for stop time, keeping ${i} for retry"
+        break
+      fi
       normalized_stop_time=
       if [[ ! -z $LOG_STOP_TIME ]];then
         if ! normalized_stop_time=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ'); then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -311,6 +311,35 @@ EOF
   End
 
   Describe "upload_wal_log()"
+    It "keeps the WAL retryable when analysis fails without a usable COMMIT"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export PG_WALDUMP_EXIT=17
+      When call upload_and_report_stop_time
+      The status should eq 0
+      The output should include "failed to inspect ${wal_name} for stop time, keeping ${wal_name}.ready for retry"
+      The output should include "stop-time=2026-08-15T23:59:00Z"
+      The contents of file "${CALL_LOG}" should not include "datasafed push"
+      The path "${LOG_DIR}/archive_status/${wal_name}.ready" should be exist
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should not be exist
+    End
+
+    It "accepts a usable COMMIT from a partial-WAL analysis failure"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export PG_WALDUMP_EXIT=17
+      export PG_WALDUMP_OUT='rmgr: Transaction desc: COMMIT 2026-08-16T00:00:00Z; origin: node'
+      export DATE_D_OUT="2026-08-16T00:00:00Z"
+      When call upload_and_report_stop_time
+      The status should eq 0
+      The output should include "stop-time=2026-08-16T00:00:00Z"
+      The contents of file "${CALL_LOG}" should include "datasafed push -z zstd ${wal_name}"
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should be exist
+      The path "${LOG_DIR}/archive_status/${wal_name}.ready" should not be exist
+    End
+
     It "keeps the WAL retryable when its stop time cannot be normalized"
       wal_name="000000010000000000000001"
       touch "${LOG_DIR}/${wal_name}"


### PR DESCRIPTION
## What changed

- preserve the direct `pg_waldump` status before parsing COMMIT output
- stop the chronological upload batch when analysis fails without a usable COMMIT
- diagnose the exact WAL and leave it `.ready` without pushing or retiring it
- continue accepting nonzero partial-WAL analysis when it produced a usable COMMIT
- preserve the tolerant `upload_wal_log` return contract used by the outer archive loop

## TDD evidence

- RED commit `2f802d9a8`: focused ShellSpec 36 examples, 1 failure with 4 assertions; analyzer rc17/no COMMIT still pushed and retired the WAL, while the usable partial-WAL boundary passed
- GREEN commit `601c80425`: focused ShellSpec 36/0; full PostgreSQL ShellSpec 249/0
- ShellCheck severity error, Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1009937 bytes

## Scope

Exact base is PR #3373 head `82f585a1876662624343ed87bbd9eed577b619b1`. This is product code and code-level test evidence only; runtime/package/environment/cleanup/formal-N validation remains tester-owned and is not claimed here.
