### PR TITLE
fix(postgresql): stop reconciliation at WAL gaps

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -286,7 +286,6 @@ function uploadMissingLogs() {
       OLDEST_FILE=$(basename $OLDEST_FILE)
       DP_log "oldest uploaded wal: ${OLDEST_FILE}"
     fi
-    local reconciliation_failed=false
     local wal_status_files
     if ! wal_status_files=$(find ./archive_status -type f -name '*.done'); then
       DP_error_log "failed to list local WAL archive status"
@@ -309,16 +308,13 @@ function uploadMissingLogs() {
         DP_log "upload ${wal_name}"
         if ! datasafed push -z zstd ${wal_name} "/${TODAY_INCR_LOG}/${wal_name}.zst"; then
           DP_error_log "failed to upload ${wal_name}, will retry reconciliation"
-          reconciliation_failed=true
+          return 1
         fi
       else
         DP_error_log "cannot reconcile ${wal_name}: local WAL file is missing"
-        reconciliation_failed=true
+        return 1
       fi
     done
-    if [[ ${reconciliation_failed} == "true" ]]; then
-      return 1
-    fi
     save_backup_status
 }
 

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -738,6 +738,21 @@ EOF
       The output should include "push-count=2"
     End
 
+    It "does not reconcile past the first failed WAL upload"
+      older_wal="000000010000000000000001"
+      newer_wal="000000010000000000000002"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      export DATASAFED_PUSH_FAIL_WAL="${older_wal}"
+      touch "${LOG_DIR}/${older_wal}" "${LOG_DIR}/${newer_wal}"
+      touch "${LOG_DIR}/archive_status/${older_wal}.done" \
+        "${LOG_DIR}/archive_status/${newer_wal}.done"
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "failed to upload ${older_wal}, will retry reconciliation"
+      The contents of file "${CALL_LOG}" should include "datasafed push -z zstd ${older_wal}"
+      The contents of file "${CALL_LOG}" should not include "datasafed push -z zstd ${newer_wal}"
+    End
+
     It "fails when a remotely missing done WAL has no local source file"
       export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
       export DATASAFED_STAT_OUT="TotalSize: 4096"
@@ -746,6 +761,19 @@ EOF
       The status should be failure
       The output should include "cannot reconcile 000000010000000000000001: local WAL file is missing"
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
+    It "does not reconcile past the first WAL whose local source is missing"
+      older_wal="000000010000000000000001"
+      newer_wal="000000010000000000000002"
+      export DATASAFED_LIST_OUT='[{"path":"/20260816/000000010000000000000000.zst","mtime":"2026-08-16T00:00:00Z"}]'
+      touch "${LOG_DIR}/${newer_wal}"
+      touch "${LOG_DIR}/archive_status/${older_wal}.done" \
+        "${LOG_DIR}/archive_status/${newer_wal}.done"
+      When call uploadMissingLogs
+      The status should be failure
+      The output should include "cannot reconcile ${older_wal}: local WAL file is missing"
+      The contents of file "${CALL_LOG}" should not include "datasafed push -z zstd ${newer_wal}"
     End
 
     It "uploads local done WALs when the repository is empty"


### PR DESCRIPTION
## Summary

- stop startup missing-WAL reconciliation at the first failed upload
- stop when a `.done` marker has no local WAL source
- prevent later WALs from being pushed across an unresolved repository gap

## TDD evidence

- RED test commit: `b9bea89d4` - 56 examples, 2 failures
- GREEN fix commit: `66953d5ad` - focused 56 examples, 0 failures
- PostgreSQL ShellSpec with Bash 5: 269 examples, 0 failures
- ShellCheck severity error: clean
- Bash 5 syntax: clean
- `git diff --check`: clean
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,116 bytes

## Behavior

Given ordered WALs 001 and 002, an upload failure or missing local source for 001 now returns immediately. WAL 002 is not pushed and backup metadata is not published until the gap is resolved.
