### PR TITLE
fix(postgresql): traverse PITR history-only archives

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -41,13 +41,6 @@ function fetch-wal-log(){
          DP_error_log "failed to sort WAL archive directory ${dir_name}"
          return 1
       fi
-      # check if the latest_wal_log after the start_wal_log
-      latest_wal=$(printf '%s\n' "${dir_files}" | tail -n 1)
-      latest_wal_name=$(get_wal_name ${latest_wal})
-      if [[ ${latest_wal_name} < $start_wal_name ]]; then
-         continue
-      fi
-
       DP_log "start to fetch wal logs from ${dir_name}"
       for file in $(printf '%s\n' "${dir_files}" | grep ".zst"); do
          wal_name=$(get_wal_name ${file})

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -296,6 +296,15 @@ EOF
       The result of function call_log should include "datasafed pull -d zstd 00000002.history.zst"
     End
 
+    It "fetches current timeline history from a history-only archive directory"
+      export DATASAFED_LIST_ROOT="20260816/"
+      export DATASAFED_LIST_DIR="00000002.history.zst"
+      When call fetch-wal-log "${tmpdir}/dest" "000000020000000000000001" "2026-01-01 00:00:00" true
+      The status should eq 0
+      The path "${tmpdir}/dest/00000002.history" should be exist
+      The result of function call_log should include "datasafed pull -d zstd 00000002.history.zst"
+    End
+
     It "stops at the first WAL pull failure instead of crossing an archive gap"
       export DATASAFED_LIST_ROOT="20260816/"
       export DATASAFED_LIST_DIR="000000010000000000000002.zst


### PR DESCRIPTION
## What
Remove the directory-level latest-WAL shortcut and rely on sorted, exact per-object filtering during PITR archive traversal.

## Why
A directory containing only required timeline-history metadata was skipped because the history basename sorted below the start WAL. Fetch returned success without downloading the metadata.

## Tests
- RED `dc172e1a1`: Bash 3.2 focused, 19 examples / 1 failure / 2 assertions
- GREEN: Bash 3.2 focused 19/0; Bash 5.3 PostgreSQL full 287/0
- ShellCheck(error), syntax, diff clean; Helm lint 1/0; render 41 docs / 1,014,136 bytes
