### PR TITLE
fix(postgresql): fail invalid PITR upload partition

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -98,7 +98,11 @@ function switch_wal_log() {
 
 # upload wal log
 function upload_wal_log() {
-    local TODAY_INCR_LOG=$(date +%Y%m%d);
+    local TODAY_INCR_LOG
+    if ! TODAY_INCR_LOG=$(date +%Y%m%d) || [[ -z ${TODAY_INCR_LOG} ]]; then
+      DP_error_log "failed to determine WAL upload partition"
+      return 1
+    fi
     local normalized_stop_time
     local wal_dump_output
     local wal_dump_status

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
       DATASAFED_PUSH_FAIL_WAL \
       DATASAFED_RM_EXIT DATASAFED_RM_FAIL_PATH \
-      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_OUT DATE_TODAY_OUT \
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
       DP_TTL_SECONDS PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT PSQL_EXIT PSQL_FAIL_ON_CALL 2>/dev/null || true
 
@@ -104,8 +104,14 @@ elif [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
     exit "${DATE_D_EXIT}"
   fi
   printf '%s\n' "${DATE_D_OUT}"
-elif [ "$1" = "+%Y%m%d" ] && [ -n "${DATE_TODAY_OUT:-}" ]; then
-  printf '%s\n' "${DATE_TODAY_OUT}"
+elif [ "$1" = "+%Y%m%d" ]; then
+  if [ "${DATE_TODAY_EXIT:-0}" -ne 0 ]; then
+    exit "${DATE_TODAY_EXIT}"
+  elif [ -n "${DATE_TODAY_OUT:-}" ]; then
+    printf '%s\n' "${DATE_TODAY_OUT}"
+  else
+    exec /bin/date "$@"
+  fi
 else
   exec /bin/date "$@"
 fi
@@ -311,6 +317,19 @@ EOF
   End
 
   Describe "upload_wal_log()"
+    It "fails before pushing when the archive partition cannot be generated"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export DATE_TODAY_EXIT=17
+      When call upload_wal_log
+      The status should be failure
+      The output should include "failed to determine WAL upload partition"
+      The contents of file "${CALL_LOG}" should not include "datasafed push"
+      The path "${LOG_DIR}/archive_status/${wal_name}.ready" should be exist
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should not be exist
+    End
+
     It "keeps the WAL retryable when analysis fails without a usable COMMIT"
       wal_name="000000010000000000000001"
       touch "${LOG_DIR}/${wal_name}"


### PR DESCRIPTION
## What changed

- preserve the direct `date +%Y%m%d` status used for the repository partition
- reject failed or empty partition generation before scanning `.ready` WALs
- diagnose and return failure without pushing or retiring any WAL segment

## TDD evidence

- RED commit `a5cdb2745`: focused ShellSpec 37 examples, 1 failure with 5 assertions; date rc17 was masked, and the WAL was pushed to `//<wal>.zst`, renamed `.done`, and reported success
- GREEN commit `b52912ab3`: focused ShellSpec 37/0; full PostgreSQL ShellSpec 250/0
- ShellCheck severity error, Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1010112 bytes

## Scope

Exact base is PR #3374 head `601c80425db8d7e0a94741d404e93491738c4968`. This is product code and code-level test evidence only; runtime/package/environment/cleanup/formal-N validation remains tester-owned and is not claimed here.
