### PR TITLE
feat(hugegraph): add distributed PD/Store/Server topology

### DIFF
--- a/addons-cluster/hugegraph/templates/cluster.yaml
+++ b/addons-cluster/hugegraph/templates/cluster.yaml
@@ -6,11 +6,28 @@ metadata:
   labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
 spec:
   clusterDef: hugegraph
-  topology: standalone
+  topology: {{ .Values.topology | default "standalone" }}
   terminationPolicy: {{ .Values.extra.terminationPolicy }}
   componentSpecs:
+    {{- if eq (.Values.topology | default "standalone") "distributed" }}
+    - name: pd
+      serviceVersion: {{ .Values.version | quote }}
+      replicas: {{ .Values.distributed.pdReplicas | default 3 }}
+      {{- include "kblib.componentResources" . | nindent 6 }}
+      {{- include "kblib.componentStorages" . | nindent 6 }}
+    - name: store
+      serviceVersion: {{ .Values.version | quote }}
+      replicas: {{ .Values.distributed.storeReplicas | default 3 }}
+      {{- include "kblib.componentResources" . | nindent 6 }}
+      {{- include "kblib.componentStorages" . | nindent 6 }}
+    - name: server
+      serviceVersion: {{ .Values.version | quote }}
+      replicas: {{ .Values.distributed.serverReplicas | default 1 }}
+      {{- include "kblib.componentResources" . | nindent 6 }}
+    {{- else }}
     - name: server
       serviceVersion: {{ .Values.version | quote }}
       replicas: 1
       {{- include "kblib.componentResources" . | nindent 6 }}
       {{- include "kblib.componentStorages" . | nindent 6 }}
+    {{- end }}

--- a/addons-cluster/hugegraph/values.yaml
+++ b/addons-cluster/hugegraph/values.yaml
@@ -1,5 +1,11 @@
 version: "1.7.0"
+topology: standalone
 replicas: 1
+
+distributed:
+  pdReplicas: 3
+  storeReplicas: 3
+  serverReplicas: 1
 
 cpu: 1
 memory: 2

--- a/addons/hugegraph/DESIGN-distributed.zh.md
+++ b/addons/hugegraph/DESIGN-distributed.zh.md
@@ -1,0 +1,62 @@
+# HugeGraph 1.7.0 分布式 Topology 设计
+
+依据 `docs/addon-api/03-cluster-definition.md`、`06-variables-and-services.md`、
+`12a-minimum-acceptance.md`、`12b-claimed-only-acceptance.md`。
+
+## 1. 拓扑含义
+
+`distributed` 是用户可选的第二种部署形态：PD + Store + Server。
+这不是 sharding。PD / Store 的多副本是同一 Raft 组里的 `replicas`。
+
+官方 1.7.0 运行时依赖是 PD healthy -> Store -> Server。
+PD 启动又需要事先知道 Store 的稳定 FQDN 列表，所以对象创建上 PD 和 Store
+放在同一 provision 阶段（逗号=并行），Server 后置。Store 启动脚本等 PD
+`/v1/health`。这符合合同：阶段内并行、阶段间有序。
+
+```text
+orders.provision:  [pd,store, server]
+orders.terminate: [server, store,pd]
+orders.update:    [pd,store, server]
+```
+
+`standalone` 仍是唯一 default。未指定 topology 时必须落到 standalone。
+
+## 2. 组件与名字
+
+| topology component | CmpD 名 | 正则 | 镜像 |
+| --- | --- | --- | --- |
+| standalone `server` | `hugegraph-{{ ver }}` | `^hugegraph-[0-9]` | `hugegraph/hugegraph:1.7.0` |
+| distributed `pd` | `hugegraph-pd-{{ ver }}` | `^hugegraph-pd-` | `hugegraph/pd:1.7.0` |
+| distributed `store` | `hugegraph-store-{{ ver }}` | `^hugegraph-store-` | `hugegraph/store:1.7.0` |
+| distributed `server` | `hugegraph-server-{{ ver }}` | `^hugegraph-server-` | `hugegraph/server:1.7.0` |
+
+standalone 原来的 `^hugegraph-` 会误伤 `hugegraph-pd-` / `hugegraph-store-` /
+`hugegraph-server-`，必须收窄。这是合同要求：`compDef` 正则要稳定命中唯一集合。
+
+## 3. Raft 身份
+
+官方用 hostname 当 Raft 成员 ID（`pd0:8610`）。合同要求不要把不可重算的
+Pod 名 / clusterUID 写进引擎成员 ID。这里用 KB `podFQDNs` 生成
+`{podFQDN}:port`，恢复或同名重建时只要 FQDN 规则不变就可以重算。
+
+本节点地址从 `podFQDNs` 里按 `hostname` / `metadata.name` 前缀匹配，不手写
+headless Service 名。
+
+## 4. 本 PR 声明 / 不声明
+
+声明：
+
+- `distributed` topology 可渲染，orders 闭合
+- 三组件 CmpD / ComponentVersion / example 名字对齐
+- PD / Store / Server 用官方 `HG_*` 环境变量启动
+- 最小规格：pd 3、store 3、server 1
+
+不声明（12b，本轮不验收）：
+
+- distributed backup / restore / PITR
+- Store scale-in / rebalance
+- PD / Store switchover、roleProbe
+- TLS、reconfigure
+- Hubble
+
+BackupPolicyTemplate 继续只命中 standalone server CmpD。

--- a/addons/hugegraph/scripts/start-pd.sh
+++ b/addons/hugegraph/scripts/start-pd.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PD_POD_FQDNS:?PD_POD_FQDNS is required}"
+: "${STORE_POD_FQDNS:?STORE_POD_FQDNS is required}"
+
+pod_name=${POD_NAME:-$(hostname)}
+
+append_port() {
+  local list=$1
+  local port=$2
+  local out="" host
+  IFS=',' read -ra hosts <<< "${list}"
+  for host in "${hosts[@]}"; do
+    [[ -n "${host}" ]] || continue
+    [[ -n "${out}" ]] && out+=","
+    out+="${host}:${port}"
+  done
+  printf '%s' "${out}"
+}
+
+self=""
+IFS=',' read -ra hosts <<< "${PD_POD_FQDNS}"
+for host in "${hosts[@]}"; do
+  short=${host%%.*}
+  if [[ "${short}" == "${pod_name}" || "${host}" == "${pod_name}" ]]; then
+    self=${host}
+    break
+  fi
+done
+[[ -n "${self}" ]] || {
+  echo "cannot map pod ${pod_name} to PD_POD_FQDNS=${PD_POD_FQDNS}" >&2
+  exit 1
+}
+
+export HG_PD_GRPC_HOST="${self}"
+export HG_PD_GRPC_PORT="${HG_PD_GRPC_PORT:-8686}"
+export HG_PD_REST_PORT="${HG_PD_REST_PORT:-8620}"
+export HG_PD_RAFT_ADDRESS="${self}:8610"
+export HG_PD_RAFT_PEERS_LIST="$(append_port "${PD_POD_FQDNS}" 8610)"
+export HG_PD_INITIAL_STORE_LIST="$(append_port "${STORE_POD_FQDNS}" 8500)"
+export HG_PD_DATA_PATH="${HG_PD_DATA_PATH:-/hugegraph-pd/pd_data}"
+export HG_PD_INITIAL_STORE_COUNT="${HG_PD_INITIAL_STORE_COUNT:-1}"
+
+mkdir -p "${HG_PD_DATA_PATH}"
+cd /hugegraph-pd
+exec /usr/bin/dumb-init -- ./docker-entrypoint.sh

--- a/addons/hugegraph/scripts/start-server.sh
+++ b/addons/hugegraph/scripts/start-server.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PD_POD_FQDNS:?PD_POD_FQDNS is required}"
+: "${STORE_POD_FQDNS:?STORE_POD_FQDNS is required}"
+
+append_port() {
+  local list=$1
+  local port=$2
+  local out="" host
+  IFS=',' read -ra hosts <<< "${list}"
+  for host in "${hosts[@]}"; do
+    [[ -n "${host}" ]] || continue
+    [[ -n "${out}" ]] && out+=","
+    out+="${host}:${port}"
+  done
+  printf '%s' "${out}"
+}
+
+first_store=${STORE_POD_FQDNS%%,*}
+
+export HG_SERVER_BACKEND=hstore
+export HG_SERVER_PD_PEERS="$(append_port "${PD_POD_FQDNS}" 8686)"
+export HG_SERVER_USE_PD=true
+export HG_SERVER_INIT_STORE_ENABLED=false
+export STORE_REST="${first_store}:8520"
+
+cd /hugegraph-server
+exec /usr/bin/dumb-init -- ./docker-entrypoint.sh

--- a/addons/hugegraph/scripts/start-store.sh
+++ b/addons/hugegraph/scripts/start-store.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PD_POD_FQDNS:?PD_POD_FQDNS is required}"
+: "${STORE_POD_FQDNS:?STORE_POD_FQDNS is required}"
+
+pod_name=${POD_NAME:-$(hostname)}
+
+append_port() {
+  local list=$1
+  local port=$2
+  local out="" host
+  IFS=',' read -ra hosts <<< "${list}"
+  for host in "${hosts[@]}"; do
+    [[ -n "${host}" ]] || continue
+    [[ -n "${out}" ]] && out+=","
+    out+="${host}:${port}"
+  done
+  printf '%s' "${out}"
+}
+
+self=""
+IFS=',' read -ra hosts <<< "${STORE_POD_FQDNS}"
+for host in "${hosts[@]}"; do
+  short=${host%%.*}
+  if [[ "${short}" == "${pod_name}" || "${host}" == "${pod_name}" ]]; then
+    self=${host}
+    break
+  fi
+done
+[[ -n "${self}" ]] || {
+  echo "cannot map pod ${pod_name} to STORE_POD_FQDNS=${STORE_POD_FQDNS}" >&2
+  exit 1
+}
+
+export HG_STORE_PD_ADDRESS="$(append_port "${PD_POD_FQDNS}" 8686)"
+first_pd=${PD_POD_FQDNS%%,*}
+for _ in $(seq 1 60); do
+  if curl -fsS "http://${first_pd}:8620/v1/health" >/dev/null; then
+    break
+  fi
+  sleep 2
+done
+export HG_STORE_GRPC_HOST="${self}"
+export HG_STORE_GRPC_PORT="${HG_STORE_GRPC_PORT:-8500}"
+export HG_STORE_REST_PORT="${HG_STORE_REST_PORT:-8520}"
+export HG_STORE_RAFT_ADDRESS="${self}:8510"
+export HG_STORE_DATA_PATH="${HG_STORE_DATA_PATH:-/hugegraph-store/storage}"
+
+mkdir -p "${HG_STORE_DATA_PATH}"
+cd /hugegraph-store
+exec /usr/bin/dumb-init -- ./docker-entrypoint.sh

--- a/addons/hugegraph/templates/_helpers.tpl
+++ b/addons/hugegraph/templates/_helpers.tpl
@@ -33,7 +33,43 @@ hugegraph-{{ .Chart.Version }}
 {{- end }}
 
 {{- define "hugegraph.cmpdPattern" -}}
-^hugegraph-
+^hugegraph-[0-9]
+{{- end }}
+
+{{- define "hugegraph.pdCmpdName" -}}
+hugegraph-pd-{{ .Chart.Version }}
+{{- end }}
+
+{{- define "hugegraph.pdCmpdPattern" -}}
+^hugegraph-pd-
+{{- end }}
+
+{{- define "hugegraph.storeCmpdName" -}}
+hugegraph-store-{{ .Chart.Version }}
+{{- end }}
+
+{{- define "hugegraph.storeCmpdPattern" -}}
+^hugegraph-store-
+{{- end }}
+
+{{- define "hugegraph.serverCmpdName" -}}
+hugegraph-server-{{ .Chart.Version }}
+{{- end }}
+
+{{- define "hugegraph.serverCmpdPattern" -}}
+^hugegraph-server-
+{{- end }}
+
+{{- define "hugegraph.pdImage" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.distributed.pd.repository }}:{{ .Values.distributed.pd.tag }}
+{{- end }}
+
+{{- define "hugegraph.storeImage" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.distributed.store.repository }}:{{ .Values.distributed.store.tag }}
+{{- end }}
+
+{{- define "hugegraph.serverImage" -}}
+{{ .Values.image.registry | default "docker.io" }}/{{ .Values.distributed.server.repository }}:{{ .Values.distributed.server.tag }}
 {{- end }}
 
 {{- define "hugegraph.scriptsTemplateName" -}}

--- a/addons/hugegraph/templates/clusterdefinition.yaml
+++ b/addons/hugegraph/templates/clusterdefinition.yaml
@@ -13,3 +13,21 @@ spec:
       components:
         - name: server
           compDef: {{ include "hugegraph.cmpdPattern" . }}
+    - name: distributed
+      components:
+        - name: pd
+          compDef: {{ include "hugegraph.pdCmpdPattern" . }}
+        - name: store
+          compDef: {{ include "hugegraph.storeCmpdPattern" . }}
+        - name: server
+          compDef: {{ include "hugegraph.serverCmpdPattern" . }}
+      orders:
+        provision:
+          - pd,store
+          - server
+        terminate:
+          - server
+          - store,pd
+        update:
+          - pd,store
+          - server

--- a/addons/hugegraph/templates/cmpd-pd.yaml
+++ b/addons/hugegraph/templates/cmpd-pd.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps.kubeblocks.io/v1
+kind: ComponentDefinition
+metadata:
+  name: {{ include "hugegraph.pdCmpdName" . }}
+  labels:
+    {{- include "hugegraph.labels" . | nindent 4 }}
+  annotations:
+    apps.kubeblocks.io/skip-immutable-check: "true"
+    {{- include "hugegraph.annotations" . | nindent 4 }}
+spec:
+  provider: kubeblocks
+  description: Apache HugeGraph 1.7.0 Placement Driver.
+  serviceKind: hugegraph-pd
+  serviceVersion: {{ .Values.serviceVersion }}
+  podManagementPolicy: Parallel
+  minReadySeconds: 10
+  replicasLimit:
+    minReplicas: 1
+    maxReplicas: 5
+  services:
+    - name: default
+      spec:
+        ports:
+          - name: rest
+            port: 8620
+            targetPort: rest
+          - name: grpc
+            port: 8686
+            targetPort: grpc
+          - name: raft
+            port: 8610
+            targetPort: raft
+  scripts:
+    - name: hugegraph-scripts
+      template: {{ include "hugegraph.scriptsTemplateName" . }}
+      namespace: {{ .Release.Namespace }}
+      volumeName: scripts
+      defaultMode: 0555
+  volumes:
+    - name: data
+  vars:
+    - name: PD_POD_FQDNS
+      valueFrom:
+        componentVarRef:
+          compDef: {{ include "hugegraph.pdCmpdPattern" . }}
+          optional: false
+          podFQDNs: Required
+    - name: STORE_POD_FQDNS
+      valueFrom:
+        componentVarRef:
+          compDef: {{ include "hugegraph.storeCmpdPattern" . }}
+          optional: false
+          podFQDNs: Required
+  runtime:
+    containers:
+      - name: pd
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /bin/bash
+          - /scripts/start-pd.sh
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: HG_PD_DATA_PATH
+            value: {{ .Values.distributed.pd.dataMountPath }}
+        ports:
+          - name: rest
+            containerPort: 8620
+          - name: grpc
+            containerPort: 8686
+          - name: raft
+            containerPort: 8610
+        startupProbe:
+          httpGet:
+            path: /v1/health
+            port: rest
+          failureThreshold: 36
+          periodSeconds: 5
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: rest
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /v1/health
+            port: rest
+          failureThreshold: 6
+          periodSeconds: 15
+          timeoutSeconds: 3
+        volumeMounts:
+          - name: data
+            mountPath: {{ .Values.distributed.pd.dataMountPath }}
+          - name: scripts
+            mountPath: /scripts

--- a/addons/hugegraph/templates/cmpd-server.yaml
+++ b/addons/hugegraph/templates/cmpd-server.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps.kubeblocks.io/v1
+kind: ComponentDefinition
+metadata:
+  name: {{ include "hugegraph.serverCmpdName" . }}
+  labels:
+    {{- include "hugegraph.labels" . | nindent 4 }}
+  annotations:
+    apps.kubeblocks.io/skip-immutable-check: "true"
+    {{- include "hugegraph.annotations" . | nindent 4 }}
+spec:
+  provider: kubeblocks
+  description: Apache HugeGraph 1.7.0 query server on HStore.
+  serviceKind: hugegraph
+  serviceVersion: {{ .Values.serviceVersion }}
+  minReadySeconds: 10
+  replicasLimit:
+    minReplicas: 1
+    maxReplicas: 5
+  services:
+    - name: default
+      spec:
+        ports:
+          - name: http
+            port: 8080
+            targetPort: http
+          - name: gremlin
+            port: 8182
+            targetPort: gremlin
+  scripts:
+    - name: hugegraph-scripts
+      template: {{ include "hugegraph.scriptsTemplateName" . }}
+      namespace: {{ .Release.Namespace }}
+      volumeName: scripts
+      defaultMode: 0555
+  vars:
+    - name: PD_POD_FQDNS
+      valueFrom:
+        componentVarRef:
+          compDef: {{ include "hugegraph.pdCmpdPattern" . }}
+          optional: false
+          podFQDNs: Required
+    - name: STORE_POD_FQDNS
+      valueFrom:
+        componentVarRef:
+          compDef: {{ include "hugegraph.storeCmpdPattern" . }}
+          optional: false
+          podFQDNs: Required
+  runtime:
+    containers:
+      - name: server
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /bin/bash
+          - /scripts/start-server.sh
+        ports:
+          - name: http
+            containerPort: 8080
+          - name: gremlin
+            containerPort: 8182
+        startupProbe:
+          httpGet:
+            path: /versions
+            port: http
+          failureThreshold: 36
+          periodSeconds: 5
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /versions
+            port: http
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /versions
+            port: http
+          failureThreshold: 6
+          periodSeconds: 15
+          timeoutSeconds: 3
+        volumeMounts:
+          - name: scripts
+            mountPath: /scripts

--- a/addons/hugegraph/templates/cmpd-store.yaml
+++ b/addons/hugegraph/templates/cmpd-store.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps.kubeblocks.io/v1
+kind: ComponentDefinition
+metadata:
+  name: {{ include "hugegraph.storeCmpdName" . }}
+  labels:
+    {{- include "hugegraph.labels" . | nindent 4 }}
+  annotations:
+    apps.kubeblocks.io/skip-immutable-check: "true"
+    {{- include "hugegraph.annotations" . | nindent 4 }}
+spec:
+  provider: kubeblocks
+  description: Apache HugeGraph 1.7.0 HStore.
+  serviceKind: hugegraph-store
+  serviceVersion: {{ .Values.serviceVersion }}
+  podManagementPolicy: Parallel
+  minReadySeconds: 10
+  replicasLimit:
+    minReplicas: 1
+    maxReplicas: 5
+  services:
+    - name: default
+      spec:
+        ports:
+          - name: rest
+            port: 8520
+            targetPort: rest
+          - name: grpc
+            port: 8500
+            targetPort: grpc
+          - name: raft
+            port: 8510
+            targetPort: raft
+  scripts:
+    - name: hugegraph-scripts
+      template: {{ include "hugegraph.scriptsTemplateName" . }}
+      namespace: {{ .Release.Namespace }}
+      volumeName: scripts
+      defaultMode: 0555
+  volumes:
+    - name: data
+  vars:
+    - name: PD_POD_FQDNS
+      valueFrom:
+        componentVarRef:
+          compDef: {{ include "hugegraph.pdCmpdPattern" . }}
+          optional: false
+          podFQDNs: Required
+    - name: STORE_POD_FQDNS
+      valueFrom:
+        componentVarRef:
+          compDef: {{ include "hugegraph.storeCmpdPattern" . }}
+          optional: false
+          podFQDNs: Required
+  runtime:
+    containers:
+      - name: store
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /bin/bash
+          - /scripts/start-store.sh
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: HG_STORE_DATA_PATH
+            value: {{ .Values.distributed.store.dataMountPath }}
+        ports:
+          - name: rest
+            containerPort: 8520
+          - name: grpc
+            containerPort: 8500
+          - name: raft
+            containerPort: 8510
+        startupProbe:
+          httpGet:
+            path: /v1/health
+            port: rest
+          failureThreshold: 48
+          periodSeconds: 5
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: rest
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /v1/health
+            port: rest
+          failureThreshold: 6
+          periodSeconds: 15
+          timeoutSeconds: 3
+        volumeMounts:
+          - name: data
+            mountPath: {{ .Values.distributed.store.dataMountPath }}
+          - name: scripts
+            mountPath: /scripts

--- a/addons/hugegraph/templates/cmpv.yaml
+++ b/addons/hugegraph/templates/cmpv.yaml
@@ -12,8 +12,32 @@ spec:
         - {{ include "hugegraph.cmpdPattern" . }}
       releases:
         - hugegraph-1.7.0
+    - compDefs:
+        - {{ include "hugegraph.pdCmpdPattern" . }}
+      releases:
+        - hugegraph-pd-1.7.0
+    - compDefs:
+        - {{ include "hugegraph.storeCmpdPattern" . }}
+      releases:
+        - hugegraph-store-1.7.0
+    - compDefs:
+        - {{ include "hugegraph.serverCmpdPattern" . }}
+      releases:
+        - hugegraph-server-1.7.0
   releases:
     - name: hugegraph-1.7.0
       serviceVersion: 1.7.0
       images:
         hugegraph: {{ include "hugegraph.image" . }}
+    - name: hugegraph-pd-1.7.0
+      serviceVersion: 1.7.0
+      images:
+        pd: {{ include "hugegraph.pdImage" . }}
+    - name: hugegraph-store-1.7.0
+      serviceVersion: 1.7.0
+      images:
+        store: {{ include "hugegraph.storeImage" . }}
+    - name: hugegraph-server-1.7.0
+      serviceVersion: 1.7.0
+      images:
+        server: {{ include "hugegraph.serverImage" . }}

--- a/addons/hugegraph/templates/script-template.yaml
+++ b/addons/hugegraph/templates/script-template.yaml
@@ -9,3 +9,9 @@ data:
     {{- .Files.Get "scripts/start.sh" | nindent 4 }}
   shutdown.sh: |-
     {{- .Files.Get "scripts/shutdown.sh" | nindent 4 }}
+  start-pd.sh: |-
+    {{- .Files.Get "scripts/start-pd.sh" | nindent 4 }}
+  start-store.sh: |-
+    {{- .Files.Get "scripts/start-store.sh" | nindent 4 }}
+  start-server.sh: |-
+    {{- .Files.Get "scripts/start-server.sh" | nindent 4 }}

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -49,11 +49,18 @@ required_files=(
   "${ADDON_DIR}/templates/actionset.yaml"
   "${ADDON_DIR}/templates/script-template.yaml"
   "${ADDON_DIR}/scripts/start.sh"
+  "${ADDON_DIR}/scripts/start-pd.sh"
+  "${ADDON_DIR}/scripts/start-store.sh"
+  "${ADDON_DIR}/scripts/start-server.sh"
   "${ADDON_DIR}/scripts/shutdown.sh"
   "${ADDON_DIR}/scripts/backup.sh"
   "${ADDON_DIR}/scripts/restore.sh"
+  "${ADDON_DIR}/templates/cmpd-pd.yaml"
+  "${ADDON_DIR}/templates/cmpd-store.yaml"
+  "${ADDON_DIR}/templates/cmpd-server.yaml"
   "${ADDON_DIR}/tests/scripts_test.sh"
   "${ADDON_DIR}/exporter/Dockerfile"
+  "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml"
   "${ADDON_DIR}/exporter/go.mod"
   "${CLUSTER_DIR}/Chart.yaml"
   "${CLUSTER_DIR}/templates/cluster.yaml"
@@ -68,6 +75,9 @@ done
 
 bash -n \
   "${ADDON_DIR}/scripts/start.sh" \
+  "${ADDON_DIR}/scripts/start-pd.sh" \
+  "${ADDON_DIR}/scripts/start-store.sh" \
+  "${ADDON_DIR}/scripts/start-server.sh" \
   "${ADDON_DIR}/scripts/shutdown.sh" \
   "${ADDON_DIR}/scripts/backup.sh" \
   "${ADDON_DIR}/scripts/restore.sh"
@@ -139,31 +149,31 @@ assert_contains "${definition_render}" 'metricsPath: /metrics'
 assert_contains "${definition_render}" 'collectionInterval: 30s'
 
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.runtime.containers | length' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.runtime.containers | length' "${definition_render}")" \
   "2" \
-  "component container count"
+  "standalone container count"
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.volumes | length' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.volumes | length' "${definition_render}")" \
   "1" \
-  "component volume count"
+  "standalone volume count"
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.volumes[0].name' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.volumes[0].name' "${definition_render}")" \
   "data" \
-  "component data volume"
+  "standalone data volume"
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.runtime.containers[] | select(.name == "hugegraph") | .volumeMounts | length' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.runtime.containers[] | select(.name == "hugegraph") | .volumeMounts | length' "${definition_render}")" \
   "2" \
   "main container volume mounts"
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.runtime.containers[] | select(.name == "hugegraph-exporter") | (.volumeMounts // []) | length' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.runtime.containers[] | select(.name == "hugegraph-exporter") | (.volumeMounts // []) | length' "${definition_render}")" \
   "0" \
   "exporter PVC mounts"
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.runtime.containers[] | select(.name == "hugegraph-exporter") | .env | length' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.runtime.containers[] | select(.name == "hugegraph-exporter") | .env | length' "${definition_render}")" \
   "2" \
   "exporter credential env count"
 assert_equal \
-  "$(yq 'select(.kind == "ComponentDefinition") | .spec.exporter.containerName' "${definition_render}")" \
+  "$(yq 'select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-1.0.0") | .spec.exporter.containerName' "${definition_render}")" \
   "hugegraph-exporter" \
   "spec.exporter container"
 assert_equal \
@@ -177,6 +187,34 @@ assert_contains "${cluster_render}" 'clusterDef: hugegraph'
 assert_contains "${cluster_render}" 'topology: standalone'
 assert_contains "${cluster_render}" 'replicas: 1'
 assert_contains "${cluster_render}" 'serviceVersion: [\"]?1\.7\.0[\"]?'
+
+assert_contains "${definition_render}" 'name: distributed'
+assert_contains "${definition_render}" 'name: hugegraph-pd-1.0.0'
+assert_contains "${definition_render}" 'name: hugegraph-store-1.0.0'
+assert_contains "${definition_render}" 'name: hugegraph-server-1.0.0'
+assert_contains "${definition_render}" 'compDef: \^hugegraph-\[0-9\]'
+assert_contains "${definition_render}" 'compDef: \^hugegraph-pd-'
+assert_contains "${definition_render}" 'docker.io/hugegraph/pd:1.7.0'
+assert_contains "${definition_render}" 'docker.io/hugegraph/store:1.7.0'
+assert_contains "${definition_render}" 'docker.io/hugegraph/server:1.7.0'
+assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_PEERS_LIST'
+assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_ADDRESS'
+assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'HG_STORE_PD_ADDRESS'
+assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_BACKEND=hstore'
+assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'topology: distributed'
+assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: pd'
+assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: store'
+
+distributed_render=$(mktemp)
+helm template hugegraph "${CLUSTER_DIR}" --namespace demo --set topology=distributed >"${distributed_render}"
+assert_contains "${distributed_render}" 'topology: distributed'
+assert_contains "${distributed_render}" 'name: pd'
+assert_contains "${distributed_render}" 'name: store'
+assert_equal \
+  "$(yq '[select(.kind == "Cluster") | .spec.componentSpecs[].name] | join(",")' "${distributed_render}")" \
+  "pd,store,server" \
+  "distributed component names"
+rm -f "${distributed_render}"
 assert_contains "${ADDON_DIR}/.helmignore" '^exporter/'
 
 package_dir=$(mktemp -d)

--- a/addons/hugegraph/values.yaml
+++ b/addons/hugegraph/values.yaml
@@ -21,6 +21,19 @@ exporter:
       cpu: 100m
       memory: 128Mi
 
+distributed:
+  pd:
+    repository: hugegraph/pd
+    tag: "1.7.0"
+    dataMountPath: /hugegraph-pd/pd_data
+  store:
+    repository: hugegraph/store
+    tag: "1.7.0"
+    dataMountPath: /hugegraph-store/storage
+  server:
+    repository: hugegraph/server
+    tag: "1.7.0"
+
 serviceVersion: "1.7.0"
 dataMountPath: /hugegraph-data
 

--- a/examples/hugegraph/README.md
+++ b/examples/hugegraph/README.md
@@ -1,6 +1,7 @@
 # HugeGraph Examples
 
-These examples target KubeBlocks `release-1.0` and HugeGraph 1.7.0 standalone.
+These examples target KubeBlocks `release-1.0` and HugeGraph 1.7.0.
+`cluster.yaml` is standalone. `cluster-distributed.yaml` is PD + Store + Server.
 
 ## Create
 

--- a/examples/hugegraph/cluster-distributed.yaml
+++ b/examples/hugegraph/cluster-distributed.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps.kubeblocks.io/v1
+kind: Cluster
+metadata:
+  name: hugegraph-distributed
+  namespace: demo
+spec:
+  clusterDef: hugegraph
+  topology: distributed
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: pd
+      serviceVersion: "1.7.0"
+      replicas: 3
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            storageClassName: ""
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 10Gi
+    - name: store
+      serviceVersion: "1.7.0"
+      replicas: 3
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            storageClassName: ""
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 20Gi
+    - name: server
+      serviceVersion: "1.7.0"
+      replicas: 1
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "500m"
+          memory: 1Gi


### PR DESCRIPTION
## Summary

Child PR for apecloud/kubeblocks-addons#3412. Adds a `distributed` topology: PD + Store + Server.

This follows addon-api ClusterDefinition rules: topology expresses composition and provision order; Store/PD multi-replica is a Raft group, not sharding; standalone stays the only default.

## What landed

- Topology `distributed` with component names `pd` / `store` / `server`
- Orders: first stage `pd,store` (PD needs Store FQDNs at start; Store waits for PD health), then `server`
- CmpDs `hugegraph-pd-*`, `hugegraph-store-*`, `hugegraph-server-*`
- Standalone `compDef` regex narrowed to `^hugegraph-[0-9]` so it cannot match the new CmpDs
- Official `hugegraph/pd|store|server:1.7.0` images and `HG_*` env from podFQDNs
- Example `examples/hugegraph/cluster-distributed.yaml`

## Not claimed

- Distributed backup/restore
- Store scale-in / rebalance
- PD/Store roleProbe or switchover
- TLS / reconfigure / Hubble

## Evidence

- `addons/hugegraph/tests/contract_test.sh` PASS
- `kubeblocks-tests` static 19/0/0 against this chart

## Pins

| Item | Pin |
| --- | --- |
| Base | `dev/hugegraph-release-1.0` @ `3634d7b8` |
| Child head | `aa6b3fe` |
| PD/Store/Server images | `docker.io/hugegraph/{pd,store,server}:1.7.0` |