### PR TITLE
fix(etcd): backport inject image pull policy [release-1.1]

### DIFF
--- a/addons/etcd/templates/cmpd.yaml
+++ b/addons/etcd/templates/cmpd.yaml
@@ -13,7 +13,7 @@ spec:
   runtime:
     initContainers:
       - name: inject-bash
-        imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.pullPolicy }}
         volumeMounts:
           - name: scripts
             mountPath: /scripts

--- a/addons/etcd/tests/README.md
+++ b/addons/etcd/tests/README.md
@@ -1,0 +1,20 @@
+# Inject Image Pull Policy Regression
+
+Requires Helm 3 or 4, Python 3.8+, and PyYAML (`python3 -m pip install PyYAML`).
+Run from the repository root:
+
+```sh
+python3 addons/etcd/tests/test_inject_pull_policy.py
+```
+
+The test copies the actual etcd chart and local kblib dependency to a temporary
+directory and uses `helm template` to render the complete chart. YAML assertions
+find `inject-bash` and `etcd` by name. The 16 render cases cover installation and
+upgrade with default, explicit `IfNotPresent`, `Always`, `Never`, empty, and null
+init policies, plus primary-only and differing primary/init policies.
+`images.pullPolicy` controls the init container; `image.pullPolicy` independently
+controls the primary container. Empty init policies fall back to `IfNotPresent`.
+
+Optional environment variables: `HELM_BIN` selects the Helm executable,
+`CHART_DIR` selects another etcd chart with adjacent kblib, and `RENDER_DIR`
+retains full rendered YAML for each case. No cluster is contacted.

--- a/addons/etcd/tests/test_inject_pull_policy.py
+++ b/addons/etcd/tests/test_inject_pull_policy.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright ApeCloud Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: LicenseRef-KubeBlocks-Enterprise
+
+"""Check the real chart's independent init and primary image pull policies."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+class InjectPullPolicyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = Path(os.environ.get("CHART_DIR", Path(__file__).resolve().parents[1]))
+        cls.helm = os.environ.get("HELM_BIN", "helm")
+        cls.temp = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls.temp.cleanup)
+        cls.chart = Path(cls.temp.name) / "etcd"
+        shutil.copytree(source, cls.chart)
+        shutil.copytree(source.parent / "kblib", Path(cls.temp.name) / "kblib")
+        subprocess.run(
+            [cls.helm, "dependency", "build", str(cls.chart)],
+            check=True, capture_output=True, text=True,
+        )
+
+    def test_pull_policy(self):
+        cases = [
+            ("default", [], "IfNotPresent", "IfNotPresent"),
+            ("explicit-default", ["--set-string", "images.pullPolicy=IfNotPresent"], "IfNotPresent", "IfNotPresent"),
+            ("always", ["--set-string", "images.pullPolicy=Always"], "Always", "IfNotPresent"),
+            ("never", ["--set-string", "images.pullPolicy=Never"], "Never", "IfNotPresent"),
+            ("empty", ["--set-string", "images.pullPolicy="], "IfNotPresent", "IfNotPresent"),
+            ("null", ["--set", "images.pullPolicy=null"], "IfNotPresent", "IfNotPresent"),
+            ("primary-only", ["--set-string", "image.pullPolicy=Never"], "IfNotPresent", "Never"),
+            ("independent", ["--set-string", "images.pullPolicy=Never,image.pullPolicy=Always"], "Never", "Always"),
+        ]
+        for mode, mode_args in [("install", []), ("upgrade", ["--is-upgrade"])]:
+            for name, values, expected_init, expected_primary in cases:
+                result = subprocess.run(
+                    [self.helm, "template", "etcd-test", str(self.chart),
+                     "--namespace", "default", *mode_args, *values],
+                    check=True, capture_output=True, text=True,
+                )
+                if output := os.environ.get("RENDER_DIR"):
+                    directory = Path(output)
+                    directory.mkdir(parents=True, exist_ok=True)
+                    (directory / f"{mode}-{name}.yaml").write_text(result.stdout)
+                documents = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+                definitions = [doc for doc in documents
+                               if doc.get("kind") == "ComponentDefinition"
+                               and doc.get("spec", {}).get("serviceKind") == "etcd"]
+                self.assertEqual(len(definitions), 1)
+                runtime = definitions[0]["spec"]["runtime"]
+                for group, container_name, expected in [
+                    ("initContainers", "inject-bash", expected_init),
+                    ("containers", "etcd", expected_primary),
+                ]:
+                    with self.subTest(mode=mode, case=name, container=container_name):
+                        containers = [c for c in runtime[group] if c["name"] == container_name]
+                        self.assertEqual(len(containers), 1)
+                        self.assertEqual(containers[0]["imagePullPolicy"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Backport the one-line etcd fix from #3126 to release-1.1. The `inject-bash`
init container currently ignores `images.pullPolicy=Always` or `Never` because
Helm `default` receives a nonempty constant as its input. Reverse the arguments
to honor explicit policies while retaining the `IfNotPresent` fallback.
The primary etcd container remains independently controlled by `image.pullPolicy`.
Main already includes this fix in `bd611ed3` and needs no duplicate template change.

Adds a real Helm/YAML regression for install and upgrade: defaults, explicit
IfNotPresent, Always, Never, empty, null, primary-only, and differing primary/init
policies. Helm 3.19.0 and 4.2.0 pass all 16 render cases on the corrected etcd
chart and on current main. The original release-1.1 chart fails six init-policy
assertions. Complete before/after manifests change only inject-bash's policy.

Also validated real Milvus + etcd renders against the Milvus fix in #3453:
default/Always/Never in install and upgrade mode, with four named containers
checked per case. The original combination fails four inject-bash assertions;
the corrected combination passes all 24 assertions. No cluster was contacted.

Design: [DOC-96@v1](https://infracreate.com/project-manager/designs/11519a1a-b650-4de8-adf2-0c23d738ec87).
Regression: `python3 addons/etcd/tests/test_inject_pull_policy.py`.
Based on release-1.1 `2a9e1758` after #3453, with only etcd changes in this PR.
`nopick` is appropriate because main already has the fix.
