### PR TITLE
fix(postgresql): parse PITR switch interval as decimal

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-backup.sh
@@ -21,7 +21,7 @@ global_old_size=0
 global_missing_logs_reconciled=false
 
 if [[ ${SWITCH_WAL_INTERVAL_SECONDS} =~ ^[0-9]+$ ]];then
-  global_switch_wal_interval=${SWITCH_WAL_INTERVAL_SECONDS}
+  global_switch_wal_interval=$((10#${SWITCH_WAL_INTERVAL_SECONDS}))
 fi
 
 global_backup_in_secondary=

--- a/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_backup_spec.sh
@@ -29,7 +29,7 @@ Describe "dataprotection/postgresql-pitr-backup.sh"
       DATASAFED_PUSH_FAIL_WAL \
       DATASAFED_RM_EXIT DATASAFED_RM_FAIL_PATH \
       DATASAFED_STAT_EXIT DATASAFED_STAT_OUT DATE_D_EXIT DATE_D_OUT DATE_EPOCH_EXIT DATE_EPOCH_FAIL_ON_CALL DATE_EPOCH_OUT DATE_TODAY_EXIT DATE_TODAY_OUT \
-      DP_TTL_SECONDS FIND_EXIT FIND_FAIL_ON_CALL LS_EXIT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
+      DP_TTL_SECONDS SWITCH_WAL_INTERVAL_SECONDS FIND_EXIT FIND_FAIL_ON_CALL LS_EXIT PG_WALDUMP_EXIT PG_WALDUMP_OUT \
       MV_EXIT MV_FAIL_SOURCE PSQL_EXIT PSQL_FAIL_ON_CALL 2>/dev/null || true
 
     write_stubs
@@ -266,6 +266,17 @@ EOF
     return "${status}"
   }
 
+  switch_with_configured_interval() {
+    export SWITCH_WAL_INTERVAL_SECONDS=00300 DATE_EPOCH_OUT=350
+    run_startup_preamble >/dev/null || return
+    global_last_switch_wal_time=123
+    local status=0
+    switch_wal_log || status=$?
+    printf 'switch-interval=%s switch-checkpoint=%s\n' \
+      "${global_switch_wal_interval}" "${global_last_switch_wal_time}"
+    return "${status}"
+  }
+
   upload_and_report_stop_time() {
     global_stop_time="2026-08-15T23:59:00Z"
     local status=0
@@ -330,6 +341,13 @@ EOF
   End
 
   Describe "switch_wal_log()"
+    It "treats a digit-only switch interval as decimal when it has leading zeros"
+      When call switch_with_configured_interval
+      The status should eq 0
+      The output should include "switch-interval=300 switch-checkpoint=123"
+      The contents of file "${CALL_LOG}" should not include "psql"
+    End
+
     It "fails before arithmetic when the current time is not a decimal epoch"
       export DATE_EPOCH_OUT="not-an-epoch"
       When call switch_and_report_checkpoint


### PR DESCRIPTION
## Summary

- parse validated `SWITCH_WAL_INTERVAL_SECONDS` explicitly as base 10 during PITR startup
- preserve the existing default for unset or malformed input
- cover leading-zero decimal intervals so Bash cannot silently shorten the WAL-switch throttle through octal interpretation

## Candidate

- target branch: `easton/pg-pitr-retention-ttl-base10`
- exact base: `cd5ef60fcffc6af5d8c6549385262f96b3973dca` (PR #3391)
- exact head: `2865c1c85`
- relevant open child PRs targeting the base: none
- other open `weicao` PostgreSQL PR targeting `main`: #3331, excluded because it is the independent PgBouncer setup lane

## Contract

- `kubeblocks-addon-docs/docs/addon-continuous-backup-pitr-chain-integrity-guide.md`: Continuous backup must keep advancing its recoverable WAL chain without silent scheduling distortion
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md`: Continuous/PITR archive production and time-range behavior must remain explainable and testable

## TDD evidence

RED commit `b8a04ccff`:

- configured `SWITCH_WAL_INTERVAL_SECONDS=00300`
- elapsed time: `350 - 123 = 227s`
- expected decimal behavior: remain throttled until `300s`, no PostgreSQL probe, checkpoint stays `123`
- observed before fix: interval remained `00300`, Bash interpreted it as octal `192`, probed PostgreSQL, and advanced checkpoint to `350`
- focused result: 1 example, 1 failure with 2 failed assertions

GREEN exact head `2865c1c85`:

- focused Bash 3.2: 61 examples, 0 failures
- full PostgreSQL Bash 5.3: 274 examples, 0 failures
- ShellCheck severity error: clean
- Bash syntax and `git diff --check`: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,462 bytes

## Runtime boundary

This is source-level scheduling arithmetic and ShellSpec validation only. Runtime packaging, environment execution, cleanup, and formal acceptance counts remain Test-owned and are not claimed by this PR.
