### PR TITLE
fix(postgresql): stop failed upload rounds

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -335,7 +335,10 @@ while true; do
   switch_wal_log
 
   # upload wal log
-  upload_wal_log
+  if ! upload_wal_log; then
+    sleep ${LOG_ARCHIVE_SECONDS}
+    continue
+  fi
 
   # save backup status which will be updated to `backup` CR by the sidecar
   save_backup_status

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -164,6 +164,24 @@ EOF
     shim="${tmpdir}/shim.sh"
     awk '/^function [a-zA-Z_]/ { capture=1 } capture { print } capture && /^\}/ { capture=0 }' \
       ../dataprotection/postgresql-pitr-backup.sh > "${shim}"
+    awk '
+      /^while true; do$/ {
+        print "archive_loop_once() {"
+        capture = 1
+        next
+      }
+      capture && /^done$/ {
+        print "}"
+        exit
+      }
+      capture {
+        if ($0 ~ /^[[:space:]]*continue[[:space:]]*$/) {
+          print "    return 1"
+        } else {
+          print
+        }
+      }
+    ' ../dataprotection/postgresql-pitr-backup.sh >> "${shim}"
     # shellcheck disable=SC1090
     . ../dataprotection/common-scripts.sh
     # shellcheck disable=SC1090
@@ -251,6 +269,25 @@ EOF
     printf 'stop-time=%s\n' "${global_stop_time}"
     return "${status}"
   }
+
+  archive_round_with_upload_listing_failure() {
+    global_missing_logs_reconciled=true
+    check_pg_process() { :; }
+    switch_wal_log() { :; }
+    purge_expired_files() { printf 'purge_expired_files\n' >> "${CALL_LOG}"; }
+    export LS_EXIT=17
+    archive_loop_once
+  }
+
+  Describe "archive loop"
+    It "stops the round before metadata and retention after a hard upload failure"
+      When call archive_round_with_upload_listing_failure
+      The status should be failure
+      The output should include "failed to list WAL archive status"
+      The contents of file "${CALL_LOG}" should not include "datasafed stat"
+      The contents of file "${CALL_LOG}" should not include "purge_expired_files"
+    End
+  End
 
   Describe "switch_wal_log()"
     It "fails before requesting a switch when archive-status inspection fails"


### PR DESCRIPTION
## Summary

- stop an archive-loop round when WAL upload setup fails hard
- skip stale metadata publication and retention after archive-status enumeration failure
- preserve tolerant per-WAL retry semantics while avoiding a tight retry loop

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 45 examples, 1 failure with 3 assertions; upload listing rc17 still returned 0, called `datasafed stat`, and entered retention
- GREEN: focused PostgreSQL PITR ShellSpec 45 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 258 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,011,572 bytes

## Stack

- exact base commit: `6ee4d29e67d58e918ac2f5425debe84083369e82` (PR #3381)
- test commit: `d237a69fe50781ff6f5bbd05da7163f53c0f722d`
- fix commit: `f142ec4d4f2435e917624c924cab7ec359dc581c`
