### PR TITLE
docs(hugegraph): mark distributed systemAccounts unsupported

### DIFF
--- a/addons/hugegraph/DESIGN-distributed.zh.md
+++ b/addons/hugegraph/DESIGN-distributed.zh.md
@@ -58,5 +58,6 @@ headless Service 名。
 - PD / Store switchover、roleProbe
 - TLS、reconfigure
 - Hubble
+- distributed `systemAccounts` / 生成 admin Secret
 
 BackupPolicyTemplate 继续只命中 standalone server CmpD。

--- a/addons/hugegraph/README.md
+++ b/addons/hugegraph/README.md
@@ -15,6 +15,7 @@ Server with embedded RocksDB. Topology `distributed` is PD + Store + Server.
 | Volume expansion | Yes, when the StorageClass supports expansion | PD/Store only, when the StorageClass supports expansion |
 | Expose | Yes | Yes |
 | Full backup/restore | RocksDB checkpoint | No |
+| System account | `admin` init Secret | No |
 | Horizontal scaling | No | No. Store scale-in/rebalance is not supported |
 | roleProbe / switchover | No | No |
 | Reconfigure | No | No |
@@ -34,6 +35,9 @@ initialization marker before the first HugeGraph process starts.
 
 `BackupPolicyTemplate` matches only the standalone Server ComponentDefinition.
 Do not treat a distributed Cluster as backup-capable.
+
+Distributed PD, Store, and Server do not declare `systemAccounts`. There is
+no generated admin Secret for `topology=distributed`.
 
 ## Storage
 

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -208,6 +208,16 @@ assert_contains "${ADDON_DIR}/README.md" 'Topology `distributed`'
 assert_contains "${ADDON_DIR}/README.md" 'Distributed backup/restore'
 assert_contains "${ADDON_DIR}/README.md" 'Store scale-in/rebalance is not supported'
 assert_contains "${ADDON_DIR}/README.md" 'matches only the standalone Server ComponentDefinition'
+assert_contains "${ADDON_DIR}/README.md" 'do not declare `systemAccounts`'
+assert_contains "${ADDON_DIR}/README.md" 'no generated admin Secret'
+assert_equal \
+  "$(yq '[select(.kind == "BackupPolicyTemplate") | .spec.compDefs[]] | join(",")' "${definition_render}" | tr -d '\n')" \
+  "^hugegraph-[0-9]" \
+  "BPT matches only standalone server"
+assert_equal \
+  "$(yq ea '[select(.kind == "ComponentDefinition" and (.metadata.name == "hugegraph-pd-1.0.0" or .metadata.name == "hugegraph-store-1.0.0" or .metadata.name == "hugegraph-server-1.0.0")) | .spec | has("systemAccounts")] | map(select(. == true)) | length' "${definition_render}" | tr -d '\n')" \
+  "0" \
+  "distributed CmpDs have no systemAccounts"
 
 distributed_render=$(mktemp)
 helm template hugegraph "${CLUSTER_DIR}" --namespace demo --set topology=distributed >"${distributed_render}"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`. Close the 12a `systemAccounts` row for `topology=distributed`.

Distributed PD / Store / Server do not declare `systemAccounts` and do not generate an admin Secret. BackupPolicyTemplate stays on the standalone server pattern only.

## Contract

- `docs/addon-api/12a-minimum-acceptance.md`: each declared topology needs systemAccounts closed or a restriction statement.
- `docs/addon-api/12b-claimed-only-acceptance.md`: unclaimed capabilities must not be written as supported.

## Test

```text
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
