### PR TITLE
fix(postgresql): fail invalid PITR reconciliation partition

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -231,7 +231,11 @@ function check_pg_process() {
 
 function uploadMissingLogs() {
     DP_log "start to upload the wal log which maybe misses"
-    local TODAY_INCR_LOG=$(date +%Y%m%d)
+    local TODAY_INCR_LOG
+    if ! TODAY_INCR_LOG=$(date +%Y%m%d) || [[ -z ${TODAY_INCR_LOG} ]]; then
+      DP_error_log "failed to determine missing-WAL upload partition"
+      return 1
+    fi
     cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
     local uploadedLogs
     if ! uploadedLogs=$(DP_list_backup_files_by_mtime); then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -460,6 +460,19 @@ EOF
   End
 
   Describe "uploadMissingLogs()"
+    It "fails before repository access when the archive partition cannot be generated"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.done"
+      export DATE_TODAY_EXIT=17
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "failed to determine missing-WAL upload partition"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should be exist
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "fails when the remote WAL listing is unavailable"
       export DATASAFED_LIST_EXIT=17
       When call uploadMissingLogs


### PR DESCRIPTION
## What changed

- preserve the direct `date +%Y%m%d` status used by startup missing-WAL reconciliation
- reject failed or empty partition generation before repository list/stat/push access
- return failure so the archive loop retains the reconciliation retry path

## TDD evidence

- RED commit `388e2c0ef`: focused ShellSpec 38 examples, 1 failure with 3 assertions; date rc17 was masked, reconciliation listed/stat'ed the repository, pushed a `.done` WAL to `//<wal>.zst`, and returned success
- GREEN commit `7800c1891`: focused ShellSpec 38/0; full PostgreSQL ShellSpec 251/0
- ShellCheck severity error, Bash syntax, and `git diff --check`: pass
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1010296 bytes

## Scope

Exact base is PR #3375 head `b52912ab3657f5db074b4210ead7dc99ab138cb2`. This is product code and code-level test evidence only; runtime/package/environment/cleanup/formal-N validation remains tester-owned and is not claimed here.
