### PR TITLE
fix(hugegraph): give distributed health waits official start budget

### DIFF
--- a/addons/hugegraph/scripts/start-server.sh
+++ b/addons/hugegraph/scripts/start-server.sh
@@ -35,7 +35,8 @@ export HG_SERVER_USE_PD=true
 export HG_SERVER_INIT_STORE_ENABLED=false
 export STORE_REST="${first_store}:8520"
 
-attempts=${HG_SERVER_HEALTH_ATTEMPTS:-60}
+# Official Store start_period is 120s. Waiting every Store needs more than 120s.
+attempts=${HG_SERVER_HEALTH_ATTEMPTS:-90}
 sleep_secs=${HG_SERVER_HEALTH_SLEEP:-2}
 # Official 3-store compose waits for every Store, not only the first.
 # With pd.initial-store-count = store count, one healthy Store is not

--- a/addons/hugegraph/scripts/start-store.sh
+++ b/addons/hugegraph/scripts/start-store.sh
@@ -45,7 +45,8 @@ done
 }
 
 export HG_STORE_PD_ADDRESS="$(append_port "${PD_POD_FQDNS}" 8686)"
-attempts=${HG_STORE_HEALTH_ATTEMPTS:-60}
+# Official PD start_period is 120s. 3-PD Raft can exceed a 120s wait.
+attempts=${HG_STORE_HEALTH_ATTEMPTS:-90}
 sleep_secs=${HG_STORE_HEALTH_SLEEP:-2}
 # Official 3-PD compose waits for every PD, not only the first.
 # One healthy PD is not a Raft majority.

--- a/addons/hugegraph/templates/cmpd-server.yaml
+++ b/addons/hugegraph/templates/cmpd-server.yaml
@@ -61,7 +61,7 @@ spec:
           httpGet:
             path: /versions
             port: http
-          failureThreshold: 36
+          failureThreshold: 72
           periodSeconds: 5
           timeoutSeconds: 3
         readinessProbe:

--- a/addons/hugegraph/templates/cmpd-store.yaml
+++ b/addons/hugegraph/templates/cmpd-store.yaml
@@ -76,7 +76,7 @@ spec:
           httpGet:
             path: /v1/health
             port: rest
-          failureThreshold: 48
+          failureThreshold: 72
           periodSeconds: 5
           timeoutSeconds: 3
         readinessProbe:

--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -206,8 +206,18 @@ assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'HG_PD_INITIAL_STORE_COUNT='
 assert_contains "${ADDON_DIR}/scripts/start-pd.sh" 'count_hosts'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'HG_STORE_PD_ADDRESS'
 assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'PD is not healthy'
+assert_contains "${ADDON_DIR}/scripts/start-store.sh" 'HG_STORE_HEALTH_ATTEMPTS:-90'
 assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_BACKEND=hstore'
 assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'Store is not healthy'
+assert_contains "${ADDON_DIR}/scripts/start-server.sh" 'HG_SERVER_HEALTH_ATTEMPTS:-90'
+assert_equal \
+  "$(yq ea '[select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-store-1.0.0") | .spec.runtime.containers[] | select(.name == "store") | .startupProbe.failureThreshold] | .[0]' "${definition_render}" | tr -d '\n')" \
+  "72" \
+  "store startupProbe covers PD wait plus process start"
+assert_equal \
+  "$(yq ea '[select(.kind == "ComponentDefinition" and .metadata.name == "hugegraph-server-1.0.0") | .spec.runtime.containers[] | select(.name == "server") | .startupProbe.failureThreshold] | .[0]' "${definition_render}" | tr -d '\n')" \
+  "72" \
+  "server startupProbe covers Store wait plus process start"
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'topology: distributed'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: pd'
 assert_contains "${ROOT_DIR}/examples/hugegraph/cluster-distributed.yaml" 'name: store'


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

Official 3-node compose gives PD/Store a 120s `start_period`. Store/Server start scripts waited 60x2s (120s) for every peer, inside startupProbes of 240s / 180s. That can fail-closed a 3-PD Raft that is still inside the official start window.

Defaults are now 90x2s (180s). Store and Server startupProbe `failureThreshold` is 72 (360s) so the wait plus process start fit.

## Test

```text
bash addons/hugegraph/tests/start_store_test.sh
bash addons/hugegraph/tests/start_server_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412
