### PR TITLE
fix(milvus): backport standalone parameter renderer

### DIFF
--- a/addons/milvus/templates/_helpers.tpl
+++ b/addons/milvus/templates/_helpers.tpl
@@ -347,6 +347,7 @@ Milvus user config - standalone
   volumeName: milvus-config
   namespace: {{.Release.Namespace}}
   defaultMode: 420
+  externalManaged: true
   restartOnFileChange: true
 - name: scripts
   template: {{ include "milvus-scripts.configTemplateName" . }}

--- a/addons/milvus/templates/paramconfigrenderer-standalone.yaml
+++ b/addons/milvus/templates/paramconfigrenderer-standalone.yaml
@@ -1,0 +1,17 @@
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParamConfigRenderer
+metadata:
+  name: milvus-standalone-pcr-{{ .Chart.Version }}
+  labels:
+    {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+    {{- include "milvus.annotations" . | nindent 4 }}
+spec:
+  componentDef: {{ include "milvus-standalone.cmpdRegexpPattern" . }}
+  parametersDefs:
+    - milvus-standalone-pd-{{ .Chart.Version }}
+  configs:
+    - name: user.yaml
+      templateName: config
+      fileFormatConfig:
+        format: yaml

--- a/addons/milvus/templates/paramdef-standalone.yaml
+++ b/addons/milvus/templates/paramdef-standalone.yaml
@@ -1,0 +1,36 @@
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: milvus-standalone-pd-{{ .Chart.Version }}
+  labels:
+    {{- include "milvus.labels" . | nindent 4 }}
+  annotations:
+    {{- include "milvus.annotations" . | nindent 4 }}
+spec:
+  fileName: user.yaml
+  parametersSchema:
+    topLevelKey: MilvusStandaloneParameter
+    cue: |-
+      #MilvusStandaloneParameter: {
+        ...
+        log?: {
+          ...
+          level?: string & ("debug" | "info" | "warn" | "error" | "panic" | "fatal") | *"info"
+        }
+        proxy?: {
+          ...
+          maxNameLength?: int & >=1 & <=32768 | *255
+          maxFieldNum?: int & >=1 & <=2048 | *64
+          maxDimension?: int & >=1 & <=32768 | *32768
+        }
+        common?: {
+          ...
+          gracefulTime?: int & >=0 & <=600000 | *5000
+        }
+      }
+  staticParameters:
+    - log.level
+    - proxy.maxNameLength
+    - proxy.maxFieldNum
+    - proxy.maxDimension
+    - common.gracefulTime

--- a/addons/milvus/tests/test_paramdef_renderer.py
+++ b/addons/milvus/tests/test_paramdef_renderer.py
@@ -1,0 +1,19 @@
+import pathlib
+import subprocess
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+def main():
+    result = subprocess.run(["helm", "template", "milvus", str(ROOT / "addons/milvus")], check=True, capture_output=True, text=True)
+    docs = [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+    pd = next(d for d in docs if d.get("kind") == "ParametersDefinition")
+    pcr = next(d for d in docs if d.get("kind") == "ParamConfigRenderer")
+    assert set(pd["spec"]) == {"fileName", "parametersSchema", "staticParameters"}
+    assert pd["spec"]["fileName"] == "user.yaml"
+    assert pcr["spec"]["componentDef"] == "^milvus-standalone-"
+    assert pcr["spec"]["parametersDefs"] == [pd["metadata"]["name"]]
+    assert pcr["spec"]["configs"] == [{"name": "user.yaml", "templateName": "config", "fileFormatConfig": {"format": "yaml"}}]
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Backport the Milvus standalone ParametersDefinition for the frozen release-1.1 KB 51883817 API. The 1.1 CRD requires component matching, parameter references, and config file binding on ParamConfigRenderer; the ParametersDefinition retains only supported fileName/schema/static fields. The standalone config is marked externalManaged. Adds a Helm render regression asserting the native 1.1 shape. Excludes Pulsar and 1.2 binding changes.