### PR TITLE
fix(postgresql): validate PITR retention TTL

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -38,6 +38,10 @@ function purge_expired_files() {
       DP_error_log "failed to determine current time for WAL retention"
       return 1
     fi
+    if [[ -n ${DP_TTL_SECONDS} && ! ${DP_TTL_SECONDS} =~ ^[0-9]+$ ]]; then
+      DP_error_log "invalid WAL retention TTL: ${DP_TTL_SECONDS}"
+      return 1
+    fi
     if [[ -z ${DP_TTL_SECONDS} || $((currentUnix - global_last_purge_time)) -lt 600 ]]; then
       return
     fi

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -421,6 +421,18 @@ EOF
       The contents of file "${CALL_LOG}" should not include "datasafed"
     End
 
+    It "fails before expiry arithmetic when the retention TTL is malformed"
+      expired_wal="/20260816/000000010000000000000001.zst"
+      export DATE_EPOCH_OUT=1000 DP_TTL_SECONDS="not-a-number"
+      export DATASAFED_LIST_OUT="${expired_wal}"
+      When call purge_and_report_checkpoint
+      The status should be failure
+      The output should include "invalid WAL retention TTL: not-a-number"
+      The output should include "purge-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "datasafed"
+      The path "${DP_BACKUP_INFO_FILE}" should not be exist
+    End
+
     It "fails without advancing the checkpoint when the expired-WAL listing fails"
       export DP_TTL_SECONDS=3600 DATASAFED_LIST_EXIT=17
       When call purge_and_report_checkpoint


### PR DESCRIPTION
## Summary

- require a configured PITR retention TTL to contain only decimal digits
- reject malformed TTL before interval and expiry arithmetic
- leave repository objects, backup metadata, and the purge checkpoint untouched on invalid configuration

## TDD evidence

- RED test commit: `e74e77a4e` - 59 examples, 1 failure with 5 failed assertions
- GREEN fix commit: `500684b7a` - focused 59 examples, 0 failures
- PostgreSQL ShellSpec with Bash 5: 272 examples, 0 failures
- ShellCheck severity error: clean
- Bash 5 syntax: clean
- `git diff --check`: clean
- `helm lint addons/postgresql`: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,445 bytes

## Behavior

Previously `DP_TTL_SECONDS=not-a-number` was interpreted as shell arithmetic variables, yielding the current epoch as the expiration cutoff. The script then deleted WALs, published metadata, advanced the checkpoint, and returned success. Invalid TTL now fails before any repository access.
