### PR TITLE
fix(postgresql): fail invalid PITR recovery times

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -4,6 +4,11 @@ export WALG_DATASAFED_CONFIG=""
 export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
 export DATASAFED_BACKEND_BASE_PATH="$DP_BACKUP_BASE_PATH"
 
+if ! recovery_target_time=$(date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z'); then
+  DP_error_log "failed to format PITR recovery timestamp ${DP_RESTORE_TIMESTAMP}"
+  exit 1
+fi
+
 if [[ -d ${DATA_DIR}.old ]] && [[ ! -d ${DATA_DIR} ]]; then
   # A previous run already completed the final staging mv. Un-staging and
   # exiting 0 here (the old behavior) left a populated DATA_DIR carrying
@@ -36,7 +41,7 @@ echo "sync;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 chmod +x ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 cat << EOF > "${CONF_DIR}/recovery.conf"
 restore_command='cp ${PITR_DIR}/%f %p'
-recovery_target_time='$( date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z' )'
+recovery_target_time='${recovery_target_time}'
 recovery_target_action='promote'
 recovery_target_timeline='latest'
 EOF

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -188,6 +188,19 @@ EOF
       The path "${DATA_DIR}.old" should be exist
     End
 
+    It "fails before repository access when the recovery target timestamp cannot be formatted"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      DP_RESTORE_TIMESTAMP="invalid-epoch"
+      export DP_RESTORE_TIMESTAMP DATE_FAIL_VALUE="@invalid-epoch"
+      When run bash "${concat}"
+      The status should be failure
+      The output should include "failed to format PITR recovery timestamp invalid-epoch"
+      The result of function call_log should not include "datasafed"
+      The path "${DATA_DIR}" should be exist
+      The path "${DATA_DIR}.old" should not be exist
+    End
+
     It "fails before staging data when the WAL repository root cannot be listed"
       mkdir -p "${DATA_DIR}/pg_wal"
       echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"


### PR DESCRIPTION
## What

Validate and format the PostgreSQL PITR recovery timestamp before repository access or restore handoff mutation.

## Why

The command substitution inside the `recovery.conf` heredoc masked `date` failures. An invalid timestamp could therefore return success, access the WAL repository, write an empty recovery target, and move `DATA_DIR` to `.old`.

## Tests

- RED (`76e2030e5`): Bash 3.2 focused ShellSpec, 15 examples / 1 failure / 5 failed assertions
- GREEN: Bash 3.2 focused ShellSpec, 15 examples / 0 failures
- GREEN: Bash 5.3 full PostgreSQL ShellSpec, 283 examples / 0 failures
- ShellCheck error severity, Bash syntax, and `git diff --check`
- `helm lint addons/postgresql`: 1 chart / 0 failures
- `helm template`: 41 documents / 1,014,156 bytes
