### PR TITLE
fix(postgresql): fail reconciliation listing errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -255,7 +255,16 @@ function uploadMissingLogs() {
       DP_log "oldest uploaded wal: ${OLDEST_FILE}"
     fi
     local reconciliation_failed=false
-    for i in $(find ./archive_status -type f | sort | grep .done); do
+    local wal_status_files
+    if ! wal_status_files=$(find ./archive_status -type f -name '*.done'); then
+      DP_error_log "failed to list local WAL archive status"
+      return 1
+    fi
+    if ! wal_status_files=$(printf '%s\n' "${wal_status_files}" | sort); then
+      DP_error_log "failed to sort local WAL archive status"
+      return 1
+    fi
+    for i in ${wal_status_files}; do
       wal_done_name=$(basename ${i})
       wal_name=${wal_done_name%.*}
       if [[ -n ${OLDEST_FILE} && "$wal_name" < "$OLDEST_FILE" ]]; then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -29,7 +29,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
       DATASAFED_PUSH_FAIL_WAL \
       DATASAFED_RM_EXIT DATASAFED_RM_FAIL_PATH \
       DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_EXIT DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
-      DP_TTL_SECONDS PG_WALDUMP_EXIT PG_WALDUMP_OUT \
+      DP_TTL_SECONDS FIND_EXIT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT MV_FAIL_SOURCE PSQL_EXIT PSQL_FAIL_ON_CALL 2>/dev/null || true
 
     write_stubs
@@ -126,6 +126,14 @@ EOF
 #!/bin/sh
 exit 0
 EOF
+    cat > "${bindir}/find" <<'EOF'
+#!/bin/sh
+printf 'find %s\n' "$*" >> "${CALL_LOG}"
+if [ "${FIND_EXIT:-0}" -ne 0 ]; then
+  exit "${FIND_EXIT}"
+fi
+exec /usr/bin/find "$@"
+EOF
     cat > "${bindir}/mv" <<'EOF'
 #!/bin/sh
 printf 'mv %s\n' "$*" >> "${CALL_LOG}"
@@ -138,7 +146,7 @@ fi
 exec /bin/mv "$@"
 EOF
     chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump" \
-      "${bindir}/date" "${bindir}/mv" "${bindir}/sleep"
+      "${bindir}/date" "${bindir}/find" "${bindir}/mv" "${bindir}/sleep"
   }
 
   build_shim() {
@@ -499,6 +507,16 @@ EOF
   End
 
   Describe "uploadMissingLogs()"
+    It "fails before metadata work when local archive-status listing is unavailable"
+      export FIND_EXIT=17
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "failed to list local WAL archive status"
+      The contents of file "${CALL_LOG}" should include "find ./archive_status -type f"
+      The contents of file "${CALL_LOG}" should not include "datasafed stat"
+      The contents of file "${CALL_LOG}" should not include "datasafed push"
+    End
+
     It "fails before repository access when the archive partition cannot be generated"
       wal_name="000000010000000000000001"
       touch "${LOG_DIR}/${wal_name}"


### PR DESCRIPTION
## Summary

- fail startup missing-WAL reconciliation when local archive-status enumeration is unavailable
- filter `.done` markers during the checked `find` operation and preserve chronological sorting
- return before metadata lookup/publication so the archive loop retries reconciliation instead of freezing a false-complete state

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 41 examples, 1 failure with 3 assertions; `find` rc17 returned success without a diagnostic and continued into `datasafed stat`
- GREEN: focused PostgreSQL PITR ShellSpec 41 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 254 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,011,010 bytes

## Stack

- exact base commit: `51a07e292ffe88916518e6b074c67e002fda7e79` (PR #3378)
- test commit: `a8bef154eaa636d2fd3f7349796edb3bdd4f4117`
- fix commit: `10c09d5e76eee3d0121e9f523dfe9f77f35233a7`
