### PR TITLE
fix(postgresql): stop uploads at missing WALs

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -131,6 +131,10 @@ function upload_wal_log() {
         *) continue ;;
       esac
       wal_name=${i%.*}
+      if [ ! -f ${wal_name} ]; then
+        DP_error_log "local WAL file ${wal_name} is missing, keeping ${i} for retry"
+        break
+      fi
       wal_dump_output=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null)
       wal_dump_status=$?
       LOG_STOP_TIME=$(printf '%s\n' "${wal_dump_output}" | grep 'desc: COMMIT' |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -411,6 +411,21 @@ EOF
   End
 
   Describe "upload_wal_log()"
+    It "does not upload past a ready marker whose WAL file is missing"
+      missing_wal="000000010000000000000001"
+      newer_wal="000000010000000000000002"
+      touch "${LOG_DIR}/${newer_wal}"
+      touch -t 202608160000.00 "${LOG_DIR}/archive_status/${missing_wal}.ready"
+      touch -t 202608160001.00 "${LOG_DIR}/archive_status/${newer_wal}.ready"
+      When call upload_wal_log
+      The status should eq 0
+      The output should include "local WAL file ${missing_wal} is missing, keeping ${missing_wal}.ready for retry"
+      The contents of file "${CALL_LOG}" should not include "datasafed push -z zstd ${newer_wal}"
+      The path "${LOG_DIR}/archive_status/${missing_wal}.ready" should be exist
+      The path "${LOG_DIR}/archive_status/${newer_wal}.ready" should be exist
+      The path "${LOG_DIR}/archive_status/${newer_wal}.done" should not be exist
+    End
+
     It "fails before pushing when archive-status enumeration fails"
       wal_name="000000010000000000000001"
       touch "${LOG_DIR}/${wal_name}"


### PR DESCRIPTION
## Summary

- detect a `.ready` marker whose local WAL source file is missing
- keep the missing marker retryable and stop the chronological upload batch
- prevent newer WALs from being pushed and retired across a local archive gap

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 46 examples, 1 failure with 4 assertions; the missing older WAL emitted no diagnostic while the newer WAL was pushed and marked done
- GREEN: focused PostgreSQL PITR ShellSpec 46 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 259 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,011,748 bytes

## Stack

- exact base commit: `f142ec4d4f2435e917624c924cab7ec359dc581c` (PR #3382)
- test commit: `a6097bbc0427627dcf0ac73b56314badf84a3929`
- fix commit: `887fe6892a0b4e1c4f4ecee80bc4a3ce61811450`
