### PR TITLE
fix(postgresql): pgdump restore tolerate only existing-object conflicts

### DIFF
--- a/addons/postgresql/dataprotection/pgdump-restore.sh
+++ b/addons/postgresql/dataprotection/pgdump-restore.sh
@@ -31,7 +31,10 @@ if [ -z "$jobs" ]; then
 fi
 
 # Build pg_dump parameters
-params="-j $jobs -Fd -v -C -d postgres"
+# Roles are not dumped by pg_dump; the target cluster (e.g. a freshly
+# restored one) usually does not have the roles referenced by ownership and
+# ACL statements, so skip restoring owners and privileges altogether.
+params="-j $jobs -Fd -v -C -d postgres --no-owner --no-privileges"
 if [ -n "$database" ]; then
     $psql_cmd -d postgres -Atc "create database $database" || echo "Failed to create database $database"
 fi
@@ -44,7 +47,6 @@ if [ -n "$schemas" ]; then
         $psql_cmd -d $database -Atc "create schema if not exists $schema" || echo "Failed to create schema $schema"
      fi
   done
-  params="$params --no-owner --no-privileges"
 fi
 
 # Handle table selection
@@ -64,9 +66,6 @@ if [ -n "$tables" ]; then
       $psql_cmd -d $database -Atc "create schema if not exists $schema" || echo "Failed to create schema $schema"
     fi
   done
-  if [ -z "$schemas" ]; then
-    params="$params --no-owner --no-privileges"
-  fi
 fi
 
 # Handle schema only
@@ -94,10 +93,21 @@ set -e
 exec 3>&-
 # Without --exit-on-error pg_restore continues past per-object errors and
 # exits 1 with "errors ignored on restore". Only the non-FAIL policies may
-# treat that as success; FAIL must propagate the failure.
-if [ $exit_code -ne 0 ] && [ "$conflict_policy" != "FAIL" ] && [ -f /tmp/pg_restore.log ] \
+# treat that as success, and only when every error is a benign conflict with
+# the existing target database: objects already present ("already exists",
+# "multiple primary keys"), or the database in use so its DROP fails. Data
+# conflicts (duplicate key values), missing objects, and permission problems
+# must fail.
+if [ "$exit_code" -ne 0 ] && [ "$conflict_policy" != "FAIL" ] && [ -f /tmp/pg_restore.log ] \
     && grep -q "pg_restore: warning: errors ignored on restore" /tmp/pg_restore.log; then
-  echo "pg_restore reported ignored errors; treating as success under conflict_policy=${conflict_policy:-CONTINUE}"
-  exit_code=0
+  total_errors=$(grep -c "^pg_restore: error:" /tmp/pg_restore.log || true)
+  existing_errors=$(grep "^pg_restore: error:" /tmp/pg_restore.log | grep -cE "already exists|multiple primary keys for table|is being accessed by other users" || true)
+  if [ "$total_errors" -gt 0 ] && [ "$total_errors" = "$existing_errors" ]; then
+    echo "pg_restore reported only pre-existing-object errors; treating as success under conflict_policy=${conflict_policy:-CONTINUE}"
+    exit_code=0
+  else
+    echo "pg_restore reported non-conflict errors; failing restore" >&2
+    grep "^pg_restore: error:" /tmp/pg_restore.log | grep -vE "already exists|multiple primary keys for table|is being accessed by other users" >&2 || true
+  fi
 fi
-exit $exit_code
+exit "$exit_code"


### PR DESCRIPTION
## What

Two fixes to `addons/postgresql/dataprotection/pgdump-restore.sh` so that restoring a pg_dump backup into a non-empty / live target database behaves predictably:

1. **Restore with `--no-owner --no-privileges`** (unconditionally, previously only for schema/table-filtered restores). `pg_dump` does not dump roles, so ownership/ACL statements referencing roles that only exist on the source (e.g. `GRANT ... TO "READWRITE_test"`) used to fail every full restore into a fresh cluster with `ERROR: role "..." does not exist`.

2. **Tighten the `conflict_policy=CONTINUE` success detection.** Previously any `pg_restore: warning: errors ignored on restore` was treated as success, which masked real failures (e.g. missing sequences). Now a failed restore is only treated as success when **every** error is a benign conflict with the existing target database:
   - `already exists` (relations, indexes, sequences, constraints, schemas, ...)
   - `multiple primary keys for table ... are not allowed`
   - `database "..." is being accessed by other users`

   Any other error (missing objects, data conflicts like `duplicate key value`, permission problems) still fails the restore, and the offending errors are printed to stderr.

## Why

Restoring into a database that already has objects (e.g. a previous partial restore, or an app-initialized DB with live connections) is a supported KubeBlocks flow under `conflict_policy=CONTINUE`/`DROP`, but the old blanket ignore made it impossible to distinguish benign conflicts from real failures, and the missing roles blocked full restores entirely.

## Verification

- `bash -n` passes
- `shellcheck`: 10 findings vs 12 on `main` (no new findings)
- Simulated pg_restore log matrix:
  - only benign conflicts (db in use + multiple PKs + already exists) -> success
  - mixed with missing object (`does not exist`) -> failure
  - data-level duplicate key -> failure
  - benign conflicts under `conflict_policy=FAIL` -> failure (propagated)