### PR TITLE
fix(postgresql): fail invalid WAL commit times

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -68,7 +68,10 @@ function fetch-wal-log(){
          if [[ -z $latest_commit_time ]]; then
             continue
          fi
-         timestamp=`date -d "$latest_commit_time" +%s`
+         if ! timestamp=$(date -d "$latest_commit_time" +%s); then
+            DP_error_log "failed to parse commit time for WAL ${wal_name}: ${latest_commit_time}"
+            return 1
+         fi
          if [[ $latest_commit_time != "" && $timestamp -gt $restore_time ]]; then
             DP_log "exit when reaching the target time log."
             exit_fetch_wal=1

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -235,6 +235,17 @@ EOF
       The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000003.zst"
     End
 
+    It "stops when a WAL commit timestamp cannot be parsed"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000002.zst
+000000010000000000000003.zst"
+      export DATE_FAIL_VALUE="2026-01-01 00:00:00 UTC"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2001-01-01 00:00:00" true
+      The status should be failure
+      The output should include "failed to parse commit time for WAL 000000010000000000000002"
+      The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000003.zst"
+    End
+
     It "stops at the target time with numeric epoch comparison (9-digit vs 10-digit)"
       export DATASAFED_LIST_ROOT="waldir/"
       export DATASAFED_LIST_DIR="000000010000000000000002.zst"


### PR DESCRIPTION
## Summary

- reject transaction commit timestamps that `date -d` cannot parse during PITR WAL inspection
- emit the affected WAL name and return before comparing an indeterminate epoch or pulling later WALs
- add focused ShellSpec coverage for this archive-chain boundary

## Contract anchors

- `docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: continuous/PITR chains fail closed rather than silently crossing uncertain segments
- `docs/addon-api/09b-backup-extensions.md`: restore must clearly fail when required repository artifacts cannot be validated
- `docs/addon-api/09c-restore-and-rebuild.md`: PITR validation includes the actual continuous chain and restored result

## TDD evidence

RED commit `626efc6b2` (Bash 3.2): 11 examples, 1 failure / 3 failed assertions. A simulated parser failure for required WAL002's commit timestamp returned success, emitted no diagnostic, and continued to pull WAL003.

GREEN commit `f4d6a90e8bfa93373fd733a682bfa2af8cccdad8`:

- focused PITR restore ShellSpec on Bash 3.2: 11 examples, 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 279 examples, 0 failures
- ShellCheck error severity, Bash syntax, and diff check: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,013,258 bytes

## Scope

Source/static product change only. Runtime package, environment, execution, cleanup, and formal repeated-full acceptance remain tester-owned and are not claimed here.
