### PR TITLE
test(hugegraph): fail closed on empty distributed FQDNs

### DIFF
--- a/addons/hugegraph/tests/start_pd_test.sh
+++ b/addons/hugegraph/tests/start_pd_test.sh
@@ -58,4 +58,41 @@ run_start_pd "${WORK_ROOT}/out5" "${WORK_ROOT}/err5"
 grep -qx 'HG_PD_INITIAL_STORE_COUNT=5' "${WORK_ROOT}/out5" \
   || fail "explicit HG_PD_INITIAL_STORE_COUNT=5 was not honored"
 
+# Empty Store FQDNs must fail closed. Count 0 would bootstrap PD as if no stores exist.
+unset HG_PD_INITIAL_STORE_COUNT || true
+set +e
+PD_POD_FQDNS=pd-0.pd-headless \
+STORE_POD_FQDNS= \
+POD_NAME=pd-0 \
+run_start_pd "${WORK_ROOT}/out-empty-store" "${WORK_ROOT}/err-empty-store"
+empty_store_rc=$?
+set -e
+[[ "$empty_store_rc" -ne 0 ]] || fail "start-pd.sh continued with empty STORE_POD_FQDNS"
+grep -q 'STORE_POD_FQDNS is required' "${WORK_ROOT}/err-empty-store" \
+  || fail "start-pd.sh did not refuse empty STORE_POD_FQDNS"
+
+# Comma-only Store FQDNs must fail closed after the required-var check.
+set +e
+PD_POD_FQDNS=pd-0.pd-headless \
+STORE_POD_FQDNS=, \
+POD_NAME=pd-0 \
+run_start_pd "${WORK_ROOT}/out-blank-store" "${WORK_ROOT}/err-blank-store"
+blank_store_rc=$?
+set -e
+[[ "$blank_store_rc" -ne 0 ]] || fail "start-pd.sh continued with comma-only STORE_POD_FQDNS"
+grep -q 'cannot derive store count' "${WORK_ROOT}/err-blank-store" \
+  || fail "start-pd.sh did not report comma-only STORE_POD_FQDNS"
+
+# Empty PD FQDNs must fail closed. PD cannot map this pod to a Raft identity.
+set +e
+PD_POD_FQDNS= \
+STORE_POD_FQDNS=store-0.store-headless \
+POD_NAME=pd-0 \
+run_start_pd "${WORK_ROOT}/out-empty-pd" "${WORK_ROOT}/err-empty-pd"
+empty_pd_rc=$?
+set -e
+[[ "$empty_pd_rc" -ne 0 ]] || fail "start-pd.sh continued with empty PD_POD_FQDNS"
+grep -q 'PD_POD_FQDNS is required' "${WORK_ROOT}/err-empty-pd" \
+  || fail "start-pd.sh did not refuse empty PD_POD_FQDNS"
+
 echo "HugeGraph start-pd initial store count tests passed"

--- a/addons/hugegraph/tests/start_server_test.sh
+++ b/addons/hugegraph/tests/start_server_test.sh
@@ -96,4 +96,31 @@ export HG_SERVER_DRY_RUN=1
 grep -qx 'stores_healthy=3' "${WORK_ROOT}/out-ok" \
   || fail "all-Store wait did not report stores_healthy=3: $(cat "${WORK_ROOT}/out-ok" "${WORK_ROOT}/err-ok")"
 
+# Empty Store FQDNs must fail closed before any health wait.
+export HG_SERVER_DRY_RUN=1
+export PD_POD_FQDNS=pd-0.pd-headless
+export STORE_POD_FQDNS=
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-server.sh"
+) >"${WORK_ROOT}/out-empty-store" 2>"${WORK_ROOT}/err-empty-store"
+empty_store_rc=$?
+set -e
+[[ "$empty_store_rc" -ne 0 ]] || fail "start-server.sh continued with empty STORE_POD_FQDNS"
+grep -q 'STORE_POD_FQDNS is required' "${WORK_ROOT}/err-empty-store" \
+  || fail "start-server.sh did not refuse empty STORE_POD_FQDNS"
+
+export STORE_POD_FQDNS=,
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-server.sh"
+) >"${WORK_ROOT}/out-blank-store" 2>"${WORK_ROOT}/err-blank-store"
+blank_store_rc=$?
+set -e
+[[ "$blank_store_rc" -ne 0 ]] || fail "start-server.sh continued with comma-only STORE_POD_FQDNS"
+grep -q 'cannot derive Store list' "${WORK_ROOT}/err-blank-store" \
+  || fail "start-server.sh did not report comma-only STORE_POD_FQDNS"
+
 echo "HugeGraph start-server Store wait tests passed"

--- a/addons/hugegraph/tests/start_store_test.sh
+++ b/addons/hugegraph/tests/start_store_test.sh
@@ -98,4 +98,32 @@ export HG_STORE_DRY_RUN=1
 grep -qx 'pds_healthy=3' "${WORK_ROOT}/out-ok" \
   || fail "all-PD wait did not report pds_healthy=3: $(cat "${WORK_ROOT}/out-ok" "${WORK_ROOT}/err-ok")"
 
+# Empty PD FQDNs must fail closed before any health wait.
+export HG_STORE_DRY_RUN=1
+export STORE_POD_FQDNS=store-0.store-headless
+export POD_NAME=store-0
+export PD_POD_FQDNS=
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-store.sh"
+) >"${WORK_ROOT}/out-empty-pd" 2>"${WORK_ROOT}/err-empty-pd"
+empty_pd_rc=$?
+set -e
+[[ "$empty_pd_rc" -ne 0 ]] || fail "start-store.sh continued with empty PD_POD_FQDNS"
+grep -q 'PD_POD_FQDNS is required' "${WORK_ROOT}/err-empty-pd" \
+  || fail "start-store.sh did not refuse empty PD_POD_FQDNS"
+
+export PD_POD_FQDNS=,
+set +e
+(
+  cd "$WORK_ROOT"
+  bash "${ADDON_DIR}/scripts/start-store.sh"
+) >"${WORK_ROOT}/out-blank-pd" 2>"${WORK_ROOT}/err-blank-pd"
+blank_pd_rc=$?
+set -e
+[[ "$blank_pd_rc" -ne 0 ]] || fail "start-store.sh continued with comma-only PD_POD_FQDNS"
+grep -q 'cannot derive PD list' "${WORK_ROOT}/err-blank-pd" \
+  || fail "start-store.sh did not report comma-only PD_POD_FQDNS"
+
 echo "HugeGraph start-store PD wait tests passed"


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

PD, Store, and Server start scripts already refuse an empty or comma-only `podFQDNs` list. Add offline tests so a missing Raft peer list cannot be treated as count 0.

## Test

```text
bash addons/hugegraph/tests/start_pd_test.sh
bash addons/hugegraph/tests/start_store_test.sh
bash addons/hugegraph/tests/start_server_test.sh
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412