### PR TITLE
fix(postgresql): fail upload status listing errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -119,8 +119,17 @@ function upload_wal_log() {
     local normalized_stop_time
     local wal_dump_output
     local wal_dump_status
+    local archive_status_files
     cd ${LOG_DIR} || { DP_error_log "failed to cd to ${LOG_DIR}"; return 1; }
-    for i in $(ls -tr ./archive_status/ | grep .ready); do
+    if ! archive_status_files=$(ls -tr ./archive_status/); then
+      DP_error_log "failed to list WAL archive status"
+      return 1
+    fi
+    for i in ${archive_status_files}; do
+      case ${i} in
+        *.ready) ;;
+        *) continue ;;
+      esac
       wal_name=${i%.*}
       wal_dump_output=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null)
       wal_dump_status=$?

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -29,7 +29,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
       DATASAFED_PUSH_FAIL_WAL \
       DATASAFED_RM_EXIT DATASAFED_RM_FAIL_PATH \
       DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_EXIT DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
-      DP_TTL_SECONDS FIND_EXIT FIND_FAIL_ON_CALL PG_WALDUMP_EXIT PG_WALDUMP_OUT \
+      DP_TTL_SECONDS FIND_EXIT FIND_FAIL_ON_CALL LS_EXIT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT MV_FAIL_SOURCE PSQL_EXIT PSQL_FAIL_ON_CALL 2>/dev/null || true
 
     write_stubs
@@ -137,6 +137,14 @@ elif [ "${FIND_EXIT:-0}" -ne 0 ]; then
 fi
 exec /usr/bin/find "$@"
 EOF
+    cat > "${bindir}/ls" <<'EOF'
+#!/bin/sh
+printf 'ls %s\n' "$*" >> "${CALL_LOG}"
+if [ "${LS_EXIT:-0}" -ne 0 ]; then
+  exit "${LS_EXIT}"
+fi
+exec /bin/ls "$@"
+EOF
     cat > "${bindir}/mv" <<'EOF'
 #!/bin/sh
 printf 'mv %s\n' "$*" >> "${CALL_LOG}"
@@ -149,7 +157,7 @@ fi
 exec /bin/mv "$@"
 EOF
     chmod +x "${bindir}/datasafed" "${bindir}/psql" "${bindir}/pg_waldump" \
-      "${bindir}/date" "${bindir}/find" "${bindir}/mv" "${bindir}/sleep"
+      "${bindir}/date" "${bindir}/find" "${bindir}/ls" "${bindir}/mv" "${bindir}/sleep"
   }
 
   build_shim() {
@@ -366,6 +374,19 @@ EOF
   End
 
   Describe "upload_wal_log()"
+    It "fails before pushing when archive-status enumeration fails"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export LS_EXIT=17
+      When call upload_wal_log
+      The status should be failure
+      The output should include "failed to list WAL archive status"
+      The contents of file "${CALL_LOG}" should include "ls -tr ./archive_status/"
+      The contents of file "${CALL_LOG}" should not include "datasafed push"
+      The path "${LOG_DIR}/archive_status/${wal_name}.ready" should be exist
+    End
+
     It "stops before later WALs when the archive-status commit fails"
       first_wal="000000010000000000000001"
       second_wal="000000010000000000000002"


### PR DESCRIPTION
## Summary

- check archive-status directory enumeration before scanning upload candidates
- fail with a clear diagnostic when enumeration fails, before any WAL analysis or push
- match only the exact `.ready` suffix while preserving chronological upload order

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 44 examples, 1 failure with 2 assertions; `ls` rc17 was observed and no push occurred, but upload returned 0 without a listing diagnostic
- GREEN: focused PostgreSQL PITR ShellSpec 44 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 257 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,011,486 bytes

## Stack

- exact base commit: `12a16e9e057b88ae77c860fd9ae4d7e5222e6577` (PR #3380)
- test commit: `ec7a4a734f86672f5bb7d06d73034f804084bf92`
- fix commit: `6ee4d29e67d58e918ac2f5425debe84083369e82`
