### PR TITLE
fix(postgresql): filter PITR start WAL files

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -16,8 +16,11 @@ fi
 
 mkdir -p ${PITR_DIR};
 
-latest_wal=$(ls ${DATA_DIR}/pg_wal -lI "*.history" | grep ^- | awk '{print $9}' | sort | tail -n 1)
-start_wal_log=`basename $latest_wal`
+start_wal_log=$(ls "${DATA_DIR}/pg_wal" -lI "*.history" | grep '^-' | awk '{print $9}' | grep -E '^[0-9A-F]{24}$' | sort | tail -n 1)
+if [[ -z ${start_wal_log} ]]; then
+  DP_error_log "failed to find a valid starting WAL in ${DATA_DIR}/pg_wal"
+  exit 1
+fi
 
 DP_log "fetch-wal-log ${PITR_DIR} ${start_wal_log} \"${DP_RESTORE_TIME}\" true"
 fetch-wal-log ${PITR_DIR} ${start_wal_log} "${DP_RESTORE_TIME}" true

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -173,6 +173,21 @@ EOF
       The path "${DATA_DIR}.old" should be exist
     End
 
+    It "ignores unrelated local files when selecting the starting WAL"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      echo x > "${DATA_DIR}/pg_wal/README"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000002.zst"
+      DP_RESTORE_TIME="2001-01-01 00:00:00"
+      export DP_RESTORE_TIME
+      When run bash "${concat}"
+      The status should eq 0
+      The output should include "fetch-wal-log ${PITR_DIR} 000000010000000000000001"
+      The result of function first_pulled_archive should eq "000000010000000000000002.zst"
+      The path "${DATA_DIR}.old" should be exist
+    End
+
     It "fails before staging data when the WAL repository root cannot be listed"
       mkdir -p "${DATA_DIR}/pg_wal"
       echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"


### PR DESCRIPTION
## Summary

- select the PITR restore start boundary only from exact 24-hex PostgreSQL WAL segment files
- ignore unrelated regular files and incomplete/non-segment artifacts in `pg_wal`
- fail clearly when no valid local starting segment exists

## Contract anchors

- `docs/addon-continuous-backup-pitr-chain-integrity-guide.md`, pit 4: continuous/PITR chains must not silently skip required segments
- `docs/addon-api/09b-backup-extensions.md`: restore inputs and artifact traversal must be validated before destructive handoff
- `docs/addon-api/09c-restore-and-rebuild.md`: PITR validation includes prepareData, continuous-chain selection, and the restored result

## TDD evidence

RED commit `777265713` (Bash 3.2): 14 examples, 1 failure / 2 failed assertions. With valid local WAL001 plus unrelated `README`, prepareData selected `README`, skipped repository WAL002, returned success, and staged the restore.

GREEN commit `cb7ad581c4f2884304dc121abbea37fc2cbef23b`:

- focused PITR restore ShellSpec on Bash 3.2: 14 examples, 0 failures
- full PostgreSQL ShellSpec on Bash 5.3: 282 examples, 0 failures
- ShellCheck error severity, Bash syntax, and diff check: clean
- Helm lint: 1 chart, 0 failures
- Helm render: 41 documents, 1,013,743 bytes

## Scope

Source/static product change only. Runtime package, environment, execution, cleanup, and formal repeated-full acceptance remain tester-owned and are not claimed here.
