### PR TITLE
fix(postgresql): validate PITR epoch output

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -7,11 +7,11 @@ export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 export KB_BACKUP_WORKDIR=${VOLUME_DATA_DIR}/kb-backup
 
 PSQL="psql -h ${DP_DB_HOST} -U ${DP_DB_USER} -d postgres"
-if ! global_last_switch_wal_time=$(date +%s) || [[ -z ${global_last_switch_wal_time} ]]; then
+if ! global_last_switch_wal_time=$(date +%s) || [[ ! ${global_last_switch_wal_time} =~ ^[0-9]+$ ]]; then
   DP_error_log "failed to determine initial WAL switch time"
   exit 1
 fi
-if ! global_last_purge_time=$(date +%s) || [[ -z ${global_last_purge_time} ]]; then
+if ! global_last_purge_time=$(date +%s) || [[ ! ${global_last_purge_time} =~ ^[0-9]+$ ]]; then
   DP_error_log "failed to determine initial WAL retention time"
   exit 1
 fi
@@ -34,7 +34,7 @@ fi
 # clean up expired logfiles, interval is 600s
 function purge_expired_files() {
     local currentUnix
-    if ! currentUnix=$(date +%s) || [[ -z ${currentUnix} ]]; then
+    if ! currentUnix=$(date +%s) || [[ ! ${currentUnix} =~ ^[0-9]+$ ]]; then
       DP_error_log "failed to determine current time for WAL retention"
       return 1
     fi
@@ -61,7 +61,7 @@ function purge_expired_files() {
 # switch wal log
 function switch_wal_log() {
     local curr_time
-    if ! curr_time=$(date +%s) || [[ -z ${curr_time} ]]; then
+    if ! curr_time=$(date +%s) || [[ ! ${curr_time} =~ ^[0-9]+$ ]]; then
       DP_error_log "failed to determine current time for WAL switch"
       return 1
     fi

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -285,6 +285,14 @@ EOF
   }
 
   Describe "startup clock initialization"
+    It "fails when the initial WAL switch clock is not a decimal epoch"
+      export DATE_EPOCH_OUT="not-an-epoch"
+      When run run_startup_preamble
+      The status should be failure
+      The output should include "failed to determine initial WAL switch time"
+      The output should not include "switch-time=not-an-epoch"
+    End
+
     It "fails when the initial WAL switch clock cannot be read"
       export DATE_EPOCH_FAIL_ON_CALL=1
       When run run_startup_preamble
@@ -322,6 +330,15 @@ EOF
   End
 
   Describe "switch_wal_log()"
+    It "fails before arithmetic when the current time is not a decimal epoch"
+      export DATE_EPOCH_OUT="not-an-epoch"
+      When call switch_and_report_checkpoint
+      The status should be failure
+      The output should include "failed to determine current time for WAL switch"
+      The output should include "switch-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "psql"
+    End
+
     It "fails before requesting a switch when archive-status inspection fails"
       export DATE_EPOCH_OUT=456 PG_WALDUMP_OUT="transaction record" FIND_EXIT=17
       When call switch_and_report_checkpoint
@@ -386,6 +403,15 @@ EOF
   End
 
   Describe "purge_expired_files()"
+    It "fails before expiry arithmetic when the retention clock is not a decimal epoch"
+      export DATE_EPOCH_OUT="not-an-epoch" DP_TTL_SECONDS=3600
+      When call purge_and_report_checkpoint
+      The status should be failure
+      The output should include "failed to determine current time for WAL retention"
+      The output should include "purge-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+    End
+
     It "fails before expiry arithmetic when the retention clock cannot be read"
       export DATE_EPOCH_EXIT=17 DP_TTL_SECONDS=3600
       When call purge_and_report_checkpoint


### PR DESCRIPTION
## Summary

- require decimal epoch output at startup, WAL-switch, and retention clock boundaries
- reject nonempty malformed clock output before state assignment or arithmetic
- preserve the existing phase-specific failure diagnostics and checkpoints

## TDD evidence

- RED: focused PostgreSQL PITR ShellSpec 52 examples, 3 failures with 7 assertions; nonnumeric epochs were accepted at startup and silently coerced by switch/retention arithmetic
- GREEN: focused PostgreSQL PITR ShellSpec 52 examples, 0 failures
- full PostgreSQL ShellSpec under Bash 5.3.9: 265 examples, 0 failures
- ShellCheck severity error and Bash syntax: pass
- `git diff --check`: pass
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,272 bytes

## Stack

- exact base commit: `306340fcf35cbf875ad1868a2b109f192e4ea6af` (PR #3385)
- test commit: `6a7cd211491d7276865219a66628667d55fc5166`
- fix commit: `952bb8d3f72adec64c0f428170da958d34488cad`
