### PR TITLE
fix(mongodb): improve shard removal and PBM workflows

### DIFF
--- a/addons/mongodb/dataprotection/common-scripts.sh
+++ b/addons/mongodb/dataprotection/common-scripts.sh
@@ -379,25 +379,31 @@ function sync_pbm_config_from_storage() {
 function wait_for_backup_completion() {
   describe_result=""
   local retry_interval=5
-  local attempt=1
+  local attempt=0
   local max_retries=12
   set +e
   while true; do
     describe_result=$(pbm describe-backup --mongodb-uri "$PBM_MONGODB_URI" "$backup_name" -o json 2>&1)
     if [ $? -eq 0 ] && [ -n "$describe_result" ]; then
       backup_status=$(echo "$describe_result" | jq -r '.status')
-      if [ "$backup_status" = "starting" ] || [ "$backup_status" = "running" ]; then
-        echo "INFO: Backup status is $backup_status, retrying in ${retry_interval}s..."
-      elif [ "$backup_status" = "" ]; then
-        echo "INFO: Backup status is $backup_status, retrying in ${retry_interval}s..."
-        attempt=$((attempt+1))
-      elif [ "$backup_status" = "done" ]; then
-        echo "INFO: Backup status is done."
-        break
-      else
-        echo "ERROR: Backup failed with status: $backup_status"
-        exit 1
-      fi
+      case "$backup_status" in
+        done)
+          echo "INFO: Backup status is done."
+          break
+          ;;
+        error|canceled)
+          echo "ERROR: Backup failed with status: $backup_status"
+          exit 1
+          ;;
+        "")
+          echo "INFO: Backup status is empty, retrying in ${retry_interval}s..."
+          attempt=$((attempt+1))
+          ;;
+        *)
+          # PBM treats every non-empty status except done, canceled, and error as running.
+          echo "INFO: Backup status is $backup_status, retrying in ${retry_interval}s..."
+          ;;
+      esac
     elif echo "$describe_result" | grep -q "not found"; then
       echo "INFO: Backup metadata not found, retrying in ${retry_interval}s..."
       attempt=$((attempt+1))
@@ -405,11 +411,11 @@ function wait_for_backup_completion() {
       echo "ERROR: Unexpected: $describe_result"
       exit 1
     fi
-    sleep $retry_interval
-    if [ $attempt -gt $max_retries ]; then
+    if [ $attempt -ge $max_retries ]; then
       echo "ERROR: Failed to get backup status after $max_retries attempts"
       exit 1
     fi
+    sleep $retry_interval
   done
   set -e
 
@@ -535,8 +541,15 @@ function get_describe_backup_info() {
 }
 
 function wait_for_restoring() {
-  local cnf_file="${MOUNT_DIR}/tmp/pbm_restore.cnf"
-  cat <<EOF > ${MOUNT_DIR}/tmp/pbm_restore.cnf
+  local cnf_file=""
+  local describe_result=""
+  local restore_status=""
+  case "${PBM_BACKUP_TYPE:-}" in
+    logical)
+      ;;
+    physical|continuous)
+      cnf_file="${MOUNT_DIR}/tmp/pbm_restore.cnf"
+      cat <<EOF > "$cnf_file"
 storage:
   type: s3
   s3:
@@ -549,28 +562,64 @@ storage:
       access-key-id: ${S3_ACCESS_KEY}
       secret-access-key: ${S3_SECRET_KEY}
 EOF
+      ;;
+    *)
+      echo "ERROR: Unsupported PBM backup type: ${PBM_BACKUP_TYPE:-<empty>}"
+      exit 1
+      ;;
+  esac
   local attempt=0
   local max_retries=12
   local try_interval=5
   while true; do
-    restore_status=$(pbm describe-restore "$restore_name" -c $cnf_file -o json | jq -r '.status')
-    echo "INFO: Restore $restore_name status: $restore_status, retrying in ${try_interval}s..."
-    if [ "$restore_status" = "done" ]; then
-      rm $cnf_file
-      break
-    elif [ "$restore_status" = "starting" ] || [ "$restore_status" = "running" ]; then
-      sleep $try_interval
-    elif [ "$restore_status" = "" ]; then
-      sleep $try_interval
-      attempt=$((attempt+1))
-      if [ $attempt -gt $max_retries ]; then
-        echo "ERROR: Restore $restore_name status is still empty after $max_retries retries"
-        rm $cnf_file
+    if [ "$PBM_BACKUP_TYPE" = "logical" ]; then
+      if describe_result=$(pbm describe-restore "$restore_name" --mongodb-uri "$PBM_MONGODB_URI" -o json 2>&1); then
+        :
+      elif echo "$describe_result" | grep -Eq "not found|no documents in result|undefined restore meta"; then
+        describe_result="{}"
+      else
+        echo "ERROR: Failed to get restore status: $describe_result"
         exit 1
       fi
     else
-      rm $cnf_file
+      if ! describe_result=$(pbm describe-restore "$restore_name" -c "$cnf_file" -o json 2>&1); then
+        echo "ERROR: Failed to get restore status: $describe_result"
+        rm -f "$cnf_file"
+        exit 1
+      fi
+    fi
+
+    if ! restore_status=$(echo "$describe_result" | jq -r '.status // empty'); then
+      echo "ERROR: Failed to parse restore status: $describe_result"
+      [ -z "$cnf_file" ] || rm -f "$cnf_file"
       exit 1
     fi
+
+    case "$restore_status" in
+      done)
+        echo "INFO: Restore $restore_name status: done."
+        [ -z "$cnf_file" ] || rm -f "$cnf_file"
+        break
+        ;;
+      error|canceled)
+        echo "ERROR: Restore $restore_name failed with status: $restore_status"
+        [ -z "$cnf_file" ] || rm -f "$cnf_file"
+        exit 1
+        ;;
+      "")
+        attempt=$((attempt+1))
+        if [ $attempt -ge $max_retries ]; then
+          echo "ERROR: Restore $restore_name status is still empty after $max_retries attempts"
+          [ -z "$cnf_file" ] || rm -f "$cnf_file"
+          exit 1
+        fi
+        echo "INFO: Restore $restore_name status is empty, retrying in ${try_interval}s..."
+        ;;
+      *)
+        # PBM treats every non-empty status except done, canceled, and error as running.
+        echo "INFO: Restore $restore_name status: $restore_status, retrying in ${try_interval}s..."
+        ;;
+    esac
+    sleep $try_interval
   done
 }

--- a/addons/mongodb/scripts/mongodb-shard-manage.sh
+++ b/addons/mongodb/scripts/mongodb-shard-manage.sh
@@ -31,8 +31,7 @@ wait_for_mongos() {
 check_shard_exists() {
     # check if the shard exists in the config database
     local shard_exists
-    shard_exists=$($CLUSTER_MONGO "db.getSiblingDB(\"config\").shards.find({ _id: \"$MONGODB_REPLICA_SET_NAME\" })" 2>/dev/null)
-    if [ $? -ne 0 ]; then
+    if ! shard_exists=$($CLUSTER_MONGO "db.getSiblingDB(\"config\").shards.find({ _id: \"$MONGODB_REPLICA_SET_NAME\" })" 2>/dev/null); then
         echo "ERROR: Failed to check if shard $MONGODB_REPLICA_SET_NAME exists." >&2
         exit 1
     fi
@@ -69,9 +68,9 @@ get_remove_shard_status() {
     # Execute the removeShard command and capture its JSON output
     local result
     if [ "$CLIENT" = "mongosh" ]; then
-        result=$($CLUSTER_MONGO "EJSON.stringify(db.adminCommand( { removeShard: \"$MONGODB_REPLICA_SET_NAME\" } ))")
+        result=$($CLUSTER_MONGO "EJSON.stringify(db.adminCommand( { removeShard: \"$MONGODB_REPLICA_SET_NAME\" } ))") || return 1
     else
-        result=$($CLUSTER_MONGO "JSON.stringify(db.adminCommand( { removeShard: \"$MONGODB_REPLICA_SET_NAME\" } ))")
+        result=$($CLUSTER_MONGO "JSON.stringify(db.adminCommand( { removeShard: \"$MONGODB_REPLICA_SET_NAME\" } ))") || return 1
     fi
     echo "$result"
 }
@@ -80,7 +79,7 @@ get_remove_shard_state() {
     local result=$1
     # Parse and log the state using jq
     local state
-    state=$(echo "$result" | jq -r '.state')
+    state=$(echo "$result" | jq -er '.state // empty') || return 1
     # Return the state as the function output
     echo "$state"
 }
@@ -90,9 +89,9 @@ get_remaining_jumbo_chunks() {
     # Parse and log the jumboChunks count using jq
     local jumbo_chunks
     if [ "$CLIENT" = "mongosh" ]; then
-        jumbo_chunks=$(echo "$result" | jq -r '.remaining.jumboChunks // 0')
+        jumbo_chunks=$(echo "$result" | jq -er '(.remaining.jumboChunks // 0) | tonumber') || return 1
     else
-        jumbo_chunks=$(echo "$result" | jq -r '.remaining.jumboChunks.numberLong // 0')
+        jumbo_chunks=$(echo "$result" | jq -er '(.remaining.jumboChunks."$numberLong" // 0) | tonumber') || return 1
     fi
     # Return the jumboChunks count as the function output
     echo "$jumbo_chunks"
@@ -103,12 +102,31 @@ get_remaining_chunks() {
     # Parse and log the chunks count using jq
     local chunks
     if [ "$CLIENT" = "mongosh" ]; then
-        chunks=$(echo "$result" | jq -r '.remaining.chunks // 0')
+        chunks=$(echo "$result" | jq -er '(.remaining.chunks // 0) | tonumber') || return 1
     else
-        chunks=$(echo "$result" | jq -r '.remaining.chunks.numberLong // 0')
+        chunks=$(echo "$result" | jq -er '(.remaining.chunks."$numberLong" // 0) | tonumber') || return 1
     fi
     # Return the chunks count as the function output
     echo "$chunks"
+}
+
+get_database_primary() {
+    local database=$1
+    local result
+    result=$($CLUSTER_MONGO "JSON.stringify(db.getSiblingDB('config').databases.findOne({ _id: \"$database\" }))") || return 1
+    echo "$result" | jq -r '.primary // empty'
+}
+
+get_destination_shard() {
+    local result
+    local shards
+    result=$($CLUSTER_MONGO "JSON.stringify(
+        db.getSiblingDB('config').shards.find({
+            _id: { \$ne: '$MONGODB_REPLICA_SET_NAME' }
+        }).toArray()
+    )") || return 1
+    shards=$(echo "$result" | jq -r '.[]._id') || return 1
+    echo "$shards" | shuf -n 1
 }
 
 delete_or_scale_in_mongodb_shard() {
@@ -116,73 +134,104 @@ delete_or_scale_in_mongodb_shard() {
 
     if ! check_shard_exists; then
         echo "INFO: Shard $MONGODB_REPLICA_SET_NAME does not exist, skipping scale-in."
-        exit 0
+        return 0
     fi
 
-    original_balance_status=$($CLUSTER_MONGO "sh.getBalancerState()")
-    if [ "$original_balance_status" = "false" ]; then
-        $CLUSTER_MONGO "sh.startBalancer()"
-    fi
+    balancer_status=$($CLUSTER_MONGO "sh.getBalancerState()") || {
+        echo "ERROR: Failed to get the balancer state." >&2
+        return 1
+    }
+    case "$balancer_status" in
+    false)
+        if ! $CLUSTER_MONGO "sh.startBalancer()"; then
+            echo "ERROR: Failed to start the balancer." >&2
+            return 1
+        fi
+        ;;
+    true)
+        ;;
+    *)
+        echo "ERROR: Unexpected balancer state: $balancer_status" >&2
+        return 1
+        ;;
+    esac
 
     echo "INFO: Shard $MONGODB_REPLICA_SET_NAME exists, scaling in..."
-    # Remove the shard and wait until the state is 'completed'
-    while true; do
-
-        if ! check_shard_exists; then
-            echo "INFO: Shard $MONGODB_REPLICA_SET_NAME does not exist, exiting."
-            exit 0
-        fi
-
-        status_json=$(get_remove_shard_status)
-        echo "INFO: Remove shard status: $status_json"
-        state=$(get_remove_shard_state "$status_json")
-        echo "INFO: Current state of shard $MONGODB_REPLICA_SET_NAME is $state"
-        if [ "$state" = "completed" ]; then
-            break
-        elif [ "$state" = "ongoing" ]; then
-            remaining_jumboChunks=$(get_remaining_jumbo_chunks "$status_json")
-            if [ "$remaining_jumboChunks" -gt 0 ]; then
-                echo "INFO: $remaining_jumboChunks jumbo chunks remaining, please clear jumbo chunks before removing the shard."
-                exit 1
-            fi
-
-            remaining_chunks=$(get_remaining_chunks "$status_json")
-            echo "INFO: $remaining_chunks chunks remaining."
-            if [ "$remaining_chunks" -eq 0 ]; then
-                dbs_to_move=$(echo "$status_json" | jq -r '.dbsToMove[]')
-                note=$(echo "$status_json" | jq -r '.note')
-                echo "INFO: $note"
-                echo "$dbs_to_move"
-                for db in $dbs_to_move; do
-                    echo "INFO: Database '$db' is scheduled for movePrimary..."
-                    if [ -z "$DESTINATION_SHARD" ]; then
-                        DESTINATION_SHARD=$($CLUSTER_MONGO "JSON.stringify(
-                            db.getSiblingDB('config').shards.find({
-                                _id: { \$ne: '$MONGODB_REPLICA_SET_NAME' }
-                            }).toArray()
-                        )" | jq -r '.[]._id' | shuf -n 1)
-                        if [ -z "$DESTINATION_SHARD" ]; then
-                            echo "ERROR: No available shard found for moving primary for database '$db'."
-                            exit 1
-                        fi
-                    fi
-                    echo "INFO: Moving primary for database '$db' to shard '$DESTINATION_SHARD'..."
-                    $CLUSTER_MONGO "db.adminCommand({ movePrimary: \"$db\", to: \"$DESTINATION_SHARD\" })"
-                done
-                continue
-            else
-                echo "INFO: $remaining_chunks chunks are still being migrated, waiting..."
-            fi
-        fi
-        sleep 2
-    done
-
-    # reset balancer state
-    if [ "$original_balance_status" = "false" ]; then
-        $CLUSTER_MONGO "sh.stopBalancer()"
-        echo "INFO: Balancer state has been reset to false."
+    # orphanCleanupDelaySecs controls how long MongoDB delays cleaning orphaned
+    # documents after a chunk migration. removeShard may wait for this delay
+    # (900 seconds by default) before the same range can be migrated again.
+    status_json=$(get_remove_shard_status) || {
+        echo "ERROR: Failed to get the remove shard status." >&2
+        return 1
+    }
+    echo "INFO: Remove shard status: $status_json"
+    state=$(get_remove_shard_state "$status_json") || {
+        echo "ERROR: Failed to parse the remove shard state." >&2
+        return 1
+    }
+    echo "INFO: Current state of shard $MONGODB_REPLICA_SET_NAME is $state"
+    if [ "$state" = "completed" ]; then
+        echo "INFO: Shard $MONGODB_REPLICA_SET_NAME has been successfully removed."
+        return 0
     fi
-    echo "INFO: Shard $MONGODB_REPLICA_SET_NAME has been successfully removed."
+
+    if [ "$state" = "ongoing" ]; then
+        remaining_jumbo_chunks=$(get_remaining_jumbo_chunks "$status_json") || {
+            echo "ERROR: Failed to parse the remaining jumbo chunks." >&2
+            return 1
+        }
+        if [ "$remaining_jumbo_chunks" -gt 0 ]; then
+            echo "ERROR: $remaining_jumbo_chunks jumbo chunks remain; clear them before removing the shard." >&2
+            return 1
+        fi
+
+        remaining_chunks=$(get_remaining_chunks "$status_json") || {
+            echo "ERROR: Failed to parse the remaining chunks." >&2
+            return 1
+        }
+        echo "INFO: $remaining_chunks chunks remaining."
+        if [ "$remaining_chunks" -eq 0 ]; then
+            dbs_to_move=$(echo "$status_json" | jq -r '.dbsToMove[]?') || {
+                echo "ERROR: Failed to parse the databases to move." >&2
+                return 1
+            }
+            note=$(echo "$status_json" | jq -r '.note // empty') || {
+                echo "ERROR: Failed to parse the remove shard note." >&2
+                return 1
+            }
+            [ -n "$note" ] && echo "INFO: $note"
+            for db in $dbs_to_move; do
+                current_primary=$(get_database_primary "$db") || {
+                    echo "ERROR: Failed to get the primary shard for database '$db'." >&2
+                    return 1
+                }
+                if [ "$current_primary" != "$MONGODB_REPLICA_SET_NAME" ]; then
+                    echo "INFO: Database '$db' no longer uses shard '$MONGODB_REPLICA_SET_NAME' as primary, skipping."
+                    continue
+                fi
+
+                if [ -z "$DESTINATION_SHARD" ]; then
+                    DESTINATION_SHARD=$(get_destination_shard) || {
+                        echo "ERROR: Failed to get a destination shard for database '$db'." >&2
+                        return 1
+                    }
+                fi
+                if [ -z "$DESTINATION_SHARD" ]; then
+                    echo "ERROR: No available shard found for moving primary for database '$db'." >&2
+                    return 1
+                fi
+
+                echo "INFO: Moving primary for database '$db' to shard '$DESTINATION_SHARD'..."
+                if ! $CLUSTER_MONGO "db.adminCommand({ movePrimary: \"$db\", to: \"$DESTINATION_SHARD\" })"; then
+                    echo "ERROR: Failed to move primary for database '$db'." >&2
+                    return 1
+                fi
+            done
+        fi
+    fi
+
+    echo "ERROR: Shard $MONGODB_REPLICA_SET_NAME has not been removed; the controller will retry." >&2
+    return 1
 }
 
 # main
@@ -202,7 +251,7 @@ if [ $# -eq 1 ]; then
     ;;
   --pre-terminate)
     delete_or_scale_in_mongodb_shard
-    exit 0
+    exit $?
     ;;
   *)
     echo "Error: invalid option '$1'"

--- a/addons/mongodb/templates/shardingdefinition.yaml
+++ b/addons/mongodb/templates/shardingdefinition.yaml
@@ -16,6 +16,8 @@ spec:
   updateStrategy: Parallel
   lifecycleActions:
     shardRemove:
+      # Each attempt is idempotent. Use the controller's default action timeout
+      # and rate limiter to retry removeShard without blocking reconciliation.
       exec:
         container: mongodb
         command:


### PR DESCRIPTION
Fixes apecloud/kubeblocks#10771
Fixes apecloud/kubeblocks#10774
Fixes apecloud/kubeblocks#10775

## What changed

- Make shard removal attempts idempotent and rely on the controller rate limiter for retries.
- Parse legacy Mongo shell Extended JSON chunk counts correctly and make `movePrimary` retry-safe.
- Treat PBM non-terminal backup states, including `dumpDone`, as still running.
- Select restore status lookup by `PBM_BACKUP_TYPE`: logical restores query MongoDB, while physical and continuous restores query storage metadata.

## Source changes

This ports the merged changes from apecloud/apecloud-addons#1966 and apecloud/apecloud-addons#1979 to the community MongoDB addon.

## Validation

- `helm lint addons/mongodb`
- `helm template mongodb-test addons/mongodb --namespace mongodb-test`
- `shellspec ... addons/mongodb/scripts-ut-spec/dataprotection_common_spec.sh` (49 examples, 0 failures)
- KubeBlocks main integration validation is in progress on a dedicated k3d cluster.