### PR TITLE
fix(hugegraph): fail server start if Store health never succeeds

### DIFF
--- a/addons/hugegraph/scripts/start-server.sh
+++ b/addons/hugegraph/scripts/start-server.sh
@@ -25,5 +25,20 @@ export HG_SERVER_USE_PD=true
 export HG_SERVER_INIT_STORE_ENABLED=false
 export STORE_REST="${first_store}:8520"
 
+attempts=${HG_SERVER_HEALTH_ATTEMPTS:-60}
+sleep_secs=${HG_SERVER_HEALTH_SLEEP:-2}
+store_healthy=0
+for _ in $(seq 1 "${attempts}"); do
+  if curl -fsS "http://${first_store}:8520/v1/health" >/dev/null; then
+    store_healthy=1
+    break
+  fi
+  sleep "${sleep_secs}"
+done
+[[ "${store_healthy}" -eq 1 ]] || {
+  echo "Store is not healthy at http://${first_store}:8520/v1/health after ${attempts} attempt(s)" >&2
+  exit 1
+}
+
 cd /hugegraph-server
 exec /usr/bin/dumb-init -- ./docker-entrypoint.sh

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -60,6 +60,7 @@ required_files=(
   "${ADDON_DIR}/templates/cmpd-server.yaml"
   "${ADDON_DIR}/tests/scripts_test.sh"
   "${ADDON_DIR}/tests/start_store_test.sh"
+  "${ADDON_DIR}/tests/start_server_test.sh"
   "${ADDON_DIR}/exporter/Dockerfile"
   "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml"
   "${ADDON_DIR}/exporter/go.mod"
@@ -203,6 +204,7 @@ assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_ADDRESS'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'HG_STORE_PD_ADDRESS'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'PD is not healthy'
 assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_BACKEND=hstore'
+assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'Store is not healthy'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'topology: distributed'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: pd'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: store'
@@ -246,5 +248,6 @@ package_bytes=$(wc -c < "${package_tgz}" | tr -d ' ')
 
 "${ADDON_DIR}/tests/scripts_test.sh"
 "${ADDON_DIR}/tests/start_store_test.sh"
+"${ADDON_DIR}/tests/start_server_test.sh"
 
 echo "HugeGraph addon offline contracts passed"

--- a/addons/hugegraph/tests/start_server_test.sh
+++ b/addons/hugegraph/tests/start_server_test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ADDON_DIR=$(cd "${TEST_DIR}/.." && pwd)
+WORK_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/hugegraph-start-server-test.XXXXXX")
+MOCK_BIN="${WORK_ROOT}/bin"
+
+cleanup() {
+  rm -rf -- "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$MOCK_BIN"
+
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+cat >"${MOCK_BIN}/dumb-init" <<'MOCK'
+#!/usr/bin/env bash
+echo "dumb-init should not run" >&2
+exit 99
+MOCK
+chmod +x "${MOCK_BIN}/dumb-init"
+
+export PATH="${MOCK_BIN}:/usr/bin:/bin"
+export PD_POD_FQDNS=pd-0.pd-headless
+export STORE_POD_FQDNS=store-0.store-headless
+export HG_SERVER_HEALTH_ATTEMPTS=2
+export HG_SERVER_HEALTH_SLEEP=0
+
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-server.sh"
+) >"${WORK_ROOT}/out" 2>"${WORK_ROOT}/err"
+rc=$?
+set -e
+
+[[ "$rc" -ne 0 ]] || fail "start-server.sh continued after Store health never succeeded"
+if grep -q 'should not run' "${WORK_ROOT}/out" "${WORK_ROOT}/err"; then
+  fail "start-server.sh reached entrypoint after Store health failed"
+fi
+grep -q 'Store is not healthy' "${WORK_ROOT}/err" \
+  || fail "start-server.sh did not report Store health failure"
+
+echo "HugeGraph start-server Store wait tests passed"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`. Official order is PD healthy -> Store -> Server. Server exported `STORE_REST` but did not wait, so it could start against a down Store.

Wait for Store `/v1/health` on 8520 and fail closed after the bounded wait. Attempts/sleep are overridable for tests.

## Test

```text
bash addons/hugegraph/tests/start_server_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
Sibling: #3417
