### PR TITLE
feat(postgresql): render optional PgBouncer in cluster chart

### DIFF
--- a/addons-cluster/postgresql/templates/_helpers.tpl
+++ b/addons-cluster/postgresql/templates/_helpers.tpl
@@ -41,6 +41,14 @@ Define postgresql ComponentSpec with ComponentDefinition.
             namespace: {{ $secretRef.namespace }}
         {{- end }}
       {{- end }}
+    {{- if .Values.pgbouncer.enabled }}
+    - name: pgbouncer
+      replicas: {{ .Values.pgbouncer.replicas }}
+      {{- with .Values.pgbouncer.version }}
+      serviceVersion: {{ . | quote }}
+      {{- end }}
+      {{- include "kblib.componentResources" (dict "Values" .Values.pgbouncer) | indent 6 }}
+    {{- end }}
 {{- end }}
 
 {{- define "postgresql-cluster.serviceRef" }}

--- a/addons-cluster/postgresql/values.schema.json
+++ b/addons-cluster/postgresql/values.schema.json
@@ -1,7 +1,32 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
+  "definitions": {
+    "positiveResource": {
+      "type": ["number", "string"],
+      "minimum": 0,
+      "exclusiveMinimum": true,
+      "pattern": "^(0*[1-9][0-9]*(\\.[0-9]+)?|0+\\.[0-9]*[1-9][0-9]*)$"
+    }
+  },
   "properties": {
+    "pgbouncer": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "replicas": {"type": "integer", "minimum": 0, "maximum": 64},
+        "version": {"type": "string"},
+        "cpu": {"$ref": "#/definitions/positiveResource"},
+        "memory": {"$ref": "#/definitions/positiveResource"},
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {"$ref": "#/definitions/positiveResource"},
+            "memory": {"$ref": "#/definitions/positiveResource"}
+          }
+        }
+      }
+    },
     "version": {
       "title": "Version",
       "description": "service version.",

--- a/addons-cluster/postgresql/values.schema.json
+++ b/addons-cluster/postgresql/values.schema.json
@@ -1,11 +1,10 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "definitions": {
     "positiveResource": {
       "type": ["number", "string"],
-      "minimum": 0,
-      "exclusiveMinimum": true,
+      "exclusiveMinimum": 0,
       "pattern": "^(0*[1-9][0-9]*(\\.[0-9]+)?|0+\\.[0-9]*[1-9][0-9]*)$"
     }
   },

--- a/addons-cluster/postgresql/values.yaml
+++ b/addons-cluster/postgresql/values.yaml
@@ -37,6 +37,20 @@ requests:
 ##
 storage: 20
 
+## @param pgbouncer.enabled Include the PgBouncer component in the Cluster.
+## @param pgbouncer.replicas PgBouncer replicas; zero keeps the component inactive.
+## @param pgbouncer.version Service version; empty lets KubeBlocks select it.
+## @param pgbouncer.cpu CPU limit in cores.
+## @param pgbouncer.memory Memory limit in Gi.
+## @param pgbouncer.requests CPU and memory requests; defaults to the limits.
+pgbouncer:
+  enabled: false
+  replicas: 0
+  version: ""
+  cpu: 0.5
+  memory: 0.5
+  requests: {}
+
 etcd:
   enabled: false
   meta:

--- a/addons/postgresql/README.md
+++ b/addons/postgresql/README.md
@@ -180,6 +180,23 @@ with 500m CPU and 512Mi memory limits.
 
 #### Enable and disable
 
+The PostgreSQL cluster chart includes PgBouncer when `pgbouncer.enabled=true`.
+Use a PostgreSQL Addon whose `replication` topology contains `pgbouncer`
+(1.0.6 or later on the release-1.0 line):
+
+```bash
+helm template pg-cluster ./addons-cluster/postgresql --dependency-update \
+  --set pgbouncer.enabled=true --set pgbouncer.replicas=2
+```
+
+The chart defaults to `pgbouncer.enabled=false`. Set `pgbouncer.enabled=true`
+and `pgbouncer.replicas=0` to render an inactive component for later scaling.
+PgBouncer has independent `pgbouncer.cpu` and `pgbouncer.memory` values, both
+defaulting to `0.5` (cores and Gi). Requests default to these limits and can be
+lowered with `pgbouncer.requests.cpu` and `pgbouncer.requests.memory`.
+Set `pgbouncer.version` to select a service version, or leave it empty for
+KubeBlocks to select it from the installed Addon.
+
 To activate PgBouncer when creating a Cluster, add it to the `replication`
 topology:
 

--- a/addons/postgresql/scripts-ut-spec/version_matrix_spec.sh
+++ b/addons/postgresql/scripts-ut-spec/version_matrix_spec.sh
@@ -12,11 +12,55 @@ Describe "PostgreSQL version matrix contract"
   }
 
   render_chart() {
-    helm template kb-addon-postgresql "$(chart_dir)" --namespace kb-system --dependency-update
+    helm dependency build "$(chart_dir)" --skip-refresh >/dev/null || return
+    helm template kb-addon-postgresql "$(chart_dir)" --namespace kb-system
   }
 
   chart_version() {
     awk '$1 == "version:" { print $2; exit }' "$1/Chart.yaml"
+  }
+
+  pgbouncer_cluster_chart_contract() {
+    helm dependency build "$(cluster_chart_dir)" --skip-refresh >/dev/null || return
+    RUBYOPT=-W0 ruby -ryaml -ropen3 -e '
+      chart = ARGV.fetch(0)
+      render = lambda do |values|
+        command = ["helm", "template", "pg-test", chart, "--namespace", "demo"]
+        values.each { |value| command.concat(["--set", value]) }
+        output, error, status = Open3.capture3(*command)
+        abort error unless status.success?
+        YAML.load_stream(output).compact.find { |doc| doc["kind"] == "Cluster" }.fetch("spec")
+      end
+      defaults = render.call([])
+      abort unless defaults["componentSpecs"].map { |c| c["name"] } == ["postgresql"]
+      abort unless render.call(["pgbouncer.replicas=2"]) == defaults
+
+      [[], ["mode=standalone"], ["remoteSetting.isStandby=true", "remoteSetting.primaryHost=primary", "remoteSetting.primaryPort=5432"],
+       ["etcd.enabled=true", "systemAccountSecret.postgres.name=pg-account", "systemAccountSecret.postgres.namespace=demo"]].each do |values|
+        baseline = render.call(values)
+        enabled = render.call(values + ["pgbouncer.enabled=true"])
+        pool = enabled.fetch("componentSpecs").pop
+        abort unless enabled == baseline
+        abort unless pool == {"name" => "pgbouncer", "replicas" => 0, "resources" => {
+          "limits" => {"cpu" => "0.5", "memory" => "0.5Gi"},
+          "requests" => {"cpu" => "0.5", "memory" => "0.5Gi"}}}
+      end
+
+      custom = render.call(["pgbouncer.enabled=true", "pgbouncer.replicas=3", "pgbouncer.version=1.25.2",
+        "pgbouncer.cpu=1", "pgbouncer.memory=2", "pgbouncer.requests.cpu=0.1", "pgbouncer.requests.memory=0.25"])
+      pool = custom.fetch("componentSpecs").pop
+      abort unless custom == defaults
+      abort unless pool == {"name" => "pgbouncer", "replicas" => 3, "serviceVersion" => "1.25.2", "resources" => {
+        "limits" => {"cpu" => "1", "memory" => "2Gi"},
+        "requests" => {"cpu" => "0.1", "memory" => "0.25Gi"}}}
+
+      %w[replicas=-1 replicas=65 replicas=1.5 enabled=yes cpu=invalid cpu=0 memory=-1 requests.cpu=0 requests.memory=invalid].each do |invalid|
+        _, error, status = Open3.capture3("helm", "template", "pg-test", chart, "--set", "pgbouncer.#{invalid}")
+        abort "accepted #{invalid}" if status.success?
+        abort error unless error.include?("pgbouncer") && error.include?("schema")
+      end
+      puts "ok"
+    ' "$(cluster_chart_dir)"
   }
 
   render_count() {
@@ -357,6 +401,12 @@ EOF
 
   It "keeps one replication topology and adds a zero-capable PgBouncer component"
     When call pgbouncer_component_contract
+    The status should eq 0
+    The output should eq "ok"
+  End
+
+  It "renders optional PgBouncer with independent resources and preserves PostgreSQL settings"
+    When call pgbouncer_cluster_chart_contract
     The status should eq 0
     The output should eq "ok"
   End


### PR DESCRIPTION
## Summary

Allow the PostgreSQL cluster chart to render the existing PgBouncer component on demand. This supplies a chart-based component specification that higher-level lifecycle operations can consume, while keeping the default PostgreSQL manifest unchanged.

## Design and implementation

The release-1.0 PostgreSQL Addon already provides PgBouncer in its `replication` topology. Previously, the cluster chart rendered only the PostgreSQL component, so callers materializing PgBouncer needed to construct its specification separately.

This change adds a conditional PgBouncer entry to the existing `componentSpecs` renderer:

- `pgbouncer.enabled=false` by default preserves the existing chart output.
- `pgbouncer.enabled=true` includes the component. Its default `replicas=0` explicitly renders an inactive component; a positive replica count activates it. The schema accepts `0..64`, matching the Addon ComponentDefinition. Product-level replica limits remain the caller's responsibility.
- `pgbouncer.cpu` and `pgbouncer.memory` independently default to 0.5 cores and 0.5 Gi. The existing `kblib.componentResources` helper renders limits and requests. Requests default to limits and can be lowered through `pgbouncer.requests`.
- An optional `pgbouncer.version` selects the service version. When empty, the field is omitted so KubeBlocks can resolve it from the installed Addon and existing topology.

The values schema validates the new inputs and explicitly declares JSON Schema Draft-07 for consistent validation with Helm 3 and Helm 4. The existing PostgreSQL configuration, topology selection, Addon runtime definitions, and Chart versions remain unchanged. Enabling the component requires an installed PostgreSQL Addon whose topology includes PgBouncer; the default chart output remains suitable for environments without that component.

The README documents the chart values and a rendering example. The existing ShellSpec contract suite covers the new behavior and builds local chart dependencies separately from YAML rendering so dependency-build messages do not enter the YAML parser.

## Validation

- `helm lint addons-cluster/postgresql`: passed with defaults and with PgBouncer enabled at zero replicas.
- PostgreSQL version-matrix/cluster-chart ShellSpec suite: 11 examples passed with both Helm 3.16.2 and Helm 4.3.0; chart lint also passed on both versions.
- Existing PgBouncer setup ShellSpec suite: 12 examples passed.
- Compared base and head rendering for six existing PostgreSQL configurations, including standalone input, replication resources, standby, etcd, and account secrets: byte-identical output with PgBouncer disabled.
- New regression checks cover enabled zero replicas, positive replicas, independent resources and service version, preservation of PostgreSQL settings, and rejection of invalid schema inputs.
- `git diff --check`: passed.
- GitHub Actions on `7f1165789e4c09bbfaa722c91a5c6f8b4c0f75f2`: chart checks and ShellCheck passed; ShellSpec completed with 580 examples and 0 failures. The label check passed with `nopick`, keeping delivery scoped to release-1.0.

This PR is scoped to chart rendering. APIServer integration and live KubeBlocks lifecycle validation are follow-up work; no environment was changed or Chart published for this PR.
