### PR TITLE
fix(postgresql): commit empty PITR purge scans

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -54,8 +54,8 @@ function purge_expired_files() {
        if ! DP_save_backup_status_info "${TOTAL_SIZE}"; then
          return 1
        fi
-       global_last_purge_time=${currentUnix}
     fi
+    global_last_purge_time=${currentUnix}
 }
 
 # switch wal log

--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -38,6 +38,9 @@ function purge_expired_files() {
       DP_error_log "failed to determine current time for WAL retention"
       return 1
     fi
+    if [[ -z ${DP_TTL_SECONDS} || $((currentUnix - global_last_purge_time)) -lt 600 ]]; then
+      return
+    fi
     local info
     if ! info=$(DP_purge_expired_files ${currentUnix} ${global_last_purge_time} / 600); then
        if [ ! -z "${info}" ]; then

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -430,6 +430,16 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "advances the checkpoint when a successful expiration scan finds no files"
+      export DATE_EPOCH_OUT=1000 DP_TTL_SECONDS=3600 DATASAFED_LIST_OUT=""
+      When call purge_and_report_checkpoint
+      The status should eq 0
+      The output should include "purge-checkpoint=1000"
+      The contents of file "${CALL_LOG}" should include "datasafed list -f --recursive --older-than"
+      The contents of file "${CALL_LOG}" should not include "datasafed stat"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "reports only successful deletions and keeps the checkpoint when one deletion fails"
       removed_wal="/20260816/000000010000000000000001.zst"
       failed_wal="/20260816/000000010000000000000002.zst"

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -430,6 +430,15 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "keeps the checkpoint when the retention interval has not elapsed"
+      export DATE_EPOCH_OUT=456 DP_TTL_SECONDS=3600
+      When call purge_and_report_checkpoint
+      The status should eq 0
+      The output should include "purge-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "advances the checkpoint when a successful expiration scan finds no files"
       export DATE_EPOCH_OUT=1000 DP_TTL_SECONDS=3600 DATASAFED_LIST_OUT=""
       When call purge_and_report_checkpoint


### PR DESCRIPTION
## Summary

- advance the PITR retention checkpoint after a due purge succeeds, including scans with no expired WAL objects
- preserve the prior checkpoint when the 600s retention interval has not elapsed
- keep list, delete, stat, and metadata publication failures retryable at the prior checkpoint

## TDD evidence

- Initial RED `8104af929`: 57 examples, 1 failure - a due empty scan left the checkpoint stale
- Initial fix `c9ffc0237`
- Repair RED `24a9aae33`: 58 examples, 1 failure - the initial fix advanced the checkpoint before the interval elapsed
- Final fix `a758cda56`: focused 58 examples, 0 failures
- PostgreSQL ShellSpec with Bash 5: 271 examples, 0 failures
- ShellCheck severity error: clean
- Bash 5 syntax: clean
- `git diff --check`: clean
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,250 bytes

## Behavior

Before 600 seconds elapse, the checkpoint remains unchanged and no repository call runs. Once due, an empty successful expiration scan commits the current checkpoint so the archive loop waits for the next interval instead of rescanning on every tick.
