### PR TITLE
test(hugegraph): pin cluster schema claimed distributed shape

### DIFF
--- a/addons/hugegraph/tests/contract_test.sh
+++ b/addons/hugegraph/tests/contract_test.sh
@@ -246,6 +246,16 @@ assert_equal \
   "pd,store,server" \
   "distributed component names"
 rm -f "${distributed_render}"
+schema="${CLUSTER_DIR}/values.schema.json"
+assert_file "${schema}"
+assert_equal \
+  "$(yq -oy '.properties.topology.enum | join(",")' "${schema}")" \
+  "standalone,distributed" \
+  "cluster schema topology enum"
+assert_equal \
+  "$(yq -oy '[.properties.distributed.properties.pdReplicas.default, .properties.distributed.properties.storeReplicas.default, .properties.distributed.properties.serverReplicas.default] | join("/")' "${schema}")" \
+  "3/3/1" \
+  "cluster schema claimed distributed defaults"
 assert_contains "${ADDON_DIR}/.helmignore" '^exporter/'
 
 package_dir=$(mktemp -d)


### PR DESCRIPTION
## Summary

Child PR into `dev/hugegraph-release-1.0`.

#3424 added `topology` and claimed 3/3/1 defaults to the cluster-chart schema. The addon offline contract now fails if those fields disappear.

## Test

```text
bash addons/hugegraph/tests/contract_test.sh
HugeGraph addon offline contracts passed
```

Main PR: apecloud/kubeblocks-addons#3412