### PR TITLE
fix(elasticsearch): honor image pull policy for plugin and exporter

### DIFF
--- a/addons/elasticsearch/templates/_helpers.tpl
+++ b/addons/elasticsearch/templates/_helpers.tpl
@@ -281,7 +281,7 @@ lifecycleActions:
 runtime:
   initContainers:
     - name: prepare-plugins
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
       command:
         - sh
         - -c

--- a/addons/elasticsearch/templates/_helpers.tpl
+++ b/addons/elasticsearch/templates/_helpers.tpl
@@ -470,6 +470,7 @@ runtime:
           readOnly: true
 {{- end }}
     - name: exporter
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
       command:
         - /bin/elasticsearch_exporter
         - "--es.uri=http://localhost:9200"


### PR DESCRIPTION
Elasticsearch ignores `image.pullPolicy` for `prepare-plugins`, and the exporter has no explicit policy. Setting `image.pullPolicy=Always` therefore fails the daemon's rendered runtime coverage check.

Use the existing image policy value for both containers. The default remains IfNotPresent. Scope: release-1.1 base eaef6cabda93d99ee80f4b946cda863e5a66e393; no change to image references or engine versions.

Validation: actual Helm rendering with default, Always and Never passes for every runtime container. The original Chart fails production runtime image coverage; the patched Chart passes coverage, frozen mapping reread and wrong-registry rejection. Registry digests were fixtures; no live Kubernetes or registry operations were performed.

ComponentDefinition runtime context: `kubeblocks-addon-docs/docs/addon-api/02-component-definition.md`. Always is the daemon's execution requirement, not a new KubeBlocks API requirement.
