### PR TITLE
fix(milvus): declare MinIO password generation [release-1.1]

### DIFF
--- a/addons/milvus/templates/cmpd-minio.yaml
+++ b/addons/milvus/templates/cmpd-minio.yaml
@@ -14,6 +14,7 @@ spec:
   systemAccounts:
     - name: admin
       initAccount: true
+      passwordConfig: {}
   vars:
     - name: MINIO_ACCESS_KEY
       valueFrom:

--- a/addons/milvus/tests/README.md
+++ b/addons/milvus/tests/README.md
@@ -18,3 +18,10 @@ Optional environment variables: `HELM_BIN` selects the Helm executable;
 `CHART_DIR` selects another Milvus source directory with an adjacent kblib;
 `RENDER_DIR` retains the complete rendered YAML for each case.
 This test does not contact a Kubernetes cluster.
+
+The password regression also renders install and upgrade manifests and checks
+that the MinIO admin account explicitly declares `passwordConfig: {}` while
+retaining the required password credential reference. This requires a matching
+KubeBlocks ComponentDefinition CRD supporting `spec.systemAccounts[].passwordConfig`
+(KubeBlocks release-1.1 PR #10739 or later); rendering alone does not validate
+API-server defaulting or runtime credential creation.

--- a/addons/milvus/tests/test_minio_pull_policy.py
+++ b/addons/milvus/tests/test_minio_pull_policy.py
@@ -29,6 +29,29 @@ class MinioPullPolicyTest(unittest.TestCase):
             check=True, capture_output=True, text=True,
         )
 
+    def test_minio_password_generation(self):
+        for mode, flags in [("install", []), ("upgrade", ["--is-upgrade"])]:
+            with self.subTest(mode=mode):
+                result = subprocess.run(
+                    [self.helm, "template", "milvus-test", str(self.chart),
+                     "--namespace", "default", *flags],
+                    check=True, capture_output=True, text=True,
+                )
+                documents = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+                definition, = [doc for doc in documents
+                               if doc.get("kind") == "ComponentDefinition"
+                               and doc.get("spec", {}).get("serviceKind") == "milvus-minio"]
+                account, = definition["spec"]["systemAccounts"]
+                self.assertEqual(account["name"], "admin")
+                self.assertIs(account["initAccount"], True)
+                self.assertIn("passwordConfig", account)
+                self.assertEqual(account["passwordConfig"], {})
+                password, = [var for var in definition["spec"]["vars"]
+                             if var["name"] == "MINIO_SECRET_KEY"]
+                self.assertEqual(password["valueFrom"]["credentialVarRef"], {
+                    "name": "admin", "optional": False, "password": "Required",
+                })
+
     def test_pull_policy(self):
         cases = [
             ("default", [], "IfNotPresent"),


### PR DESCRIPTION
The embedded MinIO ComponentDefinition requires the admin password credential,
but release-1.1 omits the explicit password-generation configuration. Add
`passwordConfig: {}` so the matching KubeBlocks CRD applies its standard defaults.
The admin account, credential references, and image pull policies stay unchanged.

This independently ports the declaration from #3180 onto release-1.1 `0cb6a190`.
It requires the ComponentDefinition CRD/API from apecloud/kubeblocks#10739
(merged as `f3a6d925`) or a compatible successor. Rendering does not prove the
deployed CRD and controller match. The original main PR remains separate.

Validation:
- Real Helm 3.19.0 and 4.2.0 install/upgrade regressions confirm the explicit
  configuration and required password reference; the unchanged pull-policy
  matrix also passes. The baseline fails both password assertions.
- Full install and upgrade output comparison changes only the account's new
  `passwordConfig` field.
- `git diff --check` passes.

Run: `python3 addons/milvus/tests/test_minio_pull_policy.py`.
Design: [DOC-97@v1](https://infracreate.com/project-manager/designs/6132c0a2-22a3-4027-b70d-84345c7c4ec8).
Live nine-suite validation is tracked separately and is not claimed by these
source/render results. No running cluster was changed for this PR.
