### PR TITLE
fix(postgresql): filter PITR restore archive objects

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -51,6 +51,9 @@ function fetch-wal-log(){
       DP_log "start to fetch wal logs from ${dir_name}"
       for file in $(printf '%s\n' "${dir_files}" | grep ".zst"); do
          wal_name=$(get_wal_name ${file})
+         if [[ ! $wal_name =~ ^[0-9A-F]{24}$ && ! $wal_name =~ ^[0-9A-F]{8}\.history$ ]]; then
+            continue
+         fi
          if [[ $wal_name < $start_wal_name ]]; then
             continue
          fi

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -265,6 +265,16 @@ EOF
       The result of function first_pulled_archive should eq "000000010000000000000002.zst"
     End
 
+    It "ignores unrelated compressed objects before fetching WAL archives"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000001metadata.zst
+000000010000000000000002.zst"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2001-01-01 00:00:00" true
+      The status should eq 0
+      The result of function first_pulled_archive should eq "000000010000000000000002.zst"
+      The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000001metadata.zst"
+    End
+
     It "stops at the first WAL pull failure instead of crossing an archive gap"
       export DATASAFED_LIST_ROOT="20260816/"
       export DATASAFED_LIST_DIR="000000010000000000000002.zst


### PR DESCRIPTION
## What

Skip compressed repository objects unless their basename is a PostgreSQL WAL segment or timeline-history archive before PITR pull and inspection.

## Why

The restore traversal accepted every name containing `.zst`. An unrelated object ordered between the local start WAL and the next valid segment could be pulled, inspected, mistaken for the target boundary, and cause the real WAL to be skipped while preparation returned success.

## Tests

- RED (`62e5df853`): Bash 3.2 focused ShellSpec, 16 examples / 1 failure / 2 failed assertions
- GREEN: Bash 3.2 focused ShellSpec, 16 examples / 0 failures
- GREEN: Bash 5.3 full PostgreSQL ShellSpec, 284 examples / 0 failures
- ShellCheck error severity, Bash syntax, and `git diff --check`
- `helm lint addons/postgresql`: 1 chart / 0 failures
- `helm template`: 41 documents / 1,014,308 bytes
