### PR TITLE
fix(postgresql): fail PITR switch clock errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -50,7 +50,11 @@ function purge_expired_files() {
 
 # switch wal log
 function switch_wal_log() {
-    local curr_time=$(date +%s)
+    local curr_time
+    if ! curr_time=$(date +%s) || [[ -z ${curr_time} ]]; then
+      DP_error_log "failed to determine current time for WAL switch"
+      return 1
+    fi
     local diff_time=$((${curr_time}-${global_last_switch_wal_time}))
     if [[ ${diff_time} -lt ${global_switch_wal_interval} ]]; then
        return

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
     unset DATASAFED_LIST_EXIT DATASAFED_LIST_OUT DATASAFED_PULL_EXIT DATASAFED_PUSH_EXIT \
       DATASAFED_PUSH_FAIL_WAL \
       DATASAFED_RM_EXIT DATASAFED_RM_FAIL_PATH \
-      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
+      DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_EXIT DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
       DP_TTL_SECONDS PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT MV_FAIL_SOURCE PSQL_EXIT PSQL_FAIL_ON_CALL 2>/dev/null || true
 
@@ -97,8 +97,14 @@ exit "${PG_WALDUMP_EXIT:-0}"
 EOF
     cat > "${bindir}/date" <<'EOF'
 #!/bin/sh
-if [ "$1" = "+%s" ] && [ -n "${DATE_EPOCH_OUT:-}" ]; then
-  printf '%s\n' "${DATE_EPOCH_OUT}"
+if [ "$1" = "+%s" ]; then
+  if [ "${DATE_EPOCH_EXIT:-0}" -ne 0 ]; then
+    exit "${DATE_EPOCH_EXIT}"
+  elif [ -n "${DATE_EPOCH_OUT:-}" ]; then
+    printf '%s\n' "${DATE_EPOCH_OUT}"
+  else
+    exec /bin/date "$@"
+  fi
 elif [ "$1" = "-d" ] && [ -n "${DATE_D_OUT:-}" ]; then
   if [ "${DATE_D_EXIT:-0}" -ne 0 ]; then
     exit "${DATE_D_EXIT}"
@@ -228,6 +234,15 @@ EOF
   }
 
   Describe "switch_wal_log()"
+    It "fails before throttle evaluation when the current time cannot be read"
+      export DATE_EPOCH_EXIT=17
+      When call switch_and_report_checkpoint
+      The status should be failure
+      The output should include "failed to determine current time for WAL switch"
+      The output should include "switch-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "psql"
+    End
+
     It "fails without advancing the checkpoint when the switch request fails"
       export DATE_EPOCH_OUT=456 PG_WALDUMP_OUT="transaction record"
       export PG_WALDUMP_EXIT=17 PSQL_FAIL_ON_CALL=2 PSQL_EXIT=17


### PR DESCRIPTION
## Summary

- fail WAL switching when the current epoch cannot be read
- return before throttle arithmetic so an empty timestamp cannot be misclassified as a normal no-op
- retain the previous switch checkpoint and avoid downstream PostgreSQL calls on clock failure

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 40 examples, 1 failure with 2 assertions; `date +%s` rc17 returned success without a diagnostic while checkpoint/no-side-effect assertions passed
- GREEN: focused PostgreSQL PITR ShellSpec 40 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 253 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,010,620 bytes

## Stack

- exact base commit: `6da0fecf7a4245a4a62faef6172ab26fe7b17030` (PR #3377)
- test commit: `f1c35c08475d38abb1ffca11f8b04f41d538d1c2`
- fix commit: `51a07e292ffe88916518e6b074c67e002fda7e79`
