### PR TITLE
fix(postgresql): fail PITR WAL inspection errors

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -64,7 +64,11 @@ function fetch-wal-log(){
          fi
 
          # check if the wal_log contains the restore_time logs. if ture, stop fetching
-         latest_commit_time=$(pg_waldump ${wal_destination_dir}/$wal_name --rmgr=Transaction 2>/dev/null |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+         if ! wal_dump=$(pg_waldump "${wal_destination_dir}/${wal_name}" --rmgr=Transaction 2>/dev/null); then
+            DP_error_log "failed to inspect WAL ${wal_name}"
+            return 1
+         fi
+         latest_commit_time=$(printf '%s\n' "${wal_dump}" | tail -n 1 | awk -F ' COMMIT ' '{print $2}' | awk -F ';' '{print $1}')
          if [[ -z $latest_commit_time ]]; then
             continue
          fi

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -28,7 +28,7 @@ Describe "dataprotection PITR restore"
     unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_LIST_DIR_20260816 \
       DATASAFED_LIST_DIR_20260817 DATASAFED_ROOT_LIST_EXIT \
       DATASAFED_DIR_LIST_EXIT DATASAFED_PULL_FAIL_OBJECT DATE_FAIL_VALUE \
-      2>/dev/null || true
+      PG_WALDUMP_FAIL_OBJECT 2>/dev/null || true
 
     write_stubs
     build_concat
@@ -75,6 +75,10 @@ esac
 EOF
     cat > "${bindir}/pg_waldump" <<'EOF'
 #!/bin/sh
+wal_name=${1##*/}
+if [ "$wal_name" = "${PG_WALDUMP_FAIL_OBJECT:-}" ]; then
+  exit 46
+fi
 echo "rmgr: Transaction desc: COMMIT 2026-01-01 00:00:00 UTC; inval msgs"
 EOF
     # minimal GNU `date -d` emulation with canned epochs; the pair is chosen
@@ -243,6 +247,17 @@ EOF
       When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2001-01-01 00:00:00" true
       The status should be failure
       The output should include "failed to parse commit time for WAL 000000010000000000000002"
+      The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000003.zst"
+    End
+
+    It "stops when an archived WAL cannot be inspected"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000002.zst
+000000010000000000000003.zst"
+      export PG_WALDUMP_FAIL_OBJECT="000000010000000000000002"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2001-01-01 00:00:00" true
+      The status should be failure
+      The output should include "failed to inspect WAL 000000010000000000000002"
       The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000003.zst"
     End
 


### PR DESCRIPTION
## Summary

- check `pg_waldump` before extracting a commit timestamp during PITR restore
- distinguish a tool failure from a successful WAL containing no transaction records
- stop before pulling later WALs when an archived segment cannot be inspected

## Contract anchors

- `docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: continuous/PITR chains fail closed rather than silently crossing uncertain segments
- `docs/addon-api/09b-backup-extensions.md`: restore must clearly fail when required repository artifacts cannot be validated
- `docs/addon-api/09c-restore-and-rebuild.md`: PITR validation includes the actual continuous chain and restored result

## TDD evidence

RED commit `294968c5a` (Bash 3.2): 12 examples, 1 failure / 3 failed assertions. A simulated `pg_waldump` rc46 on required WAL002 was treated as an empty-transaction WAL; restore returned success, pulled WAL003, and reported the target reached.

GREEN commit `15b4f7338374d178b51a3344842c4d764ea4de4a`:

- focused PITR restore ShellSpec on Bash 3.2: 12 examples, 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 280 examples, 0 failures
- ShellCheck error severity, Bash syntax, and diff check: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,013,453 bytes

## Scope

Source/static product change only. Runtime package, environment, execution, cleanup, and formal repeated-full acceptance remain tester-owned and are not claimed here.
