### PR TITLE
fix(mysql): honor configured image pull policy in release-1.1

### DIFF
--- a/addons/mysql/templates/_helpers.tpl
+++ b/addons/mysql/templates/_helpers.tpl
@@ -302,7 +302,7 @@ env:
     value: $(MYSQL_ROOT_PASSWORD)
   - name: EXPORTER_WEB_PORT
     value: "{{ .Values.metrics.service.port }}"
-imagePullPolicy: IfNotPresent
+imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
 ports:
   - name: http-metrics
     containerPort: {{ .Values.metrics.service.port }}

--- a/addons/mysql/templates/_orc.tpl
+++ b/addons/mysql/templates/_orc.tpl
@@ -248,7 +248,7 @@ switchover:
       cp -r /usr/bin/jq /kubeblocks/jq
       cp -r /scripts/orchestrator-client /kubeblocks/orchestrator-client
       cp -r /usr/local/bin/curl /kubeblocks/curl
-  imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+  imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
   name: init-jq
   volumeMounts:
     - mountPath: /kubeblocks
@@ -256,7 +256,7 @@ switchover:
 {{- end }}
 
 {{- define "mysql-orc.spec.runtime.mysql" -}}
-imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
 command:
   - bash
   - -c

--- a/addons/mysql/templates/cmpd-mysql57-orc.yaml
+++ b/addons/mysql/templates/cmpd-mysql57-orc.yaml
@@ -28,7 +28,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog,temp}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql57.yaml
+++ b/addons/mysql/templates/cmpd-mysql57.yaml
@@ -25,7 +25,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -52,7 +52,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         command:
           - syncer
           - --port
@@ -122,4 +122,3 @@ spec:
                 fieldPath: status.podIP
       - name: mysql-exporter
         {{- include "mysql.spec.runtime.exporter" . | nindent 8 }}
-

--- a/addons/mysql/templates/cmpd-mysql80-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-mgr.yaml
@@ -25,7 +25,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -42,7 +42,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql80-orc.yaml
+++ b/addons/mysql/templates/cmpd-mysql80-orc.yaml
@@ -28,7 +28,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog,temp}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data

--- a/addons/mysql/templates/cmpd-mysql80.yaml
+++ b/addons/mysql/templates/cmpd-mysql80.yaml
@@ -25,7 +25,7 @@ spec:
           - |
             mkdir -p {{ .Values.dataMountPath }}/{log,binlog,auditlog}
             cp /usr/lib/mysql/plugin/ {{ .Values.dataMountPath }}/plugin -r
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         volumeMounts:
           - mountPath: {{ .Values.dataMountPath }}
             name: data
@@ -52,7 +52,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql84-mgr.yaml
+++ b/addons/mysql/templates/cmpd-mysql84-mgr.yaml
@@ -31,7 +31,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         command:
           - syncer
           - --port

--- a/addons/mysql/templates/cmpd-mysql84.yaml
+++ b/addons/mysql/templates/cmpd-mysql84.yaml
@@ -41,7 +41,7 @@ spec:
       {{- include "mysql.spec.runtime.common" . | nindent 6 }}
     containers:
       - name: mysql
-        imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "mysql.imagePullPolicy" . }}
         command:
           - syncer
           - --port

--- a/addons/mysql/tests/test_pull_policy.py
+++ b/addons/mysql/tests/test_pull_policy.py
@@ -1,0 +1,73 @@
+"""Render regression: python3 addons/mysql/tests/test_pull_policy.py.
+
+Requires Helm and PyYAML. Uses an isolated copy of the Chart and local kblib.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+class MySQLPullPolicyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="mysql-pull-policy-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        work = Path(cls.temp.name)
+        addons = Path(__file__).resolve().parents[2]
+        for name in ("mysql", "kblib"):
+            shutil.copytree(addons / name, work / name)
+        cls.chart = work / "mysql"
+        cls.env = dict(os.environ, HELM_CACHE_HOME=str(work / "cache"),
+                       HELM_CONFIG_HOME=str(work / "config"),
+                       HELM_DATA_HOME=str(work / "data"))
+        subprocess.run(["helm", "dependency", "build", "--skip-refresh", str(cls.chart)],
+                       env=cls.env, check=True, capture_output=True, text=True)
+
+    def assert_policy(self, value, expected, extra=()):
+        command = ["helm", "template", "mysql", str(self.chart), *extra]
+        if value is not None:
+            command.extend(["--set-string", "image.pullPolicy=" + value])
+        rendered = subprocess.check_output(command, env=self.env, text=True)
+        counts = {"mysql": 0, "init": 0, "exporter": 0}
+        for document in yaml.safe_load_all(rendered):
+            if not document or document.get("kind") != "ComponentDefinition":
+                continue
+            runtime = document["spec"]["runtime"]
+            for group in ("containers", "initContainers"):
+                for container in runtime.get(group, []):
+                    name = container["name"]
+                    with self.subTest(component=document["metadata"]["name"], container=name):
+                        self.assertEqual(container.get("imagePullPolicy"), expected)
+                    if group == "initContainers":
+                        counts["init"] += 1
+                    elif name == "mysql":
+                        counts["mysql"] += 1
+                    elif "exporter" in name:
+                        counts["exporter"] += 1
+        for group, count in counts.items():
+            self.assertGreater(count, 0, "missing rendered " + group)
+
+    def test_always(self):
+        self.assert_policy("Always", "Always")
+
+    def test_never(self):
+        self.assert_policy("Never", "Never")
+
+    def test_default(self):
+        self.assert_policy(None, "IfNotPresent")
+
+    def test_empty_uses_default(self):
+        self.assert_policy("", "IfNotPresent")
+
+    def test_arm64_custom_registry(self):
+        self.assert_policy("Always", "Always", ("--set", "architecture=arm64,image.registry=registry.example.test"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Setting `image.pullPolicy=Always` in the MySQL release-1.1 Chart still rendered `IfNotPresent` for multiple MySQL/init containers and every exporter. Twelve reversed Helm `default` calls always selected the literal fallback, and the exporter policy was hardcoded.

Use the existing `mysql.imagePullPolicy` helper at all thirteen sites. The default remains `IfNotPresent`; explicit policies now apply consistently to the primary container, init containers and exporter across MySQL 5.7, 8.0, 8.4, MGR and ORC variants.

Validation: `python3 addons/mysql/tests/test_pull_policy.py` passes 5 actual Helm render tests (Always, Never, default, empty fallback, arm64/custom registry). Helm lint passes. ct-platform's unchanged `validateDatabaseRuntimeCoverage` passes the rendered release-1.1 MySQL Chart when paired with the runtime mappings in https://github.com/apecloud/ct-platform/pull/390; before this Chart fix it rejected init-data's IfNotPresent policy. No live deployment performed.
