### PR TITLE
fix(postgresql): order PITR restore archive traversal

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -17,6 +17,10 @@ function fetch-wal-log(){
        DP_error_log "failed to list the WAL archive root"
        return 1
     fi
+    if ! dir_names=$(printf '%s\n' "${dir_names}" | sort); then
+       DP_error_log "failed to sort the WAL archive root"
+       return 1
+    fi
     for dir_name in $dir_names ; do
       if [[ $exit_fetch_wal -eq 1 ]]; then
          break
@@ -24,6 +28,10 @@ function fetch-wal-log(){
 
       if ! dir_files=$(datasafed list "${dir_name}"); then
          DP_error_log "failed to list WAL archive directory ${dir_name}"
+         return 1
+      fi
+      if ! dir_files=$(printf '%s\n' "${dir_files}" | sort); then
+         DP_error_log "failed to sort WAL archive directory ${dir_name}"
          return 1
       fi
       # check if the latest_wal_log after the start_wal_log

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -25,7 +25,8 @@ Describe "dataprotection PITR restore"
     DP_DATASAFED_BIN_PATH="${bindir}"
     export PATH CALL_LOG DATA_DIR PITR_DIR CONF_DIR RESTORE_SCRIPT_DIR \
       DP_RESTORE_TIME DP_RESTORE_TIMESTAMP DP_BACKUP_BASE_PATH DP_DATASAFED_BIN_PATH
-    unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_ROOT_LIST_EXIT \
+    unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_LIST_DIR_20260816 \
+      DATASAFED_LIST_DIR_20260817 DATASAFED_ROOT_LIST_EXIT \
       DATASAFED_DIR_LIST_EXIT 2>/dev/null || true
 
     write_stubs
@@ -54,7 +55,11 @@ case "$1" in
       if [ "${DATASAFED_DIR_LIST_EXIT:-0}" -ne 0 ]; then
         exit "${DATASAFED_DIR_LIST_EXIT}"
       fi
-      printf '%s\n' "${DATASAFED_LIST_DIR:-}"
+      case "$2" in
+        20260816/) printf '%s\n' "${DATASAFED_LIST_DIR_20260816:-${DATASAFED_LIST_DIR:-}}" ;;
+        20260817/) printf '%s\n' "${DATASAFED_LIST_DIR_20260817:-${DATASAFED_LIST_DIR:-}}" ;;
+        *) printf '%s\n' "${DATASAFED_LIST_DIR:-}" ;;
+      esac
     fi
     ;;
   pull)
@@ -107,6 +112,10 @@ EOF
       cat ../dataprotection/postgresql-fetch-wal-log.sh; echo
       cat ../dataprotection/postgresql-pitr-restore.sh; echo
     } > "${concat}"
+  }
+
+  first_pulled_archive() {
+    awk '/^datasafed pull / { print $5; exit }' "${CALL_LOG}"
   }
 
   Describe "prepareData script (concatenated form)"
@@ -176,6 +185,25 @@ EOF
   Describe "fetch-wal-log()"
     Include ../dataprotection/common-scripts.sh
     Include ../dataprotection/postgresql-fetch-wal-log.sh
+
+    It "fetches older archive directories before newer ones when the repository listing is unsorted"
+      export DATASAFED_LIST_ROOT="20260817/
+20260816/"
+      export DATASAFED_LIST_DIR_20260816="000000010000000000000002.zst"
+      export DATASAFED_LIST_DIR_20260817="000000010000000000000003.zst"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2026-01-01 00:00:00" true
+      The status should eq 0
+      The result of function first_pulled_archive should eq "000000010000000000000002.zst"
+    End
+
+    It "fetches older WAL objects before newer ones when a directory listing is unsorted"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000003.zst
+000000010000000000000002.zst"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2026-01-01 00:00:00" true
+      The status should eq 0
+      The result of function first_pulled_archive should eq "000000010000000000000002.zst"
+    End
 
     It "stops at the target time with numeric epoch comparison (9-digit vs 10-digit)"
       export DATASAFED_LIST_ROOT="waldir/"


### PR DESCRIPTION
## Summary

- sort PITR repository archive directories before traversing them
- sort each directory's WAL objects before selecting the latest object and pulling segments
- prevent an unsorted newer entry from reaching the target-time stop condition before older required WALs are downloaded

## Candidate

- target branch: `easton/pg-pitr-switch-interval-base10`
- exact base: `2865c1c85f08696927fb406d75e76cb3563e593a` (PR #3392)
- exact head: `4dc19e272`
- relevant open child PRs targeting the base: none
- other open `weicao` PostgreSQL PR targeting `main`: #3331, excluded because it is the independent PgBouncer setup lane

## Contract

- `kubeblocks-addon-docs/docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: required archive segments must not be silently skipped
- `kubeblocks-addon-docs/docs/addon-api/09b-backup-extensions.md`: Continuous/PITR archive production and time-range behavior must remain explainable and testable
- `kubeblocks-addon-docs/docs/addon-api/09c-restore-and-rebuild.md`: PITR validation must cover the continuous method, parameter propagation, and restore path rather than infer success from an intent alone

## TDD evidence

RED commit `55045e816`:

- unsorted root listing: `20260817/` before `20260816/`
- unsorted object listing: WAL `...003.zst` before `...002.zst`
- both paths pulled newer `...003` before required older `...002`
- focused result: 2 examples, 2 failures

GREEN exact head `4dc19e272`:

- focused PITR restore Bash 3.2: 8 examples, 0 failures
- full PostgreSQL Bash 5.3: 276 examples, 0 failures
- ShellCheck severity error: clean
- Bash syntax and `git diff --check`: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,837 bytes

## Runtime boundary

This is source-level restore traversal and ShellSpec validation only. Runtime packaging, environment execution, cleanup, and formal acceptance counts remain Test-owned and are not claimed by this PR.
