### PR TITLE
fix(hugegraph): wait for every Store before server start

### DIFF
--- a/addons/hugegraph/scripts/start-server.sh
+++ b/addons/hugegraph/scripts/start-server.sh
@@ -17,7 +17,17 @@ append_port() {
   printf '%s' "${out}"
 }
 
-first_store=${STORE_POD_FQDNS%%,*}
+stores=()
+IFS=',' read -ra hosts <<< "${STORE_POD_FQDNS}"
+for host in "${hosts[@]}"; do
+  [[ -n "${host}" ]] || continue
+  stores+=("${host}")
+done
+[[ "${#stores[@]}" -ge 1 ]] || {
+  echo "cannot derive Store list from STORE_POD_FQDNS=${STORE_POD_FQDNS}" >&2
+  exit 1
+}
+first_store=${stores[0]}
 
 export HG_SERVER_BACKEND=hstore
 export HG_SERVER_PD_PEERS="$(append_port "${PD_POD_FQDNS}" 8686)"
@@ -27,18 +37,30 @@ export STORE_REST="${first_store}:8520"
 
 attempts=${HG_SERVER_HEALTH_ATTEMPTS:-60}
 sleep_secs=${HG_SERVER_HEALTH_SLEEP:-2}
-store_healthy=0
+# Official 3-store compose waits for every Store, not only the first.
+# With pd.initial-store-count = store count, one healthy Store is not
+# enough for Cluster_OK.
+unhealthy=""
 for _ in $(seq 1 "${attempts}"); do
-  if curl -fsS "http://${first_store}:8520/v1/health" >/dev/null; then
-    store_healthy=1
-    break
-  fi
+  unhealthy=""
+  for store in "${stores[@]}"; do
+    if ! curl -fsS "http://${store}:8520/v1/health" >/dev/null; then
+      unhealthy=${store}
+      break
+    fi
+  done
+  [[ -z "${unhealthy}" ]] && break
   sleep "${sleep_secs}"
 done
-[[ "${store_healthy}" -eq 1 ]] || {
-  echo "Store is not healthy at http://${first_store}:8520/v1/health after ${attempts} attempt(s)" >&2
+[[ -z "${unhealthy}" ]] || {
+  echo "Store is not healthy at http://${unhealthy}:8520/v1/health after ${attempts} attempt(s)" >&2
   exit 1
 }
+
+if [[ "${HG_SERVER_DRY_RUN:-0}" == "1" ]]; then
+  printf 'stores_healthy=%s\n' "${#stores[@]}"
+  exit 0
+fi
 
 cd /hugegraph-server
 exec /usr/bin/dumb-init -- ./docker-entrypoint.sh

--- a/addons/hugegraph/tests/start_server_test.sh
+++ b/addons/hugegraph/tests/start_server_test.sh
@@ -18,12 +18,6 @@ fail() {
 
 mkdir -p "$MOCK_BIN"
 
-cat >"${MOCK_BIN}/curl" <<'MOCK'
-#!/usr/bin/env bash
-exit 1
-MOCK
-chmod +x "${MOCK_BIN}/curl"
-
 cat >"${MOCK_BIN}/dumb-init" <<'MOCK'
 #!/usr/bin/env bash
 echo "dumb-init should not run" >&2
@@ -33,10 +27,18 @@ chmod +x "${MOCK_BIN}/dumb-init"
 
 export PATH="${MOCK_BIN}:/usr/bin:/bin"
 export PD_POD_FQDNS=pd-0.pd-headless
-export STORE_POD_FQDNS=store-0.store-headless
 export HG_SERVER_HEALTH_ATTEMPTS=2
 export HG_SERVER_HEALTH_SLEEP=0
 
+# 1) Every Store down — fail closed.
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+export STORE_POD_FQDNS=store-0.store-headless
+unset HG_SERVER_DRY_RUN || true
 set +e
 (
   cd "$WORK_ROOT"
@@ -44,12 +46,54 @@ set +e
 ) >"${WORK_ROOT}/out" 2>"${WORK_ROOT}/err"
 rc=$?
 set -e
-
 [[ "$rc" -ne 0 ]] || fail "start-server.sh continued after Store health never succeeded"
 if grep -q 'should not run' "${WORK_ROOT}/out" "${WORK_ROOT}/err"; then
   fail "start-server.sh reached entrypoint after Store health failed"
 fi
 grep -q 'Store is not healthy' "${WORK_ROOT}/err" \
   || fail "start-server.sh did not report Store health failure"
+
+# 2) Only the first Store is healthy — official 3-store compose waits for all.
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    http://*) url=$arg ;;
+  esac
+done
+case "$url" in
+  *store-0.store-headless:8520*) exit 0 ;;
+  *) exit 1 ;;
+esac
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+export STORE_POD_FQDNS=store-0.store-headless,store-1.store-headless,store-2.store-headless
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-server.sh"
+) >"${WORK_ROOT}/out-partial" 2>"${WORK_ROOT}/err-partial"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "start-server.sh continued when only the first Store was healthy"
+grep -q 'store-1.store-headless:8520' "${WORK_ROOT}/err-partial" \
+  || fail "start-server.sh did not report the unhealthy later Store"
+
+# 3) All Stores healthy — proceed (dry-run, do not exec the image entrypoint).
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+export HG_SERVER_DRY_RUN=1
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-server.sh"
+) >"${WORK_ROOT}/out-ok" 2>"${WORK_ROOT}/err-ok"
+grep -qx 'stores_healthy=3' "${WORK_ROOT}/out-ok" \
+  || fail "all-Store wait did not report stores_healthy=3: $(cat "${WORK_ROOT}/out-ok" "${WORK_ROOT}/err-ok")"
 
 echo "HugeGraph start-server Store wait tests passed"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

Official 3-store compose waits for every Store `/v1/health` before Server starts. `start-server.sh` only waited for the first FQDN. After #3419, `pd.initial-store-count` matches the Store list, so one healthy Store is not enough for `Cluster_OK`.

Wait for every address in `STORE_POD_FQDNS`. Fail closed if any Store never becomes healthy.

## Test

```text
bash addons/hugegraph/tests/start_server_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
