### PR TITLE
fix(hugegraph): expose claimed distributed shape in cluster schema

### DIFF
--- a/addons-cluster/hugegraph/values.schema.json
+++ b/addons-cluster/hugegraph/values.schema.json
@@ -9,6 +9,13 @@
       "default": "1.7.0",
       "enum": ["1.7.0"]
     },
+    "topology": {
+      "title": "Topology",
+      "description": "standalone is one Server with RocksDB. distributed is PD 3 + Store 3 + Server 1.",
+      "type": "string",
+      "default": "standalone",
+      "enum": ["standalone", "distributed"]
+    },
     "replicas": {
       "title": "Replicas",
       "description": "Standalone HugeGraph requires exactly one replica.",
@@ -16,6 +23,34 @@
       "default": 1,
       "minimum": 1,
       "maximum": 1
+    },
+    "distributed": {
+      "title": "Distributed",
+      "description": "Claimed distributed shape. Horizontal scaling is not supported.",
+      "type": "object",
+      "properties": {
+        "pdReplicas": {
+          "title": "PD Replicas",
+          "type": "integer",
+          "default": 3,
+          "minimum": 3,
+          "maximum": 3
+        },
+        "storeReplicas": {
+          "title": "Store Replicas",
+          "type": "integer",
+          "default": 3,
+          "minimum": 3,
+          "maximum": 3
+        },
+        "serverReplicas": {
+          "title": "Server Replicas",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 1
+        }
+      }
     },
     "cpu": {
       "title": "CPU",


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

The cluster chart already renders `topology=distributed` as pd=3/store=3/server=1. `values.schema.json` only described standalone `replicas=1`, so a form driven by the schema could not select the claimed distributed shape.

Add `topology` and lock distributed replica fields to the claimed 3/3/1. Horizontal scaling stays unsupported.

## Test

```text
python3 -m json.tool addons-cluster/hugegraph/values.schema.json
helm lint addons-cluster/hugegraph
helm template hg addons-cluster/hugegraph --set topology=distributed
```

Main PR: apecloud/kubeblocks-addons#3412