### PR TITLE
fix(postgresql): use native component TLS for PgBouncer

### DIFF
--- a/addons/postgresql/README.md
+++ b/addons/postgresql/README.md
@@ -332,29 +332,38 @@ Use `server_tls_sslmode=verify-full` to encrypt connections from PgBouncer to
 PostgreSQL and validate the server certificate's CA and Service hostname.
 The application-facing PgBouncer connection remains plain PostgreSQL protocol.
 
-Mount PostgreSQL's CA into the `pgbouncer-tls` volume of the PgBouncer component.
-Use the same Secret referenced by the PostgreSQL component's
-`issuer.secretRef`. For example, when the KBE APIServer specifies
-`pg-cluster-postgresql-ape-tls-certs` with CA key `ca.crt`, project that CA into
-PgBouncer:
+Enable the PgBouncer component's TLS configuration with the same
+`issuer.secretRef` as PostgreSQL. KubeBlocks creates and mounts the component's
+CA file according to its ComponentDefinition. For a PostgreSQL issuer Secret
+named `pg-tls` with keys `ca.crt`, `tls.crt` and `tls.key`:
 
 ```yaml
 # PgBouncer component in Cluster.spec.componentSpecs
 - name: pgbouncer
   replicas: 2
-  volumes:
-    - name: pgbouncer-tls
-      secret:
-        secretName: pg-cluster-postgresql-ape-tls-certs
-        items:
-          - key: ca.crt
-            path: ca.pem
+  tls: true
+  issuer:
+    name: UserProvided
+    secretRef:
+      name: pg-tls
+      ca: ca.crt
+      cert: tls.crt
+      key: tls.key
 ```
 
-The CA is mounted read-only at `/etc/pgbouncer/tls/ca.pem`; the PostgreSQL private
-key stays in the PostgreSQL component. Use a Secret in the same namespace and
-prepare the mount before enabling the pool. Changing the mount updates the Pod
-specification.
+The source Secret contains PostgreSQL's CA, certificate and private key.
+PgBouncer's ComponentDefinition selects only the CA for its derived Secret,
+mounted read-only at `/etc/pgbouncer/tls/ca.pem`. Enabling component TLS prepares
+this trust material; `server_tls_sslmode` stays `disable` until explicitly
+configured. Adding or removing the TLS mount changes the Pod specification.
+
+For a Cluster configured with an explicit `pgbouncer-tls` volume, replace that
+volume entry with the TLS and issuer configuration above in the same Cluster
+update.
+
+To return to a plaintext backend, reload `server_tls_sslmode=disable` before
+disabling component TLS. KubeBlocks removes the derived CA Secret when component
+TLS is disabled.
 
 For `verify-full`, the PostgreSQL certificate's SAN must include the hostname
 resolved into the PgBouncer Pod's `POSTGRESQL_HOST` environment variable.

--- a/addons/postgresql/scripts-ut-spec/version_matrix_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/version_matrix_spec.sh
@@ -131,8 +131,10 @@ Describe "PostgreSQL version matrix contract"
       state_mount = container["volumeMounts"].find { |mount| mount["name"] == "pgbouncer-state" }
       abort unless state_mount["mountPath"] == "/etc/pgbouncer"
       tls_mount = container["volumeMounts"].find { |mount| mount["name"] == "pgbouncer-tls" }
-      abort unless tls_mount == {
-        "name" => "pgbouncer-tls", "mountPath" => "/etc/pgbouncer/tls", "readOnly" => true
+      abort if tls_mount
+      abort unless pgbouncer.dig("spec", "tls") == {
+        "volumeName" => "pgbouncer-tls", "mountPath" => "/etc/pgbouncer/tls",
+        "defaultMode" => 0444, "caFile" => "ca.pem"
       }
       abort if container["volumeMounts"].any? { |mount| mount["mountPath"] == "/var/run/pgbouncer" }
       env = pgbouncer.dig("spec", "runtime", "containers", 0, "env")

--- a/addons/postgresql/templates/cmpd-pgbouncer.yaml
+++ b/addons/postgresql/templates/cmpd-pgbouncer.yaml
@@ -16,6 +16,11 @@ spec:
     maxReplicas: 64
   updateStrategy: Serial
   podManagementPolicy: Parallel
+  tls:
+    volumeName: pgbouncer-tls
+    mountPath: /etc/pgbouncer/tls
+    defaultMode: 0444
+    caFile: ca.pem
   services:
     - name: pgbouncer
       spec:
@@ -107,9 +112,6 @@ spec:
             mountPath: /kb-scripts
           - name: pgbouncer-state
             mountPath: /etc/pgbouncer
-          - name: pgbouncer-tls
-            mountPath: /etc/pgbouncer/tls
-            readOnly: true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 15


### PR DESCRIPTION
## Changes

Declare PgBouncer's CA file through the ComponentDefinition's native `spec.tls`. KubeBlocks manages the derived Secret and mount, allowing APIServer to reuse its existing cluster-scoped TLS flow.

- Replace the explicit `pgbouncer-tls` mount with native TLS configuration that projects only `ca.pem`, with mode `0444`.
- Update the README with issuer configuration, enable/disable sequencing, and migration steps for existing configurations.
- Update the version matrix test to validate the complete CA-only TLS configuration.
- Keep chart version `1.0.6`, PgBouncer image version `1.25.2`, topology, replica defaults, and the parameter contract unchanged. The backend TLS mode still defaults to `server_tls_sslmode=disable`.

## Validation

- Helm lint passed. Rendering comparisons across three registry configurations showed that only the PgBouncer ComponentDefinition changed among 52 resources.
- Setup and version matrix tests: 22 examples, 0 failures. Two independent non-author reviews passed.
- Disposable local k3d verification used KubeBlocks `1.0.3-beta.11`, PostgreSQL `14.23.0`, and PgBouncer `1.25.2`. The derived Secret contained only the CA, with the expected mount permissions.
- Native Reconfigure changed `server_tls_sslmode` from `disable` to `verify-full` and back. After waiting for the actual reload, SQL and `pg_stat_ssl` confirmed the backend connection mode. PostgreSQL and PgBouncer Pod UIDs and restart counts remained unchanged during parameter reloads.
- Local APIServer integration covered pool replicas `0 -> 1 -> 0 -> 1`, inheritance of the existing issuer on first enable, CA-only certificate download, and the parameter changes above. This used an isolated MetaDB, targeted task execution, and CR4W synchronization; it is local developer-runtime evidence.
- The test cluster, MetaDB, processes, and credentials were cleaned up. Release acceptance, Console, full background scheduling, and cross-version upgrades remain outside this verification scope.

## Upgrade and operation notes

- For clusters with an explicit `pgbouncer-tls` volume, replace that entry with `tls: true` and the actual PostgreSQL issuer reference in the same Cluster update to keep volume names unique.
- Enabling component TLS prepares CA trust material. Users configure backend encryption through the existing parameter update mechanism. Adding or removing the TLS mount updates the Pod specification.
- Before disabling component TLS, reload `server_tls_sslmode=disable`. KubeBlocks then removes the derived CA Secret.

Related issue: apecloud/apecloud#20276. This PR delivers the Addon native TLS portion.
Companion APIServer PR: apecloud/apecloud#20671.
