### PR TITLE
fix(postgresql): fail invalid PITR restore times

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -8,7 +8,10 @@ function get_wal_name() {
 function fetch-wal-log(){
     wal_destination_dir=$1
     start_wal_name=$2
-    restore_time=`date -d "$3" +%s`
+    if ! restore_time=$(date -d "$3" +%s); then
+       DP_error_log "failed to parse PITR restore time $3"
+       return 1
+    fi
     pitr=$4
     DP_log "PITR: $pitr"
 

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -27,7 +27,8 @@ Describe "dataprotection PITR restore"
       DP_RESTORE_TIME DP_RESTORE_TIMESTAMP DP_BACKUP_BASE_PATH DP_DATASAFED_BIN_PATH
     unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_LIST_DIR_20260816 \
       DATASAFED_LIST_DIR_20260817 DATASAFED_ROOT_LIST_EXIT \
-      DATASAFED_DIR_LIST_EXIT DATASAFED_PULL_FAIL_OBJECT 2>/dev/null || true
+      DATASAFED_DIR_LIST_EXIT DATASAFED_PULL_FAIL_OBJECT DATE_FAIL_VALUE \
+      2>/dev/null || true
 
     write_stubs
     build_concat
@@ -83,6 +84,9 @@ EOF
 #!/bin/sh
 if [ "$1" = "-d" ]; then
   arg=$2; shift 2; fmt=${1:-+%s}
+  if [ "$arg" = "${DATE_FAIL_VALUE:-}" ]; then
+    exit 45
+  fi
   case "$arg" in
     @*) secs=${arg#@} ;;
     "2001-01-01 00:00:00") secs=978307200 ;;
@@ -192,6 +196,14 @@ EOF
   Describe "fetch-wal-log()"
     Include ../dataprotection/common-scripts.sh
     Include ../dataprotection/postgresql-fetch-wal-log.sh
+
+    It "fails before repository access when the restore target time cannot be parsed"
+      export DATE_FAIL_VALUE="invalid-target"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "invalid-target" true
+      The status should be failure
+      The output should include "failed to parse PITR restore time invalid-target"
+      The result of function call_log should not include "datasafed"
+    End
 
     It "fetches older archive directories before newer ones when the repository listing is unsorted"
       export DATASAFED_LIST_ROOT="20260817/


### PR DESCRIPTION
## Summary

- reject restore target times that `date -d` cannot parse
- emit a phase-specific diagnostic and return before destination setup or WAL repository access
- add focused ShellSpec coverage for the fail-fast boundary

## Contract anchors

- `docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: continuous/PITR chains fail closed rather than silently crossing gaps
- `docs/addon-api/09b-backup-extensions.md`: restore must clearly fail when required inputs or repository artifacts are invalid
- `docs/addon-api/09c-restore-and-rebuild.md`: PITR validation includes restore-time parameter propagation and the actual continuous chain

## TDD evidence

RED commit `481ba4e3b` (Bash 3.2): 10 examples, 1 failure / 3 failed assertions. A simulated rc45 parsing `invalid-target` returned success, emitted no target-time diagnostic, and still listed the WAL repository.

GREEN commit `d2486d384e0d626226bcd664b333d30401a87b56`:

- focused PITR restore ShellSpec on Bash 3.2: 10 examples, 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 278 examples, 0 failures
- ShellCheck error severity, Bash syntax, and diff check: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,013,091 bytes

## Scope

Source/static product change only. Runtime package, environment, execution, cleanup, and formal repeated-full acceptance remain tester-owned and are not claimed here.
