### PR TITLE
fix(valkey): honor configured runtime image pull policies

### DIFF
--- a/addons/valkey/templates/cmpd-valkey-sentinel.yaml
+++ b/addons/valkey/templates/cmpd-valkey-sentinel.yaml
@@ -199,7 +199,7 @@ spec:
   runtime:
     containers:
       - name: valkey-sentinel
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         ports:
           - name: valkey-sentinel
             containerPort: 26379

--- a/addons/valkey/templates/cmpd.yaml
+++ b/addons/valkey/templates/cmpd.yaml
@@ -508,7 +508,7 @@ spec:
   runtime:
     containers:
       - name: valkey
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         # The startup script is responsible for:
         #   1. Writing the dynamic parts of valkey.conf (passwords, replicaof, port)
         #   2. exec-ing valkey-server
@@ -575,7 +575,7 @@ spec:
 
       {{- if $.Values.metrics.enabled }}
       - name: metrics
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ $.Values.metrics.image.pullPolicy }}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001

--- a/addons/valkey/tests/test_image_pull_policy.py
+++ b/addons/valkey/tests/test_image_pull_policy.py
@@ -1,0 +1,70 @@
+"""Offline Helm regressions. Requires helm and PyYAML; no Kubernetes access."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+class ImagePullPolicyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = Path(os.environ.get("VALKEY_CHART", Path(__file__).resolve().parents[1]))
+        scratch = tempfile.TemporaryDirectory(prefix="valkey-policy-")
+        cls.addClassCleanup(scratch.cleanup)
+        cls.chart = Path(scratch.name) / "valkey"
+        shutil.copytree(source, cls.chart)
+        shutil.copytree(source.parent / "kblib", cls.chart.parent / "kblib")
+        subprocess.run(["helm", "dependency", "build", "--skip-refresh", str(cls.chart)],
+                       check=True, capture_output=True, text=True)
+
+    def render(self, *settings):
+        command = ["helm", "template", "valkey", str(self.chart), "--namespace", "kb-system"]
+        for setting in settings:
+            command.extend(["--set", setting])
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        return [doc for doc in yaml.safe_load_all(result.stdout)
+                if doc and doc.get("kind") == "ComponentDefinition"]
+
+    def assert_policies(self, documents, engine, metrics, metrics_enabled=True):
+        self.assertEqual(len(documents), 4, "both Valkey majors and both Sentinel majors")
+        seen = []
+        for doc in documents:
+            for container in doc["spec"]["runtime"]["containers"]:
+                name = container["name"]
+                self.assertIn(name, ("valkey", "valkey-sentinel", "metrics"))
+                expected = metrics if name == "metrics" else engine
+                self.assertEqual(container["imagePullPolicy"], expected,
+                                 f'{doc["metadata"]["name"]}/{name}')
+                seen.append(name)
+        self.assertEqual(seen.count("valkey"), 2)
+        self.assertEqual(seen.count("valkey-sentinel"), 2)
+        self.assertEqual(seen.count("metrics"), 2 if metrics_enabled else 0)
+
+    def test_default_remains_if_not_present(self):
+        self.assert_policies(self.render(), "IfNotPresent", "IfNotPresent")
+
+    def test_all_supported_kubernetes_policies(self):
+        for policy in ("Always", "IfNotPresent", "Never"):
+            with self.subTest(policy=policy):
+                self.assert_policies(self.render(f"image.pullPolicy={policy}",
+                                                 f"metrics.image.pullPolicy={policy}"),
+                                     policy, policy)
+
+    def test_engine_override_does_not_change_metrics(self):
+        self.assert_policies(self.render("image.pullPolicy=Always"), "Always", "IfNotPresent")
+
+    def test_metrics_override_does_not_change_engine(self):
+        self.assert_policies(self.render("metrics.image.pullPolicy=Always"), "IfNotPresent", "Always")
+
+    def test_metrics_disabled_preserves_engine_policy(self):
+        self.assert_policies(self.render("metrics.enabled=false", "image.pullPolicy=Always"),
+                             "Always", None, metrics_enabled=False)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The Valkey Chart exposes image.pullPolicy and metrics.image.pullPolicy, but its data, Sentinel and metrics containers hardcode IfNotPresent. When daemon image mappings generate Always, Helm ignores those policy overrides and runtime coverage rejects the rendered Sentinel ComponentDefinition before tests start.

Bind the three template fields to their existing values keys. Defaults remain IfNotPresent. No test suite assertions or runner validation rules change.

Validation: five offline Helm regression tests pass, covering both supported majors, defaults, Always/IfNotPresent/Never, independent engine and metrics overrides, and metrics disabled. The same tests fail on the original Chart. A replay using the frozen daemon mappings and production values/coverage functions reproduces the original Sentinel rejection and passes all six runtime containers with the patch. Parsed default renders are identical; helm lint passes. Never is tested as a Chart setting only, not as a policy supported by this daemon. No live Run was submitted for this patch.
