### PR TITLE
fix(postgresql): fail switch status probe errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -77,7 +77,12 @@ function switch_wal_log() {
       DP_error_log "failed to inspect current WAL for switch: ${current_wal}" >&2
       return 1
     fi
-    if [ "${LAST_TRANS}" != "" ] && [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" = "" ]; then
+    local ready_wal_files
+    if ! ready_wal_files=$(find ${LOG_DIR}/archive_status/ -name '*.ready'); then
+      DP_error_log "failed to inspect WAL archive status before switch"
+      return 1
+    fi
+    if [ "${LAST_TRANS}" != "" ] && [ "${ready_wal_files}" = "" ]; then
       DP_log "start to switch wal file"
       if ! ${PSQL} -c "select pg_switch_wal()"; then
         DP_error_log "pg_switch_wal failed, will retry on the next round"
@@ -85,7 +90,11 @@ function switch_wal_log() {
       fi
       local switch_confirmed=false
       for i in $(seq 1 60); do
-        if [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" != "" ]; then
+        if ! ready_wal_files=$(find ${LOG_DIR}/archive_status/ -name '*.ready'); then
+          DP_error_log "failed to inspect WAL archive status after switch"
+          return 1
+        fi
+        if [ "${ready_wal_files}" != "" ]; then
           DP_log "switch wal file successfully"
           switch_confirmed=true
           break;

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -29,7 +29,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
       DATASAFED_PUSH_FAIL_WAL \
       DATASAFED_RM_EXIT DATASAFED_RM_FAIL_PATH \
       DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_EXIT DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
-      DP_TTL_SECONDS FIND_EXIT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
+      DP_TTL_SECONDS FIND_EXIT FIND_FAIL_ON_CALL PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT MV_FAIL_SOURCE PSQL_EXIT PSQL_FAIL_ON_CALL 2>/dev/null || true
 
     write_stubs
@@ -129,7 +129,10 @@ EOF
     cat > "${bindir}/find" <<'EOF'
 #!/bin/sh
 printf 'find %s\n' "$*" >> "${CALL_LOG}"
-if [ "${FIND_EXIT:-0}" -ne 0 ]; then
+call_count=$(awk '/^find / { calls++ } END { print calls + 0 }' "${CALL_LOG}")
+if [ "${FIND_FAIL_ON_CALL:-0}" -eq "${call_count}" ]; then
+  exit 17
+elif [ "${FIND_EXIT:-0}" -ne 0 ]; then
   exit "${FIND_EXIT}"
 fi
 exec /usr/bin/find "$@"
@@ -242,6 +245,26 @@ EOF
   }
 
   Describe "switch_wal_log()"
+    It "fails before requesting a switch when archive-status inspection fails"
+      export DATE_EPOCH_OUT=456 PG_WALDUMP_OUT="transaction record" FIND_EXIT=17
+      When call switch_and_report_checkpoint
+      The status should be failure
+      The output should include "failed to inspect WAL archive status before switch"
+      The output should not include "timed out waiting for switched WAL"
+      The output should include "switch-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "select pg_switch_wal()"
+    End
+
+    It "fails while confirming a switch when archive-status inspection fails"
+      export DATE_EPOCH_OUT=456 PG_WALDUMP_OUT="transaction record" FIND_FAIL_ON_CALL=2
+      When call switch_and_report_checkpoint
+      The status should be failure
+      The output should include "failed to inspect WAL archive status after switch"
+      The output should not include "timed out waiting for switched WAL"
+      The output should include "switch-checkpoint=123"
+      The contents of file "${CALL_LOG}" should include "select pg_switch_wal()"
+    End
+
     It "fails before throttle evaluation when the current time cannot be read"
       export DATE_EPOCH_EXIT=17
       When call switch_and_report_checkpoint


### PR DESCRIPTION
## Summary

- preserve ready-marker probe status before requesting a PostgreSQL WAL switch
- fail immediately when archive-status inspection fails before or after the request
- retain the switch checkpoint and avoid misreporting local probe failures as switch timeouts

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 42 examples, 1 failure with 3 assertions; pre-switch `find` rc17 issued `pg_switch_wal`, retried the failed probe 60 times, and reported a misleading timeout
- GREEN: focused PostgreSQL PITR ShellSpec 43 examples, 0 failures, covering both pre-request and post-request probe failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 256 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,011,411 bytes

## Stack

- exact base commit: `10c09d5e76eee3d0121e9f523dfe9f77f35233a7` (PR #3379)
- test commit: `7feaff12a64553f326fe67aafaf9590107e27731`
- fix commit: `12a16e9e057b88ae77c860fd9ae4d7e5222e6577`
