### PR TITLE
fix(postgresql): filter PITR archive roots

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
+++ b/addons/postgresql/dataprotection/postgresql-fetch-wal-log.sh
@@ -24,6 +24,7 @@ function fetch-wal-log(){
        DP_error_log "failed to list the WAL archive root"
        return 1
     fi
+    dir_names=$(printf '%s\n' "${dir_names}" | awk '/\/$/')
     if ! dir_names=$(printf '%s\n' "${dir_names}" | sort); then
        DP_error_log "failed to sort the WAL archive root"
        return 1

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -27,7 +27,8 @@ Describe "dataprotection PITR restore"
       DP_RESTORE_TIME DP_RESTORE_TIMESTAMP DP_BACKUP_BASE_PATH DP_DATASAFED_BIN_PATH
     unset DATASAFED_LIST_ROOT DATASAFED_LIST_DIR DATASAFED_LIST_DIR_20260816 \
       DATASAFED_LIST_DIR_20260817 DATASAFED_ROOT_LIST_EXIT \
-      DATASAFED_DIR_LIST_EXIT DATASAFED_PULL_FAIL_OBJECT DATE_FAIL_VALUE \
+      DATASAFED_DIR_LIST_EXIT DATASAFED_LIST_FAIL_PATH \
+      DATASAFED_PULL_FAIL_OBJECT DATE_FAIL_VALUE \
       PG_WALDUMP_FAIL_OBJECT 2>/dev/null || true
 
     write_stubs
@@ -53,6 +54,9 @@ case "$1" in
       fi
       printf '%s\n' "${DATASAFED_LIST_ROOT:-}"
     else
+      if [ "$2" = "${DATASAFED_LIST_FAIL_PATH:-}" ]; then
+        exit 43
+      fi
       if [ "${DATASAFED_DIR_LIST_EXIT:-0}" -ne 0 ]; then
         exit "${DATASAFED_DIR_LIST_EXIT}"
       fi
@@ -234,6 +238,22 @@ EOF
       The output should include "failed to list WAL archive directory waldir/"
       The path "${DATA_DIR}" should be exist
       The path "${DATA_DIR}.old" should not be exist
+    End
+
+    It "ignores unrelated repository root objects before listing archive directories"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      export DATASAFED_LIST_ROOT="!README
+20260816/"
+      export DATASAFED_LIST_FAIL_PATH="!README"
+      export DATASAFED_LIST_DIR="000000010000000000000002.zst"
+      DP_RESTORE_TIME="2001-01-01 00:00:00"
+      export DP_RESTORE_TIME
+      When run bash "${concat}"
+      The status should eq 0
+      The result of function first_pulled_archive should eq "000000010000000000000002.zst"
+      The result of function call_log should not include "datasafed list !README"
+      The path "${DATA_DIR}.old" should be exist
     End
   End
 


### PR DESCRIPTION
## What
Filter PITR repository root listings to slash-terminated archive directories before child traversal.

## Why
An unrelated root object ordered before a valid archive directory was treated as a directory; its list failure aborted fetch before the required WAL and handoff.

## Tests
- RED `f454e8984`: Bash 3.2 focused 21 examples / 1 failure / 4 assertions
- GREEN: Bash 3.2 focused 21/0; Bash 5.3 PostgreSQL full 289/0
- Static/chart gates clean; render 41 docs / 1,014,408 bytes
