### PR TITLE
fix(milvus): honor MinIO image pull policy [release-1.1]

### DIFF
--- a/addons/milvus/templates/cmpd-minio.yaml
+++ b/addons/milvus/templates/cmpd-minio.yaml
@@ -34,7 +34,7 @@ spec:
     initContainers:
       - name: volume-permissions
         image: {{ .Values.images.ostools.registry | default ( .Values.images.registry | default "docker.io" ) }}/{{ .Values.images.ostools.repository }}:{{ .Values.images.ostools.tag }}
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         command:
           - /bin/bash
           - -ec
@@ -48,7 +48,7 @@ spec:
     containers:
       - name: minio
         image: {{ .Values.images.minio.registry | default ( .Values.images.registry | default "docker.io" ) }}/{{ .Values.images.minio.repository }}:{{ .Values.images.minio.tag }}
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         command:
           - /bin/sh
           - -ce

--- a/addons/milvus/tests/README.md
+++ b/addons/milvus/tests/README.md
@@ -1,0 +1,20 @@
+# MinIO Image Pull Policy Regression
+
+Requires Helm 3 or 4, Python 3.8+, and PyYAML (`python3 -m pip install PyYAML`).
+Run from the repository root:
+
+```sh
+python3 addons/milvus/tests/test_minio_pull_policy.py
+```
+
+The test copies the actual Milvus chart and local kblib dependency to a temporary
+directory, builds dependencies there, and runs `helm template`. It checks both
+`volume-permissions` and `minio` by name in the parsed ComponentDefinition.
+The 12 render cases cover install and upgrade with the default values, explicit
+`IfNotPresent`, `Always`, `Never`, an empty string, and null. Empty values must
+fall back to `IfNotPresent`.
+
+Optional environment variables: `HELM_BIN` selects the Helm executable;
+`CHART_DIR` selects another Milvus source directory with an adjacent kblib;
+`RENDER_DIR` retains the complete rendered YAML for each case.
+This test does not contact a Kubernetes cluster.

--- a/addons/milvus/tests/test_minio_pull_policy.py
+++ b/addons/milvus/tests/test_minio_pull_policy.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright ApeCloud Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-KubeBlocks-Enterprise
+
+"""Render the real chart and check both MinIO containers' pull policies."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+class MinioPullPolicyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = Path(os.environ.get("CHART_DIR", Path(__file__).resolve().parents[1]))
+        cls.helm = os.environ.get("HELM_BIN", "helm")
+        cls.temp = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls.temp.cleanup)
+        cls.chart = Path(cls.temp.name) / "milvus"
+        shutil.copytree(source, cls.chart)
+        shutil.copytree(source.parent / "kblib", Path(cls.temp.name) / "kblib")
+        subprocess.run(
+            [cls.helm, "dependency", "build", str(cls.chart)],
+            check=True, capture_output=True, text=True,
+        )
+
+    def test_pull_policy(self):
+        cases = [
+            ("default", [], "IfNotPresent"),
+            ("explicit-default", ["--set-string", "images.pullPolicy=IfNotPresent"], "IfNotPresent"),
+            ("always", ["--set-string", "images.pullPolicy=Always"], "Always"),
+            ("never", ["--set-string", "images.pullPolicy=Never"], "Never"),
+            ("empty", ["--set-string", "images.pullPolicy="], "IfNotPresent"),
+            ("null", ["--set", "images.pullPolicy=null"], "IfNotPresent"),
+        ]
+        for mode, mode_args in [("install", []), ("upgrade", ["--is-upgrade"])]:
+            for name, values, expected in cases:
+                result = subprocess.run(
+                    [self.helm, "template", "milvus-test", str(self.chart),
+                     "--namespace", "default", *mode_args, *values],
+                    check=True, capture_output=True, text=True,
+                )
+                if output := os.environ.get("RENDER_DIR"):
+                    directory = Path(output)
+                    directory.mkdir(parents=True, exist_ok=True)
+                    (directory / f"{mode}-{name}.yaml").write_text(result.stdout)
+                documents = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+                minio = [doc for doc in documents
+                         if doc.get("kind") == "ComponentDefinition"
+                         and doc.get("spec", {}).get("serviceKind") == "milvus-minio"]
+                self.assertEqual(len(minio), 1, "expected exactly one MinIO ComponentDefinition")
+                runtime = minio[0]["spec"]["runtime"]
+                for group, container_name in [
+                    ("initContainers", "volume-permissions"), ("containers", "minio")
+                ]:
+                    with self.subTest(mode=mode, case=name, container=container_name):
+                        containers = [c for c in runtime[group] if c["name"] == container_name]
+                        self.assertEqual(len(containers), 1)
+                        self.assertEqual(containers[0]["imagePullPolicy"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Backport of #3452 to release-1.1.

Setting `images.pullPolicy=Always` or `Never` currently renders `IfNotPresent`
for both MinIO and volume-permissions. Correct the two reversed Helm `default`
arguments. Default, empty, and null values still use `IfNotPresent`.

The main commit is cherry-picked onto release-1.1 without changing this branch's
existing account configuration, image addresses, commands, or chart version.
Real Helm 3.19.0 and 4.2.0 regression passes 12 render cases and 24 container
assertions per version. Original source fails eight Always/Never assertions.
Complete before/after object comparison permits only the two intended policy
changes, and all eight default/empty/null render pairs are byte-identical.

Design: [DOC-95@v1](https://infracreate.com/project-manager/designs/b3904720-a21e-4f1a-94fb-8572a5ae85b2).
Validation: `python3 addons/milvus/tests/test_minio_pull_policy.py`.
No running cluster was changed. `nopick` is used because both target branches
have explicit PRs.
