### PR TITLE
fix(postgresql): retain current PITR timeline history

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -54,7 +54,7 @@ function fetch-wal-log(){
          if [[ ! $wal_name =~ ^[0-9A-F]{24}$ && ! $wal_name =~ ^[0-9A-F]{8}\.history$ ]]; then
             continue
          fi
-         if [[ $wal_name < $start_wal_name ]]; then
+         if [[ ! $wal_name =~ \.history$ && $wal_name < $start_wal_name ]]; then
             continue
          fi
          if [[ $pitr != "true" && $file =~ ".history"  ]]; then

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -286,6 +286,16 @@ EOF
       The path "${tmpdir}/dest/00000002.history" should be exist
     End
 
+    It "fetches current timeline history even when it sorts below the start WAL"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="00000002.history.zst
+000000020000000000000001.zst"
+      When call fetch-wal-log "${tmpdir}/dest" "000000020000000000000001" "2026-01-01 00:00:00" true
+      The status should eq 0
+      The path "${tmpdir}/dest/00000002.history" should be exist
+      The result of function call_log should include "datasafed pull -d zstd 00000002.history.zst"
+    End
+
     It "stops at the first WAL pull failure instead of crossing an archive gap"
       export DATASAFED_LIST_ROOT="20260816/"
       export DATASAFED_LIST_DIR="000000010000000000000002.zst


### PR DESCRIPTION
## What

Exempt recognized PostgreSQL timeline-history archives from the WAL start-boundary comparison during PITR traversal.

## Why

A timeline-history basename such as `00000002.history` sorts below a timeline-2 WAL segment such as `000000020000000000000001`. Applying the segment comparison first silently skipped the required current timeline history while still pulling the segment and returning success.

## Tests

- RED (`960b4ebf3`): Bash 3.2 focused ShellSpec, 18 examples / 1 failure / 2 failed assertions
- GREEN: Bash 3.2 focused ShellSpec, 18 examples / 0 failures
- GREEN: Bash 5.3 full PostgreSQL ShellSpec, 286 examples / 0 failures
- ShellCheck error severity, Bash syntax, and `git diff --check`
- `helm lint addons/postgresql`: 1 chart / 0 failures
- `helm template`: 41 documents / 1,014,451 bytes
