### PR TITLE
fix(postgresql): render PgBouncer as optional component

### DIFF
--- a/addons/postgresql/Chart.yaml
+++ b/addons/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ description: A PostgreSQL (with Patroni HA) cluster definition Helm chart for Ku
 
 type: application
 
-version: 1.0.6
+version: 1.0.7
 
 # The helm chart contains multiple kernel versions of PostgreSQL (with Patroni HA),
 # appVersion should be consistent with the highest PostgreSQL (with Patroni HA) kernel version.

--- a/addons/postgresql/scripts-ut-spec/version_matrix_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/version_matrix_spec.sh
@@ -33,12 +33,12 @@ Describe "PostgreSQL version matrix contract"
       replication = topologies.first
       abort unless replication["components"] == [
         {"name" => "postgresql", "compDef" => "postgresql-"},
-        {"name" => "pgbouncer", "compDef" => "pgbouncer-1.0.6"}
+        {"name" => "pgbouncer", "compDef" => "pgbouncer-1.0.7", "template" => true}
       ]
 
       definitions = documents.select { |document| document["kind"] == "ComponentDefinition" }
-      postgres = definitions.find { |definition| definition.dig("metadata", "name") == "postgresql-14-1.0.6" }
-      pgbouncer = definitions.find { |definition| definition.dig("metadata", "name") == "pgbouncer-1.0.6" }
+      postgres = definitions.find { |definition| definition.dig("metadata", "name") == "postgresql-14-1.0.7" }
+      pgbouncer = definitions.find { |definition| definition.dig("metadata", "name") == "pgbouncer-1.0.7" }
       abort unless pgbouncer.dig("spec", "replicasLimit") == {"minReplicas" => 0, "maxReplicas" => 64}
       abort unless pgbouncer.dig("spec", "serviceVersion") == "1.25.2"
       abort unless pgbouncer.dig("spec", "services", 0, "spec", "ports", 0, "port") == 6432
@@ -64,16 +64,16 @@ Describe "PostgreSQL version matrix contract"
       postgres_containers = postgres.dig("spec", "runtime", "containers").map { |container| container["name"] }
       abort if postgres_containers.include?("pgbouncer")
       postgres_pcr = documents.find do |document|
-        document["kind"] == "ParamConfigRenderer" && document.dig("metadata", "name") == "postgresql14-pcr-1.0.6"
+        document["kind"] == "ParamConfigRenderer" && document.dig("metadata", "name") == "postgresql14-pcr-1.0.7"
       end
       abort unless postgres_pcr.dig("spec", "configs").map { |config| config["name"] } == ["postgresql.conf"]
       pgbouncer_pcr = documents.find do |document|
         document["kind"] == "ParamConfigRenderer" &&
-          document.dig("metadata", "name") == "pgbouncer-pcr-1.0.6"
+          document.dig("metadata", "name") == "pgbouncer-pcr-1.0.7"
       end
-      abort unless pgbouncer_pcr.dig("spec", "componentDef") == "pgbouncer-1.0.6"
+      abort unless pgbouncer_pcr.dig("spec", "componentDef") == "pgbouncer-1.0.7"
       abort unless pgbouncer_pcr.dig("spec", "serviceVersion") == "1.25.2"
-      abort unless pgbouncer_pcr.dig("spec", "parametersDefs") == ["pgbouncer-pd-1.0.6"]
+      abort unless pgbouncer_pcr.dig("spec", "parametersDefs") == ["pgbouncer-pd-1.0.7"]
       pgbouncer_format = pgbouncer_pcr.dig("spec", "configs", 0)
       abort unless pgbouncer_format["name"] == "pgbouncer.ini"
       abort unless pgbouncer_format.dig("fileFormatConfig", "format") == "ini"
@@ -81,7 +81,7 @@ Describe "PostgreSQL version matrix contract"
 
       pgbouncer_pd = documents.find do |document|
         document["kind"] == "ParametersDefinition" &&
-          document.dig("metadata", "name") == "pgbouncer-pd-1.0.6"
+          document.dig("metadata", "name") == "pgbouncer-pd-1.0.7"
       end
       exposed = %w[
         pool_mode max_client_conn default_pool_size min_pool_size
@@ -137,7 +137,7 @@ Describe "PostgreSQL version matrix contract"
       ]
       pgbouncer_config = documents.find do |document|
         document["kind"] == "ConfigMap" &&
-          document.dig("metadata", "name") == "pgbouncer-configuration-1.0.6"
+          document.dig("metadata", "name") == "pgbouncer-configuration-1.0.7"
       end.dig("data", "pgbouncer.ini")
       abort unless pgbouncer_config.lines.any? { |line| line.match?(/^\s*listen_addr\s*=\s*\*\s*$/) }
       abort unless pgbouncer_config.lines.any? { |line| line.match?(/^\s*client_tls_sslmode\s*=\s*disable\s*$/) }
@@ -156,7 +156,7 @@ Describe "PostgreSQL version matrix contract"
       abort unless pgbouncer_config.include?("max_user_connections = 80")
       abort if pgbouncer_config.lines.any? { |line| line.match?(/^\s*logfile\s*=\s*\/dev\/stderr\s*$/) }
       main_config = documents.find do |document|
-        document["kind"] == "ConfigMap" && document.dig("metadata", "name") == "pgbouncer-configuration-1.0.6"
+        document["kind"] == "ConfigMap" && document.dig("metadata", "name") == "pgbouncer-configuration-1.0.7"
       end
       abort unless main_config["data"].keys == ["pgbouncer.ini"]
       abort if documents.any? do |document|
@@ -226,7 +226,7 @@ Describe "PostgreSQL version matrix contract"
         abort unless version.dig("spec", "releases").map { |release| release["name"] } == ["1.25.2", "1.25.2-test"]
         abort unless version.dig("spec", "releases", 0, "images", "pgbouncer") == "docker.io/apecloud/pgbouncer:1.25.2"
         abort unless version.dig("spec", "releases", 1, "images", "pgbouncer") == "docker.io/apecloud/pgbouncer:1.25.2-test"
-        definition = documents.find { |document| document["kind"] == "ComponentDefinition" && document.dig("metadata", "name") == "pgbouncer-1.0.6" }
+        definition = documents.find { |document| document["kind"] == "ComponentDefinition" && document.dig("metadata", "name") == "pgbouncer-1.0.7" }
         abort unless definition.dig("spec", "serviceVersion") == "1.25.2-test"
         abort unless definition.dig("spec", "runtime", "containers", 0, "imagePullPolicy") == "Always"
         puts "ok"
@@ -334,19 +334,19 @@ EOF
     fi
   }
 
-  It "advances the definition chart version to 1.0.6"
+  It "advances the definition chart version to 1.0.7"
     When call chart_version "$(chart_dir)"
     The status should eq 0
-    The output should eq "1.0.6"
+    The output should eq "1.0.7"
   End
 
-  It "keeps the cluster chart version aligned at 1.0.6"
+  It "keeps the cluster chart version at 1.0.6"
     When call chart_version "$(cluster_chart_dir)"
     The status should eq 0
     The output should eq "1.0.6"
   End
 
-  It "keeps one replication topology and adds a zero-capable PgBouncer component"
+  It "keeps PgBouncer as a topology template"
     When call pgbouncer_component_contract
     The status should eq 0
     The output should eq "ok"
@@ -376,7 +376,7 @@ EOF
   End
 
   It "publishes the PostgreSQL 13 immutable ComponentDefinition identity"
-    When call render_count '^  name: postgresql-13-1.0.6$'
+    When call render_count '^  name: postgresql-13-1.0.7$'
     The status should eq 0
     The output should eq "1"
   End

--- a/addons/postgresql/templates/clusterdefinition.yaml
+++ b/addons/postgresql/templates/clusterdefinition.yaml
@@ -14,6 +14,7 @@ spec:
           compDef: {{ include "postgresql.componentDefNamePrefix" . }}
         - name: pgbouncer
           compDef: {{ include "pgbouncer.componentDefName" . }}
+          template: true
       orders:
         provision:
           - postgresql


### PR DESCRIPTION
## Summary

Related to apecloud/apecloud#20276.

PgBouncer is an on-demand PostgreSQL component. The ClusterDefinition previously listed it as a regular topology component, which did not express the intended dynamic-component lifecycle to KubeBlocks.

This change keeps the replication topology unchanged and marks PgBouncer as a topology template. KubeBlocks 1.0 can then instantiate the component only when a Cluster explicitly uses the template ComponentDefinition. The PostgreSQL Cluster chart deliberately remains unchanged: a newly created Cluster does not declare PgBouncer by default, so an environment that has not upgraded the PostgreSQL Addon cannot receive a reference to an unknown component.

The PostgreSQL Addon identity is advanced to 1.0.7 so the revised ClusterDefinition, ComponentDefinition, ParamConfigRenderer, and ParametersDefinition can coexist with prior releases. The Cluster chart stays at 1.0.6.

The ApeCloud product layer will use the live Cluster component state: it exposes PgBouncer operations only after the Cluster has the component, and does not backfill existing Clusters during an Addon upgrade.

## Validation

- `helm lint addons/postgresql`
- `helm lint addons-cluster/postgresql`
- Rendered both charts with Helm and asserted that PgBouncer is a topology template while the PostgreSQL Cluster chart does not create a default PgBouncer component.
- `sh -n addons/postgresql/scripts-ut-spec/version_matrix_spec.sh`
- `git diff --check`
- Earlier local k3d validation on KubeBlocks 1.0 confirmed that a pre-PgBouncer Cluster was unchanged after the Addon upgrade. The revised topology and Chart behavior were revalidated by Helm rendering.

## Compatibility

This is intentionally a release-1.0 change. It preserves existing Cluster specs and does not create or restart PgBouncer on installed PostgreSQL Clusters. It also does not impose an Addon upgrade prerequisite on the existing PostgreSQL Cluster chart.