### PR TITLE
fix(hugegraph): fail store start if PD health never succeeds

### DIFF
--- a/addons/hugegraph/scripts/start-store.sh
+++ b/addons/hugegraph/scripts/start-store.sh
@@ -35,12 +35,20 @@ done
 
 export HG_STORE_PD_ADDRESS="$(append_port "${PD_POD_FQDNS}" 8686)"
 first_pd=${PD_POD_FQDNS%%,*}
-for _ in $(seq 1 60); do
+attempts=${HG_STORE_HEALTH_ATTEMPTS:-60}
+sleep_secs=${HG_STORE_HEALTH_SLEEP:-2}
+pd_healthy=0
+for _ in $(seq 1 "${attempts}"); do
   if curl -fsS "http://${first_pd}:8620/v1/health" >/dev/null; then
+    pd_healthy=1
     break
   fi
-  sleep 2
+  sleep "${sleep_secs}"
 done
+[[ "${pd_healthy}" -eq 1 ]] || {
+  echo "PD is not healthy at http://${first_pd}:8620/v1/health after ${attempts} attempt(s)" >&2
+  exit 1
+}
 export HG_STORE_GRPC_HOST="${self}"
 export HG_STORE_GRPC_PORT="${HG_STORE_GRPC_PORT:-8500}"
 export HG_STORE_REST_PORT="${HG_STORE_REST_PORT:-8520}"

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -59,6 +59,7 @@ required_files=(
   "${ADDON_DIR}/templates/cmpd-store.yaml"
   "${ADDON_DIR}/templates/cmpd-server.yaml"
   "${ADDON_DIR}/tests/scripts_test.sh"
+  "${ADDON_DIR}/tests/start_store_test.sh"
   "${ADDON_DIR}/exporter/Dockerfile"
   "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml"
   "${ADDON_DIR}/exporter/go.mod"
@@ -200,6 +201,7 @@ assert_contains "${definition_render}" 'docker.io/hugegraph/server:1.7.0'
 assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_PEERS_LIST'
 assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_ADDRESS'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'HG_STORE_PD_ADDRESS'
+assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'PD is not healthy'
 assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_BACKEND=hstore'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'topology: distributed'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: pd'
@@ -243,5 +245,6 @@ package_bytes=$(wc -c < "${package_tgz}" | tr -d ' ')
 [[ "${package_bytes}" -lt 100000 ]] || fail "packaged chart too large: ${package_bytes} bytes"
 
 "${ADDON_DIR}/tests/scripts_test.sh"
+"${ADDON_DIR}/tests/start_store_test.sh"
 
 echo "HugeGraph addon offline contracts passed"

--- a/addons/hugegraph/tests/start_store_test.sh
+++ b/addons/hugegraph/tests/start_store_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ADDON_DIR=$(cd "${TEST_DIR}/.." && pwd)
+WORK_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/hugegraph-start-store-test.XXXXXX")
+MOCK_BIN="${WORK_ROOT}/bin"
+
+cleanup() {
+  rm -rf -- "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$MOCK_BIN"
+
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+cat >"${MOCK_BIN}/dumb-init" <<'MOCK'
+#!/usr/bin/env bash
+echo "dumb-init should not run" >&2
+exit 99
+MOCK
+chmod +x "${MOCK_BIN}/dumb-init"
+
+mkdir -p "${WORK_ROOT}/hugegraph-store"
+printf '#!/usr/bin/env bash\necho entrypoint should not run\nexit 98\n' \
+  >"${WORK_ROOT}/hugegraph-store/docker-entrypoint.sh"
+chmod +x "${WORK_ROOT}/hugegraph-store/docker-entrypoint.sh"
+
+export PATH="${MOCK_BIN}:/usr/bin:/bin"
+export PD_POD_FQDNS=pd-0.pd-headless
+export STORE_POD_FQDNS=store-0.store-headless
+export POD_NAME=store-0
+export HG_STORE_HEALTH_ATTEMPTS=2
+export HG_STORE_HEALTH_SLEEP=0
+export HG_STORE_DATA_PATH="${WORK_ROOT}/store-data"
+
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-store.sh"
+) >"${WORK_ROOT}/out" 2>"${WORK_ROOT}/err"
+rc=$?
+set -e
+
+[[ "$rc" -ne 0 ]] || fail "start-store.sh continued after PD health never succeeded"
+if grep -q 'should not run' "${WORK_ROOT}/out" "${WORK_ROOT}/err"; then
+  fail "start-store.sh reached entrypoint after PD health failed"
+fi
+grep -q 'PD is not healthy' "${WORK_ROOT}/err" \
+  || fail "start-store.sh did not report PD health failure"
+
+echo "HugeGraph start-store PD wait tests passed"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`. Store start waited for PD `/v1/health` then started anyway if the wait expired. That can mark Store Ready while PD is down.

Fail closed after the bounded wait. Attempts and sleep are overridable for tests (`HG_STORE_HEALTH_ATTEMPTS`, `HG_STORE_HEALTH_SLEEP`).

## Test

```text
bash addons/hugegraph/tests/start_store_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
