### PR TITLE
fix(postgresql): fail PITR destination setup

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -15,7 +15,11 @@ function fetch-wal-log(){
     pitr=$4
     DP_log "PITR: $pitr"
 
-    exit_fetch_wal=0 && mkdir -p $wal_destination_dir
+    exit_fetch_wal=0
+    if ! mkdir -p "$wal_destination_dir"; then
+       DP_error_log "failed to create WAL destination ${wal_destination_dir}"
+       return 1
+    fi
     if ! dir_names=$(datasafed list /); then
        DP_error_log "failed to list the WAL archive root"
        return 1

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -209,6 +209,15 @@ EOF
       The result of function call_log should not include "datasafed"
     End
 
+    It "fails before repository access when the WAL destination cannot be created"
+      blocked_parent="${tmpdir}/blocked"
+      printf 'not-a-directory\n' > "${blocked_parent}"
+      When call fetch-wal-log "${blocked_parent}/dest" "000000010000000000000001" "2026-01-01 00:00:00" true
+      The status should be failure
+      The output should include "failed to create WAL destination ${blocked_parent}/dest"
+      The result of function call_log should not include "datasafed"
+    End
+
     It "fetches older archive directories before newer ones when the repository listing is unsorted"
       export DATASAFED_LIST_ROOT="20260817/
 20260816/"


### PR DESCRIPTION
## Summary

- check PITR WAL destination directory creation before repository access
- emit the failed destination path and return instead of continuing after `mkdir -p` fails
- add focused ShellSpec coverage for the setup boundary

## Contract anchors

- `docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: continuous/PITR chains fail closed rather than silently proceeding through missing state
- `docs/addon-api/09b-backup-extensions.md`: restore must clearly fail when required inputs or artifact handling cannot be initialized
- `docs/addon-api/09c-restore-and-rebuild.md`: PITR validation includes prepareData and the actual restored result

## TDD evidence

RED commit `e3832306d` (Bash 3.2): 13 examples, 1 failure / 3 failed assertions. When the destination parent was a file, `mkdir -p` failed but restore returned success, emitted no setup diagnostic, and still listed the WAL repository.

GREEN commit `1fbbc0b62463d3e12a44f81abcfca7f4337e9686`:

- focused PITR restore ShellSpec on Bash 3.2: 13 examples, 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 281 examples, 0 failures
- ShellCheck error severity, Bash syntax, and diff check: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,013,600 bytes

## Scope

Source/static product change only. Runtime package, environment, execution, cleanup, and formal repeated-full acceptance remain tester-owned and are not claimed here.
