### PR TITLE
fix(postgresql): validate WAL upload partitions

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -122,7 +122,7 @@ function switch_wal_log() {
 # upload wal log
 function upload_wal_log() {
     local TODAY_INCR_LOG
-    if ! TODAY_INCR_LOG=$(date +%Y%m%d) || [[ -z ${TODAY_INCR_LOG} ]]; then
+    if ! TODAY_INCR_LOG=$(date +%Y%m%d) || [[ ! ${TODAY_INCR_LOG} =~ ^[0-9]{8}$ ]]; then
       DP_error_log "failed to determine WAL upload partition"
       return 1
     fi
@@ -271,7 +271,7 @@ function check_pg_process() {
 function uploadMissingLogs() {
     DP_log "start to upload the wal log which maybe misses"
     local TODAY_INCR_LOG
-    if ! TODAY_INCR_LOG=$(date +%Y%m%d) || [[ -z ${TODAY_INCR_LOG} ]]; then
+    if ! TODAY_INCR_LOG=$(date +%Y%m%d) || [[ ! ${TODAY_INCR_LOG} =~ ^[0-9]{8}$ ]]; then
       DP_error_log "failed to determine missing-WAL upload partition"
       return 1
     fi

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -540,6 +540,19 @@ EOF
       The path "${LOG_DIR}/archive_status/${wal_name}.done" should not be exist
     End
 
+    It "fails before pushing when the archive partition is malformed"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.ready"
+      export DATE_TODAY_OUT="../invalid"
+      When call upload_wal_log
+      The status should be failure
+      The output should include "failed to determine WAL upload partition"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+      The path "${LOG_DIR}/archive_status/${wal_name}.ready" should be exist
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should not be exist
+    End
+
     It "keeps the WAL retryable when analysis fails without a usable COMMIT"
       wal_name="000000010000000000000001"
       touch "${LOG_DIR}/${wal_name}"
@@ -691,6 +704,18 @@ EOF
       The contents of file "${CALL_LOG}" should not include "datasafed"
       The path "${LOG_DIR}/archive_status/${wal_name}.done" should be exist
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "fails before repository access when the reconciliation partition is malformed"
+      wal_name="000000010000000000000001"
+      touch "${LOG_DIR}/${wal_name}"
+      touch "${LOG_DIR}/archive_status/${wal_name}.done"
+      export DATE_TODAY_OUT="../invalid"
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "failed to determine missing-WAL upload partition"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+      The path "${LOG_DIR}/archive_status/${wal_name}.done" should be exist
     End
 
     It "fails when the remote WAL listing is unavailable"


### PR DESCRIPTION
## Summary

- require `date +%Y%m%d` to return exactly eight decimal digits before constructing WAL repository paths
- apply the same validation to normal archive upload and startup missing-WAL reconciliation
- cover malformed partition output in both paths

## TDD evidence

- RED test commit: `f1ac0b472` - 54 examples, 2 failures, 8 failed assertions
- GREEN fix commit: `92e2da8e0` - focused 54 examples, 0 failures
- PostgreSQL ShellSpec with Bash 5: 267 examples, 0 failures
- ShellCheck severity error: clean
- Bash 5 syntax: clean
- `git diff --check`: clean
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,298 bytes

## Behavior

Malformed partition output such as `../invalid` now stops before any repository list, push, or stat operation. The WAL marker remains retryable and a phase-specific diagnostic is emitted.
