### PR TITLE
fix(postgresql): fail PITR postReady moves

### DIFF
--- a/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
+++ b/addons/postgresql/dataprotection/postgresql-pitr-restore.sh
@@ -41,6 +41,7 @@ mkdir -p ${CONF_DIR};
 chmod 777 -R ${CONF_DIR};
 mkdir -p ${RESTORE_SCRIPT_DIR};
 echo "#!/bin/bash" > ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
+echo "set -e" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 echo "[[ -d '${DATA_DIR}.old' ]] && mv -f ${DATA_DIR}.old/* ${DATA_DIR}/;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 echo "sync;" >> ${RESTORE_SCRIPT_DIR}/kb_restore.sh;
 chmod +x ${RESTORE_SCRIPT_DIR}/kb_restore.sh;

--- a/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/pitr_restore_spec.sh
@@ -151,6 +151,21 @@ EOF
       The path "${RESTORE_SCRIPT_DIR}/kb_restore.sh" should be exist
     End
 
+    It "propagates a postReady data move failure"
+      mkdir -p "${DATA_DIR}/pg_wal"
+      echo x > "${DATA_DIR}/pg_wal/000000010000000000000001"
+      bash "${concat}" >/dev/null
+      mkdir -p "${DATA_DIR}"
+      cat > "${bindir}/mv" <<'EOF'
+#!/bin/sh
+exit 47
+EOF
+      chmod +x "${bindir}/mv"
+      When run bash "${RESTORE_SCRIPT_DIR}/kb_restore.sh"
+      The status should be failure
+      The path "${DATA_DIR}.old/pg_wal" should be exist
+    End
+
     It "retries idempotently when a previous run already staged the data dir"
       mkdir -p "${DATA_DIR}.old/pg_wal"
       echo x > "${DATA_DIR}.old/pg_wal/000000010000000000000001"


### PR DESCRIPTION
RED 2ae1ba716 proved generated postReady masked mv rc47 behind sync. Adds set -e. GREEN focused Bash3.2 22/0, full Bash5.3 290/0; static/chart gates clean.