### PR TITLE
docs(hugegraph): declare distributed limits in README

### DIFF
--- a/addons/hugegraph/DESIGN.zh.md
+++ b/addons/hugegraph/DESIGN.zh.md
@@ -38,7 +38,7 @@ PVC。
 - 多 graph 之间的全局事务时间点。每个 graph 自身 checkpoint 一致，但 graph 之间
   按顺序创建 checkpoint，存在短时间窗口。
 - RebuildInstance、scaleOut.fromBackup、跨 HugeGraph 版本、跨 topology 恢复。
-- TLS、在线参数变更、分布式 PD/Store/Server topology。
+- TLS、在线参数变更。分布式 PD/Store/Server 见 `DESIGN-distributed.zh.md`；本文件只覆盖 standalone。
 
 ## 3. 存储和启动
 

--- a/addons/hugegraph/README.md
+++ b/addons/hugegraph/README.md
@@ -1,23 +1,24 @@
 # HugeGraph
 
-This addon runs Apache HugeGraph 1.7.0 as a single HugeGraph Server backed by
-RocksDB.
+This addon runs Apache HugeGraph 1.7.0. Default topology `standalone` is one
+Server with embedded RocksDB. Topology `distributed` is PD + Store + Server.
 
 ## Capabilities
 
-| Capability | Standalone |
-| --- | --- |
-| Replicas | Exactly 1 |
-| Persistent data | Yes |
-| Restart | Yes |
-| Stop/Start | Yes |
-| Vertical scaling | Yes |
-| Volume expansion | Yes, when the StorageClass supports expansion |
-| Expose | Yes |
-| Full backup/restore | RocksDB checkpoint |
-| Horizontal scaling | No |
-| Reconfigure | No |
-| TLS | No |
+| Capability | Standalone | Distributed |
+| --- | --- | --- |
+| Replicas | Exactly 1 server | pd 3, store 3, server 1 |
+| Persistent data | Yes | PD and Store data PVCs |
+| Restart | Yes | Yes |
+| Stop/Start | Yes | Yes |
+| Vertical scaling | Yes | Yes |
+| Volume expansion | Yes, when the StorageClass supports expansion | PD/Store only, when the StorageClass supports expansion |
+| Expose | Yes | Yes |
+| Full backup/restore | RocksDB checkpoint | No |
+| Horizontal scaling | No | No. Store scale-in/rebalance is not supported |
+| roleProbe / switchover | No | No |
+| Reconfigure | No | No |
+| TLS | No | No |
 
 The `checkpoint` backup method calls HugeGraph's `snapshot_create` API for
 every persistent graph. It uploads graph configurations, a format-versioned
@@ -25,11 +26,14 @@ manifest, SHA-256 checksums, and all RocksDB checkpoints through datasafed. It
 does not use CSI volume snapshots.
 
 Restore is supported only to a new HugeGraph 1.7.0 standalone Cluster. It
-restores the complete instance. Single-graph restore, PITR, incremental backup,
-RebuildInstance, cross-version restore, and cross-topology restore are not
-supported. The restore action validates every graph config and checkpoint file,
-then creates the persistent upstream initialization marker before the first
-HugeGraph process starts.
+restores the complete instance. Distributed backup/restore, single-graph
+restore, PITR, incremental backup, RebuildInstance, cross-version restore, and
+cross-topology restore are not supported. The restore action validates every
+graph config and checkpoint file, then creates the persistent upstream
+initialization marker before the first HugeGraph process starts.
+
+`BackupPolicyTemplate` matches only the standalone Server ComponentDefinition.
+Do not treat a distributed Cluster as backup-capable.
 
 ## Storage
 
@@ -66,10 +70,12 @@ transaction timestamp.
 
 ## Image
 
-The runtime and data protection actions use
-`docker.io/hugegraph/hugegraph:1.7.0`. No custom tools image is required.
+Standalone uses `docker.io/hugegraph/hugegraph:1.7.0`. Distributed uses
+`hugegraph/pd:1.7.0`, `hugegraph/store:1.7.0`, and `hugegraph/server:1.7.0`.
+No custom tools image is required. Chart CI rewrites those official names to
+`docker.io/apecloud/*` and requires amd64+arm64 indexes.
 
 ## Examples
 
-See `examples/hugegraph` for Cluster, backup, restore, restart, stop/start,
-vertical scaling, and volume expansion manifests.
+See `examples/hugegraph` for standalone Cluster, backup, restore, restart,
+stop/start, vertical scaling, volume expansion, and `cluster-distributed.yaml`.

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -204,6 +204,10 @@ assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_BACKEND=hstore
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'topology: distributed'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: pd'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: store'
+assert_contains "${ADDON_DIR}/README.md" 'Topology `distributed`'
+assert_contains "${ADDON_DIR}/README.md" 'Distributed backup/restore'
+assert_contains "${ADDON_DIR}/README.md" 'Store scale-in/rebalance is not supported'
+assert_contains "${ADDON_DIR}/README.md" 'matches only the standalone Server ComponentDefinition'
 
 distributed_render=$(mktemp)
 helm template hugegraph "${CLUSTER_DIR}" --namespace demo --set topology=distributed >"${distributed_render}"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0` for 12a restriction text after #3414 landed.

`distributed` is a declared topology. Standalone still owns checkpoint backup/restore. Distributed backup/restore, Store scale-in/rebalance, roleProbe/switchover, reconfigure, and TLS stay unsupported.

## Changes

- README capability table covers both topologies
- Explicit "not supported" for distributed BR and Store scale-in
- `BackupPolicyTemplate` remains standalone-server-only, and README says so
- `DESIGN.zh.md` points distributed design at `DESIGN-distributed.zh.md`
- `contract_test.sh` asserts the restriction sentences

## Contract

`docs/addon-api/12a-minimum-acceptance.md`: every declared topology needs independent acceptance or a restriction statement.
`docs/addon-api/12b-claimed-only-acceptance.md`: unclaimed capabilities must not be written as supported.

## Test

```text
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
