### PR TITLE
fix(redis): honor pull policy and official-registry image repos

### DIFF
--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -129,6 +129,38 @@ Define redis cluster component script template name
 redis-cluster-scripts-template-{{ .Chart.Version }}
 {{- end -}}
 
+{{- define "redis.officialRepository" -}}
+{{- $registry := .registry | default "docker.io" -}}
+{{- $repository := .repository -}}
+{{- if eq $registry "docker.io" -}}
+{{- $repository -}}
+{{- else if hasPrefix "apecloud/" $repository -}}
+{{- $repository -}}
+{{- else if eq $repository "redis" -}}
+apecloud/redis
+{{- else if eq $repository "redis/redis-stack-server" -}}
+apecloud/redis-stack-server
+{{- else if eq $repository "malexer/twemproxy" -}}
+apecloud/twemproxy
+{{- else if eq $repository "oliver006/redis_exporter" -}}
+apecloud/redis_exporter
+{{- else if eq $repository "busybox" -}}
+apecloud/busybox
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end }}
+
+{{- define "redis.qualifiedRepository" -}}
+{{- $registry := .registry | default "docker.io" -}}
+{{- $repository := include "redis.officialRepository" . | trim -}}
+{{- printf "%s/%s" $registry $repository -}}
+{{- end }}
+
+{{- define "redis.imagePullPolicy" -}}
+{{ default "IfNotPresent" .Values.image.pullPolicy }}
+{{- end }}
+
 {{- define "redis7.image" -}}
 {{- $registry := .Values.image.registry | default "docker.io" -}}
 {{- $repository := .Values.image.repository -}}
@@ -139,15 +171,16 @@ redis-cluster-scripts-template-{{ .Chart.Version }}
 {{- $tag = .defaultImageTag | default $tag -}}
 {{- end -}}
 {{- end -}}
-{{ $registry }}/{{ $repository }}:{{ $tag }}
+{{ include "redis.qualifiedRepository" (dict "registry" $registry "repository" $repository) | trim }}:{{ $tag }}
 {{- end }}
 
 {{- define "redisTwemproxy.repository" -}}
-{{ .Values.redisTwemproxyImage.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.redisTwemproxyImage.repository }}
+{{- $registry := .Values.redisTwemproxyImage.registry | default ( .Values.image.registry | default "docker.io" ) -}}
+{{- include "redis.qualifiedRepository" (dict "registry" $registry "repository" .Values.redisTwemproxyImage.repository) | trim -}}
 {{- end }}
 
 {{- define "redisTwemproxy05.image" -}}
-{{ .Values.redisTwemproxyImage.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.redisTwemproxyImage.repository }}:{{ .Values.redisTwemproxyImage.tag }}
+{{ include "redisTwemproxy.repository" . }}:{{ .Values.redisTwemproxyImage.tag }}
 {{- end }}
 
 {{- define "busybox.image" -}}
@@ -160,11 +193,12 @@ redis-cluster-scripts-template-{{ .Chart.Version }}
 {{- end }}
 
 {{- define "metrics.repository" -}}
-{{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository}}
+{{- $registry := .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) -}}
+{{- include "redis.qualifiedRepository" (dict "registry" $registry "repository" .Values.metrics.image.repository) | trim -}}
 {{- end }}
 
 {{- define "metrics.image" -}}
-{{ .Values.metrics.image.registry | default ( .Values.image.registry | default "docker.io" ) }}/{{ .Values.metrics.image.repository}}:{{ .Values.metrics.image.tag }}
+{{ include "metrics.repository" . }}:{{ .Values.metrics.image.tag }}
 {{- end }}
 
 {{- define "apeDts.image" -}}

--- a/addons/redis/templates/_helpers.tpl
+++ b/addons/redis/templates/_helpers.tpl
@@ -129,10 +129,14 @@ Define redis cluster component script template name
 redis-cluster-scripts-template-{{ .Chart.Version }}
 {{- end -}}
 
+{{- define "redis.officialRegistry" -}}
+apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+{{- end }}
+
 {{- define "redis.officialRepository" -}}
 {{- $registry := .registry | default "docker.io" -}}
 {{- $repository := .repository -}}
-{{- if eq $registry "docker.io" -}}
+{{- if ne $registry (include "redis.officialRegistry" .) -}}
 {{- $repository -}}
 {{- else if hasPrefix "apecloud/" $repository -}}
 {{- $repository -}}
@@ -161,6 +165,14 @@ apecloud/busybox
 {{ default "IfNotPresent" .Values.image.pullPolicy }}
 {{- end }}
 
+{{- define "redis.dbctlImagePullPolicy" -}}
+{{ default "IfNotPresent" .Values.dbctlImage.pullPolicy }}
+{{- end }}
+
+{{- define "redis.metricsImagePullPolicy" -}}
+{{ default "IfNotPresent" .Values.metrics.image.pullPolicy }}
+{{- end }}
+
 {{- define "redis7.image" -}}
 {{- $registry := .Values.image.registry | default "docker.io" -}}
 {{- $repository := .Values.image.repository -}}
@@ -185,10 +197,10 @@ apecloud/busybox
 
 {{- define "busybox.image" -}}
 {{ $registry := .Values.busyboxImage.registry | default ( .Values.image.registry | default "docker.io" )}}
-{{- if eq $registry "docker.io" -}}
-{{ $registry }}/busybox:{{ .Values.busyboxImage.tag }}
-{{- else -}}
+{{- if eq $registry (include "redis.officialRegistry" .) -}}
 {{ $registry }}/apecloud/busybox:{{ .Values.busyboxImage.tag }}
+{{- else -}}
+{{ $registry }}/{{ .Values.busyboxImage.repository | default "busybox" }}:{{ .Values.busyboxImage.tag }}
 {{- end -}}
 {{- end }}
 
@@ -235,9 +247,9 @@ redis-account.sh: |-
 
 {{- define "redis.ceRepository" -}}
 {{ $registry := .Values.ceImage.registry | default ( .Values.image.registry | default "docker.io" )}}
-{{- if eq $registry "docker.io" -}}
-{{- .Values.ceImage.repository -}}
-{{- else -}}
+{{- if eq $registry (include "redis.officialRegistry" .) -}}
 apecloud/redis
+{{- else -}}
+{{- .Values.ceImage.repository -}}
 {{- end -}}
 {{- end -}}

--- a/addons/redis/templates/backupactionset.yaml
+++ b/addons/redis/templates/backupactionset.yaml
@@ -115,7 +115,7 @@ spec:
     - name: LOG_ARCHIVE_SECONDS
       value: "3"
     - name: IMAGE
-      value: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+      value: {{ include "redis.qualifiedRepository" (dict "registry" (.Values.image.registry | default "docker.io") "repository" .Values.image.repository) | trim }}:{{ .Values.image.tag.major7.minor72 }}
   backup:
     preBackup: []
     postBackup: []

--- a/addons/redis/templates/backuppolicytemplate.yaml
+++ b/addons/redis/templates/backuppolicytemplate.yaml
@@ -46,7 +46,7 @@ spec:
             {{- range .Values.redisVersions }}
             {{- $defaultRepository := .repository -}}
             {{- range .mirrorVersions }}
-            {{- $redisRepository := printf "%s/%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) }}
+            {{- $redisRepository := include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim }}
              - serviceVersions:
                - {{ .version }}
                mappedValue: {{ $redisRepository }}:{{ .imageTag }}

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -525,7 +525,7 @@ spec:
           - -r
           - /bin/dbctl
           - /tools/
-        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
+        imagePullPolicy: {{ include "redis.dbctlImagePullPolicy" $ }}
         volumeMounts:
           - mountPath: /tools
             name: tools
@@ -587,7 +587,7 @@ spec:
                 - /scripts/redis-cluster-replica-pre-stop.sh
   {{- if $.Values.enableMetrics }}
       - name: metrics
-        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
+        imagePullPolicy: {{ include "redis.metricsImagePullPolicy" $ }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001

--- a/addons/redis/templates/cmpd-redis-cluster.yaml
+++ b/addons/redis/templates/cmpd-redis-cluster.yaml
@@ -525,13 +525,13 @@ spec:
           - -r
           - /bin/dbctl
           - /tools/
-        imagePullPolicy: {{ default "IfNotPresent" $.Values.dbctlImage.pullPolicy }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
         volumeMounts:
           - mountPath: /tools
             name: tools
     containers:
       - name: redis-cluster
-        imagePullPolicy: {{ default "IfNotPresent" $.Values.image.pullPolicy }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
         ports:
           - name: redis-cluster
             containerPort: 6379
@@ -587,7 +587,7 @@ spec:
                 - /scripts/redis-cluster-replica-pre-stop.sh
   {{- if $.Values.enableMetrics }}
       - name: metrics
-        imagePullPolicy: {{ $.Values.metrics.image.pullPolicy | quote }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001

--- a/addons/redis/templates/cmpd-redis-sentinel.yaml
+++ b/addons/redis/templates/cmpd-redis-sentinel.yaml
@@ -223,7 +223,7 @@ spec:
   runtime:
     containers:
     - name: redis-sentinel
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
       ports:
         - containerPort: 26379
           name: redis-sentinel

--- a/addons/redis/templates/cmpd-redis-twemproxy.yaml
+++ b/addons/redis/templates/cmpd-redis-twemproxy.yaml
@@ -74,7 +74,7 @@ spec:
   runtime:
     initContainers:
       - name: init-redis-twemproxy
-        imagePullPolicy: {{ default .Values.busyboxImage.pullPolicy "IfNotPresent" }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" . }}
         command:
           - /scripts/redis-twemproxy-setup-v2.sh
         volumeMounts:
@@ -88,7 +88,7 @@ spec:
             name: scripts
     containers:
     - name: redis-twemproxy
-      imagePullPolicy: {{ default .Values.redisTwemproxyImage.pullPolicy "IfNotPresent" }}
+      imagePullPolicy: {{ include "redis.imagePullPolicy" . }}
       command:
         - sh
         - -c

--- a/addons/redis/templates/cmpd-redis.yaml
+++ b/addons/redis/templates/cmpd-redis.yaml
@@ -406,13 +406,13 @@ spec:
           - -r
           - /bin/dbctl
           - /tools/
-        imagePullPolicy: {{ default "IfNotPresent" $.Values.dbctlImage.pullPolicy }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
         volumeMounts:
           - mountPath: /tools
             name: tools
     containers:
       - name: redis
-        imagePullPolicy: {{ default "IfNotPresent" $.Values.image.pullPolicy }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
         command: [ "/scripts/{{ $redisStartScripts }}" ]
         ports:
           - name: redis
@@ -466,7 +466,7 @@ spec:
                 - /scripts/redis-pre-stop.sh
   {{- if $.Values.enableMetrics }}
       - name: metrics
-        imagePullPolicy: {{ $.Values.metrics.image.pullPolicy | quote }}
+        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001

--- a/addons/redis/templates/cmpd-redis.yaml
+++ b/addons/redis/templates/cmpd-redis.yaml
@@ -406,7 +406,7 @@ spec:
           - -r
           - /bin/dbctl
           - /tools/
-        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
+        imagePullPolicy: {{ include "redis.dbctlImagePullPolicy" $ }}
         volumeMounts:
           - mountPath: /tools
             name: tools
@@ -466,7 +466,7 @@ spec:
                 - /scripts/redis-pre-stop.sh
   {{- if $.Values.enableMetrics }}
       - name: metrics
-        imagePullPolicy: {{ include "redis.imagePullPolicy" $ }}
+        imagePullPolicy: {{ include "redis.metricsImagePullPolicy" $ }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001

--- a/addons/redis/templates/cmpv-redis-cluster.yaml
+++ b/addons/redis/templates/cmpv-redis-cluster.yaml
@@ -20,7 +20,7 @@ spec:
   {{- range .Values.redisVersions }}
   {{- $defaultRepository := .repository -}}
   {{- range .mirrorVersions }}
-  {{- $redisRepository := printf "%s/%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) }}
+  {{- $redisRepository := include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim }}
   - name: {{ .version }}
     serviceVersion: {{ .version }}
     images:

--- a/addons/redis/templates/cmpv-redis-sentinel.yaml
+++ b/addons/redis/templates/cmpv-redis-sentinel.yaml
@@ -20,7 +20,7 @@ spec:
   {{- range .Values.redisVersions }}
   {{- $defaultRepository := .repository -}}
   {{- range .mirrorVersions }}
-  {{- $redisRepository := printf "%s/%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) }}
+  {{- $redisRepository := include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim }}
   - name: {{ .version }}
     serviceVersion: {{ .version }}
     images:

--- a/addons/redis/templates/cmpv-redis.yaml
+++ b/addons/redis/templates/cmpv-redis.yaml
@@ -20,7 +20,7 @@ spec:
   {{- range .Values.redisVersions }}
   {{- $defaultRepository := .repository -}}
   {{- range .mirrorVersions }}
-  {{- $redisRepository := printf "%s/%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) }}
+  {{- $redisRepository := include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim }}
   - name: {{ .version }}
     serviceVersion: {{ .version }}
     images:

--- a/addons/redis/templates/opsdefinition-rebalance.yaml
+++ b/addons/redis/templates/opsdefinition-rebalance.yaml
@@ -71,7 +71,7 @@ spec:
         podSpec:
           containers:
             - name: redis-rebalance
-              image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:7.4.0-v8
+              image: {{ include "redis.qualifiedRepository" (dict "registry" (.Values.image.registry | default "docker.io") "repository" .Values.image.repository) | trim }}:7.4.0-v8
               imagePullPolicy: IfNotPresent
               command:
                 - bash

--- a/addons/redis/templates/opsdefinition-reset-master.yaml
+++ b/addons/redis/templates/opsdefinition-reset-master.yaml
@@ -41,7 +41,7 @@ spec:
         podSpec:
           containers:
             - name: reset-master
-              image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag.major7.minor72 }}
+              image: {{ include "redis.qualifiedRepository" (dict "registry" (.Values.image.registry | default "docker.io") "repository" .Values.image.repository) | trim }}:{{ .Values.image.tag.major7.minor72 }}
               imagePullPolicy: IfNotPresent
               command:
                 - bash

--- a/addons/redis/templates/paramsdef-redis-cluster.yaml
+++ b/addons/redis/templates/paramsdef-redis-cluster.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.redisVersions }}
 {{- $defaultRepository := .repository -}}
-{{- $redisImage := printf "%s/%s:%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) .defaultImageTag }}
+{{- $redisImage := printf "%s:%s" (include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim) .defaultImageTag }}
 {{- $pd := $.Files.Get "config/redis-config-effect-scope.yaml" | fromYaml }}
 ---
 apiVersion: parameters.kubeblocks.io/v1alpha1
@@ -26,7 +26,7 @@ spec:
             image: {{ $redisImage }}
             imageMappings:
             {{- range .mirrorVersions }}
-            {{- $redisRepository := printf "%s/%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) }}
+            {{- $redisRepository := include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim }}
             - serviceVersions:
                 - {{ .version }}
               image: {{ $redisRepository }}:{{ .imageTag }}

--- a/addons/redis/templates/paramsdef-redis.yaml
+++ b/addons/redis/templates/paramsdef-redis.yaml
@@ -1,7 +1,7 @@
 # reuse redis7-config-effect-scope.
 {{- range .Values.redisVersions }}
 {{- $defaultRepository := .repository -}}
-{{- $redisImage := printf "%s/%s:%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) .defaultImageTag }}
+{{- $redisImage := printf "%s:%s" (include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim) .defaultImageTag }}
 {{- $pd := $.Files.Get "config/redis-config-effect-scope.yaml" | fromYaml }}
 ---
 apiVersion: parameters.kubeblocks.io/v1alpha1
@@ -27,7 +27,7 @@ spec:
             image: {{ $redisImage }}
             imageMappings:
             {{- range .mirrorVersions }}
-            {{- $redisRepository := printf "%s/%s" ( $.Values.image.registry | default "docker.io" ) ( .repository | default $defaultRepository ) }}
+            {{- $redisRepository := include "redis.qualifiedRepository" (dict "registry" ($.Values.image.registry | default "docker.io") "repository" (.repository | default $defaultRepository)) | trim }}
             - serviceVersions:
                 - {{ .version }}
               image: {{ $redisRepository }}:{{ .imageTag }}

--- a/addons/redis/tests/test_pull_policy.py
+++ b/addons/redis/tests/test_pull_policy.py
@@ -1,0 +1,115 @@
+"""Render regression: python3 addons/redis/tests/test_pull_policy.py.
+
+Requires Helm and PyYAML. Uses an isolated copy of the Chart and local kblib.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+OFFICIAL_REGISTRY = "apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com"
+
+
+class RedisPullPolicyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="redis-pull-policy-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        work = Path(cls.temp.name)
+        addons = Path(__file__).resolve().parents[2]
+        for name in ("redis", "kblib"):
+            shutil.copytree(addons / name, work / name)
+        cls.chart = work / "redis"
+        cls.env = dict(
+            os.environ,
+            HELM_CACHE_HOME=str(work / "cache"),
+            HELM_CONFIG_HOME=str(work / "config"),
+            HELM_DATA_HOME=str(work / "data"),
+        )
+        subprocess.run(
+            ["helm", "dependency", "build", "--skip-refresh", str(cls.chart)],
+            env=cls.env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def render(self, extra=()):
+        command = ["helm", "template", "redis", str(self.chart), *extra]
+        return subprocess.check_output(command, env=self.env, text=True)
+
+    def assert_policy(self, value, expected, extra=()):
+        command = list(extra)
+        if value is not None:
+            command.extend(["--set-string", "image.pullPolicy=" + value])
+        rendered = self.render(command)
+        counts = {"redis": 0, "sentinel": 0, "twemproxy": 0, "init": 0, "metrics": 0}
+        for document in yaml.safe_load_all(rendered):
+            if not document or document.get("kind") != "ComponentDefinition":
+                continue
+            runtime = document["spec"]["runtime"]
+            for group in ("containers", "initContainers"):
+                for container in runtime.get(group, []):
+                    name = container["name"]
+                    with self.subTest(component=document["metadata"]["name"], container=name):
+                        self.assertEqual(container.get("imagePullPolicy"), expected)
+                    if group == "initContainers":
+                        counts["init"] += 1
+                    elif name in {"redis", "redis-cluster"}:
+                        counts["redis"] += 1
+                    elif name == "redis-sentinel":
+                        counts["sentinel"] += 1
+                    elif name == "redis-twemproxy":
+                        counts["twemproxy"] += 1
+                    elif name == "metrics":
+                        counts["metrics"] += 1
+        for group, count in counts.items():
+            self.assertGreater(count, 0, "missing rendered " + group)
+
+    def test_always(self):
+        self.assert_policy("Always", "Always")
+
+    def test_never(self):
+        self.assert_policy("Never", "Never")
+
+    def test_default(self):
+        self.assert_policy(None, "IfNotPresent")
+
+    def test_empty_uses_default(self):
+        self.assert_policy("", "IfNotPresent")
+
+    def test_official_registry_rewrites_repositories(self):
+        rendered = self.render(
+            (
+                "--set-string",
+                "image.pullPolicy=Always",
+                "--set",
+                "image.registry=" + OFFICIAL_REGISTRY,
+            )
+        )
+        self.assertIn(OFFICIAL_REGISTRY + "/apecloud/redis:7.2.16", rendered)
+        self.assertIn(OFFICIAL_REGISTRY + "/apecloud/redis-stack-server:7.2.0-v19", rendered)
+        self.assertIn(OFFICIAL_REGISTRY + "/apecloud/redis_exporter:v1.80.1", rendered)
+        self.assertIn(OFFICIAL_REGISTRY + "/apecloud/twemproxy:0.5.0", rendered)
+        self.assertIn(OFFICIAL_REGISTRY + "/apecloud/busybox:1.36", rendered)
+        self.assertNotIn(OFFICIAL_REGISTRY + "/redis:", rendered)
+        self.assertNotIn(OFFICIAL_REGISTRY + "/redis/redis-stack-server:", rendered)
+        self.assertNotIn(OFFICIAL_REGISTRY + "/malexer/twemproxy:", rendered)
+        self.assertNotIn(OFFICIAL_REGISTRY + "/oliver006/redis_exporter:", rendered)
+
+    def test_docker_io_keeps_public_repositories(self):
+        rendered = self.render()
+        self.assertIn("docker.io/redis:7.2.16", rendered)
+        self.assertIn("docker.io/redis/redis-stack-server:7.2.0-v19", rendered)
+        self.assertIn("docker.io/malexer/twemproxy:0.5.0", rendered)
+        self.assertIn("docker.io/oliver006/redis_exporter:v1.80.1", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/redis/tests/test_pull_policy.py
+++ b/addons/redis/tests/test_pull_policy.py
@@ -44,31 +44,39 @@ class RedisPullPolicyTest(unittest.TestCase):
         command = ["helm", "template", "redis", str(self.chart), *extra]
         return subprocess.check_output(command, env=self.env, text=True)
 
-    def assert_policy(self, value, expected, extra=()):
-        command = list(extra)
-        if value is not None:
-            command.extend(["--set-string", "image.pullPolicy=" + value])
-        rendered = self.render(command)
-        counts = {"redis": 0, "sentinel": 0, "twemproxy": 0, "init": 0, "metrics": 0}
+    def iter_runtime_containers(self, rendered):
         for document in yaml.safe_load_all(rendered):
             if not document or document.get("kind") != "ComponentDefinition":
                 continue
             runtime = document["spec"]["runtime"]
             for group in ("containers", "initContainers"):
                 for container in runtime.get(group, []):
-                    name = container["name"]
-                    with self.subTest(component=document["metadata"]["name"], container=name):
-                        self.assertEqual(container.get("imagePullPolicy"), expected)
-                    if group == "initContainers":
-                        counts["init"] += 1
-                    elif name in {"redis", "redis-cluster"}:
-                        counts["redis"] += 1
-                    elif name == "redis-sentinel":
-                        counts["sentinel"] += 1
-                    elif name == "redis-twemproxy":
-                        counts["twemproxy"] += 1
-                    elif name == "metrics":
-                        counts["metrics"] += 1
+                    yield document["metadata"]["name"], group, container
+
+    def assert_policy(self, value, expected, extra=(), skip_names=("metrics", "init-dbctl")):
+        command = list(extra)
+        if value is not None:
+            command.extend(["--set-string", "image.pullPolicy=" + value])
+        rendered = self.render(command)
+        skip = set(skip_names)
+        counts = {"redis": 0, "sentinel": 0, "twemproxy": 0, "init": 0, "metrics": 0, "init-dbctl": 0}
+        for component, group, container in self.iter_runtime_containers(rendered):
+            name = container["name"]
+            if name not in skip:
+                with self.subTest(component=component, container=name):
+                    self.assertEqual(container.get("imagePullPolicy"), expected)
+            if group == "initContainers":
+                counts["init"] += 1
+                if name == "init-dbctl":
+                    counts["init-dbctl"] += 1
+            elif name in {"redis", "redis-cluster"}:
+                counts["redis"] += 1
+            elif name == "redis-sentinel":
+                counts["sentinel"] += 1
+            elif name == "redis-twemproxy":
+                counts["twemproxy"] += 1
+            elif name == "metrics":
+                counts["metrics"] += 1
         for group, count in counts.items():
             self.assertGreater(count, 0, "missing rendered " + group)
 
@@ -109,6 +117,54 @@ class RedisPullPolicyTest(unittest.TestCase):
         self.assertIn("docker.io/redis/redis-stack-server:7.2.0-v19", rendered)
         self.assertIn("docker.io/malexer/twemproxy:0.5.0", rendered)
         self.assertIn("docker.io/oliver006/redis_exporter:v1.80.1", rendered)
+
+    def test_metrics_and_dbctl_keep_own_pull_policy(self):
+        rendered = self.render(
+            (
+                "--set-string",
+                "image.pullPolicy=Always",
+                "--set-string",
+                "metrics.image.pullPolicy=Never",
+                "--set-string",
+                "dbctlImage.pullPolicy=Never",
+            )
+        )
+        metrics = 0
+        dbctl = 0
+        redis = 0
+        for component, _group, container in self.iter_runtime_containers(rendered):
+            name = container["name"]
+            policy = container.get("imagePullPolicy")
+            if name == "metrics":
+                metrics += 1
+                with self.subTest(component=component, container=name):
+                    self.assertEqual(policy, "Never")
+            elif name == "init-dbctl":
+                dbctl += 1
+                with self.subTest(component=component, container=name):
+                    self.assertEqual(policy, "Never")
+            elif name in {"redis", "redis-cluster", "redis-sentinel"}:
+                redis += 1
+                with self.subTest(component=component, container=name):
+                    self.assertEqual(policy, "Always")
+        self.assertEqual(metrics, 8)
+        self.assertEqual(dbctl, 8)
+        self.assertGreater(redis, 0)
+
+    def test_custom_registry_keeps_repository_path(self):
+        custom = "registry.example.test"
+        rendered = self.render(
+            (
+                "--set",
+                "image.registry=" + custom,
+                "--set",
+                "image.repository=redis",
+            )
+        )
+        self.assertIn(custom + "/redis:", rendered)
+        self.assertNotIn(custom + "/apecloud/redis:", rendered)
+        self.assertIn(custom + "/busybox:", rendered)
+        self.assertNotIn(custom + "/apecloud/busybox:", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Redis/sentinel/twemproxy/cluster runtime containers still use `image.pullPolicy` (`redis.imagePullPolicy`).
- `metrics.image.pullPolicy` and `dbctlImage.pullPolicy` are honored again. Setting those to `Never` while `image.pullPolicy=Always` leaves the 8 metrics + 8 init-dbctl containers on `Never`. Platform Always is bound from ct-platform mappings (`metrics.image.pullPolicy`, `dbctlImage.pullPolicy`), not by ignoring Chart fields.
- `apecloud/` repository rewrite applies only when `image.registry` is `apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com`. `docker.io` keeps public repos. A custom registry such as `registry.example.test` with `image.repository=redis` stays `registry.example.test/redis`, not `.../apecloud/redis`. Same rule for busybox and `ceRepository`.
- `python3 addons/redis/tests/test_pull_policy.py` 8/8. `helm lint` passes. Pair with ct-platform #391 (42 official `apecloud/*` refs). No live deployment.

## Test plan
- [x] `python3 addons/redis/tests/test_pull_policy.py`
- [x] `helm lint addons/redis`
- [x] official ACR rewrite still emits `apecloud/*`; custom registry keeps declared repository paths; metrics/dbctl keep their own pullPolicy