### PR TITLE
fix(nebula): honor configured image pull policy

### DIFF
--- a/addons/nebula/templates/_helpers.tpl
+++ b/addons/nebula/templates/_helpers.tpl
@@ -149,7 +149,7 @@ Define logrotate container
 {{- define "nebula.graphdAgentContainer" -}}
 - name: agent
   image: {{ $.Values.images.nebula.agent.registry | default ( $.Values.images.registry | default "docker.io" ) }}/{{ $.Values.images.nebula.agent.repository }}:3.7.1
-  imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+  imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
   command:
   - /bin/sh
   - -ecx
@@ -172,7 +172,7 @@ Define agent container
 {{- define "nebula.agentContainer" -}}
 - name: agent
   image: {{ $.Values.images.nebula.agent.registry | default ( $.Values.images.registry | default "docker.io" ) }}/{{ $.Values.images.nebula.agent.repository }}:3.7.1
-  imagePullPolicy: {{ default $.Values.images.pullPolicy "IfNotPresent"}}
+  imagePullPolicy: {{ $.Values.images.pullPolicy | default "IfNotPresent" }}
   command:
   - /bin/bash
   - -ecx
@@ -217,7 +217,7 @@ Define agent container
 {{- define "nebula.exporterContainer" -}}
 - name: exporter
   image: {{ $.Values.images.nebula.exporter.registry | default ( $.Values.images.registry | default "docker.io" ) }}/{{ $.Values.images.nebula.exporter.repository }}:v3.8.0
-  imagePullPolicy: {{ default $.Values.images.pullPolicy "IfNotPresent"}}
+  imagePullPolicy: {{ $.Values.images.pullPolicy | default "IfNotPresent" }}
   command:
   - /bin/sh
   - -ecx

--- a/addons/nebula/templates/cmpd-graphd.yaml
+++ b/addons/nebula/templates/cmpd-graphd.yaml
@@ -129,7 +129,7 @@ spec:
           - -c
           - |
             cp /usr/local/bin/nebula-console /usr/local/nebula/console/nebula-console
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: nebula-console
             mountPath: /usr/local/nebula/console
@@ -139,7 +139,7 @@ spec:
         - -c
         - |
           cp /usr/local/bin/agent /usr/local/nebula/console/agent
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: nebula-console
             mountPath: /usr/local/nebula/console
@@ -150,7 +150,7 @@ spec:
           - -c
           - |
             /scripts/start-graphd.sh
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         ports:
           - containerPort: 9669
             name: thrift

--- a/addons/nebula/templates/cmpd-metad.yaml
+++ b/addons/nebula/templates/cmpd-metad.yaml
@@ -67,7 +67,7 @@ spec:
           - -c
           - |
             cp /usr/local/bin/agent /usr/local/nebula/console/agent
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: nebula-console
             mountPath: /usr/local/nebula/console
@@ -78,7 +78,7 @@ spec:
           - -c
           - |
             /scripts/start-metad.sh
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         ports:
           - containerPort: 9559
             name: thrift

--- a/addons/nebula/templates/cmpd-storaged.yaml
+++ b/addons/nebula/templates/cmpd-storaged.yaml
@@ -134,7 +134,7 @@ spec:
           - -c
           - |
             cp /usr/local/bin/nebula-console /usr/local/nebula/console/nebula-console
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: nebula-console
             mountPath: /usr/local/nebula/console
@@ -144,7 +144,7 @@ spec:
           - -c
           - |
             cp /usr/local/bin/agent /usr/local/nebula/console/agent
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: nebula-console
             mountPath: /usr/local/nebula/console
@@ -155,7 +155,7 @@ spec:
           - -c
           - |
             /scripts/start-storaged.sh
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" }}
         ports:
           - containerPort: 9779
             name: thrift

--- a/addons/nebula/templates/opsdefinition.yaml
+++ b/addons/nebula/templates/opsdefinition.yaml
@@ -34,7 +34,7 @@ spec:
           containers:
             - name: balance-data
               image: {{ $.Values.images.registry | default "docker.io"  }}/{{ $.Values.images.nebula.tool }}
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: {{ $.Values.images.pullPolicy | default "IfNotPresent" }}
               command:
                 - bash
                 - -c


### PR DESCRIPTION
NebulaGraph's Helm `default` arguments are reversed for runtime pull policies, so `images.pullPolicy=Always` still produces IfNotPresent. The balance-data operation also hardcodes IfNotPresent. This prevents the daemon's rendered runtime coverage from accepting the selected Chart.

Apply the configured value before falling back to IfNotPresent, including the operation Pod. The default remains unchanged. Scope: release-1.1 base eaef6cabda93d99ee80f4b946cda863e5a66e393; no change to image references or engine versions.

Validation: actual Helm rendering with default, Always and Never passes for all runtime and operation containers. The original Chart fails production runtime image coverage; the patched Chart passes coverage, frozen mapping reread and wrong-registry rejection. Registry digests were fixtures; no live Kubernetes or registry operations were performed.

ComponentDefinition runtime context: `kubeblocks-addon-docs/docs/addon-api/02-component-definition.md`. Always is the daemon's execution requirement, not a new KubeBlocks API requirement.
