### PR TITLE
fix(postgresql): reject ambiguous PITR data dirs

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -9,6 +9,11 @@ if ! recovery_target_time=$(date -d "@${DP_RESTORE_TIMESTAMP}" '+%F %T%::z'); th
   exit 1
 fi
 
+if [[ -d ${DATA_DIR}.old ]] && [[ -d ${DATA_DIR} ]]; then
+  DP_error_log "both ${DATA_DIR} and ${DATA_DIR}.old exist; refusing ambiguous PITR handoff"
+  exit 1
+fi
+
 if [[ -d ${DATA_DIR}.old ]] && [[ ! -d ${DATA_DIR} ]]; then
   # A previous run already completed the final staging mv. Un-staging and
   # exiting 0 here (the old behavior) left a populated DATA_DIR carrying

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -158,6 +158,18 @@ EOF
       The path "${CONF_DIR}/recovery.conf" should be exist
     End
 
+    It "fails before repository access when live and staged data directories both exist"
+      mkdir -p "${DATA_DIR}/pg_wal" "${DATA_DIR}.old/pg_wal"
+      echo live > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      echo staged > "${DATA_DIR}.old/pg_wal/000000010000000000000001"
+      When run bash "${concat}"
+      The status should be failure
+      The output should include "both ${DATA_DIR} and ${DATA_DIR}.old exist"
+      The result of function call_log should not include "datasafed"
+      The path "${DATA_DIR}" should be exist
+      The path "${DATA_DIR}.old/data" should not be exist
+    End
+
     It "continues preparation after the target WAL is found before another archive directory"
       mkdir -p "${DATA_DIR}/pg_wal"
       echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"


### PR DESCRIPTION
## What
Fail before repository access when both the live and staged PostgreSQL data directories exist.

## Why
The final `mv DATA_DIR DATA_DIR.old` treated an existing staged directory as a container, nested live data under `.old/data`, and returned success despite an ambiguous handoff state.

## Tests
- RED `3ae0c3387`: Bash 3.2 focused, 20 examples / 1 failure / 5 assertions
- GREEN: Bash 3.2 focused 20/0; Bash 5.3 PostgreSQL full 288/0
- ShellCheck(error), syntax, diff clean; Helm lint 1/0; render 41 docs / 1,014,340 bytes
