### PR TITLE
fix(postgresql): fail retention clock errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -27,7 +27,11 @@ fi
 
 # clean up expired logfiles, interval is 600s
 function purge_expired_files() {
-    local currentUnix=$(date +%s)
+    local currentUnix
+    if ! currentUnix=$(date +%s) || [[ -z ${currentUnix} ]]; then
+      DP_error_log "failed to determine current time for WAL retention"
+      return 1
+    fi
     local info
     if ! info=$(DP_purge_expired_files ${currentUnix} ${global_last_purge_time} / 600); then
        if [ ! -z "${info}" ]; then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -354,6 +354,15 @@ EOF
   End
 
   Describe "purge_expired_files()"
+    It "fails before expiry arithmetic when the retention clock cannot be read"
+      export DATE_EPOCH_EXIT=17 DP_TTL_SECONDS=3600
+      When call purge_and_report_checkpoint
+      The status should be failure
+      The output should include "failed to determine current time for WAL retention"
+      The output should include "purge-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+    End
+
     It "fails without advancing the checkpoint when the expired-WAL listing fails"
       export DP_TTL_SECONDS=3600 DATASAFED_LIST_EXIT=17
       When call purge_and_report_checkpoint


### PR DESCRIPTION
## Summary

- preserve the status of the retention `date +%s` capture
- fail with a phase-specific diagnostic on failed or empty clock output
- prevent shifted arguments and raw arithmetic errors before repository access

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 47 examples, 1 failure; `date +%s` rc17 was masked and exposed raw `123-/` expiry arithmetic stderr
- GREEN: focused PostgreSQL PITR ShellSpec 47 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 260 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,011,928 bytes

## Stack

- exact base commit: `887fe6892a0b4e1c4f4ecee80bc4a3ce61811450` (PR #3383)
- test commit: `75d4791723f77946f36fde50549d23d7755253b1`
- fix commit: `671151bcc567a302bdfc5f44a4d2283971676c6b`
