### PR TITLE
fix(hugegraph): wait for every PD before store start

### DIFF
--- a/addons/hugegraph/scripts/start-store.sh
+++ b/addons/hugegraph/scripts/start-store.sh
@@ -33,20 +33,36 @@ done
   exit 1
 }
 
+pds=()
+IFS=',' read -ra hosts <<< "${PD_POD_FQDNS}"
+for host in "${hosts[@]}"; do
+  [[ -n "${host}" ]] || continue
+  pds+=("${host}")
+done
+[[ "${#pds[@]}" -ge 1 ]] || {
+  echo "cannot derive PD list from PD_POD_FQDNS=${PD_POD_FQDNS}" >&2
+  exit 1
+}
+
 export HG_STORE_PD_ADDRESS="$(append_port "${PD_POD_FQDNS}" 8686)"
-first_pd=${PD_POD_FQDNS%%,*}
 attempts=${HG_STORE_HEALTH_ATTEMPTS:-60}
 sleep_secs=${HG_STORE_HEALTH_SLEEP:-2}
-pd_healthy=0
+# Official 3-PD compose waits for every PD, not only the first.
+# One healthy PD is not a Raft majority.
+unhealthy=""
 for _ in $(seq 1 "${attempts}"); do
-  if curl -fsS "http://${first_pd}:8620/v1/health" >/dev/null; then
-    pd_healthy=1
-    break
-  fi
+  unhealthy=""
+  for pd in "${pds[@]}"; do
+    if ! curl -fsS "http://${pd}:8620/v1/health" >/dev/null; then
+      unhealthy=${pd}
+      break
+    fi
+  done
+  [[ -z "${unhealthy}" ]] && break
   sleep "${sleep_secs}"
 done
-[[ "${pd_healthy}" -eq 1 ]] || {
-  echo "PD is not healthy at http://${first_pd}:8620/v1/health after ${attempts} attempt(s)" >&2
+[[ -z "${unhealthy}" ]] || {
+  echo "PD is not healthy at http://${unhealthy}:8620/v1/health after ${attempts} attempt(s)" >&2
   exit 1
 }
 export HG_STORE_GRPC_HOST="${self}"
@@ -54,6 +70,11 @@ export HG_STORE_GRPC_PORT="${HG_STORE_GRPC_PORT:-8500}"
 export HG_STORE_REST_PORT="${HG_STORE_REST_PORT:-8520}"
 export HG_STORE_RAFT_ADDRESS="${self}:8510"
 export HG_STORE_DATA_PATH="${HG_STORE_DATA_PATH:-/hugegraph-store/storage}"
+
+if [[ "${HG_STORE_DRY_RUN:-0}" == "1" ]]; then
+  printf 'pds_healthy=%s\n' "${#pds[@]}"
+  exit 0
+fi
 
 mkdir -p "${HG_STORE_DATA_PATH}"
 cd /hugegraph-store

--- a/addons/hugegraph/tests/start_store_test.sh
+++ b/addons/hugegraph/tests/start_store_test.sh
@@ -18,12 +18,6 @@ fail() {
 
 mkdir -p "$MOCK_BIN"
 
-cat >"${MOCK_BIN}/curl" <<'MOCK'
-#!/usr/bin/env bash
-exit 1
-MOCK
-chmod +x "${MOCK_BIN}/curl"
-
 cat >"${MOCK_BIN}/dumb-init" <<'MOCK'
 #!/usr/bin/env bash
 echo "dumb-init should not run" >&2
@@ -31,19 +25,22 @@ exit 99
 MOCK
 chmod +x "${MOCK_BIN}/dumb-init"
 
-mkdir -p "${WORK_ROOT}/hugegraph-store"
-printf '#!/usr/bin/env bash\necho entrypoint should not run\nexit 98\n' \
-  >"${WORK_ROOT}/hugegraph-store/docker-entrypoint.sh"
-chmod +x "${WORK_ROOT}/hugegraph-store/docker-entrypoint.sh"
-
 export PATH="${MOCK_BIN}:/usr/bin:/bin"
-export PD_POD_FQDNS=pd-0.pd-headless
 export STORE_POD_FQDNS=store-0.store-headless
 export POD_NAME=store-0
 export HG_STORE_HEALTH_ATTEMPTS=2
 export HG_STORE_HEALTH_SLEEP=0
 export HG_STORE_DATA_PATH="${WORK_ROOT}/store-data"
 
+# 1) Every PD down — fail closed.
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 1
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+export PD_POD_FQDNS=pd-0.pd-headless
+unset HG_STORE_DRY_RUN || true
 set +e
 (
   cd "$WORK_ROOT"
@@ -51,12 +48,54 @@ set +e
 ) >"${WORK_ROOT}/out" 2>"${WORK_ROOT}/err"
 rc=$?
 set -e
-
 [[ "$rc" -ne 0 ]] || fail "start-store.sh continued after PD health never succeeded"
 if grep -q 'should not run' "${WORK_ROOT}/out" "${WORK_ROOT}/err"; then
   fail "start-store.sh reached entrypoint after PD health failed"
 fi
 grep -q 'PD is not healthy' "${WORK_ROOT}/err" \
   || fail "start-store.sh did not report PD health failure"
+
+# 2) Only the first PD is healthy — official 3-PD compose waits for all.
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    http://*) url=$arg ;;
+  esac
+done
+case "$url" in
+  *pd-0.pd-headless:8620*) exit 0 ;;
+  *) exit 1 ;;
+esac
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+export PD_POD_FQDNS=pd-0.pd-headless,pd-1.pd-headless,pd-2.pd-headless
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-store.sh"
+) >"${WORK_ROOT}/out-partial" 2>"${WORK_ROOT}/err-partial"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "start-store.sh continued when only the first PD was healthy"
+grep -q 'pd-1.pd-headless:8620' "${WORK_ROOT}/err-partial" \
+  || fail "start-store.sh did not report the unhealthy later PD"
+
+# 3) All PDs healthy — proceed (dry-run, do not exec the image entrypoint).
+cat >"${MOCK_BIN}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+chmod +x "${MOCK_BIN}/curl"
+
+export HG_STORE_DRY_RUN=1
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-store.sh"
+) >"${WORK_ROOT}/out-ok" 2>"${WORK_ROOT}/err-ok"
+grep -qx 'pds_healthy=3' "${WORK_ROOT}/out-ok" \
+  || fail "all-PD wait did not report pds_healthy=3: $(cat "${WORK_ROOT}/out-ok" "${WORK_ROOT}/err-ok")"
 
 echo "HugeGraph start-store PD wait tests passed"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

Official 3-PD compose waits for every PD `/v1/health` before Store starts. `start-store.sh` only waited for the first FQDN. One healthy PD is not a Raft majority.

Wait for every address in `PD_POD_FQDNS`. Fail closed if any PD never becomes healthy.

## Test

```text
bash addons/hugegraph/tests/start_store_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
