### PR TITLE
fix(postgresql): preserve PITR timeline history

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -70,6 +70,10 @@ function fetch-wal-log(){
             return 1
          fi
 
+         if [[ $wal_name =~ \.history$ ]]; then
+            continue
+         fi
+
          # check if the wal_log contains the restore_time logs. if ture, stop fetching
          if ! wal_dump=$(pg_waldump "${wal_destination_dir}/${wal_name}" --rmgr=Transaction 2>/dev/null); then
             DP_error_log "failed to inspect WAL ${wal_name}"

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -275,6 +275,17 @@ EOF
       The result of function call_log should not include "datasafed pull -d zstd 000000010000000000000001metadata.zst"
     End
 
+    It "pulls timeline history without inspecting it as a WAL segment"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="000000010000000000000002.zst
+00000002.history.zst"
+      export PG_WALDUMP_FAIL_OBJECT="00000002.history"
+      When call fetch-wal-log "${tmpdir}/dest" "000000010000000000000001" "2026-01-01 00:00:00" true
+      The status should eq 0
+      The output should not include "failed to inspect WAL 00000002.history"
+      The path "${tmpdir}/dest/00000002.history" should be exist
+    End
+
     It "stops at the first WAL pull failure instead of crossing an archive gap"
       export DATASAFED_LIST_ROOT="20260816/"
       export DATASAFED_LIST_DIR="000000010000000000000002.zst


### PR DESCRIPTION
## What

Pull PostgreSQL timeline-history archives for PITR, but bypass `pg_waldump` transaction inspection for those non-WAL files.

## Why

Timeline-history files are required by recovery across timelines, but they are metadata, not WAL segments. The restore traversal pulled them and then treated `pg_waldump` rejection as a hard WAL-inspection failure, aborting preparation before handoff.

## Tests

- RED (`70eecc321`): Bash 3.2 focused ShellSpec, 17 examples / 1 failure / 2 failed assertions
- GREEN: Bash 3.2 focused ShellSpec, 17 examples / 0 failures
- GREEN: Bash 5.3 full PostgreSQL ShellSpec, 285 examples / 0 failures
- ShellCheck error severity, Bash syntax, and `git diff --check`
- `helm lint addons/postgresql`: 1 chart / 0 failures
- `helm template`: 41 documents / 1,014,422 bytes
