### PR TITLE
fix(tidb): fix tidb create failed tikv crash

### DIFF
--- a/addons/tidb/config/tikv.toml.tpl
+++ b/addons/tidb/config/tikv.toml.tpl
@@ -114,7 +114,7 @@ abort-on-panic = false
 ## So how can `memory-usage-limit` influence TiKV? When a TiKV's memory usage almost reaches
 ## this threshold, it can squeeze some internal components (e.g. evicting cached Raft entries)
 ## to release memory.
-memory-usage-limit = "0B"
+## memory-usage-limit = "0B"
 
 [quota]
 ## Quota is use to add some limitation for the read write flow and then


### PR DESCRIPTION
fix #3432 

fix https://github.com/apecloud/apecloud/issues/20162

## Summary

Remove the explicit `memory-usage-limit` setting from the TiKV config template.

TiKV will now use its built-in default memory limit instead of receiving `0B` from the template, which caused startup to fail with:

`The sum of storage.block-cache.capacity and rocksdb.write-buffer-limit is greater than memory-usage-limit`
