### PR TITLE
fix(postgresql): parse PITR retention TTL as decimal

### DIFF
--- a/addons/postgresql/dataprotection/common-scripts.sh
+++ b/addons/postgresql/dataprotection/common-scripts.sh
@@ -100,7 +100,7 @@ function DP_purge_expired_files() {
   if [[ -z ${DP_TTL_SECONDS} || ${diff_time} -lt ${interval_seconds} ]]; then
      return
   fi
-  local expiredUnix=$((${currentUnix}-${DP_TTL_SECONDS}))
+  local expiredUnix=$((${currentUnix}-10#${DP_TTL_SECONDS}))
   local files
   if ! files=$(datasafed list -f --recursive --older-than ${expiredUnix} ${root_path}); then
       DP_error_log "failed to list expired WAL files" >&2

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -433,6 +433,14 @@ EOF
       The path "${DP_BACKUP_INFO_FILE}" should not be exist
     End
 
+    It "treats a digit-only retention TTL as decimal when it has leading zeros"
+      export DATE_EPOCH_OUT=10000 DP_TTL_SECONDS=03600 DATASAFED_LIST_OUT=""
+      When call purge_and_report_checkpoint
+      The status should eq 0
+      The output should include "purge-checkpoint=10000"
+      The contents of file "${CALL_LOG}" should include "datasafed list -f --recursive --older-than 6400 /"
+    End
+
     It "fails without advancing the checkpoint when the expired-WAL listing fails"
       export DP_TTL_SECONDS=3600 DATASAFED_LIST_EXIT=17
       When call purge_and_report_checkpoint


### PR DESCRIPTION
## Summary

- parse the already validated `DP_TTL_SECONDS` value explicitly as base 10 during PITR expiry cutoff arithmetic
- cover leading-zero decimal TTLs so Bash cannot silently reinterpret them as octal

## Candidate

- target branch: `easton/pg-pitr-retention-ttl-validation`
- exact base: `500684b7a6f07e86b16b5d59b1e4c3c6113dcbc2` (PR #3390)
- exact head: `cd5ef60fc`
- relevant open child PRs targeting the base: none
- other open `weicao` PostgreSQL PR targeting `main`: #3331, excluded because it is the independent PgBouncer setup lane

## Contract

- `kubeblocks-addon-docs/docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 3: retention cleanup must keep the advertised recovery window aligned with repository artifacts
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md`: Continuous/PITR time ranges and repository retention must remain explainable and testable

## TDD evidence

RED commit `1d5f0a29e`:

- `DP_TTL_SECONDS=03600`
- expected decimal cutoff: `10000 - 3600 = 6400`
- observed before fix: cutoff `8080`, because Bash parsed `03600` as octal `1920`
- focused result: 1 example, 1 failure

GREEN exact head `cd5ef60fc`:

- focused Bash 3.2: 60 examples, 0 failures
- full PostgreSQL Bash 5.3: 273 examples, 0 failures
- ShellCheck severity error: clean
- Bash syntax and `git diff --check`: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,454 bytes

## Runtime boundary

This is source-level arithmetic and ShellSpec validation only. Runtime packaging, environment execution, cleanup, and formal acceptance counts remain Test-owned and are not claimed by this PR.
