### PR TITLE
fix(hugegraph): derive PD initial store count from store FQDNs

### DIFF
--- a/addons/hugegraph/scripts/start-pd.sh
+++ b/addons/hugegraph/scripts/start-pd.sh
@@ -19,6 +19,17 @@ append_port() {
   printf '%s' "${out}"
 }
 
+count_hosts() {
+  local list=$1
+  local n=0 host
+  IFS=',' read -ra hosts <<< "${list}"
+  for host in "${hosts[@]}"; do
+    [[ -n "${host}" ]] || continue
+    n=$((n + 1))
+  done
+  printf '%s' "${n}"
+}
+
 self=""
 IFS=',' read -ra hosts <<< "${PD_POD_FQDNS}"
 for host in "${hosts[@]}"; do
@@ -33,6 +44,12 @@ done
   exit 1
 }
 
+store_count="$(count_hosts "${STORE_POD_FQDNS}")"
+[[ "${store_count}" -ge 1 ]] || {
+  echo "cannot derive store count from STORE_POD_FQDNS=${STORE_POD_FQDNS}" >&2
+  exit 1
+}
+
 export HG_PD_GRPC_HOST="${self}"
 export HG_PD_GRPC_PORT="${HG_PD_GRPC_PORT:-8686}"
 export HG_PD_REST_PORT="${HG_PD_REST_PORT:-8620}"
@@ -40,7 +57,17 @@ export HG_PD_RAFT_ADDRESS="${self}:8610"
 export HG_PD_RAFT_PEERS_LIST="$(append_port "${PD_POD_FQDNS}" 8610)"
 export HG_PD_INITIAL_STORE_LIST="$(append_port "${STORE_POD_FQDNS}" 8500)"
 export HG_PD_DATA_PATH="${HG_PD_DATA_PATH:-/hugegraph-pd/pd_data}"
-export HG_PD_INITIAL_STORE_COUNT="${HG_PD_INITIAL_STORE_COUNT:-1}"
+# Official pd.initial-store-count must match the expected store count
+# (3 for 3 stores). Defaulting to 1 activates the cluster on the first
+# Store and can leave the remaining members out of the first partition
+# allocation.
+export HG_PD_INITIAL_STORE_COUNT="${HG_PD_INITIAL_STORE_COUNT:-${store_count}}"
+
+if [[ "${HG_PD_DRY_RUN:-0}" == "1" ]]; then
+  printf 'HG_PD_INITIAL_STORE_COUNT=%s\n' "${HG_PD_INITIAL_STORE_COUNT}"
+  printf 'HG_PD_INITIAL_STORE_LIST=%s\n' "${HG_PD_INITIAL_STORE_LIST}"
+  exit 0
+fi
 
 mkdir -p "${HG_PD_DATA_PATH}"
 cd /hugegraph-pd

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -59,6 +59,7 @@ required_files=(
   "${ADDON_DIR}/templates/cmpd-store.yaml"
   "${ADDON_DIR}/templates/cmpd-server.yaml"
   "${ADDON_DIR}/tests/scripts_test.sh"
+  "${ADDON_DIR}/tests/start_pd_test.sh"
   "${ADDON_DIR}/tests/start_store_test.sh"
   "${ADDON_DIR}/tests/start_server_test.sh"
   "${ADDON_DIR}/exporter/Dockerfile"
@@ -201,6 +202,8 @@ assert_contains "${definition_render}" 'docker.io/hugegraph/store:1.7.0'
 assert_contains "${definition_render}" 'docker.io/hugegraph/server:1.7.0'
 assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_PEERS_LIST'
 assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_RAFT_ADDRESS'
+assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_INITIAL_STORE_COUNT='
+assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'count_hosts'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'HG_STORE_PD_ADDRESS'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'PD is not healthy'
 assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_BACKEND=hstore'
@@ -247,6 +250,7 @@ package_bytes=$(wc -c < "${package_tgz}" | tr -d ' ')
 [[ "${package_bytes}" -lt 100000 ]] || fail "packaged chart too large: ${package_bytes} bytes"
 
 "${ADDON_DIR}/tests/scripts_test.sh"
+"${ADDON_DIR}/tests/start_pd_test.sh"
 "${ADDON_DIR}/tests/start_store_test.sh"
 "${ADDON_DIR}/tests/start_server_test.sh"
 

--- a/addons/hugegraph/tests/start_pd_test.sh
+++ b/addons/hugegraph/tests/start_pd_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ADDON_DIR=$(cd "${TEST_DIR}/.." && pwd)
+WORK_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/hugegraph-start-pd-test.XXXXXX")
+
+cleanup() {
+  rm -rf -- "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_start_pd() {
+  local out=$1
+  local err=$2
+  (
+    export HG_PD_DRY_RUN=1
+    export HG_PD_DATA_PATH="${WORK_ROOT}/pd-data"
+    export PD_POD_FQDNS STORE_POD_FQDNS POD_NAME
+    if [ -n "${HG_PD_INITIAL_STORE_COUNT+x}" ]; then
+      export HG_PD_INITIAL_STORE_COUNT
+    fi
+    bash "${ADDON_DIR}/scripts/start-pd.sh"
+  ) >"${out}" 2>"${err}"
+}
+
+# 3-store list must set initial-store-count to 3 (official 3x3 bootstrap).
+unset HG_PD_INITIAL_STORE_COUNT || true
+PD_POD_FQDNS=pd-0.pd-headless,pd-1.pd-headless,pd-2.pd-headless \
+STORE_POD_FQDNS=store-0.store-headless,store-1.store-headless,store-2.store-headless \
+POD_NAME=pd-0 \
+run_start_pd "${WORK_ROOT}/out3" "${WORK_ROOT}/err3"
+grep -qx 'HG_PD_INITIAL_STORE_COUNT=3' "${WORK_ROOT}/out3" \
+  || fail "3-store FQDNs did not yield HG_PD_INITIAL_STORE_COUNT=3: $(cat "${WORK_ROOT}/out3" "${WORK_ROOT}/err3")"
+grep -q 'HG_PD_INITIAL_STORE_LIST=store-0.store-headless:8500,store-1.store-headless:8500,store-2.store-headless:8500' \
+  "${WORK_ROOT}/out3" \
+  || fail "3-store FQDNs did not build the store list"
+
+# 1-store list must stay at 1.
+PD_POD_FQDNS=pd-0.pd-headless \
+STORE_POD_FQDNS=store-0.store-headless \
+POD_NAME=pd-0 \
+run_start_pd "${WORK_ROOT}/out1" "${WORK_ROOT}/err1"
+grep -qx 'HG_PD_INITIAL_STORE_COUNT=1' "${WORK_ROOT}/out1" \
+  || fail "1-store FQDNs did not yield HG_PD_INITIAL_STORE_COUNT=1"
+
+# Explicit override wins.
+PD_POD_FQDNS=pd-0.pd-headless,pd-1.pd-headless,pd-2.pd-headless \
+STORE_POD_FQDNS=store-0.store-headless,store-1.store-headless,store-2.store-headless \
+POD_NAME=pd-0 \
+HG_PD_INITIAL_STORE_COUNT=5 \
+run_start_pd "${WORK_ROOT}/out5" "${WORK_ROOT}/err5"
+grep -qx 'HG_PD_INITIAL_STORE_COUNT=5' "${WORK_ROOT}/out5" \
+  || fail "explicit HG_PD_INITIAL_STORE_COUNT=5 was not honored"
+
+echo "HugeGraph start-pd initial store count tests passed"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

Official HugeGraph PD requires `pd.initial-store-count` to match the expected Store count (3 for a 3-store cluster). `start-pd.sh` already builds `HG_PD_INITIAL_STORE_LIST` from `STORE_POD_FQDNS` but hardcoded `HG_PD_INITIAL_STORE_COUNT=1`. That can mark the cluster operational after the first Store and leave later Stores out of the first partition allocation.

Derive the default count from the Store FQDN list. An explicit `HG_PD_INITIAL_STORE_COUNT` still wins.

## Test

```text
bash addons/hugegraph/tests/start_pd_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
