### PR TITLE
fix(postgresql): stop failed PITR WAL pulls

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -55,7 +55,10 @@ function fetch-wal-log(){
          fi
          DP_log "copying $wal_name"
          # pull and decompress
-         datasafed pull -d zstd $file ${wal_destination_dir}/$wal_name
+         if ! datasafed pull -d zstd "$file" "${wal_destination_dir}/${wal_name}"; then
+            DP_error_log "failed to pull WAL archive ${file}"
+            return 1
+         fi
 
          # check if the wal_log contains the restore_time logs. if ture, stop fetching
          latest_commit_time=$(pg_waldump ${wal_destination_dir}/$wal_name --rmgr=Transaction 2>/dev/null |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -27,7 +27,7 @@ Describe "dataprotection PITR restore"
       DP_RESTORE_TIME DP_RESTORE_TIMESTAMP DP_BACKUP_BASE_PATH DP_DATASAFED_BIN_PATH
     unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_LIST_DIR_20260816 \
       DATASAFED_LIST_DIR_20260817 DATASAFED_ROOT_LIST_EXIT \
-      DATASAFED_DIR_LIST_EXIT 2>/dev/null || true
+      DATASAFED_DIR_LIST_EXIT DATASAFED_PULL_FAIL_OBJECT 2>/dev/null || true
 
     write_stubs
     build_concat
@@ -63,6 +63,9 @@ case "$1" in
     fi
     ;;
   pull)
+    if [ "$4" = "${DATASAFED_PULL_FAIL_OBJECT:-}" ]; then
+      exit 44
+    fi
     # last arg is the destination file
     for arg; do dest="$arg"; done
     echo "wal-bytes" > "$dest"
@@ -116,6 +119,10 @@ EOF
 
   first_pulled_archive() {
     awk '/^datasafed pull / { print $5; exit }' "${CALL_LOG}"
+  }
+
+  call_log() {
+    cat "${CALL_LOG}"
   }
 
   Describe "prepareData script (concatenated form)"
@@ -203,6 +210,17 @@ EOF
       When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2026-01-01 00:00:00" true
       The status should eq 0
       The result of function first_pulled_archive should eq "000000010000000000000002.zst"
+    End
+
+    It "stops at the first WAL pull failure instead of crossing an archive gap"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000002.zst
+000000010000000000000003.zst"
+      export DATASAFED_PULL_FAIL_OBJECT="000000010000000000000002.zst"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2026-01-01 00:00:00" true
+      The status should be failure
+      The output should include "failed to pull WAL archive 000000010000000000000002.zst"
+      The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000003.zst"
     End
 
     It "stops at the target time with numeric epoch comparison (9-digit vs 10-digit)"


### PR DESCRIPTION
## Summary

- fail PITR restore immediately when `datasafed pull` cannot retrieve a required archived WAL
- stop before inspecting the missing destination or pulling later WALs across the resulting archive gap
- add focused ShellSpec coverage for the first-failure boundary

## Contract anchors

- `docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: archive chains fail closed at missing segments
- `docs/addon-api/09b-backup-extensions.md`: restore must fail clearly when required repository artifacts are unavailable
- `docs/addon-api/09c-restore-and-rebuild.md`: PITR acceptance requires the continuous chain and post-restore result, not only a restore timestamp

## TDD evidence

RED commit `87c2e128b` (Bash 3.2): 9 examples, 1 failure / 3 failed assertions. A simulated rc44 pulling required WAL002 returned success, emitted no pull diagnostic, and continued to pull WAL003.

GREEN commit `7fe7358b05a2cc7d3e11300e089f06407cbeeee8`:

- focused PITR restore ShellSpec on Bash 3.2: 9 examples, 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 277 examples, 0 failures
- ShellCheck error severity, Bash syntax, and diff check: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,012,973 bytes

## Scope

Source/static product change only. Runtime package, environment, execution, cleanup, and formal repeated-full acceptance remain tester-owned and are not claimed here.
